### PR TITLE
Overhaul validations to use warnings

### DIFF
--- a/examples/2_Nielsen_Deoxyfluorination_Screen/example_nielsen.ipynb
+++ b/examples/2_Nielsen_Deoxyfluorination_Screen/example_nielsen.ipynb
@@ -642,7 +642,7 @@
     }
    ],
    "source": [
-    "reaction = validations.validate_message(reaction)\n",
+    "validations.validate_message(reaction)\n",
     "print(reaction)"
    ]
   },
@@ -846,7 +846,7 @@
     "    this_condition.outcomes[0].products[0].compound_yield.value = y\n",
     "\n",
     "    # Validate\n",
-    "    this_condition = validations.validate_message(this_condition)\n",
+    "    validations.validate_message(this_condition)\n",
     "\n",
     "    # Save\n",
     "    reactions.append(this_condition)"

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -85,18 +85,15 @@ def validate_message(message, recurse=True, raise_on_error=True):
         # us to think about what is necessary if/when new messages are added.
         raise NotImplementedError(f"Don't know how to validate {type(message)}")
 
-    warnings_to_emit = []
     with warnings.catch_warnings(record=True) as tape:
         _VALIDATOR_SWITCH[type(message)](message)
-        for warning in tape:
-            if issubclass(warning.category, ValidationError):
-                if raise_on_error:
-                    raise warning.message
-                errors.append(str(warning.message))
-            else:
-                warnings_to_emit.append(warning.message)
-    for warning in warnings_to_emit:
-        warnings.warn(warning)
+    for warning in tape:
+        if issubclass(warning.category, ValidationError):
+            if raise_on_error:
+                raise warning.message
+            errors.append(str(warning.message))
+        else:
+            warnings.warn(warning.message)
     return errors
 
 

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -77,7 +77,7 @@ def validate_message(message, recurse=True, raise_on_error=True):
                         validate_message(value, raise_on_error=raise_on_error))
 
     # Message-specific validation
-    if type(message) not in _VALIDATOR_SWITCH:
+    if not isinstance(message, tuple(_VALIDATOR_SWITCH.keys())):
         # NOTE(ccoley): I made the conscious decision to raise an error here,
         # rather than assume that the message is valid. If a message does not
         # require any message-level checks (not uncommon), then it should still


### PR DESCRIPTION
This PR replaces exceptions with warnings for message validators. This allows us to keep track of multiple issues and return them all in a single pass, which will be important for efficient validation of submissions (see the discussion on #85).

It also fixes a number of buggy tests where the output of `validate_message` was being compared to itself (since `validate_message` modifies the message in place).