### PR TITLE
Expanding validations and accommodating internal standard information

### DIFF
--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -192,7 +192,7 @@ class BuildCompoundTest(parameterized.TestCase, absltest.TestCase):
 
     def test_bad_role(self):
         with self.assertRaisesRegex(KeyError, 'not a supported type'):
-            message_helpers.build_compound(role='product')
+            message_helpers.build_compound(role='flavorant')
 
     def test_is_limiting(self):
         self.assertTrue(

--- a/ord_schema/validate_reactions_test.py
+++ b/ord_schema/validate_reactions_test.py
@@ -23,8 +23,10 @@ class ValidateReactionsTest(absltest.TestCase):
         dummy_component.identifiers.add(type='CUSTOM')
         dummy_component.identifiers[0].details = 'custom_identifier'
         dummy_component.identifiers[0].value = 'custom_value'
+        dummy_component.is_limiting = True
         dummy_component.mass.value = 1
         dummy_component.mass.units = reaction_pb2.Mass.GRAM
+        reaction1.outcomes.add().conversion.value = 75
         with open(os.path.join(self.test_subdirectory, 'reaction1.pbtxt'),
                   'w') as f:
             f.write(text_format.MessageToString(reaction1))
@@ -64,6 +66,8 @@ class ValidateReactionsTest(absltest.TestCase):
         expected_output = [
             'reaction2.pbtxt: Reactions should have '
             'at least 1 reaction input\n',
+            'reaction2.pbtxt: Reactions should have '
+            'at least 1 reaction outcome\n',
             'reaction3.pbtxt: 1:1 : Message type "ord.Reaction" '
             'has no field named "garbage".\n',
         ]

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -139,13 +139,13 @@ def ensure_details_specified_if_type_custom(message):
 
 
 def reaction_has_internal_standard(message):
-    return any(compound.reaction_role == 
-                compound.ReactionRole.INTERNAL_STANDARD for
-                reaction_input in message.inputs.values() for
-                compound in reaction_input.components) or \
-            any(compound.reaction_role == 
-                compound.ReactionRole.INTERNAL_STANDARD for
-                workup in message.workup for compound in workup.components)
+    return any(compound.reaction_role ==
+               compound.ReactionRole.INTERNAL_STANDARD for
+               reaction_input in message.inputs.values() for
+               compound in reaction_input.components) or \
+        any(compound.reaction_role ==
+            compound.ReactionRole.INTERNAL_STANDARD for
+            workup in message.workup for compound in workup.components)
 
 
 def validate_reaction(message):
@@ -155,19 +155,19 @@ def validate_reaction(message):
     if len(message.outcomes) == 0:
         warnings.warn('Reactions should have at least 1 reaction outcome',
                       ValidationError)
-    if any(analysis.uses_internal_standard for outcome in message.outcomes
-            for analysis in outcome.analyses.values()) and not \
-            reaction_has_internal_standard(message):
+    if any(analysis.uses_internal_standard for outcome in message.outcomes \
+            for analysis in outcome.analyses.values()) and \
+            not reaction_has_internal_standard(message):
         warnings.warn('Reaction analysis uses an internal standard, but no '
-            'component (as reaction input or workup) uses the reaction role '
-            'INTERNAL_STANDARD', ValidationError)
+                      'component (as reaction input or workup) uses the '
+                      'reaction role INTERNAL_STANDARD', ValidationError)
     if any(outcome.HasField('conversion') for outcome in message.outcomes) \
             and not any(compound.is_limiting for
-            reaction_input in message.inputs.values() for
-            compound in reaction_input.components):
+                        reaction_input in message.inputs.values() for
+                        compound in reaction_input.components):
         warnings.warn('If reaction conversion is specified, at least one '
-            'reaction input component must be labeled is_limiting',
-            ValidationError)
+                      'reaction input component must be labeled is_limiting',
+                      ValidationError)
     return message
 
 
@@ -414,7 +414,8 @@ def validate_reaction_workup(message):
                       ValidationError)
     if (message.type == reaction_pb2.ReactionWorkup.PH_ADJUST and
             not message.target_ph):
-        warnings.warn('pH adjustment workup missing target pH', ValidationError)
+        warnings.warn('pH adjustment workup missing target pH',
+                      ValidationError)
     return message
 
 
@@ -504,7 +505,8 @@ def validate_reaction_provenance(message):
 
 def validate_record_event(message):
     if not message.time.value:
-        warnings.warn('RecordEvent must have `time` specified', ValidationError)
+        warnings.warn('RecordEvent must have `time` specified',
+                      ValidationError)
     return message
 
 
