### PR TITLE
Validation scripts

### DIFF
--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -6,7 +6,8 @@ import re
 import math
 import dateutil.parser
 
-def ValidateMessage(message, recurse=True):
+
+def validate_message(message, recurse=True):
     """Template function for validating custom messages in the schema.
 
     Messages are not validated to check enum values, since these are enforced 
@@ -30,83 +31,31 @@ def ValidateMessage(message, recurse=True):
 
     # Recurse through submessages
     if recurse:
-        for field in message.DESCRIPTOR.fields:
+        for field, value in message.ListFields():
             if field.type == field.TYPE_MESSAGE: # need to recurse
                 if field.label == field.LABEL_REPEATED:
                     if field.message_type.GetOptions().map_entry: # map
-                        if field.message_type.fields[1].type == field.TYPE_MESSAGE: # value is message
-                            for key,submessage in getattr(message, field.name).items():
+                        if field.message_type.fields_by_name['value'].type == field.TYPE_MESSAGE: # value is message
+                            for key,submessage in value.items():
                                 submessage.CopyFrom(
-                                    ValidateMessage(submessage)
+                                    validate_message(submessage)
                                 )
                         else: # value is a primitive
                             pass
                     else: # Just a repeated message
-                        for submessage in getattr(message, field.name):
+                        for submessage in value:
                             submessage.CopyFrom(
-                                ValidateMessage(submessage)
+                                validate_message(submessage)
                             )
                 else: # no recursion needed
-                    submessage = getattr(message, field.name)
+                    submessage = value
                     submessage.CopyFrom(
-                        ValidateMessage(submessage)
+                        validate_message(submessage)
                     )
 
     # Message-specific validation
     try:
-        return {
-            schema.Reaction: ValidateReaction,
-            # Basics
-            schema.ReactionIdentifier: ValidateReactionIdentifier,
-            schema.ReactionInput: ValidateReactionInput,
-            # Compounds
-            schema.Compound: ValidateCompound,
-            schema.Compound.Feature: ValidateCompoundFeature,
-            schema.CompoundPreparation: ValidateCompoundPreparation,
-            schema.CompoundIdentifier: ValidateCompoundIdentifier,
-            # Setup
-            schema.Vessel: ValidateVessel,
-            schema.ReactionSetup: ValidateReactionSetup,
-            # Conditions
-            schema.ReactionConditions: ValidateReactionConditions,
-            schema.TemperatureConditions: ValidateTemperatureConditions,
-            schema.TemperatureConditions.Measurement: ValidateTemperatureMeasurement,
-            schema.PressureConditions: ValidatePressureConditions,
-            schema.PressureConditions.Measurement: ValidatePressureMeasurement,
-            schema.StirringConditions: ValidateStirringConditions,
-            schema.IlluminationConditions: ValidateIlluminationConditions,
-            schema.ElectrochemistryConditions: ValidateElectrochemistryConditions,
-            schema.ElectrochemistryConditions.Measurement: ValidateElectrochemistryMeasurement,
-            schema.FlowConditions: ValidateFlowConditions,
-            schema.FlowConditions.Tubing: ValidateTubing,
-            # Annotations
-            schema.ReactionNotes: ValidateReactionNotes,
-            schema.ReactionObservation: ValidateReactionObservation,
-            # Outcome
-            schema.ReactionWorkup: ValidateReactionWorkup,
-            schema.ReactionOutcome: ValidateReactionOutcome,
-            schema.ReactionProduct: ValidateReactionProduct,
-            schema.Selectivity: ValidateSelectivity,
-            schema.DateTime: ValidateDateTime,
-            schema.ReactionAnalysis: ValidateReactionAnalysis,
-            # Metadata
-            schema.ReactionProvenance: ValidateReactionProvenance,
-            schema.Person: ValidatePerson,
-            # Units
-            schema.Time: ValidateTime,
-            schema.Mass: ValidateMass,
-            schema.Moles: ValidateMoles,
-            schema.Volume: ValidateVolume,
-            schema.Concentration: ValidateConcentration,
-            schema.Pressure: ValidatePressure,
-            schema.Temperature: ValidateTemperature,
-            schema.Current: ValidateCurrent,
-            schema.Voltage: ValidateVoltage,
-            schema.Length: ValidateLength,
-            schema.Wavelength: ValidateWavelength,
-            schema.FlowRate: ValidateFlowRate,
-            schema.Percentage: ValidatePercentage,
-        }[type(message)](message)
+        return _VALIDATOR_SWITCH[type(message)](message)
     except KeyError:
         # NOTE(ccoley): I made the conscious decision to raise an error here,
         # rather than assume that the message is valid. If a message does not
@@ -115,15 +64,8 @@ def ValidateMessage(message, recurse=True):
         # us to think about what is necessary if/when new messages are added.
         raise NotImplementedError(f"Don't know how to validate {type(message)}")
 
-
 class ValidationWarning(Warning):
     pass
-
-def return_message_if_valid(func):
-    def wrapper(message):
-        func(message)
-        return message
-    return wrapper
 
 def ensure_float_nonnegative(message, field):
     if getattr(message, field) < 0:
@@ -136,139 +78,128 @@ def ensure_float_range(message, field, min=-math.inf, max=math.inf):
             f'{type(message).DESCRIPTOR.name} must be between {min} and {max}')
 
 def ensure_units_specified_if_value_defined(message):
-    if message.value: # can't distinguish 0 and unspecified anyway
-        if message.units == message.UNSPECIFIED:
-            raise ValueError(f'Unspecified units for {type(message)} with ' \
-                f'value defined ({message.value})')
+    if message.value and message.units == message.UNSPECIFIED:
+        raise ValueError(f'Unspecified units for {type(message)} with ' \
+            f'value defined ({message.value})')
 
 def ensure_details_specified_if_type_custom(message):
-    if message.type == message.CUSTOM:
-        if not message.details:
-            raise ValueError(f'Custom type defined for {type(message)}, ' \
-                'but details field is empty')
+    if message.type == message.CUSTOM and not message.details:
+        raise ValueError(f'Custom type defined for {type(message)}, ' \
+            'but details field is empty')
+    return message
 
-@return_message_if_valid
-def ValidateReaction(message):
+def validate_reaction(message):
     if len(message.inputs) == 0:
         raise ValueError('Reactions should have at least 1 reaction input')
     # TODO(ccoley) Should outcomes also have a minimum length?
+    return message
 
-@return_message_if_valid
-def ValidateReactionIdentifier(message):
+def validate_reaction_identifier(message):
     ensure_details_specified_if_type_custom(message)
+    return message
 
-@return_message_if_valid
-def ValidateReactionInput(message):
+def validate_reaction_input(message):
     if len(message.components) == 0:
         raise ValueError('Reaction inputs must have at least one component')
+    return message
 
-@return_message_if_valid
-def ValidateCompound(message):
+def validate_compound(message):
     if len(message.identifiers) == 0:
         raise ValueError('Compounds must have at least one identifier')
+    return message
 
-@return_message_if_valid
-def ValidateCompoundFeature(message):
-    pass
+def validate_compound_feature(message):
+    return message
 
-@return_message_if_valid
-def ValidateCompoundPreparation(message):
+def validate_compound_preparation(message):
     ensure_details_specified_if_type_custom(message)
+    return message
 
-@return_message_if_valid
-def ValidateCompoundIdentifier(message):
+def validate_compound_identifier(message):
     ensure_details_specified_if_type_custom(message)
     # TODO(ccoley): Add identifier-specific validation, e.g., by using
     # RDKit to try to parse SMILES, looking up NAMEs using online resolvers
+    return message
 
-@return_message_if_valid
-def ValidateVessel(message):
-    if message.type == message.VesselType.CUSTOM:
-        if not message.details:
-            raise ValueError('VesselType custom, but no details provided')
-    if message.material == message.VesselMaterial.CUSTOM:
-        if not message.material_details:
-            raise ValueError('VesselMaterial custom, but no details provided')
-    if message.preparation == message.VesselPreparation.CUSTOM:
-        if not message.preparation_details:
-            raise ValueError('VesselPreparation custom, but no details provided')
+def validate_vessel(message):
+    if message.type == message.VesselType.CUSTOM and not message.details:
+        raise ValueError('VesselType custom, but no details provided')
+    if message.material == message.VesselMaterial.CUSTOM and \
+            not message.material_details:
+        raise ValueError('VesselMaterial custom, but no details provided')
+    if message.preparation == message.VesselPreparation.CUSTOM and \
+            not message.preparation_details:
+        raise ValueError('VesselPreparation custom, but no details provided')
+    return message
 
-@return_message_if_valid
-def ValidateReactionSetup(message):
-    pass
+def validate_reaction_setup(message):
+    return message
 
-@return_message_if_valid
-def ValidateReactionConditions(message):
-    if message.conditions_are_dynamic:
-        if not message.details:
-            raise ValueError('Reaction conditions are dynamic, but no details' \
-                ' provided to explain how procedure deviates from normal ' \
-                'single-step reaction conditions.')
+def validate_reaction_conditions(message):
+    if message.conditions_are_dynamic and not message.details:
+        raise ValueError('Reaction conditions are dynamic, but no details' \
+            ' provided to explain how procedure deviates from normal ' \
+            'single-step reaction conditions.')
+    return message
 
-@return_message_if_valid
-def ValidateTemperatureConditions(message):
-    if message.type == message.TemperatureControl.CUSTOM:
-        if not message.details:
-            raise ValueError('Temperature control custom, but no details provided')
+def validate_temperature_conditions(message):
+    if message.type == message.TemperatureControl.CUSTOM and \
+            not message.details:
+        raise ValueError('Temperature control custom, but no details provided')
+    return message
 
-@return_message_if_valid
-def ValidateTemperatureMeasurement(message):
+def validate_temperature_measurement(message):
     ensure_details_specified_if_type_custom(message)
+    return message
 
-@return_message_if_valid
-def ValidatePressureConditions(message):
-    if message.type == message.PressureControl.CUSTOM:
-        if not message.details:
-            raise ValueError('Pressure control custom, but no details provided')
-    if message.atmosphere == message.Atmosphere.CUSTOM:
-        if not message.atmosphere_details:
-            raise ValueError('Atmosphere custom, but no atmosphere_details provided')
+def validate_pressure_conditions(message):
+    if message.type == message.PressureControl.CUSTOM and not message.details:
+        raise ValueError('Pressure control custom, but no details provided')
+    if message.atmosphere == message.Atmosphere.CUSTOM and \
+            not message.atmosphere_details:
+        raise ValueError('Atmosphere custom, but no atmosphere_details provided')
+    return message
 
-@return_message_if_valid
-def ValidatePressureMeasurement(message):
+def validate_pressure_measurement(message):
     ensure_details_specified_if_type_custom(message)
+    return message
 
-@return_message_if_valid
-def ValidateStirringConditions(message):
+def validate_stirring_conditions(message):
     ensure_float_nonnegative(message, 'rpm')
-    if message.type == message.StirringMethod.CUSTOM:
-        if not message.details:
-            raise ValueError('Stirring method custom, but no details provided')
+    if message.type == message.StirringMethod.CUSTOM and not message.details:
+        raise ValueError('Stirring method custom, but no details provided')
+    return message
 
-@return_message_if_valid
-def ValidateIlluminationConditions(message):
+def validate_illumination_conditions(message):
     ensure_details_specified_if_type_custom(message)
+    return message
 
-@return_message_if_valid
-def ValidateElectrochemistryConditions(message):
+def validate_electrochemistry_conditions(message):
     ensure_details_specified_if_type_custom(message)
+    return message
 
-@return_message_if_valid
-def ValidateElectrochemistryMeasurement(message):
-    pass
+def validate_electrochemistry_measurement(message):
+    return message
 
-@return_message_if_valid
-def ValidateFlowConditions(message):
+def validate_flow_conditions(message):
     ensure_details_specified_if_type_custom(message)
+    return message
 
-@return_message_if_valid
-def ValidateTubing(message):
+def validate_tubing(message):
     ensure_details_specified_if_type_custom(message)
+    return message
 
-@return_message_if_valid
-def ValidateReactionNotes(message):
-    pass
+def validate_reaction_notes(message):
+    return message
 
-@return_message_if_valid
-def ValidateReactionObservation(message):
-    pass
+def validate_reaction_observation(message):
+    return message
 
-@return_message_if_valid
-def ValidateReactionWorkup(message):
+def validate_reaction_workup(message):
     ensure_details_specified_if_type_custom(message)
+    return message
 
-@return_message_if_valid
-def ValidateReactionOutcome(message):
+def validate_reaction_outcome(message):
     # Can only have one desired product
     if sum(product.is_desired_product for product in message.products) > 1:
         raise ValueError('Cannot have more than one desired product!')
@@ -282,16 +213,16 @@ def ValidateReactionOutcome(message):
                 if key not in analysis_keys:
                     raise ValueError(f'Undefined analysis key {key} '\
                         'in ReactionProduct')
+    return message
 
-@return_message_if_valid
-def ValidateReactionProduct(message):
-    if message.texture == message.Texture.CUSTOM:
-        if not message.texture_details:
-            raise ValueError(f'Custom texture defined for {type(message)}, ' \
-                'but texture_details field is empty')
+def validate_reaction_product(message):
+    if message.texture == message.Texture.CUSTOM and \
+            not message.texture_details:
+        raise ValueError(f'Custom texture defined for {type(message)}, ' \
+            'but texture_details field is empty')
+    return message
 
-@return_message_if_valid
-def ValidateSelectivity(message):
+def validate_selectivity(message):
     ensure_float_nonnegative(message, 'precision')
     if message.type == message.EE:
         ensure_float_range(message, 'value', 0, 100)
@@ -299,22 +230,22 @@ def ValidateSelectivity(message):
             raise ValidationWarning('EE selectivity values are 0-100, ' \
                 f'not fractions ({message.value} used)')
     ensure_details_specified_if_type_custom(message)
+    return message
 
-@return_message_if_valid
-def ValidateDateTime(message):
+def validate_dateTime(message):
     if message.value:
         try:
             message.value = dateutil.parser.parse(message.value).ctime()
         except dateutil.parser.ParserError:
             raise ValueError(f'Could not parse DateTime string {message.value}')
+    return message
 
-@return_message_if_valid
-def ValidateReactionAnalysis(message):
+def validate_reaction_analysis(message):
     # TODO(ccoley): Will be lots to expand here if we add structured data.
     ensure_details_specified_if_type_custom(message)
+    return message
 
-@return_message_if_valid
-def ValidateReactionProvenance(message):
+def validate_reaction_provenance(message):
     # Prepare datetimes
     if message.experiment_start.value:
         experiment_start = dateutil.parser.parse(message.experiment_start.value)
@@ -334,53 +265,53 @@ def ValidateReactionProvenance(message):
         if (record_modified - record_created).total_seconds() < 0:
             raise ValueError('Record modified time should be after creation')
     # TODO(ccoley) could check if publication_url is valid, etc.
+    return message
 
-@return_message_if_valid
-def ValidatePerson(message):
+def validate_person(message):
     # NOTE(ccoley): final character is checksum, but ignoring that for now
     if message.orcid:
         if not re.match('[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]', 
                 message.orcid):
             raise ValueError('Invalid ORCID: Enter as 0000-0000-0000-0000')
+    return message
 
-@return_message_if_valid
-def ValidateTime(message):
+def validate_time(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
+    return message
 
-@return_message_if_valid
-def ValidateMass(message):
+def validate_mass(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
+    return message
 
-@return_message_if_valid
-def ValidateMoles(message):
+def validate_moles(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
+    return message
 
-@return_message_if_valid
-def ValidateVolume(message):
+def validate_volume(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
+    return message
 
-@return_message_if_valid
-def ValidateConcentration(message):
+def validate_concentration(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
+    return message
 
-@return_message_if_valid
-def ValidatePressure(message):
+def validate_pressure(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
+    return message
 
-@return_message_if_valid
-def ValidateTemperature(message):
+def validate_temperature(message):
     if message.units == message.CELSIUS:
         ensure_float_range(message, 'value', min=-273.15)
     elif message.units == message.FAHRENHEIT:
@@ -389,39 +320,39 @@ def ValidateTemperature(message):
         ensure_float_range(message, 'value', min=0)
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
+    return message
 
-@return_message_if_valid
-def ValidateCurrent(message):
+def validate_current(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
+    return message
 
-@return_message_if_valid
-def ValidateVoltage(message):
+def validate_voltage(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
+    return message
 
-@return_message_if_valid
-def ValidateLength(message):
+def validate_length(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
+    return message
 
-@return_message_if_valid
-def ValidateWavelength(message):
+def validate_wavelength(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
+    return message
 
-@return_message_if_valid
-def ValidateFlowRate(message):
+def validate_flowRate(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
+    return message
 
-@return_message_if_valid
-def ValidatePercentage(message):
+def validate_percentage(message):
     if 0 < message.value < 1:
         raise ValidationWarning('Percentage values are 0-100, ' \
             f'not fractions ({message.value} used)')
@@ -429,4 +360,56 @@ def ValidatePercentage(message):
     ensure_float_nonnegative(message, 'precision')
     ensure_float_range(message, 'value', 0, 105)  # generous upper bound
 
-
+_VALIDATOR_SWITCH = {
+    schema.Reaction: validate_reaction,
+    # Basics
+    schema.ReactionIdentifier: validate_reaction_identifier,
+    schema.ReactionInput: validate_reaction_input,
+    # Compounds
+    schema.Compound: validate_compound,
+    schema.Compound.Feature: validate_compound_feature,
+    schema.CompoundPreparation: validate_compound_preparation,
+    schema.CompoundIdentifier: validate_compound_identifier,
+    # Setup
+    schema.Vessel: validate_vessel,
+    schema.ReactionSetup: validate_reaction_setup,
+    # Conditions
+    schema.ReactionConditions: validate_reaction_conditions,
+    schema.TemperatureConditions: validate_temperature_conditions,
+    schema.TemperatureConditions.Measurement: validate_temperature_measurement,
+    schema.PressureConditions: validate_pressure_conditions,
+    schema.PressureConditions.Measurement: validate_pressure_measurement,
+    schema.StirringConditions: validate_stirring_conditions,
+    schema.IlluminationConditions: validate_illumination_conditions,
+    schema.ElectrochemistryConditions: validate_electrochemistry_conditions,
+    schema.ElectrochemistryConditions.Measurement: validate_electrochemistry_measurement,
+    schema.FlowConditions: validate_flow_conditions,
+    schema.FlowConditions.Tubing: validate_tubing,
+    # Annotations
+    schema.ReactionNotes: validate_reaction_notes,
+    schema.ReactionObservation: validate_reaction_observation,
+    # Outcome
+    schema.ReactionWorkup: validate_reaction_workup,
+    schema.ReactionOutcome: validate_reaction_outcome,
+    schema.ReactionProduct: validate_reaction_product,
+    schema.Selectivity: validate_selectivity,
+    schema.DateTime: validate_dateTime,
+    schema.ReactionAnalysis: validate_reaction_analysis,
+    # Metadata
+    schema.ReactionProvenance: validate_reaction_provenance,
+    schema.Person: validate_person,
+    # Units
+    schema.Time: validate_time,
+    schema.Mass: validate_mass,
+    schema.Moles: validate_moles,
+    schema.Volume: validate_volume,
+    schema.Concentration: validate_concentration,
+    schema.Pressure: validate_pressure,
+    schema.Temperature: validate_temperature,
+    schema.Current: validate_current,
+    schema.Voltage: validate_voltage,
+    schema.Length: validate_length,
+    schema.Wavelength: validate_wavelength,
+    schema.FlowRate: validate_flowRate,
+    schema.Percentage: validate_percentage,
+}

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -92,7 +92,7 @@ def ValidateMessage(message, recurse=True):
             schema.Wavelength: ValidateWavelength,
             schema.FlowRate: ValidateFlowRate,
             schema.Percentage: ValidatePercentage,
-        }[type(message)]
+        }[type(message)](message)
     except KeyError:
         # NOTE(ccoley): I made the conscious decision to raise an error here,
         # rather than assume that the message is valid. If a message does not
@@ -112,17 +112,17 @@ def return_message_if_valid(func):
     return wrapper
 
 def ensure_float_nonnegative(message, field):
-    if gettattr(message, field) < 0:
+    if getattr(message, field) < 0:
         raise ValueError(f'Field {field} of message '\
             f'{type(message).DESCRIPTOR.name} must be non-negative')
 
 def ensure_float_range(message, field, min, max):
-    if gettattr(message, field) < min or getattr(message, field) > max:
+    if getattr(message, field) < min or getattr(message, field) > max:
         raise ValueError(f'Field {field} of message '\
             f'{type(message).DESCRIPTOR.name} must be between {min} and {max}')
 
 def ensure_units_specified_if_value_defined(message):
-    if mesage.value: # can't distinguish 0 and unspecified anyway
+    if message.value: # can't distinguish 0 and unspecified anyway
         if message.units == message.UNSPECIFIED:
             raise ValueError(f'Unspecified units for {type(message)} with ' \
                 f'value defined ({message.value})')

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -4,7 +4,7 @@ from ord_schema.proto import ord_schema_pb2 as schema
 
 import re
 import math
-import dateutil.parser
+from dateutil import parser
 
 
 def validate_message(message, recurse=True):
@@ -272,8 +272,8 @@ def validate_selectivity(message):
 def validate_dateTime(message):
     if message.value:
         try:
-            message.value = dateutil.parser.parse(message.value).ctime()
-        except dateutil.parser.ParserError:
+            message.value = parser.parse(message.value).ctime()
+        except parser.ParserError:
             raise ValueError(f'Could not parse DateTime string {message.value}')
     return message
 
@@ -287,12 +287,12 @@ def validate_reaction_analysis(message):
 def validate_reaction_provenance(message):
     # Prepare datetimes
     if message.experiment_start.value:
-        experiment_start = dateutil.parser.parse(
+        experiment_start = parser.parse(
             message.experiment_start.value)
     if message.record_created.value:
-        record_created = dateutil.parser.parse(message.record_created.value)
+        record_created = parser.parse(message.record_created.value)
     if message.record_modified.value:
-        record_modified = dateutil.parser.parse(message.record_created.value)
+        record_modified = parser.parse(message.record_created.value)
     # Check if record_created undefined
     if message.record_modified.value and not message.record_created.value:
         raise ValidationWarning('record_created not defined, but '

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -323,10 +323,10 @@ def ValidateReactionProvenance(message):
             'record_modified is')
     # Check signs of time differences
     if message.experiment_start.value and message.record_created.value:
-        if (record_created - experiment_start) < 0:
+        if (record_created - experiment_start).seconds < 0:
             raise ValueError('Record creation time should be after experiment')
     if message.record_modified.value and message.record_created.value:
-        if (record_modified - record_created) < 0:
+        if (record_modified - record_created).seconds < 0:
             raise ValueError('Record modified time should be after creation')
     # TODO(ccoley) could check if publication_url is valid, etc.
 

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -286,7 +286,7 @@ def ValidateReactionProduct(message):
 def ValidateSelectivity(message):
     ensure_float_nonnegative(message, 'precision')
     if message.type == message.EE:
-        ensure_float_range(message, 0, 100)
+        ensure_float_range(message, 'value', 0, 100)
         if message.value > 0 and message.value < 1:
             raise ValidationWarning('EE selectivity values are 0-100, ' \
                 f'not fractions ({message.value} used)')
@@ -419,6 +419,6 @@ def ValidatePercentage(message):
             f'not fractions ({message.value} used)')
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
-    ensure_float_range(message, 0, 105)  # generous upper bound
+    ensure_float_range(message, 'value', 0, 105)  # generous upper bound
 
 

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -36,7 +36,7 @@ def validate_message(message, recurse=True):
                 if field.label == field.LABEL_REPEATED:
                     if field.message_type.GetOptions().map_entry:  # map
                         # value is message
-                        if field.message_type.fields_by_name['value'].type ==
+                        if field.message_type.fields_by_name['value'].type == \
                                 field.TYPE_MESSAGE:
                             for key, submessage in value.items():
                                 submessage.CopyFrom(

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -3,6 +3,7 @@
 from ord_schema.proto import ord_schema_pb2 as schema
 
 import re
+from math import inf
 from dateutil import parser as dateparser
 
 def ValidateMessage(message, recurse=True):
@@ -323,10 +324,10 @@ def ValidateReactionProvenance(message):
             'record_modified is')
     # Check signs of time differences
     if message.experiment_start.value and message.record_created.value:
-        if (record_created - experiment_start).seconds < 0:
+        if (record_created - experiment_start).total_seconds() < 0:
             raise ValueError('Record creation time should be after experiment')
     if message.record_modified.value and message.record_created.value:
-        if (record_modified - record_created).seconds < 0:
+        if (record_modified - record_created).total_seconds() < 0:
             raise ValueError('Record modified time should be after creation')
     # TODO(ccoley) could check if publication_url is valid, etc.
 
@@ -377,11 +378,11 @@ def ValidatePressure(message):
 @return_message_if_valid
 def ValidateTemperature(message):
     if message.units == message.CELSIUS:
-        ensure_float_nonnegative(message, 'value')
+        ensure_float_range(message, 'value', -273.15, inf)
     elif message.units == message.FAHRENHEIT:
-        ensure_float_nonnegative(message + 459.67, 'value')
+        ensure_float_range(message, 'value', -459, inf)
     elif message.units == message.KELVIN:
-        ensure_float_nonnegative(message + 273.15, 'value')
+        ensure_float_range(message, 'value', 0, inf)
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
 

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -1,0 +1,418 @@
+"""Helpers validating specific Message types."""
+
+from ord_schema.proto import ord_schema_pb2 as schema
+
+import re
+import dateutil
+
+def ValidateMessage(message, recurse=True):
+    """Template function for validating custom messages in the schema.
+
+        Messages are not validated to check enum values, since these
+        are enforced by the schema. Instead, we only check for validity
+        of items that cannot be enforced in the schema (e.g., non-negativity
+        of certain measurements, consistency of cross-referenced keys)
+        
+        Args:
+            message: a message to validate.
+
+        Returns:
+            The input message, with any unambiguous changes made as
+            needed to ensure validity.
+
+        Raises:
+            ValueError: If any fields are invalid."""
+
+    # Recurse through submessages
+    if recurse:
+        for field in message.DESCRIPTOR.fields:
+            if field.type == field.TYPE_MESSAGE: # recurse
+                if field.label == field.LABEL_REPEATED:
+                    for submessage in getattr(message, field.name):
+                        submessage.CopyFrom(
+                            ValidateMessage(submessage, recurse=recurse)
+                        )
+                else: # no recursion needed
+                    submessage = getattr(message, field.name)
+                    submessage.CopyFrom(
+                        ValidateMessage(submessage, recurse=recurse)
+                    )
+
+    # Message-specific validation
+    try:
+        return {
+            schema.Reaction: ValidateReaction,
+            # Basics
+            schema.ReactionIdentifier: ValidateReactionIdentifier,
+            schema.ReactionInput: ValidateReactionInput,
+            # Compounds
+            schema.Compound: ValidateCompound,
+            schema.Compound.Feature: ValidateCompoundFeature,
+            schema.CompoundPreparation: ValidateCompoundPreparation,
+            schema.CompoundIdentifier: ValidateCompoundIdentifier,
+            # Setup
+            schema.Vessel: ValidateVessel,
+            schema.ReactionSetup: ValidateReactionSetup,
+            # Conditions
+            schema.ReactionConditions: ValidateReactionConditions,
+            schema.TemperatureConditions: ValidateTemperatureConditions,
+            schema.TemperatureConditions.Measurement: ValidateTemperatureMeasurement,
+            schema.PressureConditions: ValidatePressureConditions,
+            schema.PressureConditions.Measurement: ValidatePressureMeasurement,
+            schema.StirringConditions: ValidateStirringConditions,
+            schema.IlluminationConditions: ValidateIlluminationConditions,
+            schema.ElectrochemistryConditions: ValidateElectrochemistryConditions,
+            schema.ElectrochemistryConditions.Measurement: ValidateElectrochemistryMeasurement,
+            schema.FlowConditions: ValidateFlowConditions,
+            schema.FlowConditions.Tubing: ValidateTubing,
+            # Annotations
+            schema.ReactionNotes: ValidateReactionNotes,
+            schema.ReactionObservation: ValidateReactionObservation,
+            # Outcome
+            schema.ReactionWorkup: ValidateReactionWorkup,
+            schema.ReactionOutcome: ValidateReactionOutcome,
+            schema.ReactionProduct: ValidateReactionProduct,
+            schema.Selectivity: ValidateSelectivity,
+            schema.DateTime: ValidateDateTime,
+            schema.ReactionAnalysis: ValidateReactionAnalysis,
+            # Metadata
+            schema.ReactionProvenance: ValidateReactionProvenance,
+            schema.Person: ValidatePerson,
+            # Units
+            schema.Time: ValidateTime,
+            schema.Mass: ValidateMass,
+            schema.Moles: ValidateMoles,
+            schema.Volume: ValidateVolume,
+            schema.Concentration: ValidateConcentration,
+            schema.Pressure: ValidatePressure,
+            schema.Temperature: ValidateTemperature,
+            schema.Current: ValidateCurrent,
+            schema.Voltage: ValidateVoltage,
+            schema.Length: ValidateLength,
+            schema.Wavelength: ValidateWavelength,
+            schema.FlowRate: ValidateFlowRate,
+            schema.Percentage: ValidatePercentage,
+        }[type(message)]
+    except KeyError:
+        # NOTE(ccoley): I made the conscious decision to raise an error here,
+        # rather than assume that the message is valid. If a message does not
+        # require any message-level checks (not uncommon), then it should still
+        # be listed in the dictionary switch above withpass. This will force
+        # us to think about what is necessary if/when new messages are added.
+        raise NotImplementedError(f"Don't know how to validate {type(message)}")
+
+
+class ValidationWarning(Warning):
+    pass
+
+def return_message_if_valid(func):
+    def wrapper(message):
+        func(message)
+        return message
+    return wrapper
+
+def ensure_float_nonnegative(message, field):
+    if gettattr(message, field) < 0:
+        raise ValueError(f'Field {field} of message '\
+            f'{type(message).DESCRIPTOR.name} must be non-negative')
+
+def ensure_float_range(message, field, min, max):
+    if gettattr(message, field) < min or getattr(message, field) > max:
+        raise ValueError(f'Field {field} of message '\
+            f'{type(message).DESCRIPTOR.name} must be between {min} and {max}')
+
+def ensure_units_specified_if_value_defined(message):
+    if mesage.value: # can't distinguish 0 and unspecified anyway
+        if message.units == message.UNSPECIFIED:
+            raise ValueError(f'Unspecified units for {type(message)} with ' \
+                f'value defined ({message.value})')
+
+def ensure_details_specified_if_type_custom(message):
+    if message.type == message.CUSTOM:
+        if not message.details:
+            raise ValueError(f'Custom type defined for {type(message)}, ' \
+                'but details field is empty')
+
+@return_message_if_valid
+def ValidateReaction(message):
+    if len(message.inputs) == 0:
+        raise ValueError('Reactions should have at least 1 reaction input')
+    # TODO(ccoley) Should outcomes also have a minimum length?
+
+@return_message_if_valid
+def ValidateReactionIdentifier(message):
+    ensure_details_specified_if_type_custom(message)
+
+@return_message_if_valid
+def ValidateReactionInput(message):
+    if len(message.components) == 0:
+        raise ValueError('Reaction inputs must have at least one component')
+
+@return_message_if_valid
+def ValidateCompound(message):
+    if len(message.identifiers) == 0:
+        raise ValueError('Compounds must have at least one identifier')
+
+@return_message_if_valid
+def ValidateCompoundFeature(message):
+    pass
+
+@return_message_if_valid
+def ValidateCompoundPreparation(message):
+    ensure_details_specified_if_type_custom(message)
+
+@return_message_if_valid
+def ValidateCompoundIdentifier(message):
+    ensure_details_specified_if_type_custom(message)
+    # TODO(ccoley): Add identifier-specific validation, e.g., by using
+    # RDKit to try to parse SMILES, looking up NAMEs using online resolvers
+
+@return_message_if_valid
+def ValidateVessel(message):
+    if message.type == message.VesselType.CUSTOM:
+        if not message.details:
+            raise ValueError('VesselType custom, but no details provided')
+    if message.material == message.VesselMaterial.CUSTOM:
+        if not message.material_details:
+            raise ValueError('VesselMaterial custom, but no details provided')
+    if message.preparation == message.VesselPreparation.CUSTOM:
+        if not message.preparation_details:
+            raise ValueError('VesselPreparation custom, but no details provided')
+
+@return_message_if_valid
+def ValidateReactionSetup(message):
+    pass
+
+@return_message_if_valid
+def ValidateReactionConditions(message):
+    if message.conditions_are_dynamic:
+        if not message.details:
+            raise ValueError('Reaction conditions are dynamic, but no details' \
+                ' provided to explain how procedure deviates from normal ' \
+                'single-step reaction conditions.')
+
+@return_message_if_valid
+def ValidateTemperatureConditions(message):
+    if message.type == message.TemperatureControl.CUSTOM:
+        if not message.details:
+            raise ValueError('Temperature control custom, but no details provided')
+
+@return_message_if_valid
+def ValidateTemperatureMeasurement(message):
+    ensure_details_specified_if_type_custom(message)
+
+@return_message_if_valid
+def ValidatePressureConditions(message):
+    if message.type == message.PressureControl.CUSTOM:
+        if not message.details:
+            raise ValueError('Pressure control custom, but no details provided')
+    if message.atmosphere == message.Atmosphere.CUSTOM:
+        if not message.atmosphere_details:
+            raise ValueError('Atmosphere custom, but no atmosphere_details provided')
+
+@return_message_if_valid
+def ValidatePressureMeasurement(message):
+    ensure_details_specified_if_type_custom(message)
+
+@return_message_if_valid
+def ValidateStirringConditions(message):
+    ensure_float_nonnegative(rpm, 'precision')
+    if message.type == message.StirringMethod.CUSTOM:
+        if not message.details:
+            raise ValueError('Stirring method custom, but no details provided')
+
+@return_message_if_valid
+def ValidateIlluminationConditions(message):
+    ensure_details_specified_if_type_custom(message)
+
+@return_message_if_valid
+def ValidateElectrochemistryConditions(message):
+    ensure_details_specified_if_type_custom(message)
+
+@return_message_if_valid
+def ValidateElectrochemistryMeasurement(message):
+    pass
+
+@return_message_if_valid
+def ValidateFlowConditions(message):
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidateTubing(message):
+    ensure_details_specified_if_type_custom(message)
+
+@return_message_if_valid
+def ValidateReactionNotes(message):
+    pass
+
+@return_message_if_valid
+def ValidateReactionObservation(message):
+    pass
+
+@return_message_if_valid
+def ValidateReactionWorkup(message):
+    ensure_details_specified_if_type_custom(message)
+
+@return_message_if_valid
+def ValidateReactionOutcome(message):
+    # Can only have one desired product
+    if sum(product.is_desired_product for product in message.products) > 1:
+        raise ValueError('Cannot have more than one desired product!')
+    # Check key values for product analyses
+    # NOTE(ccoley): Could use any(), but using expanded loops for clarity
+    analysis_keys = list(message.analyses.keys())
+    for product in message.products:
+        for field in ['analysis_identity', 'analysis_yield', 'analysis_purity',
+                      'analysis_selectivity']:
+            for key in getattr(product, field):
+                if key not in analysis_keys:
+                    raise ValueError(f'Undefined analysis key {key} '\
+                        'in ReactionProduct')
+
+@return_message_if_valid
+def ValidateReactionProduct(message):
+    if message.texture == message.Texture.CUSTOM:
+        if not message.texture_details:
+            raise ValueError(f'Custom texture defined for {type(message)}, ' \
+                'but texture_details field is empty')
+
+@return_message_if_valid
+def ValidateSelectivity(message):
+    ensure_float_nonnegative(message, 'precision')
+    if message.type == message.EE:
+        ensure_float_range(message, 0, 100)
+        if message.value > 0 and message.value < 1:
+            raise ValidationWarning('EE selectivity values are 0-100, ' \
+                f'not fractions ({message.value} used)')
+    ensure_details_specified_if_type_custom(message)
+
+@return_message_if_valid
+def ValidateDateTime(message):
+    if message.value:
+        try:
+            message.value = dateutil.parser.parse(message.value).ctime()
+        except dateutil.parser.ParserError:
+            raise ValueError(f'Could not parse DateTime string {message.value}')
+
+@return_message_if_valid
+def ValidateReactionAnalysis(message):
+    # TODO(ccoley): Will be lots to expand here if we add structured data.
+    ensure_details_specified_if_type_custom(message)
+
+@return_message_if_valid
+def ValidateReactionProvenance(message):
+    # Prepare datetimes
+    if message.experiment_start:
+        experiment_start = dateutil.parser.parse(message.experiment_start)
+    if message.record_created:
+        record_created = dateutil.parser.parse(message.record_created)
+    if message.record_modified:
+        record_modified = dateutil.parser.parse(message.record_created)
+    # Check if record_created undefined
+    if message.record_modified and not message.record_created:
+        raise ValidationWarning('record_created not defined, but ' \
+            'record_modified is')
+    # Check signs of time differences
+    if message.experiment_start and message.record_created:
+        if (record_created - experiment_start) < 0:
+            raise ValueError('Record creation time should be after experiment')
+    if message.record_modified and message.record_created:
+        if (record_modified - record_created) < 0:
+            raise ValueError('Record modified time should be after creation')
+    # TODO(ccoley) could check if publication_url is valid, etc.
+
+@return_message_if_valid
+def ValidatePerson(message):
+    # NOTE(ccoley): final character is checksum, but ignoring that for now
+    if message.orcid:
+        if not re.match('[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]', 
+                message.orcid):
+            raise ValueError('Invalid ORCID: Enter as 0000-0000-0000-0000')
+
+@return_message_if_valid
+def ValidateTime(message):
+    ensure_float_nonnegative(message, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidateMass(message):
+    ensure_float_nonnegative(message, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidateMoles(message):
+    ensure_float_nonnegative(message, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidateVolume(message):
+    ensure_float_nonnegative(message, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidateConcentration(message):
+    ensure_float_nonnegative(message, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidatePressure(message):
+    ensure_float_nonnegative(message, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidateTemperature(message):
+    if message.units == message.CELSIUS:
+        ensure_float_nonnegative(message, 'value')
+    elif message.units == message.FAHRENHEIT:
+        ensure_float_nonnegative(message + 459.67, 'value')
+    elif message.units == message.KELVIN:
+        ensure_float_nonnegative(message + 273.15, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidateCurrent(message):
+    ensure_float_nonnegative(message, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidateVoltage(message):
+    ensure_float_nonnegative(message, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidateLength(message):
+    ensure_float_nonnegative(message, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidateWavelength(message):
+    ensure_float_nonnegative(message, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidateFlowRate(message):
+    ensure_float_nonnegative(message, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_units_specified_if_value_defined(message)
+
+@return_message_if_valid
+def ValidatePercentage(message):
+    if message.value > 0 and message.value < 1:
+        raise ValidationWarning('Percentage values are 0-100, ' \
+            f'not fractions ({message.value} used)')
+    ensure_float_nonnegative(message, 'value')
+    ensure_float_nonnegative(message, 'precision')
+    ensure_float_range(message, 0, 105)  # generous upper bound
+
+

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -10,15 +10,15 @@ import dateutil.parser
 def validate_message(message, recurse=True):
     """Template function for validating custom messages in the schema.
 
