### PR TITLE
Add RDKIT_BINARY identifier types

### DIFF
--- a/ord_schema/proto/reaction_pb2_test.py
+++ b/ord_schema/proto/reaction_pb2_test.py
@@ -1,6 +1,10 @@
 """Tests for ord_schema.proto.reaction_pb2."""
 
 from absl.testing import absltest
+try:
+    from rdkit import Chem
+except ImportError:
+    Chem = None
 
 from ord_schema.proto import reaction_pb2
 
@@ -17,6 +21,14 @@ class ReactionPb2Test(absltest.TestCase):
         with self.assertRaisesRegex(ValueError,
                                     'Reaction has no field not_a_field'):
             reaction.HasField('not_a_field')
+
+    @absltest.skipIf(Chem is None, 'no rdkit')
+    def test_rdkit_binary_compound_identifier(self):
+        mol = Chem.MolFromSmiles('COO')
+        identifier = reaction_pb2.CompoundIdentifier(type='RDKIT_BINARY',
+                                                     bytes_value=mol.ToBinary())
+        self.assertEqual(Chem.MolToSmiles(mol),
+                         Chem.MolToSmiles(Chem.Mol(identifier.bytes_value)))
 
 
 if __name__ == '__main__':

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -110,6 +110,8 @@ def validate_reaction(message):
 
 def validate_reaction_identifier(message):
     ensure_details_specified_if_type_custom(message)
+    if not message.value and not message.bytes_value:
+        raise ValueError('{bytes_}value must be set')
     return message
 
 
@@ -136,6 +138,8 @@ def validate_compound_preparation(message):
 
 def validate_compound_identifier(message):
     ensure_details_specified_if_type_custom(message)
+    if not message.value and not message.bytes_value:
+        raise ValueError('{bytes_}value must be set')
     # TODO(ccoley): Add identifier-specific validation, e.g., by using
     # RDKit to try to parse SMILES, looking up NAMEs using online resolvers
     return message

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -70,6 +70,7 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         with self.assertRaisesRegex(ValueError, 'details'):
             validations.validate_message(message)
         dummy_component.identifiers[0].details = 'custom_identifier'
+        dummy_component.identifiers[0].value = 'custom_value'
         self.assertEqual(validations.validate_message(message), message)
         outcome = message.outcomes.add()
         _ = outcome.analyses['dummy_analysis']

--- a/proto/reaction.proto
+++ b/proto/reaction.proto
@@ -52,10 +52,14 @@ message ReactionIdentifier {
     ATOM_MAPPED_SMILES = 3;
     RINCHI = 4;  // Reaction InChI.
     NAME = 5;  // Named reaction or reaction category.
+    RDKIT_BINARY = 6;  // RDKit binary format (for fast loading).
   }
   IdentifierType type = 1;
   string details = 2;
-  string value = 3;
+  oneof kind {
+    string value = 3;
+    bytes bytes_value = 4;
+  }
 }
 
 message ReactionInput {
@@ -239,12 +243,17 @@ message CompoundIdentifier {
     UNIPROT_ID = 13;
     // Protein data bank ID (for enzymes)
     PDB_ID = 14;
+    // RDKit binary format (for fast loading)
+    RDKIT_BINARY = 15;
   }
   IdentifierType type = 1;
   string details = 2;
   // Value of the compound identifier; certain types (e.g., PUBCHEM_CID) may
   // cast the string as an integer for downstream processing and validation.
-  string value = 3;
+  oneof kind {
+    string value = 3;
+    bytes bytes_value = 4;
+  }
 }
 
 message Vessel {


### PR DESCRIPTION
Parsing molecules (and presumably reactions) from RDKit's binary format is *much* faster than re-parsing the SMILES each time. In the live version of the database, I expect we will want binary representations of compounds and reactions to enable faster searching/matching. 

Note that I punted on the question of adding RDKit as a dep here (I think it's a good idea, but it will take some work on the CI side to get RDKit installed when running tests for PRs); we can address that in another PR.