### PR TITLE
Add BinaryData message

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -458,7 +458,7 @@ name-group=
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=^_|^test|.*Test$|^main$|setUp
+no-docstring-rgx=^_|^test|.*Test$|^main$|^setUp$
 
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.

--- a/.pylintrc
+++ b/.pylintrc
@@ -458,7 +458,7 @@ name-group=
 
 # Regular expression which should only match function or class names that do
 # not require a docstring.
-no-docstring-rgx=^_|^test|.*Test$|^main$
+no-docstring-rgx=^_|^test|.*Test$|^main$|setUp
 
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -1,5 +1,7 @@
 """Helper functions for constructing Protocol Buffer messages."""
 
+import os
+
 from ord_schema import units
 from ord_schema.proto import ord_schema_pb2 as schema
 
@@ -79,23 +81,23 @@ def build_compound(smiles=None, name=None, amount=None, role=None,
     return compound
 
 
-def build_binary_data(filename, description=None, include_filename=True):
+def build_binary_data(filename, description=None):
     """Reads raw data from a file and creates a BinaryData message.
 
     Args:
         filename: Text filename.
         description: Text description of the data.
-        include_filename: Boolean whether to populate the `filename` field in
-            the resulting message.
 
     Returns:
         BinaryData message.
     """
+    _, extension = os.path.splitext(filename)
+    if not extension.startswith('.'):
+        raise ValueError(f'cannot deduce the file format for {filename}')
     data = schema.BinaryData()
+    data.format = extension[1:]
     with open(filename, 'rb') as f:
         data.value = f.read()
     if description:
         data.description = description
-    if include_filename:
-        data.filename = filename
     return data

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -3,6 +3,7 @@
 from ord_schema import units
 from ord_schema.proto import ord_schema_pb2 as schema
 
+
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-branches
 
@@ -76,3 +77,16 @@ def build_compound(smiles=None, name=None, amount=None, role=None,
     if vendor:
         compound.vendor_source = vendor
     return compound
+
+
+def read_bytes(filename):
+    """Reads the raw data from a file.
+
+    Args:
+        filename: Text filename.
+
+    Returns:
+        Bytes file data.
+    """
+    with open(filename, 'rb') as f:
+        return f.read()

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -79,14 +79,23 @@ def build_compound(smiles=None, name=None, amount=None, role=None,
     return compound
 
 
-def read_bytes(filename):
-    """Reads the raw data from a file.
+def build_binary_data(filename, description=None, include_filename=True):
+    """Reads raw data from a file and creates a BinaryData message.
 
     Args:
         filename: Text filename.
+        description: Text description of the data.
+        include_filename: Boolean whether to populate the `filename` field in
+            the resulting message.
 
     Returns:
-        Bytes file data.
+        BinaryData message.
     """
+    data = schema.BinaryData()
     with open(filename, 'rb') as f:
-        return f.read()
+        data.value = f.read()
+    if description:
+        data.description = description
+    if include_filename:
+        data.filename = filename
+    return data

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -1,10 +1,28 @@
 """Tests for ord_schema.message_helpers."""
 
+import os
+import tempfile
+
+from absl import flags
 from absl.testing import absltest
 from absl.testing import parameterized
 
 from ord_schema import message_helpers
 from ord_schema.proto import ord_schema_pb2 as schema
+
+
+class MessageHelpersTest(absltest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.test_subdirectory = tempfile.mkdtemp(dir=flags.FLAGS.test_tmpdir)
+
+    def test_read_bytes(self):
+        filename = os.path.join(self.test_subdirectory, 'test.data')
+        data = b'test data'
+        with open(filename, 'wb') as f:
+            f.write(data)
+        self.assertEqual(data, message_helpers.read_bytes(filename))
 
 
 class BuildCompoundTest(parameterized.TestCase, absltest.TestCase):

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -11,18 +11,35 @@ from ord_schema import message_helpers
 from ord_schema.proto import ord_schema_pb2 as schema
 
 
-class MessageHelpersTest(absltest.TestCase):
+class BuildBinaryDataTest(absltest.TestCase):
 
     def setUp(self):
         super().setUp()
         self.test_subdirectory = tempfile.mkdtemp(dir=flags.FLAGS.test_tmpdir)
+        self.data = b'test data'
+        self.filename = os.path.join(self.test_subdirectory, 'test.data')
+        with open(self.filename, 'wb') as f:
+            f.write(self.data)
 
-    def test_read_bytes(self):
-        filename = os.path.join(self.test_subdirectory, 'test.data')
-        data = b'test data'
-        with open(filename, 'wb') as f:
-            f.write(data)
-        self.assertEqual(data, message_helpers.read_bytes(filename))
+    def test_defaults(self):
+        message = message_helpers.build_binary_data(self.filename)
+        self.assertEqual(message.value, self.data)
+        self.assertEqual(message.description, '')
+        self.assertEqual(message.filename, self.filename)
+
+    def test_description(self):
+        message = message_helpers.build_binary_data(self.filename,
+                                                    description='binary data')
+        self.assertEqual(message.value, self.data)
+        self.assertEqual(message.description, 'binary data')
+        self.assertEqual(message.filename, self.filename)
+
+    def test_noinclude_filename(self):
+        message = message_helpers.build_binary_data(self.filename,
+                                                    include_filename=False)
+        self.assertEqual(message.value, self.data)
+        self.assertEqual(message.description, '')
+        self.assertEqual(message.filename, '')
 
 
 class BuildCompoundTest(parameterized.TestCase, absltest.TestCase):

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -25,21 +25,19 @@ class BuildBinaryDataTest(absltest.TestCase):
         message = message_helpers.build_binary_data(self.filename)
         self.assertEqual(message.value, self.data)
         self.assertEqual(message.description, '')
-        self.assertEqual(message.filename, self.filename)
+        self.assertEqual(message.format, 'data')
 
     def test_description(self):
         message = message_helpers.build_binary_data(self.filename,
                                                     description='binary data')
         self.assertEqual(message.value, self.data)
         self.assertEqual(message.description, 'binary data')
-        self.assertEqual(message.filename, self.filename)
+        self.assertEqual(message.format, 'data')
 
-    def test_noinclude_filename(self):
-        message = message_helpers.build_binary_data(self.filename,
-                                                    include_filename=False)
-        self.assertEqual(message.value, self.data)
-        self.assertEqual(message.description, '')
-        self.assertEqual(message.filename, '')
+    def test_bad_filename(self):
+        with self.assertRaisesRegex(ValueError,
+                                    'cannot deduce the file format'):
+            message_helpers.build_binary_data('testdata')
 
 
 class BuildCompoundTest(parameterized.TestCase, absltest.TestCase):

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -429,6 +429,13 @@ def validate_percentage(message):
     return message
 
 
+def validate_binary_data(message):
+    if not message.value:
+        raise ValueError('value is required for BinaryData')
+    if not message.format:
+        raise ValidationWarning('No format specified for BinaryData')
+
+
 # pylint: enable=missing-function-docstring
 
 _VALIDATOR_SWITCH = {
@@ -485,4 +492,5 @@ _VALIDATOR_SWITCH = {
     schema.Wavelength: validate_wavelength,
     schema.FlowRate: validate_flow_rate,
     schema.Percentage: validate_percentage,
+    schema.BinaryData: validate_binary_data,
 }

--- a/proto/ord_schema.proto
+++ b/proto/ord_schema.proto
@@ -294,7 +294,7 @@ message ReactionSetup {
   // Automated platform name, brand, or model number.
   string automation_platform = 3;
   // Raw automation code or synthetic recipe definition.
-  map<string, bytes> automation_code = 4;
+  repeated BinaryData automation_code = 4;
 }
 
 message ReactionConditions {
@@ -512,11 +512,8 @@ message ReactionNotes {
 
 message ReactionObservation {
   Time time = 1;
-  oneof kind {
-    string color = 2;
-    bytes image = 3;
-    string comment = 4;
-  }
+  string comment = 2;  // e.g. what color is the reaction?
+  BinaryData image = 3;
 }
 
 message ReactionWorkup {
@@ -684,9 +681,9 @@ message ReactionAnalysis {
   // Any details about analysis (e.g., NMR type, columns, gradients, conditions)
   string details = 2;
   // Data files (processed or annotated).
-  map<string, bytes> data_processed = 3;
+  repeated BinaryData processed_data = 3;
   // Data files (raw) obtained directly from the instrument
-  map<string, bytes> data_raw = 4;
+  repeated BinaryData raw_data = 4;
   string instrument_manufacturer = 5;
   DateTime instrument_last_calibrated = 6;
 }
@@ -885,4 +882,11 @@ message Percentage {
   float value = 1;
   // Precision of the measurement (with the same units as `value`).
   float precision = 2;
+}
+
+// BinaryData is a container for binary (bytes) data.
+message BinaryData {
+  bytes value = 1;
+  string filename = 2;
+  string description = 3;
 }

--- a/proto/ord_schema.proto
+++ b/proto/ord_schema.proto
@@ -294,7 +294,7 @@ message ReactionSetup {
   // Automated platform name, brand, or model number.
   string automation_platform = 3;
   // Raw automation code or synthetic recipe definition.
-  repeated BinaryData automation_code = 4;
+  map<string, BinaryData> automation_code = 4;
 }
 
 message ReactionConditions {
@@ -681,9 +681,9 @@ message ReactionAnalysis {
   // Any details about analysis (e.g., NMR type, columns, gradients, conditions)
   string details = 2;
   // Data files (processed or annotated).
-  repeated BinaryData processed_data = 3;
+  map<string, BinaryData> processed_data = 3;
   // Data files (raw) obtained directly from the instrument
-  repeated BinaryData raw_data = 4;
+  map<string, BinaryData> raw_data = 4;
   string instrument_manufacturer = 5;
   DateTime instrument_last_calibrated = 6;
 }
@@ -887,6 +887,8 @@ message Percentage {
 // BinaryData is a container for binary (bytes) data.
 message BinaryData {
   bytes value = 1;
-  string filename = 2;
-  string description = 3;
+  string description = 2;
+  // Description of the file format; usually the file extension. For example,
+  // 'png' or 'tiff' for images.
+  string format = 3;
 }


### PR DESCRIPTION
I wanted to include more metadata for `bytes` values, so I created a `BinaryData` message and replaced maps with repeated fields. 

Happy to keep using maps if we also want "names" for these messages...