### PR TITLE
First pass on proto definition

### DIFF
--- a/proto/ord_schema.proto
+++ b/proto/ord_schema.proto
@@ -1,0 +1,369 @@
+// Schema for the Open Reaction Database.
+syntax = "proto3";
+
+message Reaction {
+  string reaction_smiles = 1;
+  string atom_mapped_reaction_smiles = 2;
+  string how_atom_mapped = 3;
+  string rinchi = 4;
+  string reaction_name = 5;
+  // List of reactants, reagents, etc.
+  repeated ReactionInput inputs = 6;
+  ReactionSetup setup = 7;
+  ReactionConditions conditions = 8;
+  message ReactionNotes {
+    // Equivalent to "not single phase".
+    bool is_heterogeneous = 1;
+    bool is_exothermic = 2;
+    bool is_offgasses = 3;
+    bool is_moisture_sensitive = 4;
+    bool is_oxygen_sensitive = 5;
+    string safety_notes = 6;
+  }
+  ReactionNotes notes = 9;
+  message ReactionObservation {
+    float time_in_h = 1;
+    oneof kind {
+      string color = 2;
+      bytes image = 3;
+      string comment = 4;
+    }
+  }
+  repeated ReactionObservation observations = 10;
+  ReactionWorkup workup = 11;
+  repeated ReactionOutcome outcomes = 12;
+  ReactionProvenance provenance = 13;
+}
+
+message ReactionInput {
+  Compound compound = 1;
+  enum ReactionRole {
+    REACTION_ROLE_UNKNOWN = 0;
+    REACTION_ROLE_REACTANT = 1;
+    REACTION_ROLE_REAGENT = 2;
+    REACTION_ROLE_SOLVENT = 3;
+    REACTION_ROLE_CATALYST = 4;
+  }
+  ReactionRole reaction_role = 2;
+  bool is_limiting = 3;
+  int32 addition_stage = 4;
+  float addition_time = 5;
+  enum AdditionSpeed {
+    ADDITION_SPEED_UNKNOWN = 0;
+    ADDITION_SPEED_ALL_AT_ONCE = 1;
+    ADDITION_SPEED_FAST = 2;
+    ADDITION_SPEED_SLOW = 3;
+    ADDITION_SPEED_DROPWISE = 4;
+    ADDITION_SPEED_CONTINUOUS = 5;
+  }
+  AdditionSpeed addition_speed = 6;
+}
+
+message Compound {
+  string smiles = 1;
+  string inchi = 2;
+  string molfile = 3;
+  string iupac_name = 4;
+  // Any accepted common name, trade name, etc.
+  string name = 5;
+  string cas_number = 6;
+  int32 pubchem_sid = 7;
+  int32 chemspider_id = 8;
+  message Amount {
+    // TODO(kearnes): Should this be a float value and a type enum?
+    oneof value {
+      float mass_in_g = 1;
+      float moles = 2;
+      float volume_in_ml = 3;
+      float concentration_in_m = 4;
+    }
+    Compound solvent = 5;
+    // For catalysts on supports.
+    Compound support = 6;
+    float weight_percent = 7;
+    // Precision of the measurement, as a percentage of the value.
+    float precision_in_percent = 8;
+  }
+  Amount amount = 9;
+  enum CompoundPreparation {
+    COMPOUND_PREPARATION_UNKNOWN = 0;
+    COMPOUND_PREPARATION_NONE = 1;
+    COMPOUND_PREPARATION_REPURIFIED = 2;
+    COMPOUND_PREPARATION_SPARGED = 3;
+    COMPOUND_PREPARATION_DRIED = 4;
+  }
+  CompoundPreparation preparation = 10;
+  string vendor_source = 11;
+  string vendor_lot = 12;
+  message CompoundFeature {
+    string name = 1;
+    oneof kind {
+      string string_value = 2;
+      float float_value = 3;
+    }
+    string how_computed = 4;
+  }
+  repeated CompoundFeature features = 13;
+}
+
+message ReactionSetup {
+  enum VesselType {
+    VESSEL_TYPE_UNKNOWN = 0;
+    VESSEL_TYPE_ROUND_BOTTOM_FLASK = 1;
+    VESSEL_TYPE_WELL_PLATE = 2;
+    VESSEL_TYPE_MICROWAVE_VIAL = 3;
+    VESSEL_TYPE_TUBE = 4;
+    VESSEL_TYPE_CONTINUOUS_STIRRED_TANK_REACTOR = 5;
+  }
+  VesselType vessel_type = 1;
+  // Used to describe an UNKNOWN vessel type.
+  string custom_vessel_type = 2;
+  enum VesselPrep {
+    VESSEL_PREP_UNKNOWN = 0;
+    VESSEL_PREP_NONE = 1;
+    VESSEL_PREP_OVEN_DRIED = 2;
+  }
+  VesselPrep vessel_prep = 3;
+  // Used to describe an UNKNOWN vessel prep.
+  string custom_vessel_prep = 4;
+  float vessel_volume_in_ml = 5;
+  bool is_automated = 6;
+  string automation_platform = 7;
+  // TODO(kearnes): Do we need this? Is this the right format?
+  map <string, bytes> automation_code = 8;
+}
+
+message ReactionConditions {
+  TemperatureConditions temperature = 1;
+  PressureConditions pressure = 2;
+  StirringConditions stirring = 3;
+  IlluminationConditions illumination = 4;
+  ElectrochemistryConditions electrochemistry = 5;
+  FlowConditions flow = 6;
+  bool reflux = 7;
+  float pH = 8;
+}
+
+message TemperatureConditions {
+  enum TemperatureControl {
+    TEMPERATURE_CONTROL_UNKNOWN = 0;
+    TEMPERATURE_CONTROL_AMBIENT = 1;
+    TEMPERATURE_CONTROL_OIL_BATH = 2;
+    TEMPERATURE_CONTROL_SAND_BATH = 3;
+    TEMPERATURE_CONTROL_ICE_BATH = 4;
+    TEMPERATURE_CONTROL_DRY_ALUMINUM_PLATE = 5;
+    TEMPERATURE_CONTROL_MICROWAVE = 6;
+    TEMPERATURE_CONTROL_DRY_ICE_AND_ACETONE_BATH = 7;
+    TEMPERATURE_CONTROL_AIR_FAN = 8;
+    TEMPERATURE_CONTROL_LIQUID_NITROGEN = 9;
+  }
+  TemperatureControl temperature_control = 1;
+  // Used to describe an UNKNOWN temperature control.
+  string custom_temperature_control = 2;
+  float setpoint_in_c = 3;
+  float precision_in_c = 4;
+  message Measurement {
+    float time_in_h = 1;
+    float value_in_c = 2;
+  }
+  repeated Measurement measurements = 5;
+  // Thermocouple, pressure transducer, etc.
+  // TODO(kearnes): Should this be an enum?
+  string measurement_method = 6;
+}
+
+message PressureConditions {
+  enum PressureControl {
+    PRESSURE_CONTROL_UNKNOWN = 0;
+    PRESSURE_CONTROL_AMBIENT = 1;
+    PRESSURE_CONTROL_BALLOON = 2;
+  }
+  PressureControl pressure_control = 1;
+  // Used to describe an UNKNOWN pressure control.
+  string pressure_control_custom = 2;
+  float setpoint_in_barg = 3;
+  float precision_in_barg = 4;
+  enum Atmosphere {
+    ATMOSPHERE_UNKNOWN = 0;
+    ATMOSPHERE_AIR = 1;
+    ATMOSPHERE_NITROGEN = 2;
+    ATMOSPHERE_ARGON = 3;
+    ATMOSPHERE_OXYGEN = 4;
+    ATMOSPHERE_HYDROGEN = 5;
+  }
+  Atmosphere atmosphere = 5;
+  // Used to describe an UNKNOWN atmosphere.
+  string custom_atmosphere = 6;
+  message Measurement {
+    float time_in_h = 1;
+    float value_in_barg = 2;
+  }
+  repeated Measurement measurements = 7;
+  // TODO(kearnes): Do we want a measurement_method here like we have in
+  // TemperatureConditions?
+}
+
+message StirringConditions {
+  enum StirringType {
+    STIRRING_TYPE_UNKNOWN = 0;
+    STIRRING_TYPE_NONE = 1;
+    STIRRING_TYPE_STIR_BAR = 2;
+    STIRRING_TYPE_OVERHEAD_MIXER = 3;
+    STIRRING_TYPE_AGITATION = 4;
+  }
+  StirringType stirring_type = 1;
+  // Used to describe an UNKNOWN stirring type.
+  string custom_stirring_type = 2;
+  enum StirringRate {
+    STIRRING_RATE_UNKNOWN = 0;
+    STIRRING_RATE_HIGH = 1;
+    STIRRING_RATE_MEDIUM = 2;
+    STIRRING_RATE_LOW = 3;
+  }
+  // TODO(kearnes): Should this be a oneof?
+  StirringRate stirring_rate = 3;
+  int32 stirring_rpm = 4;
+}
+
+message IlluminationConditions {
+  enum IlluminationType {
+    ILLUMINATION_TYPE_UNKNOWN = 0;
+    ILLUMINATION_TYPE_AMBIENT = 1;
+    ILLUMINATION_TYPE_DARK = 2;
+    ILLUMINATION_TYPE_LED = 3;
+    ILLUMINATION_TYPE_HALOGEN_LAMP = 4;
+    ILLUMINATION_TYPE_DEUTERIUM_LAMP = 5;
+    ILLUMINATION_TYPE_SOLAR_SIMULATOR = 6;
+    ILLUMINATION_TYPE_BROAD_SPECTRUM = 7;
+  }
+  IlluminationType illumination_type = 1;
+  // Used to describe an UKNOWN illumination type.
+  string custom_illumination_type = 2;
+  int32 peak_wavelength_in_nm = 3;
+  string color = 4;
+  // Approximate distance to vessel.
+  float distance_in_cm = 5;
+}
+
+message ElectrochemistryConditions {
+  enum ElectrochemistryType {
+    ELECTROCHEMISTRY_TYPE_NONE = 0;
+    ELECTROCHEMISTRY_TYPE_CONSTANT_CURRENT = 1;
+    ELECTROCHEMISTRY_TYPE_CONSTANT_VOLTAGE = 2;
+  }
+  ElectrochemistryType electrochemistry_type = 1;
+  float current_in_a = 2;
+  float voltage_in_v = 3;
+  string anode_material = 4;
+  string cathode_material = 5;
+  float electrode_distance_in_mm = 6;
+}
+
+message FlowConditions {
+  enum FlowType {
+    FLOW_TYPE_NONE = 0;
+    FLOW_TYPE_PLUG_FLOW_REACTOR = 1;
+    FLOW_TYPE_CONTINUOUS_STIRRED_TANK_REACTOR = 2;
+  }
+  FlowType flow_type = 1;
+  string pump_type = 2;
+  // TODO(kearnes): Should this be an enum?
+  string tube_material = 3;
+}
+
+message ReactionWorkup {
+  enum WorkupType {
+    WORKUP_TYPE_NONE = 0;
+    WORKUP_TYPE_THERMAL = 1;
+    WORKUP_TYPE_SOLVENT = 2;
+  }
+  WorkupType workup_type = 1;
+  // TODO(kearnes): Should this be a oneof?
+  TemperatureConditions thermal_quench = 2;
+  Compound solvent_quench = 3;
+}
+
+message ReactionOutcome {
+  float reaction_time_in_h = 1;
+  // Conversion wrt the limiting reactant.
+  float conversion_in_percent = 2;
+  repeated ReactionProduct products = 3;
+  repeated ReactionAnalysis analyses = 4;
+}
+
+message ReactionProduct {
+  Compound compound = 1;
+  bool is_desired_product = 2;
+  float yield_in_percent = 3;
+  float yield_precision_in_percent = 4;
+  // TODO(kearnes): Is this the right name? Should this be YieldMeasurementType?
+  // Or maybe this should be a ReactionAnalysis.AnalysisType?
+  enum YieldType {
+    YIELD_TYPE_UNKNOWN = 0;
+    YIELD_TYPE_NMR = 1;
+    YIELD_TYPE_HPLC = 2;
+    YIELD_TYPE_MS = 3;  // TODO(kearnes): Should this be LCMS?
+  }
+  YieldType yield_type = 5;
+  // Used to describe an UNKNOWN yield type.
+  string custom_yield_type = 6;
+  float purity_in_percent = 7;
+  enum SelectivityType {
+    SELECTIVITY_TYPE_UNKNOWN = 0;
+    SELECTIVITY_TYPE_EE = 1;
+    SELECTIVITY_TYPE_ER = 2;
+    SELECTIVITY_TYPE_DE = 3;
+  }
+  SelectivityType selectivity_type = 8;
+  // TODO(kearnes): Units?
+  float selectivity_value = 9;
+  float selectivity_precision = 10;
+}
+
+// TODO(kearnes): Time zone (e.g. as +/-UTC)?
+message DateTime {
+  int32 year = 1;
+  int32 month = 2;
+  int32 day = 3;
+  int32 hour = 4;
+  int32 minute = 5;
+  float second = 6;
+}
+
+message ReactionAnalysis {
+  enum AnalysisType {
+    ANALYSIS_TYPE_UNKNOWN = 0;
+    ANALYSIS_TYPE_HPLC = 1;
+    ANALYSIS_TYPE_IR = 2;
+    ANALYSIS_TYPE_NMR = 3;
+    ANALYSIS_TYPE_MP = 4;
+    ANALYSIS_TYPE_UV = 5;
+    ANALYSIS_TYPE_TLC = 6;
+    ANALYSIS_TYPE_HRMS = 7;
+  }
+  AnalysisType analysis_type = 1;
+  // Used to describe an UNKNOWN analysis type.
+  string custom_analysis_type = 2;
+  map <string, bytes> processed_data = 3;
+  map <string, bytes> raw_data = 4;
+  string instrument_manufacturer = 5;
+  DateTime instrument_last_calibrated = 6;
+}
+
+message ReactionProvenance {
+  message Person {
+    string username = 1;
+    string name = 2;
+    string orcid = 3;
+    string organization = 4;
+  }
+  Person experimenter = 1;
+  string city = 2;
+  DateTime experiment_start = 3;
+  oneof publication {
+    string doi = 4;
+    string patent = 5;
+  }
+  DateTime record_created = 6;
+  DateTime record_modified = 7;
+}


### PR DESCRIPTION
A few notes (besides abundant TODOs in the code):
* Modified a few names for brevity; e.g. `ReactionInputType` -> `ReactionRole`
* Included units in variable names where appropriate
* Removed `TemporalData` in favor of local `Measurement` messages for better unit support
* For enums, note that the 0 value is the default; usually I put `UNKNOWN, but sometimes `NONE` when that seemed more reasonable (e.g. for `ElectrochemistryType`). I think this probably makes sense for any Type enum that doesn't support custom values.
* Due to enum scoping restrictions (can't use `UNKNOWN` more than once in a message), I prefixed all enum values with their type names. The protoc error is helpful: `Note that enum values use C++ scoping rules, meaning that enum values are siblings of their type, not children of it.  Therefore, "UNKNOWN" must be unique within "PressureConditions", not just within "Atmosphere".` This helps justify some of the naming stutter :)

Let me know if you hate any of these changes.