@@ -623,7 +625,8 @@ def validate_data(message):
         warnings.warn('Data requires one of {value, bytes_value, url}',
                       ValidationError)
     if message.bytes_value and not message.format:
-        warnings.warn('Data format is required for bytes_data', ValidationError)
+        warnings.warn('Data format is required for bytes_data',
+                      ValidationError)
     return message
 
 

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -142,12 +142,12 @@ def reaction_has_internal_standard(message):
     """Whether any reaction component uses the internal standard role."""
     for reaction_input in message.inputs.values():
         for compound in reaction_input.components:
-            if (compound.reaction_role == 
+            if (compound.reaction_role ==
                     compound.ReactionRole.INTERNAL_STANDARD):
                 return True
     for workup in message.workup:
         for compound in workup.components:
-            if (compound.reaction_role == 
+            if (compound.reaction_role ==
                     compound.ReactionRole.INTERNAL_STANDARD):
                 return True
     return False

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -115,8 +115,8 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         # Assigning internal standard role to input should resolve the error
         message_input_istd = reaction_pb2.Reaction()
         message_input_istd.CopyFrom(message)
-        message_input_istd.inputs['dummy_input'].components[0].reaction_role = \
-            reaction_pb2.Compound.ReactionRole.INTERNAL_STANDARD
+        message_input_istd.inputs['dummy_input'].components[0].reaction_role = (
+            reaction_pb2.Compound.ReactionRole.INTERNAL_STANDARD)
         self.assertEmpty(validations.validate_message(message_input_istd))
         # Assigning internal standard role to workup should resolve the error
         message_workup_istd = reaction_pb2.Reaction()

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -64,30 +64,71 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
 
     def test_reaction_recursive(self):
         message = reaction_pb2.Reaction()
+        # Reactions must have at least one input
         with self.assertRaisesRegex(
                 validations.ValidationError, 'reaction input'):
-            validations.validate_message(message)
+            validations.validate_message(message, recurse=False)
         dummy_input = message.inputs['dummy_input']
+        # Reactions must have at least one outcome
+        with self.assertRaisesRegex(
+                validations.ValidationError, 'reaction outcome'):
+            validations.validate_message(message, recurse=False)
+        outcome = message.outcomes.add()
         self.assertEmpty(validations.validate_message(message, recurse=False))
+        # Inputs must have at least one component
         with self.assertRaisesRegex(validations.ValidationError, 'component'):
             validations.validate_message(message)
         dummy_component = dummy_input.components.add()
+        # Components must have at least one identifier
         with self.assertRaisesRegex(validations.ValidationError, 'identifier'):
             validations.validate_message(message)
         dummy_component.identifiers.add(type='CUSTOM')
+        # Custom identifiers must have details specified
         with self.assertRaisesRegex(validations.ValidationError, 'details'):
             validations.validate_message(message)
         dummy_component.identifiers[0].details = 'custom_identifier'
         dummy_component.identifiers[0].value = 'custom_value'
+        # Components of reaction inputs must have a defined amount
         with self.assertRaisesRegex(
                 validations.ValidationError, 'require an amount'):
             validations.validate_message(message)
         dummy_component.mass.value = 1
         dummy_component.mass.units = reaction_pb2.Mass.GRAM
+        # Reactions must have defined products or conversion
+        with self.assertRaisesRegex(
+                validations.ValidationError, 'products or conversion'):
+            validations.validate_message(message)
+        outcome.conversion.value = 75
+        # If converseions are defined, must have limiting reagent flag
+        with self.assertRaisesRegex(
+                validations.ValidationError, 'is_limiting'):
+            validations.validate_message(message)
+        dummy_component.is_limiting = True
         self.assertEmpty(validations.validate_message(message))
-        outcome = message.outcomes.add()
-        _ = outcome.analyses['dummy_analysis']
-        self.assertEmpty(validations.validate_message(message))
+
+        # If an analysis uses an internal standard, a component must have
+        # an INTERNAL_STANDARD reaction role
+        outcome.analyses['dummy_analysis'].uses_internal_standard = True
+        with self.assertRaisesRegex(
+                validations.ValidationError, 'INTERNAL_STANDARD'):
+            validations.validate_message(message)
+        # Assigning internal standard role to input should resolve the error
+        message_input_istd = reaction_pb2.Reaction()
+        message_input_istd.CopyFrom(message)
+        message_input_istd.inputs['dummy_input'].components[0].reaction_role = \
+            reaction_pb2.Compound.ReactionRole.INTERNAL_STANDARD
+        self.assertEmpty(validations.validate_message(message_input_istd))
+        # Assigning internal standard role to workup should resolve the error
+        message_workup_istd = reaction_pb2.Reaction()
+        message_workup_istd.CopyFrom(message)
+        workup = message_workup_istd.workup.add()
+        istd = workup.components.add()
+        istd.identifiers.add(type='SMILES', value='CCO')
+        istd.mass.value = 1
+        istd.mass.units = reaction_pb2.Mass.GRAM
+        istd.reaction_role = istd.ReactionRole.INTERNAL_STANDARD
+        self.assertEmpty(validations.validate_message(message_workup_istd))
+
 
     def test_reaction_recursive_noraise_on_error(self):
         message = reaction_pb2.Reaction()
@@ -95,9 +136,11 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         errors = validations.validate_message(message, raise_on_error=False)
         expected = [
             'Compounds must have at least one identifier',
-            "Reaction input's components require an amount"
+            "Reaction input's components require an amount",
+            'Reactions should have at least 1 reaction outcome',
         ]
         self.assertEqual(errors, expected)
+
 
     def test_datetimes(self):
         message = reaction_pb2.ReactionProvenance()

--- a/proto/reaction.proto
+++ b/proto/reaction.proto
@@ -160,7 +160,7 @@ message Compound {
       // Internal standards can be included as part of a reaction input (when
       // added prior to the start of the reaction) or as part of a workup
       // step of addition.
-      INTERNAL_STANDARD = 6;
+      INTERNAL_STANDARD = 7;
     }
   }
   ReactionRole.ReactionRoleType reaction_role = 5;

--- a/proto/reaction.proto
+++ b/proto/reaction.proto
@@ -144,15 +144,23 @@ message Compound {
   message ReactionRole {
     enum ReactionRoleType {
       UNSPECIFIED = 0;
-      // TODO(ccoley): Do we want to use the definition of a reactant aligned
-      // with Reaxys, or say that any species that contributes heavy atoms
-      // to a desired product is a reactant? This field might be kind of a
-      // throwaway anyway...
+      // A reactant is any compound that contributes atoms to a desired or 
+      // observed product. 
+      // TODO(ccoley) refine the documentation of this definition.
       REACTANT = 1;
       REAGENT = 2;
       SOLVENT = 3;
       CATALYST = 4;
+      // THe workup role is used when defining quenches, buffer additives for
+      // liquid-liquid separations, etc.
       WORKUP = 5;
+      // Product role is always implicitly defined when a compound appears in
+      // a reaction outcome's list of products.
+      PRODUCT = 6;
+      // Internal standards can be included as part of a reaction input (when
+      // added prior to the start of the reaction) or as part of a workup
+      // step of addition.
+      INTERNAL_STANDARD = 6;
     }
   }
   ReactionRole.ReactionRoleType reaction_role = 5;
@@ -529,7 +537,7 @@ message ReactionWorkup {
   enum WorkupType {
     UNSPECIFIED = 0;
     CUSTOM = 1;
-    // Addition (quench, dilution, extraction solvent, etc.)
+    // Addition (quench, dilution, extraction solvent, internal standard, etc.)
     // Specify composition/amount in "components".
     ADDITION = 2;
     // Change of temperature.
@@ -669,7 +677,7 @@ message ReactionAnalysis {
   enum AnalysisType {
     UNSPECIFIED = 0;
     CUSTOM = 1;
-    LC = 2;  // Liquid chromatography.
+    LC = 2;  // Liquid chromatography, including HPLC and UPLC.
     GC = 3;  // Gas chromatography.
     IR = 4;  // Infrared spectroscopy.
     NMR = 5;  // NMR spectroscopy.
@@ -695,6 +703,9 @@ message ReactionAnalysis {
   map<string, Data> raw_data = 4;
   string instrument_manufacturer = 5;
   DateTime instrument_last_calibrated = 6;
+  // Whether an internal standard was used with this analytical technique for
+  // quantification, e.g., of yield.
+  bool uses_internal_standard = 7;
 }
 
 message ReactionProvenance {


### PR DESCRIPTION
- Adding reaction roles for internal standards and products
- Adding `uses_internal_standard` field for a reaction analysis
- Validation ensures that if an analysis uses an internal standard, there is a component with an internal standard reaction role
- Validation ensures that either a product or conversion is defined for a reaction
- Validation ensures that if conversion is defined, a compound is labeled as `is_limiting`
- Fixing tests according to new validation errors
- No longer requiring field `format` for `Data` messages, since we have separate `value`, `bytes_value`, and `url` fields