-    Messages are not validated to check enum values, since these are enforced 
+    Messages are not validated to check enum values, since these are enforced
     by the schema. Instead, we only check for validity of items that cannot be
-    enforced in the schema (e.g., non-negativity of certain measurements, 
+    enforced in the schema (e.g., non-negativity of certain measurements,
     consistency of cross-referenced keys).
-    
+
     Args:
         message: A message to validate.
         recurse: A boolean that controls whether submessages of message (i.e.,
-            fields that are messages) should also be validated. Defaults to 
+            fields that are messages) should also be validated. Defaults to
             True.
 
     Returns:
@@ -32,22 +32,24 @@ def validate_message(message, recurse=True):
     # Recurse through submessages
     if recurse:
         for field, value in message.ListFields():
-            if field.type == field.TYPE_MESSAGE: # need to recurse
+            if field.type == field.TYPE_MESSAGE:  # need to recurse
                 if field.label == field.LABEL_REPEATED:
-                    if field.message_type.GetOptions().map_entry: # map
-                        if field.message_type.fields_by_name['value'].type == field.TYPE_MESSAGE: # value is message
-                            for key,submessage in value.items():
+                    if field.message_type.GetOptions().map_entry:  # map
+                        # value is message
+                        if field.message_type.fields_by_name['value'].type ==
+                                field.TYPE_MESSAGE:
+                            for key, submessage in value.items():
                                 submessage.CopyFrom(
                                     validate_message(submessage)
                                 )
