### PR TITLE
Add RecordEvent message for provenance

### DIFF
--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -77,10 +77,10 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
     def test_datetimes(self):
         message = schema.ReactionProvenance()
         message.experiment_start.value = '11 am'
-        message.record_created.value = '10 am'
+        message.record_created.time.value = '10 am'
         with self.assertRaisesRegex((ValueError), 'after'):
             validations.validate_message(message)
-        message.record_created.value = '11:15 am'
+        message.record_created.time.value = '11:15 am'
         self.assertEqual(validations.validate_message(message), message)
 
 if __name__ == '__main__':

--- a/proto/ord_schema.proto
+++ b/proto/ord_schema.proto
@@ -698,12 +698,18 @@ message ReactionProvenance {
   string doi = 4;
   string patent = 5;
   string publication_url = 6;
-  DateTime record_created = 7;
-  DateTime record_modified = 8;
+  // Metadata for the public database.
+  message RecordEvent {
+    DateTime time = 1;
+    Person person = 2;
+    string details = 3;
+  }
+  RecordEvent record_created = 7;
+  repeated RecordEvent record_modified = 8;
   // TODO(ccoley): is it useful to create a unique ID field 
   // that the centralized database can write to? (I know uniqueness is not
   // enforceable)
-  int32 id = 9;
+  string record_id = 9;
 }
 
 message Person {


### PR DESCRIPTION
Fixes #44 

Also changes `id` to `record_id` and makes it a string field for flexibility (people shouldn't be typing record IDs by hand anyway).