### PR TITLE
Trigger tests with colab badges commits

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,12 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: 
-      - master
-  pull_request:
-    branches: 
-      - master
+on: push
 
 jobs:
   build_and_test:

--- a/.github/workflows/colab_badges.yml
+++ b/.github/workflows/colab_badges.yml
@@ -9,7 +9,7 @@ name: colab_badges
 on:
   push:
     branches-ignore: 
-      - master  # master is protected
+      - master  # master is protected.
 
 jobs:
   colab_badges:
@@ -19,7 +19,9 @@ jobs:
     - name: Colab Badge Action
       uses: skearnes/colab-badge-action@v1.1.3
       with:
-        github_token: ${{ secrets.trigger_workflows }}
-        check: "all"
+        # Do not use GITHUB_TOKEN here since it will not trigger events in response; see
+        # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token.
+        github_token: ${{ secrets.TRIGGER_WORKFLOWS }}
+        check: all
         update: True
         target_branch: master

--- a/.github/workflows/colab_badges.yml
+++ b/.github/workflows/colab_badges.yml
@@ -25,7 +25,7 @@ jobs:
       uses: skearnes/colab-badge-action@v1.2
       with:
         github_token: ${{ secrets.TRIGGER_WORKFLOWS }}
-        check: all
+        check: latest
         update: True
         target_branch: master
         target_repository: Open-Reaction-Database/ord-schema

--- a/.github/workflows/colab_badges.yml
+++ b/.github/workflows/colab_badges.yml
@@ -22,9 +22,10 @@ jobs:
         # See https://stackoverflow.com/a/60418414.
         token: ${{ secrets.TRIGGER_WORKFLOWS }}
     - name: Colab Badge Action
-      uses: skearnes/colab-badge-action@v1.1.3
+      uses: skearnes/colab-badge-action@v1.2
       with:
         github_token: ${{ secrets.TRIGGER_WORKFLOWS }}
         check: all
         update: True
         target_branch: master
+        target_repository: Open-Reaction-Database/ord-schema

--- a/.github/workflows/colab_badges.yml
+++ b/.github/workflows/colab_badges.yml
@@ -12,15 +12,18 @@ on:
       - master  # master is protected.
 
 jobs:
+  # Do not use GITHUB_TOKEN here since it will not trigger events in response; see
+  # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token.
   colab_badges:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        # See https://stackoverflow.com/a/60418414.
+        token: ${{ secrets.TRIGGER_WORKFLOWS }}
     - name: Colab Badge Action
       uses: skearnes/colab-badge-action@v1.1.3
       with:
-        # Do not use GITHUB_TOKEN here since it will not trigger events in response; see
-        # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token.
         github_token: ${{ secrets.TRIGGER_WORKFLOWS }}
         check: all
         update: True

--- a/.github/workflows/colab_badges.yml
+++ b/.github/workflows/colab_badges.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Colab Badge Action
       uses: skearnes/colab-badge-action@v1.1.3
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.trigger_workflows }}
         check: "all"
         update: True
         target_branch: master

--- a/examples/example_template.ipynb
+++ b/examples/example_template.ipynb
@@ -1,123 +1,118 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "name": "example_template.ipynb",
-   "provenance": [],
-   "collapsed_sections": []
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  }
- },
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "UuYMhx3e-xlw",
-    "badge": true,
-    "repo_name": "Open-Reaction-Database/ord-schema",
-    "branch": "master",
-    "nb_path": "examples/example_template.ipynb",
-    "comment": "This badge cell was added by colab-badge-action"
-   },
-   "source": [
-    "# ORD Example Template\n",
-    "\n",
-    "<a href=\"https://colab.research.google.com/github/Open-Reaction-Database/ord-schema/blob/master/examples/example_template.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "FkGs9wsG6hbC",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "# Import or install ord_schema.\n",
-    "try:\n",
-    "  import ord_schema\n",
-    "except ImportError:\n",
-    "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
-    "  %cd ord-schema\n",
-    "  !git pull\n",
-    "  !python setup.py build_py\n",
-    "  !python setup.py install\n",
-    "\n",
-    "  from IPython import display\n",
-    "  display.clear_output()  # The installation is noisy."
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "WNYlhmmX64wp",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "from ord_schema.proto import reaction_pb2\n",
-    "from ord_schema.units import UnitResolver\n",
-    "from ord_schema import validations\n",
-    "from ord_schema import message_helpers\n",
-    "\n",
-    "unit_resolver = UnitResolver()"
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "kX_Pp3fA7UWB",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "reaction = reaction_pb2.Reaction()"
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "MMhWUQYCOpuK",
-    "colab_type": "code",
-    "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
     "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 85
+      "name": "example_template.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
     }