-                        else: # value is a primitive
+                        else:  # value is a primitive
                             pass
-                    else: # Just a repeated message
+                    else:  # Just a repeated message
                         for submessage in value:
                             submessage.CopyFrom(
                                 validate_message(submessage)
                             )
-                else: # no recursion needed
+                else:  # no recursion needed
                     submessage = value
                     submessage.CopyFrom(
                         validate_message(submessage)
@@ -64,29 +66,37 @@ def validate_message(message, recurse=True):
         # us to think about what is necessary if/when new messages are added.
         raise NotImplementedError(f"Don't know how to validate {type(message)}")
 
+
 class ValidationWarning(Warning):
     pass
 
+
 def ensure_float_nonnegative(message, field):
     if getattr(message, field) < 0:
-        raise ValueError(f'Field {field} of message '\
-            f'{type(message).DESCRIPTOR.name} must be non-negative')
+        raise ValueError(f'Field {field} of message '
+                         f'{type(message).DESCRIPTOR.name} must be'
+                         ' non-negative')
+
 
 def ensure_float_range(message, field, min=-math.inf, max=math.inf):
     if getattr(message, field) < min or getattr(message, field) > max:
-        raise ValueError(f'Field {field} of message '\
-            f'{type(message).DESCRIPTOR.name} must be between {min} and {max}')
+        raise ValueError(f'Field {field} of message '
+                         f'{type(message).DESCRIPTOR.name} must be between'
+                         f' {min} and {max}')
+
 
 def ensure_units_specified_if_value_defined(message):
     if message.value and message.units == message.UNSPECIFIED:
-        raise ValueError(f'Unspecified units for {type(message)} with ' \
-            f'value defined ({message.value})')
+        raise ValueError(f'Unspecified units for {type(message)} with '
+                         f'value defined ({message.value})')
+
 
 def ensure_details_specified_if_type_custom(message):
     if message.type == message.CUSTOM and not message.details:
-        raise ValueError(f'Custom type defined for {type(message)}, ' \
-            'but details field is empty')
+        raise ValueError(f'Custom type defined for {type(message)}, '
+                         'but details field is empty')
     return message
+
 
 def validate_reaction(message):
     if len(message.inputs) == 0:
@@ -94,32 +104,39 @@ def validate_reaction(message):
     # TODO(ccoley) Should outcomes also have a minimum length?
     return message
 
+
 def validate_reaction_identifier(message):
     ensure_details_specified_if_type_custom(message)
     return message
+
 
 def validate_reaction_input(message):
     if len(message.components) == 0:
         raise ValueError('Reaction inputs must have at least one component')
     return message
 
+
 def validate_compound(message):
     if len(message.identifiers) == 0:
         raise ValueError('Compounds must have at least one identifier')
     return message
 
+
 def validate_compound_feature(message):
     return message
+
 
 def validate_compound_preparation(message):
     ensure_details_specified_if_type_custom(message)
     return message
+
 
 def validate_compound_identifier(message):
     ensure_details_specified_if_type_custom(message)
     # TODO(ccoley): Add identifier-specific validation, e.g., by using
     # RDKit to try to parse SMILES, looking up NAMEs using online resolvers
     return message
+
 
 def validate_vessel(message):
     if message.type == message.VesselType.CUSTOM and not message.details:
@@ -132,15 +149,18 @@ def validate_vessel(message):
         raise ValueError('VesselPreparation custom, but no details provided')
     return message
 
+
 def validate_reaction_setup(message):
     return message
 
+
 def validate_reaction_conditions(message):
     if message.conditions_are_dynamic and not message.details:
-        raise ValueError('Reaction conditions are dynamic, but no details' \
-            ' provided to explain how procedure deviates from normal ' \
-            'single-step reaction conditions.')
+        raise ValueError('Reaction conditions are dynamic, but no details'
+                         ' provided to explain how procedure deviates from'
+                         ' normal single-step reaction conditions.')
     return message
+
 
 def validate_temperature_conditions(message):
     if message.type == message.TemperatureControl.CUSTOM and \
@@ -148,21 +168,26 @@ def validate_temperature_conditions(message):
         raise ValueError('Temperature control custom, but no details provided')
     return message
 
+
 def validate_temperature_measurement(message):
     ensure_details_specified_if_type_custom(message)
     return message
+
 
 def validate_pressure_conditions(message):
     if message.type == message.PressureControl.CUSTOM and not message.details:
         raise ValueError('Pressure control custom, but no details provided')
     if message.atmosphere == message.Atmosphere.CUSTOM and \
             not message.atmosphere_details:
-        raise ValueError('Atmosphere custom, but no atmosphere_details provided')
+        raise ValueError(
+            'Atmosphere custom, but no atmosphere_details provided')
     return message
+
 
 def validate_pressure_measurement(message):
     ensure_details_specified_if_type_custom(message)
     return message
+
 
 def validate_stirring_conditions(message):
     ensure_float_nonnegative(message, 'rpm')
@@ -170,34 +195,43 @@ def validate_stirring_conditions(message):
         raise ValueError('Stirring method custom, but no details provided')
     return message
 
+
 def validate_illumination_conditions(message):
     ensure_details_specified_if_type_custom(message)
     return message
+
 
 def validate_electrochemistry_conditions(message):
     ensure_details_specified_if_type_custom(message)
     return message
 
+
 def validate_electrochemistry_measurement(message):
     return message
+
 
 def validate_flow_conditions(message):
     ensure_details_specified_if_type_custom(message)
     return message
 
+
 def validate_tubing(message):
     ensure_details_specified_if_type_custom(message)
     return message
 
+
 def validate_reaction_notes(message):
     return message
+
 
 def validate_reaction_observation(message):
     return message
 
+
 def validate_reaction_workup(message):
     ensure_details_specified_if_type_custom(message)
     return message
+
 
 def validate_reaction_outcome(message):
     # Can only have one desired product
@@ -211,26 +245,29 @@ def validate_reaction_outcome(message):
                       'analysis_selectivity']:
             for key in getattr(product, field):
                 if key not in analysis_keys:
-                    raise ValueError(f'Undefined analysis key {key} '\
-                        'in ReactionProduct')
+                    raise ValueError(f'Undefined analysis key {key} '
+                                     'in ReactionProduct')
     return message
+
 
 def validate_reaction_product(message):
     if message.texture == message.Texture.CUSTOM and \
             not message.texture_details:
-        raise ValueError(f'Custom texture defined for {type(message)}, ' \
-            'but texture_details field is empty')
+        raise ValueError(f'Custom texture defined for {type(message)}, '
+                         'but texture_details field is empty')
     return message
+
 
 def validate_selectivity(message):
     ensure_float_nonnegative(message, 'precision')
     if message.type == message.EE:
         ensure_float_range(message, 'value', 0, 100)
         if 0 < message.value < 1:
-            raise ValidationWarning('EE selectivity values are 0-100, ' \
-                f'not fractions ({message.value} used)')
+            raise ValidationWarning('EE selectivity values are 0-100, '
+                                    f'not fractions ({message.value} used)')
     ensure_details_specified_if_type_custom(message)
     return message
+
 
 def validate_dateTime(message):
     if message.value:
@@ -240,23 +277,26 @@ def validate_dateTime(message):
             raise ValueError(f'Could not parse DateTime string {message.value}')
     return message
 
