### PR TITLE
Expanding validations, especially of compound identifiers

### DIFF
--- a/examples/2_Nielsen_Deoxyfluorination_Screen/example_nielsen.ipynb
+++ b/examples/2_Nielsen_Deoxyfluorination_Screen/example_nielsen.ipynb
@@ -1,41 +1,15 @@
 {
- "nbformat": 4,
- "nbformat_minor": 0,
- "metadata": {
-  "colab": {
-   "name": "example_nielsen.ipynb",
-   "provenance": [],
-   "collapsed_sections": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.1"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
    "metadata": {
     "badge": true,
-    "repo_name": "Open-Reaction-Database/ord-schema",
     "branch": "master",
-    "nb_path": "examples/2_Nielsen_Deoxyfluorination_Screen/example_nielsen.ipynb",
+    "colab_type": "text",
     "comment": "This badge cell was added by colab-badge-action",
     "id": "BE_c3Flesrel",
-    "colab_type": "text"
+    "nb_path": "examples/2_Nielsen_Deoxyfluorination_Screen/example_nielsen.ipynb",
+    "repo_name": "Open-Reaction-Database/ord-schema"
    },
    "source": [
     "<a href=\"https://colab.research.google.com/github/Open-Reaction-Database/ord-schema/blob/master/examples/2_Nielsen_Deoxyfluorination_Screen/example_nielsen.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -52,7 +26,7 @@
     "\n",
     "DOI: 10.1021/jacs.8b01523\n",
     "\n",
-    "J. Am. Chem. Soc. 2018, 140, 5004\u22125008\n",
+    "J. Am. Chem. Soc. 2018, 140, 5004−5008\n",
     "\n",
     "## Defining protos for reaction data in Figure 1"
    ]
@@ -69,11 +43,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "kqbqnfM06xsH",
-    "colab": {}
+    "id": "kqbqnfM06xsH"
    },
+   "outputs": [],
    "source": [
     "try:\n",
     "  import ord_schema\n",
@@ -83,9 +59,7 @@
     "  !git pull\n",
     "  !python setup.py build_py\n",
     "  !python setup.py install"
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -99,11 +73,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "WNYlhmmX64wp",
-    "colab": {}
+    "id": "WNYlhmmX64wp"
    },
+   "outputs": [],
    "source": [
     "from datetime import datetime\n",
     "from ord_schema.proto import reaction_pb2\n",
@@ -112,9 +88,7 @@
     "from ord_schema import message_helpers\n",
     "\n",
     "unit_resolver = UnitResolver()"
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -130,24 +104,18 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "metadata": {
-    "colab_type": "code",
-    "id": "kX_Pp3fA7UWB",
-    "outputId": "950bbcf1-719c-4407-b4e4-5aaadcbc513a",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 85
-    }
+    },
+    "colab_type": "code",
+    "id": "kX_Pp3fA7UWB",
+    "outputId": "950bbcf1-719c-4407-b4e4-5aaadcbc513a"
    },
-   "source": [
-    "reaction = reaction_pb2.Reaction()\n",
-    "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
-    "reaction"
-   ],
-   "execution_count": 3,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "identifiers {\n",
@@ -156,11 +124,15 @@
        "}"
       ]
      },
-     "metadata": {
-      "tags": []
-     },
-     "execution_count": 3
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "reaction = reaction_pb2.Reaction()\n",
+    "reaction.identifiers.add(value=r'deoxyfluorination', type='NAME')\n",
+    "reaction"
    ]
   },
   {
@@ -178,11 +150,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "-tHbGCMiyhE3",
-    "colab": {}
+    "id": "-tHbGCMiyhE3"
    },
+   "outputs": [],
    "source": [
     "# Input 1a: 0.1 mmol alcohol in 125 uL THF\n",
     "input_1a = reaction.inputs['alcohol in THF']\n",
@@ -206,17 +180,17 @@
     "## Note: more lengthy way to specify volume w/o unit resolver\n",
     "# solvent.volume.value = 125\n",
     "# solvent.volume.units = reaction_pb2.Volume.MICROLITER"
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "YS5VpUzn3AK-",
-    "colab": {}
+    "id": "YS5VpUzn3AK-"
    },
+   "outputs": [],
    "source": [
     "# Input sf: 0.11 mmol sulfonyl fluoride in 125 uL THF\n",
     "input_sf = reaction.inputs['sulfonyl fluoride']\n",
@@ -227,7 +201,7 @@
     "\n",
     "solute.reaction_role = reaction_pb2.Compound.ReactionRole.REACTANT \n",
     "solute.identifiers.add(value=r'4-chlorobenzenesulfonyl fluoride', type='NAME')\n",
-    "solute.identifiers.add(value=r'Clc1ccc(S=O(=O)F)cc1', type='SMILES')\n",
+    "solute.identifiers.add(value=r'Clc1ccc(S(=O)(=O)F)cc1', type='SMILES')\n",
     "solute.moles.CopyFrom(unit_resolver.resolve('0.11 mmol'))\n",
     "solute.preparation.type = reaction_pb2.CompoundPreparation.PreparationType.SYNTHESIZED\n",
     "\n",
@@ -236,17 +210,17 @@
     "solvent.identifiers.add(value=r'C1CCCO1', type='SMILES')\n",
     "solvent.volume.CopyFrom(unit_resolver.resolve('125 uL'))\n",
     "solvent.preparation.type = reaction_pb2.CompoundPreparation.PreparationType.DRIED"
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "lR1ff-uq71TL",
-    "colab": {}
+    "id": "lR1ff-uq71TL"
    },