-   },
-   "source": [
-    "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
-    "reaction"
-   ],
-   "execution_count": 0,
-   "outputs": [
+  },
+  "cells": [
     {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "identifiers {\n",
-       "  type: NAME\n",
-       "  value: \"deoxyfluorination\"\n",
-       "}"
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "UuYMhx3e-xlw"
+      },
+      "source": [
+        "# ORD Example Template\n",
+        "\n",
+        "{{ badge }}"
       ]
-     },
-     "metadata": {
-      "tags": []
-     },
-     "execution_count": 4
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FkGs9wsG6hbC",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Import or install ord_schema.\n",
+        "try:\n",
+        "  import ord_schema\n",
+        "except ImportError:\n",
+        "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
+        "  %cd ord-schema\n",
+        "  !git pull\n",
+        "  !python setup.py build_py\n",
+        "  !python setup.py install\n",
+        "\n",
+        "  from IPython import display\n",
+        "  display.clear_output()  # Clean up after noisy installation."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "WNYlhmmX64wp",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from ord_schema.proto import reaction_pb2\n",
+        "from ord_schema.units import UnitResolver\n",
+        "from ord_schema import validations\n",
+        "from ord_schema import message_helpers\n",
+        "\n",
+        "unit_resolver = UnitResolver()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "kX_Pp3fA7UWB",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "reaction = reaction_pb2.Reaction()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "MMhWUQYCOpuK",
+        "colab_type": "code",
+        "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 85
+        }
+      },
+      "source": [
+        "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
+        "reaction"
+      ],
+      "execution_count": 0,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "identifiers {\n",
+              "  type: NAME\n",
+              "  value: \"deoxyfluorination\"\n",
+              "}"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 4
+        }
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/examples/example_template.ipynb
+++ b/examples/example_template.ipynb
@@ -1,123 +1,118 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "name": "example_template.ipynb",
-   "provenance": [],
-   "collapsed_sections": []
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  }
- },
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "UuYMhx3e-xlw",
-    "badge": true,
-    "repo_name": "Open-Reaction-Database/ord-schema",
-    "branch": "master",
-    "nb_path": "examples/example_template.ipynb",
-    "comment": "This badge cell was added by colab-badge-action"
-   },
-   "source": [
-    "# ORD Example Template\n",
-    "\n",
-    "<a href=\"https://colab.research.google.com/github/Open-Reaction-Database/ord-schema/blob/master/examples/example_template.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "FkGs9wsG6hbC",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "# Import or install ord_schema.\n",
-    "try:\n",
-    "  import ord_schema\n",
-    "except ImportError:\n",
-    "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
-    "  %cd ord-schema\n",
-    "  !git pull\n",
-    "  !python setup.py build_py\n",
-    "  !python setup.py install\n",
-    "\n",
-    "  from IPython import display\n",
-    "  display.clear_output()  # Installation is noisy."
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "WNYlhmmX64wp",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "from ord_schema.proto import reaction_pb2\n",
-    "from ord_schema.units import UnitResolver\n",
-    "from ord_schema import validations\n",
-    "from ord_schema import message_helpers\n",
-    "\n",
-    "unit_resolver = UnitResolver()"
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "kX_Pp3fA7UWB",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "reaction = reaction_pb2.Reaction()"
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "MMhWUQYCOpuK",
-    "colab_type": "code",
-    "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
     "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 85
+      "name": "example_template.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
     }
