### PR TITLE
Fixing provenance validation

### DIFF
--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -292,7 +292,7 @@ def validate_reaction_provenance(message):
     record_modified = None
     if message.experiment_start.value:
         experiment_start = parser.parse(message.experiment_start.value)
-    if message.record_created.time:
+    if message.record_created.time.value:
         record_created = parser.parse(message.record_created.time.value)
     for record in message.record_modified:
         # Use the last record as the most recent modification time.


### PR DESCRIPTION
```record_created.time``` always evaluates to True, so need to check ```value``` field. Otherwise, validation fails when ```record_created``` has not been specified (but other ```provenance``` fields have been)