+
 def validate_reaction_analysis(message):
     # TODO(ccoley): Will be lots to expand here if we add structured data.
     ensure_details_specified_if_type_custom(message)
     return message
 
+
 def validate_reaction_provenance(message):
     # Prepare datetimes
     if message.experiment_start.value:
-        experiment_start = dateutil.parser.parse(message.experiment_start.value)
+        experiment_start = dateutil.parser.parse(
+            message.experiment_start.value)
     if message.record_created.value:
         record_created = dateutil.parser.parse(message.record_created.value)
     if message.record_modified.value:
         record_modified = dateutil.parser.parse(message.record_created.value)
     # Check if record_created undefined
     if message.record_modified.value and not message.record_created.value:
-        raise ValidationWarning('record_created not defined, but ' \
-            'record_modified is')
+        raise ValidationWarning('record_created not defined, but '
+                                'record_modified is')
     # Check signs of time differences
     if message.experiment_start.value and message.record_created.value:
         if (record_created - experiment_start).total_seconds() < 0:
@@ -267,13 +307,15 @@ def validate_reaction_provenance(message):
     # TODO(ccoley) could check if publication_url is valid, etc.
     return message
 
+
 def validate_person(message):
     # NOTE(ccoley): final character is checksum, but ignoring that for now
     if message.orcid:
-        if not re.match('[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]', 
-                message.orcid):
+        if not re.match('[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]',
+                        message.orcid):
             raise ValueError('Invalid ORCID: Enter as 0000-0000-0000-0000')
     return message
+
 
 def validate_time(message):
     ensure_float_nonnegative(message, 'value')
@@ -281,11 +323,13 @@ def validate_time(message):
     ensure_units_specified_if_value_defined(message)
     return message
 
+
 def validate_mass(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
     return message
+
 
 def validate_moles(message):
     ensure_float_nonnegative(message, 'value')
@@ -293,11 +337,13 @@ def validate_moles(message):
     ensure_units_specified_if_value_defined(message)
     return message
 
+
 def validate_volume(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
     return message
+
 
 def validate_concentration(message):
     ensure_float_nonnegative(message, 'value')
@@ -305,11 +351,13 @@ def validate_concentration(message):
     ensure_units_specified_if_value_defined(message)
     return message
 
+
 def validate_pressure(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
     return message
+
 
 def validate_temperature(message):
     if message.units == message.CELSIUS:
@@ -322,11 +370,13 @@ def validate_temperature(message):
     ensure_units_specified_if_value_defined(message)
     return message
 
+
 def validate_current(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
     return message
+
 
 def validate_voltage(message):
     ensure_float_nonnegative(message, 'value')
@@ -334,11 +384,13 @@ def validate_voltage(message):
     ensure_units_specified_if_value_defined(message)
     return message
 
+
 def validate_length(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
     return message
+
 
 def validate_wavelength(message):
     ensure_float_nonnegative(message, 'value')
@@ -346,19 +398,22 @@ def validate_wavelength(message):
     ensure_units_specified_if_value_defined(message)
     return message
 
+
 def validate_flowRate(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
     return message
 
+
 def validate_percentage(message):
     if 0 < message.value < 1:
-        raise ValidationWarning('Percentage values are 0-100, ' \
-            f'not fractions ({message.value} used)')
+        raise ValidationWarning('Percentage values are 0-100, '
+                                f'not fractions ({message.value} used)')
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_float_range(message, 'value', 0, 105)  # generous upper bound
+
 
 _VALIDATOR_SWITCH = {
     schema.Reaction: validate_reaction,
@@ -382,7 +437,8 @@ _VALIDATOR_SWITCH = {
     schema.StirringConditions: validate_stirring_conditions,
     schema.IlluminationConditions: validate_illumination_conditions,
     schema.ElectrochemistryConditions: validate_electrochemistry_conditions,
-    schema.ElectrochemistryConditions.Measurement: validate_electrochemistry_measurement,
+    schema.ElectrochemistryConditions.Measurement: 
+        validate_electrochemistry_measurement,
     schema.FlowConditions: validate_flow_conditions,
     schema.FlowConditions.Tubing: validate_tubing,
     # Annotations

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -269,7 +269,7 @@ def validate_selectivity(message):
     return message
 
 
-def validate_dateTime(message):
+def validate_date_time(message):
     if message.value:
         try:
             message.value = parser.parse(message.value).ctime()
@@ -399,7 +399,7 @@ def validate_wavelength(message):
     return message
 
 
-def validate_flowRate(message):
+def validate_flow_rate(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
@@ -449,7 +449,7 @@ _VALIDATOR_SWITCH = {
     schema.ReactionOutcome: validate_reaction_outcome,
     schema.ReactionProduct: validate_reaction_product,
     schema.Selectivity: validate_selectivity,
-    schema.DateTime: validate_dateTime,
+    schema.DateTime: validate_date_time,
     schema.ReactionAnalysis: validate_reaction_analysis,
     # Metadata
     schema.ReactionProvenance: validate_reaction_provenance,
@@ -466,6 +466,6 @@ _VALIDATOR_SWITCH = {
     schema.Voltage: validate_voltage,
     schema.Length: validate_length,
     schema.Wavelength: validate_wavelength,
-    schema.FlowRate: validate_flowRate,
+    schema.FlowRate: validate_flow_rate,
     schema.Percentage: validate_percentage,
 }

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -3,8 +3,8 @@
 from ord_schema.proto import ord_schema_pb2 as schema
 
 import re
-from math import inf
-from dateutil import parser as dateparser
+import math
+import dateutil.parser
 
 def ValidateMessage(message, recurse=True):
     """Template function for validating custom messages in the schema.
@@ -300,8 +300,8 @@ def ValidateSelectivity(message):
 def ValidateDateTime(message):
     if message.value:
         try:
-            message.value = dateparser.parse(message.value).ctime()
-        except dateparser.ParserError:
+            message.value = dateutil.parser.parse(message.value).ctime()
+        except dateutil.parser.ParserError:
             raise ValueError(f'Could not parse DateTime string {message.value}')
 
 @return_message_if_valid
@@ -313,11 +313,11 @@ def ValidateReactionAnalysis(message):
 def ValidateReactionProvenance(message):
     # Prepare datetimes
     if message.experiment_start.value:
-        experiment_start = dateparser.parse(message.experiment_start.value)
+        experiment_start = dateutil.parser.parse(message.experiment_start.value)
     if message.record_created.value:
-        record_created = dateparser.parse(message.record_created.value)
+        record_created = dateutil.parser.parse(message.record_created.value)
     if message.record_modified.value:
-        record_modified = dateparser.parse(message.record_created.value)
+        record_modified = dateutil.parser.parse(message.record_created.value)
     # Check if record_created undefined
     if message.record_modified.value and not message.record_created.value:
         raise ValidationWarning('record_created not defined, but ' \
@@ -378,11 +378,11 @@ def ValidatePressure(message):
 @return_message_if_valid
 def ValidateTemperature(message):
     if message.units == message.CELSIUS:
-        ensure_float_range(message, 'value', -273.15, inf)
+        ensure_float_range(message, 'value', -273.15, math.inf)
     elif message.units == message.FAHRENHEIT:
-        ensure_float_range(message, 'value', -459, inf)
+        ensure_float_range(message, 'value', -459, math.inf)
     elif message.units == message.KELVIN:
-        ensure_float_range(message, 'value', 0, inf)
+        ensure_float_range(message, 'value', 0, math.inf)
     ensure_float_nonnegative(message, 'precision')
     ensure_units_specified_if_value_defined(message)
 

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -26,13 +26,16 @@ def ValidateMessage(message, recurse=True):
     # Recurse through submessages
     if recurse:
         for field in message.DESCRIPTOR.fields:
-            if field.type == field.TYPE_MESSAGE: # recurse
+            if field.type == field.TYPE_MESSAGE: # need to recurse
                 if field.label == field.LABEL_REPEATED:
                     if field.message_type.GetOptions().map_entry: # map
-                        for key,submessage in getattr(message, field.name).items():
-                            submessage.CopyFrom(
-                                ValidateMessage(submessage)
-                            )
+                        if field.message_type.fields[1].type == field.TYPE_MESSAGE: # value is message
+                            for key,submessage in getattr(message, field.name).items():
+                                submessage.CopyFrom(
+                                    ValidateMessage(submessage)
+                                )
+                        else: # value is a primitive
+                            pass
                     else: # Just a repeated message
                         for submessage in getattr(message, field.name):
                             submessage.CopyFrom(

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -413,7 +413,7 @@ def validate_percentage(message):
     ensure_float_nonnegative(message, 'value')
     ensure_float_nonnegative(message, 'precision')
     ensure_float_range(message, 'value', 0, 105)  # generous upper bound
-
+    return message
 
 _VALIDATOR_SWITCH = {
     schema.Reaction: validate_reaction,

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -11,7 +11,6 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.validations = validations
 
     @parameterized.named_parameters(
         ('volume', schema.Volume(value=15.0, units=schema.Volume.MILLILITER)),
@@ -19,7 +18,7 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         ('mass', schema.Mass(value=32.1, units=schema.Mass.GRAM)),
     )
     def test_units(self, message):
-        self.assertEqual(self.validations.ValidateMessage(message), message)
+        self.assertEqual(validations.ValidateMessage(message), message)
 
     @parameterized.named_parameters(
         ('neg volume', 
@@ -38,49 +37,51 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
     )
     def test_units_should_fail(self, message, expected_error):
         with self.assertRaisesRegex((ValueError), expected_error):
-            self.validations.ValidateMessage(message)
+            validations.ValidateMessage(message)
 
     def test_orcid(self):
         message = schema.Person(orcid='0000-0001-2345-678X')
-        self.assertEqual(self.validations.ValidateMessage(message), message)
+        self.assertEqual(validations.ValidateMessage(message), message)
 
     def test_orcid_should_fail(self):
         message = schema.Person(orcid='abcd-0001-2345-678X')
         with self.assertRaisesRegex((ValueError), 'Invalid'):
-            self.validations.ValidateMessage(message)
+            validations.ValidateMessage(message)
 
     def test_reaction(self):
         message = schema.Reaction()
         with self.assertRaisesRegex((ValueError), 'reaction input'):
-            self.validations.ValidateReaction(message)
+            validations.ValidateReaction(message)
 
     def test_reaction_recursive(self):
         message = schema.Reaction()
         with self.assertRaisesRegex((ValueError), 'reaction input'):
-            self.validations.ValidateMessage(message, recurse=False)
+            validations.ValidateMessage(message)
         dummy_input = message.inputs['dummy_input']
+        self.assertEqual(validations.ValidateMessage(message, recurse=False), 
+            message)
         with self.assertRaisesRegex((ValueError), 'component'):
-            self.validations.ValidateMessage(message)
+            validations.ValidateMessage(message)
         dummy_component = dummy_input.components.add()
         with self.assertRaisesRegex((ValueError), 'identifier'):
-            self.validations.ValidateMessage(message)
+            validations.ValidateMessage(message)
         dummy_component.identifiers.add(type='CUSTOM')
         with self.assertRaisesRegex((ValueError), 'details'):
-            self.validations.ValidateMessage(message)
+            validations.ValidateMessage(message)
         dummy_component.identifiers[0].details = 'custom_identifier'
-        self.assertEqual(self.validations.ValidateMessage(message), message)
+        self.assertEqual(validations.ValidateMessage(message), message)
         outcome = message.outcomes.add()
         analysis = outcome.analyses['dummy_analysis']
-        self.assertEqual(self.validations.ValidateMessage(message), message)
+        self.assertEqual(validations.ValidateMessage(message), message)
 
     def test_datetimes(self):
         message = schema.ReactionProvenance()
         message.experiment_start.value = '11 am'
         message.record_created.value = '10 am'
         with self.assertRaisesRegex((ValueError), 'after'):
-            self.validations.ValidateMessage(message)
+            validations.ValidateMessage(message)
         message.record_created.value = '11:15 am'
-        self.assertEqual(self.validations.ValidateMessage(message), message)
+        self.assertEqual(validations.ValidateMessage(message), message)
 
 if __name__ == '__main__':
     absltest.main()

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -66,6 +66,9 @@ class UnitsTest(parameterized.TestCase, absltest.TestCase):
             self.validations.ValidateMessage(message)
         dummy_component.identifiers[0].details = 'custom_identifier'
         self.assertEqual(self.validations.ValidateMessage(message), message)
+        outcome = message.outcomes.add()
+        analysis = outcome.analyses['dummy_analysis']
+        self.assertEqual(self.validations.ValidateMessage(message), message)
 
 if __name__ == '__main__':
     absltest.main()

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -7,7 +7,7 @@ from ord_schema import validations
 from ord_schema.proto import ord_schema_pb2 as schema
 
 
-class UnitsTest(parameterized.TestCase, absltest.TestCase):
+class ValidationsTest(parameterized.TestCase, absltest.TestCase):
 
     def setUp(self):
         super().setUp()

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -31,6 +31,10 @@ class UnitsTest(parameterized.TestCase, absltest.TestCase):
             'non-negative'),
         ('no units', schema.FlowRate(value=5), 'units'),
         ('percentage out of range', schema.Percentage(value=200), 'between'),
+        ('low temperature', schema.Temperature(value=-5, units='KELVIN'),
+            'between'),
+        ('low temperature 2', schema.Temperature(value=-500, units='CELSIUS'),
+            'between'),
     )
     def test_units_should_fail(self, message, expected_error):
         with self.assertRaisesRegex((ValueError), expected_error):
@@ -49,7 +53,6 @@ class UnitsTest(parameterized.TestCase, absltest.TestCase):
         message = schema.Reaction()
         with self.assertRaisesRegex((ValueError), 'reaction input'):
             self.validations.ValidateReaction(message)
-        
 
     def test_reaction_recursive(self):
         message = schema.Reaction()
@@ -68,6 +71,15 @@ class UnitsTest(parameterized.TestCase, absltest.TestCase):
         self.assertEqual(self.validations.ValidateMessage(message), message)
         outcome = message.outcomes.add()
         analysis = outcome.analyses['dummy_analysis']
+        self.assertEqual(self.validations.ValidateMessage(message), message)
+
+    def test_datetimes(self):
+        message = schema.ReactionProvenance()
+        message.experiment_start.value = '11 am'
+        message.record_created.value = '10 am'
+        with self.assertRaisesRegex((ValueError), 'after'):
+            self.validations.ValidateMessage(message)
+        message.record_created.value = '11:15 am'
         self.assertEqual(self.validations.ValidateMessage(message), message)
 
 if __name__ == '__main__':

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -25,13 +25,13 @@ class UnitsTest(parameterized.TestCase, absltest.TestCase):
     @parameterized.named_parameters(
         ('neg volume', 
             schema.Volume(value=-15.0, units=schema.Volume.MILLILITER),
-            'nonnegative'),
+            'non-negative'),
         ('neg time', schema.Time(value=-24, units=schema.Time.HOUR), 
-            'nonnegative'),
+            'non-negative'),
         ('neg mass', schema.Mass(value=-32.1, units=schema.Mass.GRAM),
-            'nonnegative'),
+            'non-negative'),
         ('invalid ORCID', schema.Person(orcid='abcd-0001-2345-678X'), 
-            'invalid'),
+            'Invalid'),
     )
     def test_resolve_should_fail(self, message, expected_error):
         with self.assertRaisesRegex((ValueError), expected_error):

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -1,0 +1,42 @@
+"""Tests for ord_schema.units."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from ord_schema import validations
+from ord_schema.proto import ord_schema_pb2 as schema
+
+
+class UnitsTest(parameterized.TestCase, absltest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.validations = validations
+
+    @parameterized.named_parameters(
+        ('volume', schema.Volume(value=15.0, units=schema.Volume.MILLILITER)),
+        ('time', schema.Time(value=24, units=schema.Time.HOUR)),
+        ('mass', schema.Mass(value=32.1, units=schema.Mass.GRAM)),
+        ('orcid', schema.Person(orcid='0000-0001-2345-678X'))
+    )
+    def test_resolve(self, message):
+        self.assertEqual(self.validations.ValidateMessage(message), message)
+
+    @parameterized.named_parameters(
+        ('neg volume', 
+            schema.Volume(value=-15.0, units=schema.Volume.MILLILITER),
+            'nonnegative'),
+        ('neg time', schema.Time(value=-24, units=schema.Time.HOUR), 
+            'nonnegative'),
+        ('neg mass', schema.Mass(value=-32.1, units=schema.Mass.GRAM),
+            'nonnegative'),
+        ('invalid ORCID', schema.Person(orcid='abcd-0001-2345-678X'), 
+            'invalid'),
+    )
+    def test_resolve_should_fail(self, message, expected_error):
+        with self.assertRaisesRegex((ValueError), expected_error):
+            self.validations.ValidateMessage(message)
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -30,6 +30,7 @@ class UnitsTest(parameterized.TestCase, absltest.TestCase):
         ('neg mass', schema.Mass(value=-32.1, units=schema.Mass.GRAM),
             'non-negative'),
         ('no units', schema.FlowRate(value=5), 'units'),
+        ('percentage out of range', schema.Percentage(value=200), 'between'),
     )
     def test_units_should_fail(self, message, expected_error):
         with self.assertRaisesRegex((ValueError), expected_error):

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -18,7 +18,7 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         ('mass', schema.Mass(value=32.1, units=schema.Mass.GRAM)),
     )
     def test_units(self, message):
-        self.assertEqual(validations.ValidateMessage(message), message)
+        self.assertEqual(validations.validate_message(message), message)
 
     @parameterized.named_parameters(
         ('neg volume', 
@@ -37,51 +37,51 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
     )
     def test_units_should_fail(self, message, expected_error):
         with self.assertRaisesRegex((ValueError), expected_error):
-            validations.ValidateMessage(message)
+            validations.validate_message(message)
 
     def test_orcid(self):
         message = schema.Person(orcid='0000-0001-2345-678X')
-        self.assertEqual(validations.ValidateMessage(message), message)
+        self.assertEqual(validations.validate_message(message), message)
 
     def test_orcid_should_fail(self):
         message = schema.Person(orcid='abcd-0001-2345-678X')
         with self.assertRaisesRegex((ValueError), 'Invalid'):
-            validations.ValidateMessage(message)
+            validations.validate_message(message)
 
     def test_reaction(self):
         message = schema.Reaction()
         with self.assertRaisesRegex((ValueError), 'reaction input'):
-            validations.ValidateReaction(message)
+            validations.validate_reaction(message)
 
     def test_reaction_recursive(self):
         message = schema.Reaction()
         with self.assertRaisesRegex((ValueError), 'reaction input'):
-            validations.ValidateMessage(message)
+            validations.validate_message(message)
         dummy_input = message.inputs['dummy_input']
-        self.assertEqual(validations.ValidateMessage(message, recurse=False), 
+        self.assertEqual(validations.validate_message(message, recurse=False), 
             message)
         with self.assertRaisesRegex((ValueError), 'component'):
-            validations.ValidateMessage(message)
+            validations.validate_message(message)
         dummy_component = dummy_input.components.add()
         with self.assertRaisesRegex((ValueError), 'identifier'):
-            validations.ValidateMessage(message)
+            validations.validate_message(message)
         dummy_component.identifiers.add(type='CUSTOM')
         with self.assertRaisesRegex((ValueError), 'details'):
-            validations.ValidateMessage(message)
+            validations.validate_message(message)
         dummy_component.identifiers[0].details = 'custom_identifier'
-        self.assertEqual(validations.ValidateMessage(message), message)
+        self.assertEqual(validations.validate_message(message), message)
         outcome = message.outcomes.add()
         analysis = outcome.analyses['dummy_analysis']
-        self.assertEqual(validations.ValidateMessage(message), message)
+        self.assertEqual(validations.validate_message(message), message)
 
     def test_datetimes(self):
         message = schema.ReactionProvenance()
         message.experiment_start.value = '11 am'
         message.record_created.value = '10 am'
         with self.assertRaisesRegex((ValueError), 'after'):
-            validations.ValidateMessage(message)
+            validations.validate_message(message)
         message.record_created.value = '11:15 am'
-        self.assertEqual(validations.ValidateMessage(message), message)
+        self.assertEqual(validations.validate_message(message), message)
 
 if __name__ == '__main__':
     absltest.main()

--- a/proto/ord_schema.proto
+++ b/proto/ord_schema.proto
@@ -506,6 +506,8 @@ message ReactionNotes {
   bool is_sensitive_to_oxygen = 5;
   bool is_sensitive_to_light = 6;
   string safety_notes = 7;
+  // Overflow field for full procedure details
+  string procedure_details = 8;
 }
 
 message ReactionObservation {

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
         url='https://github.com/Open-Reaction-Database/ord-schema',
         license='Apache License, Version 2.0',
         install_requires=['absl-py>=0.9.0', 'protobuf>=3.11.0',
-            'python-dateutil'>=1.10.0],
+            'python-dateutil>=1.10.0'],
         version="0.1",
         packages=setuptools.find_packages(),
         cmdclass={'build_py': BuildPyCommand})

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ if __name__ == '__main__':
         description='Schema for the Open Reaction Database',
         url='https://github.com/Open-Reaction-Database/ord-schema',
         license='Apache License, Version 2.0',
-        install_requires=['absl-py>=0.9.0', 'protobuf>=3.11.0'],
+        install_requires=['absl-py>=0.9.0', 'protobuf>=3.11.0',
+            'python-dateutil'>=1.10.0],
         version="0.1",
         packages=setuptools.find_packages(),
         cmdclass={'build_py': BuildPyCommand})


### PR DESCRIPTION
- Every message has its own ```ValidateMESSAGE()``` function
- The generic ```ValidateMessage``` will determine the appropriate validation function based on the message type
- The generic ```ValidateMessage``` will also default to recursing through the message (PTAL at the logic used for recursion; I think it's good but there may be unforeseen edge cases)
- Compound identities/names are not checked for validity to avoid RDKit dependency for now
- Common requirements like int/float ranges and nonnegativity use helper functions
- If a value is defined for a unit'd message, we require units to be specified
- If a CUSTOM type is defined for an enum, we require the details to be specified
- In product characterization, the keys of analyses that led to certain results (e.g., ```analysis_yield```) must match defined analyses in the outcome. This actually helped me catch a typo in one of our Colab examples where ```'chiral HPLC'``` was used instead of ```'chiral SFC'```.
- DateTimes are now parsed by ```dateutil.parser.parse()```. In the schema, a DateTime message is simple a wrapper for a string value.
- DateTimes of ```experiment_start```, ```record_created```, and ```record_modified``` must be in a logical order
- ORCIDs must match expected format (though we do not use the checksum character in a meaningful way)

- The code is written so that in the future, we would be able to have the validation steps modify values within the messages (i.e., using assignments and ```CopyFrom```s. For example, canonicalize a SMILES or add a SMILES identifier based on a NAME identifier. This has not been tested.