-   },
-   "source": [
-    "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
-    "reaction"
-   ],
-   "execution_count": 0,
-   "outputs": [
+  },
+  "cells": [
     {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "identifiers {\n",
-       "  type: NAME\n",
-       "  value: \"deoxyfluorination\"\n",
-       "}"
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "UuYMhx3e-xlw"
+      },
+      "source": [
+        "# ORD Example Template\n",
+        "\n",
+        "{{ badge }}"
       ]
-     },
-     "metadata": {
-      "tags": []
-     },
-     "execution_count": 4
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FkGs9wsG6hbC",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Import or install ord_schema.\n",
+        "try:\n",
+        "  import ord_schema\n",
+        "except ImportError:\n",
+        "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
+        "  %cd ord-schema\n",
+        "  !git pull\n",
+        "  !python setup.py build_py\n",
+        "  !python setup.py install\n",
+        "\n",
+        "  from IPython import display\n",
+        "  display.clear_output()  # Installation is noisy."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "WNYlhmmX64wp",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from ord_schema.proto import reaction_pb2\n",
+        "from ord_schema.units import UnitResolver\n",
+        "from ord_schema import validations\n",
+        "from ord_schema import message_helpers\n",
+        "\n",
+        "unit_resolver = UnitResolver()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "kX_Pp3fA7UWB",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "reaction = reaction_pb2.Reaction()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "MMhWUQYCOpuK",
+        "colab_type": "code",
+        "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 85
+        }
+      },
+      "source": [
+        "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
+        "reaction"
+      ],
+      "execution_count": 0,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "identifiers {\n",
+              "  type: NAME\n",
+              "  value: \"deoxyfluorination\"\n",
+              "}"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 4
+        }
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/examples/example_template.ipynb
+++ b/examples/example_template.ipynb
@@ -1,123 +1,118 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "name": "example_template.ipynb",
-   "provenance": [],
-   "collapsed_sections": []
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  }
- },
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "UuYMhx3e-xlw",
-    "badge": true,
-    "repo_name": "Open-Reaction-Database/ord-schema",
-    "branch": "master",
-    "nb_path": "examples/example_template.ipynb",
-    "comment": "This badge cell was added by colab-badge-action"
-   },
-   "source": [
-    "# ORD Example Template\n",
-    "\n",
-    "<a href=\"https://colab.research.google.com/github/Open-Reaction-Database/ord-schema/blob/master/examples/example_template.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "FkGs9wsG6hbC",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "# Import or install ord_schema.\n",
-    "try:\n",
-    "  import ord_schema\n",
-    "except ImportError:\n",
-    "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
-    "  %cd ord-schema\n",
-    "  !git pull\n",
-    "  !python setup.py build_py\n",
-    "  !python setup.py install\n",
-    "\n",
-    "  from IPython import display\n",
-    "  display.clear_output()  # Clean up after noisy installation."
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "WNYlhmmX64wp",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "from ord_schema.proto import reaction_pb2\n",
-    "from ord_schema.units import UnitResolver\n",
-    "from ord_schema import validations\n",
-    "from ord_schema import message_helpers\n",
-    "\n",
-    "unit_resolver = UnitResolver()"
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "kX_Pp3fA7UWB",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "reaction = reaction_pb2.Reaction()"
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "MMhWUQYCOpuK",
-    "colab_type": "code",
-    "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
     "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 85
+      "name": "example_template.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
     }