+   "outputs": [],
    "source": [
     "# Input base: 0.15 mmol pure\n",
     "input_base = reaction.inputs['base']\n",
@@ -259,9 +233,7 @@
     "base.preparation.type = reaction_pb2.CompoundPreparation.PreparationType.NONE\n",
     "base.vendor_source = 'Sigma-Millipore'\n",
     "base.is_limiting = False"
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -275,11 +247,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "m2Ud6UqK8-LL",
-    "colab": {}
+    "id": "m2Ud6UqK8-LL"
    },
+   "outputs": [],
    "source": [
     "# Reactions performed in 1 mL glass vial\n",
     "reaction.setup.vessel.CopyFrom(\n",
@@ -290,57 +264,55 @@
     "    )\n",
     ")\n",
     "reaction.setup.is_automated = False"
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "W_mov8JIYQUC",
-    "colab": {}
+    "id": "W_mov8JIYQUC"
    },
+   "outputs": [],
    "source": [
     "# No temperature control = ambient conitions\n",
     "t_conds = reaction.conditions.temperature\n",
     "t_conds.type = t_conds.TemperatureControl.AMBIENT"
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "zygxzC8ziJTr",
-    "colab": {}
+    "id": "zygxzC8ziJTr"
    },
+   "outputs": [],
    "source": [
     "# Vials were sealed under ambient conditions\n",
     "p_conds = reaction.conditions.pressure\n",
     "p_conds.type = p_conds.PressureControl.SEALED\n",
     "p_conds.atmosphere = p_conds.Atmosphere.AIR"
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "TjyZ_Urkix6_",
-    "colab": {}
+    "id": "TjyZ_Urkix6_"
    },
+   "outputs": [],
    "source": [
     "# Vials contained stir bars at 600 rpm\n",
     "s_conds = reaction.conditions.stirring\n",
     "s_conds.type = s_conds.StirringMethod.STIR_BAR\n",
     "s_conds.rate = s_conds.StirringRate.HIGH # qualitative\n",
     "s_conds.rpm = 600"
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -354,11 +326,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 11,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "OZm3Src4i0ro",
-    "colab": {}
+    "id": "OZm3Src4i0ro"
    },
+   "outputs": [],
    "source": [
     "# No safety notes\n",
     "reaction.notes.safety_notes = ''\n",
@@ -367,9 +341,7 @@
     "# observation = reaction.observations.add()\n",
     "# observation.time = \n",
     "# observation.comment = "
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -385,11 +357,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "nMZKW4ZSkyeY",
-    "colab": {}
+    "id": "nMZKW4ZSkyeY"
    },
+   "outputs": [],
    "source": [
     "outcome = reaction.outcomes.add()\n",
     "outcome.reaction_time.CopyFrom(unit_resolver.resolve('48 hrs'))\n",
@@ -427,9 +401,7 @@
     "reaction.provenance.record_created.person.CopyFrom(reaction_pb2.Person(\n",
     "    name='Connor W. Coley', organization='MIT', orcid='0000-0002-8271-8723'\n",
     "))"
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -443,22 +415,19 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 13,
    "metadata": {
-    "colab_type": "code",
-    "id": "yM9bpRndSpul",
-    "outputId": "1452473a-a5a8-4a0a-b394-a7ae854fe5ea",
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 1000
-    }
+    },
+    "colab_type": "code",
+    "id": "yM9bpRndSpul",
+    "outputId": "1452473a-a5a8-4a0a-b394-a7ae854fe5ea"
    },