-   },
-   "source": [
-    "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
-    "reaction"
-   ],
-   "execution_count": 0,
-   "outputs": [
+  },
+  "cells": [
     {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "identifiers {\n",
-       "  type: NAME\n",
-       "  value: \"deoxyfluorination\"\n",
-       "}"
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "UuYMhx3e-xlw"
+      },
+      "source": [
+        "# ORD Example Template\n",
+        "\n",
+        "{{ badge }}"
       ]
-     },
-     "metadata": {
-      "tags": []
-     },
-     "execution_count": 4
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FkGs9wsG6hbC",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Import or install ord_schema.\n",
+        "try:\n",
+        "  import ord_schema\n",
+        "except ImportError:\n",
+        "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
+        "  %cd ord-schema\n",
+        "  !git pull\n",
+        "  !python setup.py build_py\n",
+        "  !python setup.py install\n",
+        "\n",
+        "  from IPython import display\n",
+        "  display.clear_output()  # Installation is noisy."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "WNYlhmmX64wp",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from ord_schema.proto import reaction_pb2\n",
+        "from ord_schema.units import UnitResolver\n",
+        "from ord_schema import validations\n",
+        "from ord_schema import message_helpers\n",
+        "\n",
+        "unit_resolver = UnitResolver()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "kX_Pp3fA7UWB",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "reaction = reaction_pb2.Reaction()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "MMhWUQYCOpuK",
+        "colab_type": "code",
+        "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 85
+        }
+      },
+      "source": [
+        "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
+        "reaction"
+      ],
+      "execution_count": 0,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "identifiers {\n",
+              "  type: NAME\n",
+              "  value: \"deoxyfluorination\"\n",
+              "}"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 4
+        }
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/examples/example_template.ipynb
+++ b/examples/example_template.ipynb
@@ -1,123 +1,118 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "name": "example_template.ipynb",
-   "provenance": [],
-   "collapsed_sections": []
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  }
- },
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "UuYMhx3e-xlw",
-    "badge": true,
-    "repo_name": "Open-Reaction-Database/ord-schema",
-    "branch": "master",
-    "nb_path": "examples/example_template.ipynb",
-    "comment": "This badge cell was added by colab-badge-action"
-   },
-   "source": [
-    "# ORD Example Template\n",
-    "\n",
-    "<a href=\"https://colab.research.google.com/github/Open-Reaction-Database/ord-schema/blob/master/examples/example_template.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "FkGs9wsG6hbC",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "try:\n",
-    "  import ord_schema\n",
-    "except ImportError:\n",
-    "  # Install ord_schema from GitHub.\n",
-    "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
-    "  %cd ord-schema\n",
-    "  !git pull\n",
-    "  !python setup.py build_py\n",
-    "  !python setup.py install\n",
-    "\n",
-    "  from IPython import display\n",
-    "  display.clear_output()  # Installation is noisy."
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "WNYlhmmX64wp",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "from ord_schema.proto import reaction_pb2\n",
-    "from ord_schema.units import UnitResolver\n",
-    "from ord_schema import validations\n",
-    "from ord_schema import message_helpers\n",
-    "\n",
-    "unit_resolver = UnitResolver()"
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "kX_Pp3fA7UWB",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "reaction = reaction_pb2.Reaction()"
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "MMhWUQYCOpuK",
-    "colab_type": "code",
-    "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
     "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 85
+      "name": "example_template.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
     }
-   },
-   "source": [
-    "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
-    "reaction"
-   ],
-   "execution_count": 0,
-   "outputs": [
+  },
+  "cells": [
     {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "identifiers {\n",
-       "  type: NAME\n",
-       "  value: \"deoxyfluorination\"\n",
-       "}"
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "UuYMhx3e-xlw"
+      },
+      "source": [
+        "# ORD Example Template\n",
+        "\n",
+        "{{ badge }}"
       ]
-     },
-     "metadata": {
-      "tags": []
-     },
-     "execution_count": 4
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FkGs9wsG6hbC",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Import or install ord_schema.\n",
+        "try:\n",
+        "  import ord_schema\n",
+        "except ImportError:\n",
+        "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
+        "  %cd ord-schema\n",
+        "  !git pull\n",
+        "  !python setup.py build_py\n",
+        "  !python setup.py install\n",
+        "\n",
+        "  from IPython import display\n",
+        "  display.clear_output()  # Installation is noisy."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "WNYlhmmX64wp",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from ord_schema.proto import reaction_pb2\n",
+        "from ord_schema.units import UnitResolver\n",
+        "from ord_schema import validations\n",
+        "from ord_schema import message_helpers\n",
+        "\n",
+        "unit_resolver = UnitResolver()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "kX_Pp3fA7UWB",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "reaction = reaction_pb2.Reaction()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "MMhWUQYCOpuK",
+        "colab_type": "code",
+        "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 85
+        }
+      },
+      "source": [
+        "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
+        "reaction"
+      ],
+      "execution_count": 0,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "identifiers {\n",
+              "  type: NAME\n",
+              "  value: \"deoxyfluorination\"\n",
+              "}"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 4
+        }
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/examples/example_template.ipynb
+++ b/examples/example_template.ipynb
@@ -1,118 +1,123 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "example_template.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "name": "example_template.ipynb",
+   "provenance": [],
+   "collapsed_sections": []
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "UuYMhx3e-xlw"
-      },
-      "source": [
-        "# ORD Example Template\n",
-        "\n",
-        "{{ badge }}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "FkGs9wsG6hbC",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Import or install ord_schema.\n",
-        "try:\n",
-        "  import ord_schema\n",
-        "except ImportError:\n",
-        "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
-        "  %cd ord-schema\n",
-        "  !git pull\n",
-        "  !python setup.py build_py\n",
-        "  !python setup.py install\n",
-        "\n",
-        "  from IPython import display\n",
-        "  display.clear_output()  # Installation is noisy."
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "WNYlhmmX64wp",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "from ord_schema.proto import reaction_pb2\n",
-        "from ord_schema.units import UnitResolver\n",
-        "from ord_schema import validations\n",
-        "from ord_schema import message_helpers\n",
-        "\n",
-        "unit_resolver = UnitResolver()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "kX_Pp3fA7UWB",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "reaction = reaction_pb2.Reaction()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "MMhWUQYCOpuK",
-        "colab_type": "code",
-        "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
-        }
-      },
-      "source": [
-        "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
-        "reaction"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "identifiers {\n",
-              "  type: NAME\n",
-              "  value: \"deoxyfluorination\"\n",
-              "}"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 4
-        }
-      ]
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "UuYMhx3e-xlw",
+    "badge": true,
+    "repo_name": "Open-Reaction-Database/ord-schema",
+    "branch": "master",
+    "nb_path": "examples/example_template.ipynb",
+    "comment": "This badge cell was added by colab-badge-action"
+   },
+   "source": [
+    "# ORD Example Template\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/Open-Reaction-Database/ord-schema/blob/master/examples/example_template.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "FkGs9wsG6hbC",
+    "colab_type": "code",
+    "colab": {}
+   },
+   "source": [
+    "# Import or install ord_schema.\n",
+    "try:\n",
+    "  import ord_schema\n",
+    "except ImportError:\n",
+    "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
+    "  %cd ord-schema\n",
+    "  !git pull\n",
+    "  !python setup.py build_py\n",
+    "  !python setup.py install\n",
+    "\n",
+    "  from IPython import display\n",
+    "  display.clear_output()  # Installation is noisy."
+   ],
+   "execution_count": 0,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "WNYlhmmX64wp",
+    "colab_type": "code",
+    "colab": {}
+   },
+   "source": [
+    "from ord_schema.proto import reaction_pb2\n",
+    "from ord_schema.units import UnitResolver\n",
+    "from ord_schema import validations\n",
+    "from ord_schema import message_helpers\n",
+    "\n",
+    "unit_resolver = UnitResolver()"
+   ],
+   "execution_count": 0,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "kX_Pp3fA7UWB",
+    "colab_type": "code",
+    "colab": {}
+   },
+   "source": [
+    "reaction = reaction_pb2.Reaction()"
+   ],
+   "execution_count": 0,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "MMhWUQYCOpuK",
+    "colab_type": "code",
+    "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 85
     }