-   "source": [
-    "reaction = validations.validate_message(reaction)\n",
-    "print(reaction)"
-   ],
-   "execution_count": 13,
    "outputs": [
     {
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "identifiers {\n",
@@ -472,6 +441,10 @@
       "      identifiers {\n",
       "        type: SMILES\n",
       "        value: \"c1ccccc1CCC(O)C\"\n",
+      "      }\n",
+      "      identifiers {\n",
+      "        type: RDKIT_BINARY\n",
+      "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\013\\000\\000\\000\\013\\000\\000\\000\\200\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@(\\000\\000\\000\\003\\004\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\003\\001\\010\\000`\\000\\000\\000\\001\\001\\006\\000`\\000\\000\\000\\001\\003\\013\\000\\001h\\014\\001\\002h\\014\\002\\003h\\014\\003\\004h\\014\\004\\005h\\014\\005\\006\\000\\006\\007\\000\\007\\010\\000\\010\\t\\000\\010\\n\\000\\005\\000h\\014\\024\\001\\006\\000\\005\\004\\003\\002\\001\\027\\000\\000\\000\\000\\026\"\n",
       "      }\n",
       "      moles {\n",
       "        value: 0.10000000149011612\n",
@@ -492,6 +465,10 @@
       "        type: SMILES\n",
       "        value: \"C1CCCO1\"\n",
       "      }\n",
+      "      identifiers {\n",
+      "        type: RDKIT_BINARY\n",
+      "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\005\\000\\000\\000\\005\\000\\000\\000\\200\\001\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\010\\000 \\000\\000\\000\\002\\013\\000\\001\\000\\001\\002\\000\\002\\003\\000\\003\\004\\000\\004\\000\\000\\024\\001\\005\\000\\001\\002\\003\\004\\027\\000\\000\\000\\000\\026\"\n",
+      "      }\n",
       "      volume {\n",
       "        value: 125.0\n",
       "        units: MICROLITER\n",
@@ -511,6 +488,10 @@
       "      identifiers {\n",
       "        type: SMILES\n",
       "        value: \"N\\\\2=C1\\\\N(CCCCC1)CCC/2\"\n",
+      "      }\n",
+      "      identifiers {\n",
+      "        type: RDKIT_BINARY\n",
+      "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\013\\000\\000\\000\\014\\000\\000\\000\\200\\001\\007\\000(\\000\\000\\000\\003\\003\\006\\000(\\000\\000\\000\\003\\004\\007\\000(\\000\\000\\000\\003\\003\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\013\\000\\001(\\002\\001\\002$\\003\\002\\003\\000\\003\\004\\000\\004\\005\\000\\005\\006\\000\\006\\007\\000\\002\\010\\000\\010\\t\\000\\t\\n\\000\\007\\001\\000\\000\\n\\004\\003\\024\\002\\006\\000\\n\\t\\010\\002\\001\\007\\003\\002\\001\\007\\006\\005\\004\\027\\000\\000\\000\\000\\026\"\n",
       "      }\n",
       "      moles {\n",
       "        value: 0.15000000596046448\n",
@@ -535,7 +516,11 @@
       "      }\n",
       "      identifiers {\n",
       "        type: SMILES\n",
-      "        value: \"Clc1ccc(S=O(=O)F)cc1\"\n",
+      "        value: \"Clc1ccc(S(=O)(=O)F)cc1\"\n",
+      "      }\n",
+      "      identifiers {\n",
+      "        type: RDKIT_BINARY\n",
+      "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\013\\000\\000\\000\\013\\000\\000\\000\\200\\001\\021\\000 \\000\\000\\000\\001\\006@(\\000\\000\\000\\003\\004\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@(\\000\\000\\000\\003\\004\\020\\000 \\000\\000\\000\\006\\010\\000(\\000\\000\\000\\003\\002\\010\\000(\\000\\000\\000\\003\\002\\t\\000 \\000\\000\\000\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\013\\000\\001\\000\\001\\002h\\014\\002\\003h\\014\\003\\004h\\014\\004\\005\\000\\005\\006\\010\\002\\005\\007\\010\\002\\005\\010\\000\\004\\th\\014\\t\\nh\\014\\n\\001h\\014\\024\\001\\006\\001\\n\\t\\004\\003\\002\\027\\000\\000\\000\\000\\026\"\n",
       "      }\n",
       "      moles {\n",
       "        value: 0.10999999940395355\n",
@@ -554,6 +539,10 @@
       "      identifiers {\n",
       "        type: SMILES\n",
       "        value: \"C1CCCO1\"\n",
+      "      }\n",
+      "      identifiers {\n",
+      "        type: RDKIT_BINARY\n",
+      "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\005\\000\\000\\000\\005\\000\\000\\000\\200\\001\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\010\\000 \\000\\000\\000\\002\\013\\000\\001\\000\\001\\002\\000\\002\\003\\000\\003\\004\\000\\004\\000\\000\\024\\001\\005\\000\\001\\002\\003\\004\\027\\000\\000\\000\\000\\026\"\n",
       "      }\n",
       "      volume {\n",
       "        value: 125.0\n",
@@ -604,6 +593,10 @@
       "        type: SMILES\n",
       "        value: \"c1ccccc1CCC(F)C\"\n",
       "      }\n",
+      "      identifiers {\n",
+      "        type: RDKIT_BINARY\n",
+      "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\013\\000\\000\\000\\013\\000\\000\\000\\200\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@(\\000\\000\\000\\003\\004\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\003\\001\\t\\000 \\000\\000\\000\\001\\006\\000`\\000\\000\\000\\001\\003\\013\\000\\001h\\014\\001\\002h\\014\\002\\003h\\014\\003\\004h\\014\\004\\005h\\014\\005\\006\\000\\006\\007\\000\\007\\010\\000\\010\\t\\000\\010\\n\\000\\005\\000h\\014\\024\\001\\006\\000\\005\\004\\003\\002\\001\\027\\000\\000\\000\\000\\026\"\n",
+      "      }\n",
       "    }\n",
       "    is_desired_product: true\n",
       "    compound_yield {\n",
@@ -628,7 +621,7 @@
       "  publication_url: \"https://pubs.acs.org/doi/10.1021/jacs.8b01523\"\n",
       "  record_created {\n",
       "    time {\n",
-      "      value: \"Fri Apr 10 20:23:11 2020\"\n",
+      "      value: \"Sun Apr 12 21:08:35 2020\"\n",
       "    }\n",
       "    person {\n",
       "      name: \"Connor W. Coley\"\n",
@@ -638,9 +631,19 @@
       "  }\n",
       "}\n",
       "\n"
-     ],
-     "name": "stdout"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/ccoley/miniconda3/envs/askcos_newrdkit/lib/python3.6/site-packages/ord_schema-0.1-py3.6.egg/ord_schema/validations.py:253: ValidationWarning: Temperature setpoints should be specified; even if using ambient conditions, estimate room temperature and the precision of your estimate.\n"
+     ]
     }