-  ]
+   },
+   "source": [
+    "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
+    "reaction"
+   ],
+   "execution_count": 0,
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "identifiers {\n",
+       "  type: NAME\n",
+       "  value: \"deoxyfluorination\"\n",
+       "}"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "execution_count": 4
+    }
+   ]
+  }
+ ]
 }

--- a/examples/example_template.ipynb
+++ b/examples/example_template.ipynb
@@ -1,118 +1,123 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "example_template.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "name": "example_template.ipynb",
+   "provenance": [],
+   "collapsed_sections": []
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "UuYMhx3e-xlw"
-      },
-      "source": [
-        "# ORD Example Template\n",
-        "\n",
-        "{{ badge }}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "FkGs9wsG6hbC",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Import or install ord_schema.\n",
-        "try:\n",
-        "  import ord_schema\n",
-        "except ImportError:\n",
-        "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
-        "  %cd ord-schema\n",
-        "  !git pull\n",
-        "  !python setup.py build_py\n",
-        "  !python setup.py install\n",
-        "\n",
-        "  from IPython import display\n",
-        "  display.clear_output()  # Clean up after noisy installation."
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "WNYlhmmX64wp",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "from ord_schema.proto import reaction_pb2\n",
-        "from ord_schema.units import UnitResolver\n",
-        "from ord_schema import validations\n",
-        "from ord_schema import message_helpers\n",
-        "\n",
-        "unit_resolver = UnitResolver()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "kX_Pp3fA7UWB",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "reaction = reaction_pb2.Reaction()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "MMhWUQYCOpuK",
-        "colab_type": "code",
-        "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
-        }
-      },
-      "source": [
-        "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
-        "reaction"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "identifiers {\n",
-              "  type: NAME\n",
-              "  value: \"deoxyfluorination\"\n",
-              "}"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 4
-        }
-      ]
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "UuYMhx3e-xlw",
+    "badge": true,
+    "repo_name": "Open-Reaction-Database/ord-schema",
+    "branch": "master",
+    "nb_path": "examples/example_template.ipynb",
+    "comment": "This badge cell was added by colab-badge-action"
+   },
+   "source": [
+    "# ORD Example Template\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/Open-Reaction-Database/ord-schema/blob/master/examples/example_template.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "FkGs9wsG6hbC",
+    "colab_type": "code",
+    "colab": {}
+   },
+   "source": [
+    "# Import or install ord_schema.\n",
+    "try:\n",
+    "  import ord_schema\n",
+    "except ImportError:\n",
+    "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
+    "  %cd ord-schema\n",
+    "  !git pull\n",
+    "  !python setup.py build_py\n",
+    "  !python setup.py install\n",
+    "\n",
+    "  from IPython import display\n",
+    "  display.clear_output()  # Clean up after noisy installation."
+   ],
+   "execution_count": 0,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "WNYlhmmX64wp",
+    "colab_type": "code",
+    "colab": {}
+   },
+   "source": [
+    "from ord_schema.proto import reaction_pb2\n",
+    "from ord_schema.units import UnitResolver\n",
+    "from ord_schema import validations\n",
+    "from ord_schema import message_helpers\n",
+    "\n",
+    "unit_resolver = UnitResolver()"
+   ],
+   "execution_count": 0,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "kX_Pp3fA7UWB",
+    "colab_type": "code",
+    "colab": {}
+   },
+   "source": [
+    "reaction = reaction_pb2.Reaction()"
+   ],
+   "execution_count": 0,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "MMhWUQYCOpuK",
+    "colab_type": "code",
+    "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 85
     }
-  ]
+   },
+   "source": [
+    "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
+    "reaction"
+   ],
+   "execution_count": 0,
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "identifiers {\n",
+       "  type: NAME\n",
+       "  value: \"deoxyfluorination\"\n",
+       "}"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "execution_count": 4
+    }
+   ]
+  }
+ ]
 }