+   ],
+   "source": [
+    "reaction = validations.validate_message(reaction)\n",
+    "print(reaction)"
    ]
   },
   {
@@ -657,11 +660,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 14,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "YJv51yW-qWBT",
-    "colab": {}
+    "id": "YJv51yW-qWBT"
    },
+   "outputs": [],
    "source": [
     "# Defining all major reactants, reagents, and products used in screen\n",
     "\n",
@@ -677,7 +682,7 @@
     "  '2d': message_helpers.build_compound(r'F[C@H]1C[C@@H](C(OC)=O)N(C(OC(C)(C)C)=O)C1'),\n",
     "  \n",
     "  # Sulfonyl fluorides\n",
-    "  '3-Cl': message_helpers.build_compound(r'Clc1ccc(S=O(=O)F)cc1'),\n",
+    "  '3-Cl': message_helpers.build_compound(r'Clc1ccc(S(=O)(=O)F)cc1'),\n",
     "  'PyFluor': message_helpers.build_compound(r'O=S(C1=CC=CC=N1)(F)=O', name='PyFluor'),\n",
     "  '3-CF3': message_helpers.build_compound(r'O=S(C1=CC=C(C(F)(F)F)C=C1)(F)=O'),\n",
     "  '3-NO2': message_helpers.build_compound(r'O=S(C1=CC=C([N+]([O-])=O)C=C1)(F)=O'),\n",
@@ -693,17 +698,17 @@
     "  'BTPP': message_helpers.build_compound(r'CC(C)(C)N=P(N1CCCC1)(N2CCCC2)N3CCCC3', \n",
     "                            name='BTPP', vendor='Millipore-Sigma'),\n",
     "}"
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 15,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "_w2k1q_Us-oZ",
-    "colab": {}
+    "id": "_w2k1q_Us-oZ"
    },
+   "outputs": [],
    "source": [
     "# Define yield tables\n",
     "data = [ # reactant, product, sulfonyl fluoride, base, yield percent\n",
@@ -792,9 +797,7 @@
     "  ('1d', '2d', 'PBSF', 'BTMG', 64),\n",
     "  ('1d', '2d', 'PBSF', 'BTPP', 58),\n",
     "]"
-   ],
-   "execution_count": 0,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "markdown",
@@ -810,11 +813,13 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 16,
    "metadata": {
+    "colab": {},
     "colab_type": "code",
-    "id": "3ZLtrKI254si",
-    "colab": {}
+    "id": "3ZLtrKI254si"
    },
+   "outputs": [],
    "source": [
     "reactions = []\n",
     "for alc, prod, sf, base, y in data:\n",
@@ -845,54 +850,47 @@
     "\n",
     "  # Save\n",
     "  reactions.append(this_condition)"
-   ],
-   "execution_count": 0,
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "metadata": {
-    "colab_type": "code",
-    "id": "ith5vNbfC05O",
-    "outputId": "1769c066-416b-4b96-a7a1-2e68652e1d52",
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 34
-    }
-   },
-   "source": [
-    "print(f'Generated {len(reactions)} reactions')"
-   ],
-   "execution_count": 17,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "text": [
-      "Generated 80 reactions\n"
-     ],
-     "name": "stdout"
-    }
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 17,
    "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 34
+    },
     "colab_type": "code",
-    "id": "3sR-EPjuVbYk",
-    "outputId": "3cf8428d-9183-4bf5-e0c8-4f24f5560552",
+    "id": "ith5vNbfC05O",
+    "outputId": "1769c066-416b-4b96-a7a1-2e68652e1d52"
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated 80 reactions\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'Generated {len(reactions)} reactions')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
      "height": 1000
-    }
+    },
+    "colab_type": "code",
+    "id": "3sR-EPjuVbYk",
+    "outputId": "3cf8428d-9183-4bf5-e0c8-4f24f5560552"
    },
-   "source": [
-    "# Inspect random reaction from this set\n",
-    "reactions[42]"
-   ],
-   "execution_count": 18,
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "identifiers {\n",
@@ -906,6 +904,10 @@
        "      identifiers {\n",
        "        type: SMILES\n",
        "        value: \"O[C@@H]1C[C@H](OCC2=CC=CC=C2)C1\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: RDKIT_BINARY\n",
+       "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\r\\000\\000\\000\\016\\000\\000\\000\\200\\001\\010\\000`\\000\\000\\000\\001\\001\\006 4\\000\\000\\000\\002\\001\\004\\006\\000`\\000\\000\\000\\002\\002\\006 4\\000\\000\\000\\002\\001\\004\\010\\000 \\000\\000\\000\\002\\006\\000`\\000\\000\\000\\002\\002\\006@(\\000\\000\\000\\003\\004\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006\\000`\\000\\000\\000\\002\\002\\013\\000\\001\\000\\001\\002\\000\\002\\003\\000\\003\\004\\000\\004\\005\\000\\005\\006\\000\\006\\007h\\014\\007\\010h\\014\\010\\th\\014\\t\\nh\\014\\n\\013h\\014\\003\\014\\000\\014\\001\\000\\013\\006h\\014\\024\\002\\004\\001\\014\\003\\002\\006\\007\\010\\t\\n\\013\\006\\027\\000\\000\\000\\000\\026\"\n",
        "      }\n",
        "      moles {\n",
        "        value: 0.10000000149011612\n",
@@ -924,6 +926,10 @@
        "      identifiers {\n",
        "        type: SMILES\n",
        "        value: \"C1CCCO1\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: RDKIT_BINARY\n",
+       "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\005\\000\\000\\000\\005\\000\\000\\000\\200\\001\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\010\\000 \\000\\000\\000\\002\\013\\000\\001\\000\\001\\002\\000\\002\\003\\000\\003\\004\\000\\004\\000\\000\\024\\001\\005\\000\\001\\002\\003\\004\\027\\000\\000\\000\\000\\026\"\n",
        "      }\n",
        "      volume {\n",
        "        value: 125.0\n",
@@ -949,6 +955,10 @@
        "        type: NAME\n",
        "        value: \"BTMG\"\n",
        "      }\n",
+       "      identifiers {\n",
+       "        type: RDKIT_BINARY\n",
+       "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\014\\000\\000\\000\\013\\000\\000\\000\\200\\001\\006\\000`\\000\\000\\000\\001\\003\\006\\000 \\000\\000\\000\\004\\006\\000`\\000\\000\\000\\001\\003\\006\\000`\\000\\000\\000\\001\\003\\007\\000(\\000\\000\\000\\003\\003\\006\\000(\\000\\000\\000\\003\\004\\007\\000(\\000\\000\\000\\003\\003\\006\\000`\\000\\000\\000\\001\\003\\006\\000`\\000\\000\\000\\001\\003\\007\\000(\\000\\000\\000\\003\\003\\006\\000`\\000\\000\\000\\001\\003\\006\\000`\\000\\000\\000\\001\\003\\013\\000\\001\\000\\001\\002\\000\\001\\003\\000\\001\\004\\000\\004\\005(\\002\\005\\006 \\006\\007\\000\\006\\010\\000\\005\\t \\t\\n\\000\\t\\013\\000\\024\\000\\027\\000\\000\\000\\000\\026\"\n",
+       "      }\n",
        "      moles {\n",
        "        value: 0.15000000596046448\n",
        "        units: MILLIMOLES\n",
@@ -967,7 +977,11 @@
        "    components {\n",
        "      identifiers {\n",
        "        type: SMILES\n",
-       "        value: \"Clc1ccc(S=O(=O)F)cc1\"\n",
+       "        value: \"Clc1ccc(S(=O)(=O)F)cc1\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: RDKIT_BINARY\n",
+       "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\013\\000\\000\\000\\013\\000\\000\\000\\200\\001\\021\\000 \\000\\000\\000\\001\\006@(\\000\\000\\000\\003\\004\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@(\\000\\000\\000\\003\\004\\020\\000 \\000\\000\\000\\006\\010\\000(\\000\\000\\000\\003\\002\\010\\000(\\000\\000\\000\\003\\002\\t\\000 \\000\\000\\000\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\013\\000\\001\\000\\001\\002h\\014\\002\\003h\\014\\003\\004h\\014\\004\\005\\000\\005\\006\\010\\002\\005\\007\\010\\002\\005\\010\\000\\004\\th\\014\\t\\nh\\014\\n\\001h\\014\\024\\001\\006\\001\\n\\t\\004\\003\\002\\027\\000\\000\\000\\000\\026\"\n",
        "      }\n",
        "      moles {\n",
        "        value: 0.10999999940395355\n",
@@ -985,6 +999,10 @@
        "      identifiers {\n",
        "        type: SMILES\n",
        "        value: \"C1CCCO1\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: RDKIT_BINARY\n",
+       "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\005\\000\\000\\000\\005\\000\\000\\000\\200\\001\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\010\\000 \\000\\000\\000\\002\\013\\000\\001\\000\\001\\002\\000\\002\\003\\000\\003\\004\\000\\004\\000\\000\\024\\001\\005\\000\\001\\002\\003\\004\\027\\000\\000\\000\\000\\026\"\n",
        "      }\n",
        "      volume {\n",
        "        value: 125.0\n",
@@ -1035,6 +1053,10 @@
        "        type: SMILES\n",
        "        value: \"F[C@@H]1C[C@H](OCC2=CC=CC=C2)C1\"\n",
        "      }\n",
+       "      identifiers {\n",
+       "        type: RDKIT_BINARY\n",
+       "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\r\\000\\000\\000\\016\\000\\000\\000\\200\\001\\t\\000 \\000\\000\\000\\001\\006 4\\000\\000\\000\\002\\001\\004\\006\\000`\\000\\000\\000\\002\\002\\006 4\\000\\000\\000\\002\\001\\004\\010\\000 \\000\\000\\000\\002\\006\\000`\\000\\000\\000\\002\\002\\006@(\\000\\000\\000\\003\\004\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006\\000`\\000\\000\\000\\002\\002\\013\\000\\001\\000\\001\\002\\000\\002\\003\\000\\003\\004\\000\\004\\005\\000\\005\\006\\000\\006\\007h\\014\\007\\010h\\014\\010\\th\\014\\t\\nh\\014\\n\\013h\\014\\003\\014\\000\\014\\001\\000\\013\\006h\\014\\024\\002\\004\\001\\014\\003\\002\\006\\007\\010\\t\\n\\013\\006\\027\\000\\000\\000\\000\\026\"\n",
+       "      }\n",
        "      preparation {\n",
        "      }\n",
        "    }\n",