--- a/examples/example_template.ipynb
+++ b/examples/example_template.ipynb
@@ -1,118 +1,123 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "example_template.ipynb",
-      "provenance": [],
-      "collapsed_sections": []
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
+ "nbformat": 4,
+ "nbformat_minor": 0,
+ "metadata": {
+  "colab": {
+   "name": "example_template.ipynb",
+   "provenance": [],
+   "collapsed_sections": []
   },
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "UuYMhx3e-xlw"
-      },
-      "source": [
-        "# ORD Example Template\n",
-        "\n",
-        "{{ badge }}"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "FkGs9wsG6hbC",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "# Import or install ord_schema.\n",
-        "try:\n",
-        "  import ord_schema\n",
-        "except ImportError:\n",
-        "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
-        "  %cd ord-schema\n",
-        "  !git pull\n",
-        "  !python setup.py build_py\n",
-        "  !python setup.py install\n",
-        "\n",
-        "  from IPython import display\n",
-        "  display.clear_output()  # The installation is noisy."
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "WNYlhmmX64wp",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "from ord_schema.proto import reaction_pb2\n",
-        "from ord_schema.units import UnitResolver\n",
-        "from ord_schema import validations\n",
-        "from ord_schema import message_helpers\n",
-        "\n",
-        "unit_resolver = UnitResolver()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "kX_Pp3fA7UWB",
-        "colab_type": "code",
-        "colab": {}
-      },
-      "source": [
-        "reaction = reaction_pb2.Reaction()"
-      ],
-      "execution_count": 0,
-      "outputs": []
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "MMhWUQYCOpuK",
-        "colab_type": "code",
-        "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 85
-        }
-      },
-      "source": [
-        "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
-        "reaction"
-      ],
-      "execution_count": 0,
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "data": {
-            "text/plain": [
-              "identifiers {\n",
-              "  type: NAME\n",
-              "  value: \"deoxyfluorination\"\n",
-              "}"
-            ]
-          },
-          "metadata": {
-            "tags": []
-          },
-          "execution_count": 4
-        }
-      ]
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "colab_type": "text",
+    "id": "UuYMhx3e-xlw",
+    "badge": true,
+    "repo_name": "Open-Reaction-Database/ord-schema",
+    "branch": "master",
+    "nb_path": "examples/example_template.ipynb",
+    "comment": "This badge cell was added by colab-badge-action"
+   },
+   "source": [
+    "# ORD Example Template\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/Open-Reaction-Database/ord-schema/blob/master/examples/example_template.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "FkGs9wsG6hbC",
+    "colab_type": "code",
+    "colab": {}
+   },
+   "source": [
+    "# Import or install ord_schema.\n",
+    "try:\n",
+    "  import ord_schema\n",
+    "except ImportError:\n",
+    "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
+    "  %cd ord-schema\n",
+    "  !git pull\n",
+    "  !python setup.py build_py\n",
+    "  !python setup.py install\n",
+    "\n",
+    "  from IPython import display\n",
+    "  display.clear_output()  # The installation is noisy."
+   ],
+   "execution_count": 0,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "WNYlhmmX64wp",
+    "colab_type": "code",
+    "colab": {}
+   },
+   "source": [
+    "from ord_schema.proto import reaction_pb2\n",
+    "from ord_schema.units import UnitResolver\n",
+    "from ord_schema import validations\n",
+    "from ord_schema import message_helpers\n",
+    "\n",
+    "unit_resolver = UnitResolver()"
+   ],
+   "execution_count": 0,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "kX_Pp3fA7UWB",
+    "colab_type": "code",
+    "colab": {}
+   },
+   "source": [
+    "reaction = reaction_pb2.Reaction()"
+   ],
+   "execution_count": 0,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "id": "MMhWUQYCOpuK",
+    "colab_type": "code",
+    "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 85
     }
-  ]
+   },
+   "source": [
+    "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
+    "reaction"
+   ],
+   "execution_count": 0,
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/plain": [
+       "identifiers {\n",
+       "  type: NAME\n",
+       "  value: \"deoxyfluorination\"\n",
+       "}"
+      ]
+     },
+     "metadata": {
+      "tags": []
+     },
+     "execution_count": 4
+    }
+   ]
+  }
+ ]
 }