@@ -1061,7 +1083,7 @@
        "  publication_url: \"https://pubs.acs.org/doi/10.1021/jacs.8b01523\"\n",
        "  record_created {\n",
        "    time {\n",
-       "      value: \"Fri Apr 10 20:23:11 2020\"\n",
+       "      value: \"Sun Apr 12 21:08:35 2020\"\n",
        "    }\n",
        "    person {\n",
        "      name: \"Connor W. Coley\"\n",
@@ -1072,12 +1094,266 @@
        "}"
       ]
      },
-     "metadata": {
-      "tags": []
-     },
-     "execution_count": 18
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
     }
+   ],
+   "source": [
+    "# Inspect random reaction from this set\n",
+    "reactions[42]"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "identifiers {\n",
+       "  type: NAME\n",
+       "  value: \"deoxyfluorination\"\n",
+       "}\n",
+       "inputs {\n",
+       "  key: \"alcohol in THF\"\n",
+       "  value {\n",
+       "    components {\n",
+       "      identifiers {\n",
+       "        type: SMILES\n",
+       "        value: \"O[C@@H]1C[C@H](OCC2=CC=CC=C2)C1\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: RDKIT_BINARY\n",
+       "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\r\\000\\000\\000\\016\\000\\000\\000\\200\\001\\010\\000`\\000\\000\\000\\001\\001\\006 4\\000\\000\\000\\002\\001\\004\\006\\000`\\000\\000\\000\\002\\002\\006 4\\000\\000\\000\\002\\001\\004\\010\\000 \\000\\000\\000\\002\\006\\000`\\000\\000\\000\\002\\002\\006@(\\000\\000\\000\\003\\004\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006\\000`\\000\\000\\000\\002\\002\\013\\000\\001\\000\\001\\002\\000\\002\\003\\000\\003\\004\\000\\004\\005\\000\\005\\006\\000\\006\\007h\\014\\007\\010h\\014\\010\\th\\014\\t\\nh\\014\\n\\013h\\014\\003\\014\\000\\014\\001\\000\\013\\006h\\014\\024\\002\\004\\001\\014\\003\\002\\006\\007\\010\\t\\n\\013\\006\\027\\000\\000\\000\\000\\026\"\n",
+       "      }\n",
+       "      moles {\n",
+       "        value: 0.10000000149011612\n",
+       "        units: MILLIMOLES\n",
+       "      }\n",
+       "      reaction_role: REACTANT\n",
+       "      is_limiting: true\n",
+       "      preparation {\n",
+       "      }\n",
+       "    }\n",
+       "    components {\n",
+       "      identifiers {\n",
+       "        type: NAME\n",
+       "        value: \"THF\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: SMILES\n",
+       "        value: \"C1CCCO1\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: RDKIT_BINARY\n",
+       "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\005\\000\\000\\000\\005\\000\\000\\000\\200\\001\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\010\\000 \\000\\000\\000\\002\\013\\000\\001\\000\\001\\002\\000\\002\\003\\000\\003\\004\\000\\004\\000\\000\\024\\001\\005\\000\\001\\002\\003\\004\\027\\000\\000\\000\\000\\026\"\n",
+       "      }\n",
+       "      volume {\n",
+       "        value: 125.0\n",
+       "        units: MICROLITER\n",
+       "      }\n",
+       "      reaction_role: SOLVENT\n",
+       "      preparation {\n",
+       "        type: DRIED\n",
+       "      }\n",
+       "    }\n",
+       "    addition_order: 1\n",
+       "  }\n",
+       "}\n",
+       "inputs {\n",
+       "  key: \"base\"\n",
+       "  value {\n",
+       "    components {\n",
+       "      identifiers {\n",
+       "        type: SMILES\n",
+       "        value: \"CC(C)(C)N=C(N(C)C)N(C)C\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: NAME\n",
+       "        value: \"BTMG\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: RDKIT_BINARY\n",
+       "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\014\\000\\000\\000\\013\\000\\000\\000\\200\\001\\006\\000`\\000\\000\\000\\001\\003\\006\\000 \\000\\000\\000\\004\\006\\000`\\000\\000\\000\\001\\003\\006\\000`\\000\\000\\000\\001\\003\\007\\000(\\000\\000\\000\\003\\003\\006\\000(\\000\\000\\000\\003\\004\\007\\000(\\000\\000\\000\\003\\003\\006\\000`\\000\\000\\000\\001\\003\\006\\000`\\000\\000\\000\\001\\003\\007\\000(\\000\\000\\000\\003\\003\\006\\000`\\000\\000\\000\\001\\003\\006\\000`\\000\\000\\000\\001\\003\\013\\000\\001\\000\\001\\002\\000\\001\\003\\000\\001\\004\\000\\004\\005(\\002\\005\\006 \\006\\007\\000\\006\\010\\000\\005\\t \\t\\n\\000\\t\\013\\000\\024\\000\\027\\000\\000\\000\\000\\026\"\n",
+       "      }\n",
+       "      moles {\n",
+       "        value: 0.15000000596046448\n",
+       "        units: MILLIMOLES\n",
+       "      }\n",
+       "      reaction_role: REAGENT\n",
+       "      preparation {\n",
+       "      }\n",
+       "      vendor_source: \"Millipore-Sigma\"\n",
+       "    }\n",
+       "    addition_order: 3\n",
+       "  }\n",
+       "}\n",
+       "inputs {\n",
+       "  key: \"sulfonyl fluoride\"\n",
+       "  value {\n",
+       "    components {\n",
+       "      identifiers {\n",
+       "        type: SMILES\n",
+       "        value: \"Clc1ccc(S(=O)(=O)F)cc1\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: RDKIT_BINARY\n",
+       "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\013\\000\\000\\000\\013\\000\\000\\000\\200\\001\\021\\000 \\000\\000\\000\\001\\006@(\\000\\000\\000\\003\\004\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@(\\000\\000\\000\\003\\004\\020\\000 \\000\\000\\000\\006\\010\\000(\\000\\000\\000\\003\\002\\010\\000(\\000\\000\\000\\003\\002\\t\\000 \\000\\000\\000\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\013\\000\\001\\000\\001\\002h\\014\\002\\003h\\014\\003\\004h\\014\\004\\005\\000\\005\\006\\010\\002\\005\\007\\010\\002\\005\\010\\000\\004\\th\\014\\t\\nh\\014\\n\\001h\\014\\024\\001\\006\\001\\n\\t\\004\\003\\002\\027\\000\\000\\000\\000\\026\"\n",
+       "      }\n",
+       "      moles {\n",
+       "        value: 0.10999999940395355\n",
+       "        units: MILLIMOLES\n",
+       "      }\n",
+       "      reaction_role: REACTANT\n",
+       "      preparation {\n",
+       "      }\n",
+       "    }\n",
+       "    components {\n",
+       "      identifiers {\n",
+       "        type: NAME\n",
+       "        value: \"THF\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: SMILES\n",
+       "        value: \"C1CCCO1\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: RDKIT_BINARY\n",
+       "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\005\\000\\000\\000\\005\\000\\000\\000\\200\\001\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\006\\000`\\000\\000\\000\\002\\002\\010\\000 \\000\\000\\000\\002\\013\\000\\001\\000\\001\\002\\000\\002\\003\\000\\003\\004\\000\\004\\000\\000\\024\\001\\005\\000\\001\\002\\003\\004\\027\\000\\000\\000\\000\\026\"\n",
+       "      }\n",
+       "      volume {\n",
+       "        value: 125.0\n",
+       "        units: MICROLITER\n",
+       "      }\n",
+       "      reaction_role: SOLVENT\n",
+       "      preparation {\n",
+       "        type: DRIED\n",
+       "      }\n",
+       "    }\n",
+       "    addition_order: 2\n",
+       "  }\n",
+       "}\n",
+       "setup {\n",
+       "  vessel {\n",
+       "    type: VIAL\n",
+       "    material: GLASS\n",
+       "    volume {\n",
+       "      value: 1.0\n",
+       "      units: MILLILITER\n",
+       "    }\n",
+       "  }\n",
+       "}\n",
+       "conditions {\n",
+       "  temperature {\n",
+       "    type: AMBIENT\n",
+       "  }\n",
+       "  pressure {\n",
+       "    type: SEALED\n",
+       "    atmosphere: AIR\n",
+       "  }\n",
+       "  stirring {\n",
+       "    type: STIR_BAR\n",
+       "    rate: HIGH\n",
+       "    rpm: 600\n",
+       "  }\n",
+       "}\n",
+       "notes {\n",
+       "}\n",
+       "outcomes {\n",
+       "  reaction_time {\n",
+       "    value: 48.0\n",
+       "    units: HOUR\n",
+       "  }\n",
+       "  products {\n",
+       "    compound {\n",
+       "      identifiers {\n",
+       "        type: SMILES\n",
+       "        value: \"F[C@@H]1C[C@H](OCC2=CC=CC=C2)C1\"\n",
+       "      }\n",
+       "      identifiers {\n",
+       "        type: RDKIT_BINARY\n",
+       "        bytes_value: \"\\357\\276\\255\\336\\000\\000\\000\\000\\n\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\r\\000\\000\\000\\016\\000\\000\\000\\200\\001\\t\\000 \\000\\000\\000\\001\\006 4\\000\\000\\000\\002\\001\\004\\006\\000`\\000\\000\\000\\002\\002\\006 4\\000\\000\\000\\002\\001\\004\\010\\000 \\000\\000\\000\\002\\006\\000`\\000\\000\\000\\002\\002\\006@(\\000\\000\\000\\003\\004\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006@h\\000\\000\\000\\003\\003\\001\\006\\000`\\000\\000\\000\\002\\002\\013\\000\\001\\000\\001\\002\\000\\002\\003\\000\\003\\004\\000\\004\\005\\000\\005\\006\\000\\006\\007h\\014\\007\\010h\\014\\010\\th\\014\\t\\nh\\014\\n\\013h\\014\\003\\014\\000\\014\\001\\000\\013\\006h\\014\\024\\002\\004\\001\\014\\003\\002\\006\\007\\010\\t\\n\\013\\006\\027\\000\\000\\000\\000\\026\"\n",
+       "      }\n",
+       "      preparation {\n",
+       "      }\n",
+       "    }\n",
+       "    is_desired_product: true\n",
+       "    compound_yield {\n",
+       "      value: 1.0\n",
+       "      precision: 4.800000190734863\n",
+       "    }\n",
+       "    analysis_identity: \"19f nmr of crude\"\n",
+       "    analysis_yield: \"19f nmr of crude\"\n",
+       "  }\n",
+       "  analyses {\n",
+       "    key: \"19f nmr of crude\"\n",
+       "    value {\n",
+       "      type: NMR\n",
+       "      details: \"19F NMR using 1 equiv 1-fluoronaphthalene in 250 uL chloroform as internal standard\"\n",
+       "      instrument_manufacturer: \"Bruker\"\n",
+       "    }\n",
+       "  }\n",
+       "}\n",
+       "provenance {\n",
+       "  city: \"Princeton, NJ\"\n",
+       "  doi: \"10.1021/jacs.8b01523\"\n",
+       "  publication_url: \"https://pubs.acs.org/doi/10.1021/jacs.8b01523\"\n",
+       "  record_created {\n",
+       "    time {\n",
+       "      value: \"Sun Apr 12 21:08:35 2020\"\n",
+       "    }\n",
+       "    person {\n",
+       "      name: \"Connor W. Coley\"\n",
+       "      orcid: \"0000-0002-8271-8723\"\n",
+       "      organization: \"MIT\"\n",
+       "    }\n",
+       "  }\n",
+       "}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "validations.validate_message(reactions[42])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "colab": {
+   "collapsed_sections": [],
+   "name": "example_nielsen.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python3 (askcos_newrdkit)",
+   "language": "python",
+   "name": "askcos_newrdkit"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
 }

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -171,12 +171,12 @@ def validate_compound(message):
                 this_mol = Chem.MolFromSmiles(identifier.value)
                 if this_mol is None:
                     raise ValueError(f'RDKit {RDKIT_VERSION} could not validate'
-                                     ' SMILES identifier {identifier.value}')
+                                     f' SMILES identifier {identifier.value}')
             elif identifier.type == identifier.INCHI:
                 this_mol = Chem.MolFromInchi(identifier.value)
                 if this_mol is None:
                     raise ValueError(f'RDKit {RDKIT_VERSION} could not validate'
-                                     ' InChI identifier {identifier.value}')
+                                     f' InChI identifier {identifier.value}')
             elif identifier.type == identifier.MOLBLOCK:
                 this_mol = Chem.MolFromMolBlock(identifier.value)
                 if this_mol is None:
@@ -324,7 +324,7 @@ def validate_reaction_workup(message):
                          'temperature conditions')
     if (message.type in (reaction_pb2.ReactionWorkup.EXTRACTION,
                          reaction_pb2.ReactionWorkup.FILTRATION) and
-            not message.keep_hase):
+            not message.keep_phase):
         raise ValueError('Workup step EXTRACTION or FILTRATION missing '
                          'required field keep_phase')
     if (message.type in (reaction_pb2.ReactionWorkup.ADDITION,
@@ -335,7 +335,7 @@ def validate_reaction_workup(message):
                          reaction_pb2.ReactionWorkup.PH_ADJUST) and
             not message.components):
         raise ValueError('Workup step missing required components definition')
-    if (message.type == reaction_pb2.ReactionWorkupSTIRRING and
+    if (message.type == reaction_pb2.ReactionWorkup.STIRRING and
             not message.stirring):
         raise ValueError('Stirring workup step missing stirring definition')
     if (message.type == reaction_pb2.ReactionWorkup.PH_ADJUST and

--- a/proto/reaction.proto
+++ b/proto/reaction.proto
@@ -221,8 +221,8 @@ message CompoundIdentifier {
     SMILES = 2;
     // IUPAC International Chemical Identifier.
     INCHI = 3;
-    // MDL Molfile V3000.
-    MOLFILE = 4;
+    // Molblock from a MDL Molfile V3000.
+    MOLBLOCK = 4;
     // Chemical name following IUPAC nomenclature recommendations.
     IUPAC_NAME = 5;
     // Any accepted common name, trade name, etc.
@@ -712,9 +712,7 @@ message ReactionProvenance {
   }
   RecordEvent record_created = 7;
   repeated RecordEvent record_modified = 8;
-  // TODO(ccoley): is it useful to create a unique ID field 
-  // that the centralized database can write to? (I know uniqueness is not
-  // enforceable)
+  // This is a unique ID field that the centralized database will write to
   string record_id = 9;
 }
 


### PR DESCRIPTION
- Numerous validations added for Workup; not tested, but validated on examples at least
- Replaced MolFile identifier with MolBlock to match RDKit function
- Using RDKit to resolve SMILES, InChI, and MolBlocks
- Resolved Compounds will try to add RDKIT_BINARY identifier if
  rdkit is installed
- In the absence of a structural identifier, use the PubChem API to
  resolve a NAME CompoundIdentifier
- Tests added for these new features