--- a/examples/example_template.ipynb
+++ b/examples/example_template.ipynb
@@ -1,123 +1,118 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "name": "example_template.ipynb",
-   "provenance": [],
-   "collapsed_sections": []
-  },
-  "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3"
-  }
- },
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "colab_type": "text",
-    "id": "UuYMhx3e-xlw",
-    "badge": true,
-    "repo_name": "Open-Reaction-Database/ord-schema",
-    "branch": "master",
-    "nb_path": "examples/example_template.ipynb",
-    "comment": "This badge cell was added by colab-badge-action"
-   },
-   "source": [
-    "# ORD Example Template\n",
-    "\n",
-    "<a href=\"https://colab.research.google.com/github/Open-Reaction-Database/ord-schema/blob/master/examples/example_template.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "FkGs9wsG6hbC",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "# Import or install ord_schema.\n",
-    "try:\n",
-    "  import ord_schema\n",
-    "except ImportError:\n",
-    "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
-    "  %cd ord-schema\n",
-    "  !git pull\n",
-    "  !python setup.py build_py\n",
-    "  !python setup.py install\n",
-    "\n",
-    "  from IPython import display\n",
-    "  display.clear_output()  # Installation is noisy."
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "WNYlhmmX64wp",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "from ord_schema.proto import reaction_pb2\n",
-    "from ord_schema.units import UnitResolver\n",
-    "from ord_schema import validations\n",
-    "from ord_schema import message_helpers\n",
-    "\n",
-    "unit_resolver = UnitResolver()"
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "kX_Pp3fA7UWB",
-    "colab_type": "code",
-    "colab": {}
-   },
-   "source": [
-    "reaction = reaction_pb2.Reaction()"
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "id": "MMhWUQYCOpuK",
-    "colab_type": "code",
-    "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
     "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 85
+      "name": "example_template.ipynb",
+      "provenance": [],
+      "collapsed_sections": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
     }
-   },
-   "source": [
-    "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
-    "reaction"
-   ],
-   "execution_count": 0,
-   "outputs": [
+  },
+  "cells": [
     {
-     "output_type": "execute_result",
-     "data": {
-      "text/plain": [
-       "identifiers {\n",
-       "  type: NAME\n",
-       "  value: \"deoxyfluorination\"\n",
-       "}"
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "UuYMhx3e-xlw"
+      },
+      "source": [
+        "# ORD Example Template\n",
+        "\n",
+        "{{ badge }}"
       ]
-     },
-     "metadata": {
-      "tags": []
-     },
-     "execution_count": 4
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "FkGs9wsG6hbC",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# Import or install ord_schema.\n",
+        "try:\n",
+        "  import ord_schema\n",
+        "except ImportError:\n",
+        "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
+        "  %cd ord-schema\n",
+        "  !git pull\n",
+        "  !python setup.py build_py\n",
+        "  !python setup.py install\n",
+        "\n",
+        "  from IPython import display\n",
+        "  display.clear_output()  # The installation is noisy."
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "WNYlhmmX64wp",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "from ord_schema.proto import reaction_pb2\n",
+        "from ord_schema.units import UnitResolver\n",
+        "from ord_schema import validations\n",
+        "from ord_schema import message_helpers\n",
+        "\n",
+        "unit_resolver = UnitResolver()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "kX_Pp3fA7UWB",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "reaction = reaction_pb2.Reaction()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "MMhWUQYCOpuK",
+        "colab_type": "code",
+        "outputId": "19ba37e2-a408-4d4f-9d11-e54c7c54b4a2",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 85
+        }
+      },
+      "source": [
+        "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
+        "reaction"
+      ],
+      "execution_count": 0,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "identifiers {\n",
+              "  type: NAME\n",
+              "  value: \"deoxyfluorination\"\n",
+              "}"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 4
+        }
+      ]
     }
-   ]
-  }
- ]
+  ]
 }


### PR DESCRIPTION
Uses a personal access token to trigger tests after colab badges `push` events. Fixes #74.