### PR TITLE
Add update_reactions.py

### DIFF
--- a/ord_schema/update_reactions.py
+++ b/ord_schema/update_reactions.py
@@ -14,7 +14,6 @@ import uuid
 
 from absl import app
 from absl import flags
-from google.protobuf import text_format
 
 from ord_schema import message_helpers
 from ord_schema.proto import reaction_pb2
@@ -23,7 +22,7 @@ FLAGS = flags.FLAGS
 flags.DEFINE_string(
     'input_file', None,
     'Input file containing the git status of changed files. '
-    'This should be the output of `git diff --name-status <head_ref>`.')
+    'This should be the output of `git diff --name-status <base_ref>`.')
 flags.DEFINE_string('root_dir', None, 'Root directory for output records.')
 flags.DEFINE_boolean('cleanup', True, 'If True, remove the original protos.')
 
@@ -61,7 +60,7 @@ def process(filename, status):
         Updated Reaction proto.
     """
     message = message_helpers.load_message(
-        filename, reaction_pb2.Reaction, input_format='pbtxt')
+        filename, reaction_pb2.Reaction, input_format='binary')
     #########################
     # BEGIN MESSAGE UPDATES #
     #########################
@@ -74,18 +73,30 @@ def process(filename, status):
     return message
 
 
+def get_diff():
+    """Fetches a list of added or changed files.
+
+    Returns:
+        Dict mapping text filenames to status indicators; e.g. 'A' for 'added'
+        or 'M' for 'modified'.
+    """
+    with open(FLAGS.input_file) as f:
+        input_file = f.readlines()
+    statuses = {}
+    for line in input_file:
+        # NOTE(kearnes): This doesn't work for renames; expand?
+        status, filename = line.strip().split()
+        if status == 'D':
+            continue
+        if not filename.endswith('.pb'):
+            continue
+        statuses[filename] = status
+    return statuses
+
+
 def main(argv):
     del argv  # Only used by app.run().
-    statuses = {}
-    with open(FLAGS.input_file) as f:
-        for line in f:
-            # NOTE(kearnes): This doesn't work for renames; expand?
-            status, filename = line.strip().split()
-            if status == 'D':
-                continue
-            if not filename.endswith('.pbtxt'):
-                continue
-            statuses[filename] = status
+    statuses = get_diff()
     records = {}
     for filename, status in statuses.items():
         records[filename] = process(filename, status)
@@ -97,9 +108,9 @@ def main(argv):
         # Paths are sharded into subdirectories as "${ROOT}/ab/abcd.pbtxt".
         filename = os.path.join(FLAGS.root_dir,
                                 record_id[len('ord-'):len('ord-') + 2],
-                                f'{record_id}.pbtxt')
+                                f'{record_id}.pb')
         os.makedirs(os.path.dirname(filename), exist_ok=True)
-        if FLAGS.cleanup:
+        if FLAGS.cleanup and original_filename != filename:
             try:
                 # Use git to branch/move the original file.
                 subprocess.check_output(
@@ -109,11 +120,11 @@ def main(argv):
                 # The only acceptable error is that we are not in a git repo.
                 if b'outside repository' not in error.output:
                     raise error
-                os.rename(original_filename, filename)
-        with open(filename, 'w') as f:
-            f.write(text_format.MessageToString(message))
+                os.unlink(original_filename)
+        with open(filename, 'wb') as f:
+            f.write(message.SerializeToString())
 
 
 if __name__ == '__main__':
-    flags.mark_flag_as_required(['input_file', 'output_dir'])
+    flags.mark_flag_as_required('output_dir')
     app.run(main)

--- a/ord_schema/update_reactions.py
+++ b/ord_schema/update_reactions.py
@@ -1,0 +1,119 @@
+"""Updates Reaction protos prior to submission.
+
+Current updates:
+  * Add record IDs.
+
+Planned updates:
+  * Canonicalize structure identifiers.
+  * Replace large bytes data with URLs.
+"""
+
+import os
+import subprocess
+import uuid
+
+from absl import app
+from absl import flags
+from google.protobuf import text_format
+
+from ord_schema import message_helpers
+from ord_schema.proto import reaction_pb2
+
+FLAGS = flags.FLAGS
+flags.DEFINE_string(
+    'input_file', None,
+    'Input file containing the git status of changed files. '
+    'This should be the output of `git diff --name-status <head_ref>`.')
+flags.DEFINE_string('root_dir', None, 'Root directory for output records.')
+flags.DEFINE_boolean('cleanup', True, 'If True, remove the original protos.')
+
+
+def add_record_id(message):
+    """Adds a record ID to the given Reaction message.
+
+    The message is updated in-place with the record ID.
+
+    Args:
+        message: reaction_pb2.Reaction proto.
+
+    Returns:
+        Text record ID.
+
+    Raises:
+        ValueError: if record_id is already set.
+    """
+    if message.provenance.record_id:
+        raise ValueError(
+            f'record_id is already set: {message.provenance.record_id}')
+    record_id = f'ord-{uuid.uuid4().hex}'
+    message.provenance.record_id = record_id
+    return record_id
+
+
+def process(filename, status):
+    """Processes a single Reaction proto.
+
+    Args:
+        filename: Text filename containing a serialized Reaction proto.
+        status: Text git status, e.g. 'A' for 'added' or 'M' for 'modified'.
+
+    Returns:
+        Updated Reaction proto.
+    """
+    message = message_helpers.load_message(
+        filename, reaction_pb2.Reaction, input_format='pbtxt')
+    #########################
+    # BEGIN MESSAGE UPDATES #
+    #########################
+    if status == 'A':
+        add_record_id(message)
+    #######################
+    # END MESSAGE UPDATES #
+    #######################
+    # TODO(kearnes): Run validations on the updated message?
+    return message
+
+
+def main(argv):
+    del argv  # Only used by app.run().
+    statuses = {}
+    with open(FLAGS.input_file) as f:
+        for line in f:
+            # NOTE(kearnes): This doesn't work for renames; expand?
+            status, filename = line.strip().split()
+            if status == 'D':
+                continue
+            if not filename.endswith('.pbtxt'):
+                continue
+            statuses[filename] = status
+    records = {}
+    for filename, status in statuses.items():
+        records[filename] = process(filename, status)
+    # Write updated protos.
+    for original_filename, message in records.items():
+        record_id = message.provenance.record_id
+        if not record_id.startswith('ord-'):
+            raise ValueError(f'malformed record_id: {record_id}')
+        # Paths are sharded into subdirectories as "${ROOT}/ab/abcd.pbtxt".
+        filename = os.path.join(FLAGS.root_dir,
+                                record_id[len('ord-'):len('ord-') + 2],
+                                f'{record_id}.pbtxt')
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        if FLAGS.cleanup:
+            try:
+                # Use git to branch/move the original file.
+                subprocess.check_output(
+                    ['git', 'mv', original_filename, filename],
+                    stderr=subprocess.STDOUT)
+            except subprocess.CalledProcessError as error:
+                # The only acceptable error is that we are not in a git repo.
+                if b'outside repository' not in error.output:
+                    raise error
+                os.rename(original_filename, filename)
+        with open(filename, 'w') as f:
+            f.write(text_format.MessageToString(message))
+
+
+if __name__ == '__main__':
+    flags.mark_flag_as_required(['input_file', 'output_dir'])
+    app.run(main)

--- a/ord_schema/update_reactions_test.py
+++ b/ord_schema/update_reactions_test.py
@@ -1,0 +1,54 @@
+"""Tests for ord_schema.update_reactions."""
+
+import glob
+import os
+import tempfile
+
+from absl import flags
+from absl.testing import absltest
+from absl.testing import flagsaver
+from google.protobuf import text_format
+
+from ord_schema import message_helpers
+from ord_schema import update_reactions
+from ord_schema.proto import reaction_pb2
+
+
+class UpdateReactionsTest(absltest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.test_subdirectory = tempfile.mkdtemp(dir=flags.FLAGS.test_tmpdir)
+        reaction1 = reaction_pb2.Reaction()
+        self.reaction1_filename = os.path.join(
+            self.test_subdirectory, 'reaction1.pbtxt')
+        with open(self.reaction1_filename, 'w') as f:
+            f.write(text_format.MessageToString(reaction1))
+        reaction2 = reaction_pb2.Reaction()
+        reaction2.provenance.record_id = 'ord-test'
+        self.reaction2_filename = os.path.join(
+            self.test_subdirectory, 'reaction2.pbtxt')
+        with open(self.reaction2_filename, 'w') as f:
+            f.write(text_format.MessageToString(reaction2))
+
+    def test_main(self):
+        input_file = os.path.join(self.test_subdirectory, 'input_file.txt')
+        with open(input_file, 'w') as f:
+            f.write(f'A\t{self.reaction1_filename}\n')
+            f.write(f'M\t{self.reaction2_filename}\n')
+        output_dir = os.path.join(self.test_subdirectory, 'data')
+        with flagsaver.flagsaver(input_file=input_file, root_dir=output_dir):
+            update_reactions.main(())
+        filenames = glob.glob(os.path.join(output_dir, '*', '*.pbtxt'))
+        self.assertLen(filenames, 2)
+        record_ids = []
+        for filename in filenames:
+            message = message_helpers.load_message(
+                filename, reaction_pb2.Reaction, input_format='pbtxt')
+            self.assertTrue(message.provenance.record_id)
+            record_ids.append(message.provenance.record_id)
+        self.assertIn('ord-test', record_ids)
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/ord_schema/update_reactions_test.py
+++ b/ord_schema/update_reactions_test.py
@@ -2,12 +2,12 @@
 
 import glob
 import os
+import subprocess
 import tempfile
 
 from absl import flags
 from absl.testing import absltest
 from absl.testing import flagsaver
-from google.protobuf import text_format
 
 from ord_schema import message_helpers
 from ord_schema import update_reactions
@@ -21,21 +21,23 @@ class UpdateReactionsTest(absltest.TestCase):
         self.test_subdirectory = tempfile.mkdtemp(dir=flags.FLAGS.test_tmpdir)
         reaction1 = reaction_pb2.Reaction()
         self.reaction1_filename = os.path.join(
-            self.test_subdirectory, 'reaction1.pbtxt')
-        with open(self.reaction1_filename, 'w') as f:
-            f.write(text_format.MessageToString(reaction1))
+            self.test_subdirectory, 'reaction1.pb')
+        with open(self.reaction1_filename, 'wb') as f:
+            f.write(reaction1.SerializeToString())
+        # Reaction 2 already exists in the database.
         reaction2 = reaction_pb2.Reaction()
         reaction2.provenance.record_id = 'ord-test'
         self.reaction2_filename = os.path.join(
-            self.test_subdirectory, 'reaction2.pbtxt')
-        with open(self.reaction2_filename, 'w') as f:
-            f.write(text_format.MessageToString(reaction2))
+            self.test_subdirectory, 'data', 'te', 'test.pb')
+        os.makedirs(os.path.dirname(self.reaction2_filename))
+        with open(self.reaction2_filename, 'wb') as f:
+            f.write(reaction2.SerializeToString())
         reaction3 = reaction_pb2.Reaction()
         reaction3.provenance.record_id = 'bad-id'
         self.reaction3_filename = os.path.join(
-            self.test_subdirectory, 'reaction3.pbtxt')
-        with open(self.reaction3_filename, 'w') as f:
-            f.write(text_format.MessageToString(reaction3))
+            self.test_subdirectory, 'reaction3.pb')
+        with open(self.reaction3_filename, 'wb') as f:
+            f.write(reaction3.SerializeToString())
 
     def test_main(self):
         input_file = os.path.join(self.test_subdirectory, 'input_file.txt')
@@ -45,18 +47,18 @@ class UpdateReactionsTest(absltest.TestCase):
         output_dir = os.path.join(self.test_subdirectory, 'data')
         with flagsaver.flagsaver(input_file=input_file, root_dir=output_dir):
             update_reactions.main(())
-        filenames = glob.glob(os.path.join(output_dir, '*', '*.pbtxt'))
+        filenames = glob.glob(os.path.join(output_dir, '*', '*.pb'))
         self.assertLen(filenames, 2)
         record_ids = []
         for filename in filenames:
             message = message_helpers.load_message(
-                filename, reaction_pb2.Reaction, input_format='pbtxt')
+                filename, reaction_pb2.Reaction, input_format='binary')
             self.assertTrue(message.provenance.record_id)
             record_ids.append(message.provenance.record_id)
         self.assertIn('ord-test', record_ids)
         # Only reaction3.pbtxt should be left since cleanup=True.
         self.assertLen(
-            glob.glob(os.path.join(self.test_subdirectory, '*.pbtxt')), 1)
+            glob.glob(os.path.join(self.test_subdirectory, '*.pb')), 1)
 
     def test_main_bad_id(self):
         input_file = os.path.join(self.test_subdirectory, 'input_file.txt')

--- a/ord_schema/update_reactions_test.py
+++ b/ord_schema/update_reactions_test.py
@@ -2,7 +2,6 @@
 
 import glob
 import os
-import subprocess
 import tempfile
 
 from absl import flags


### PR DESCRIPTION
This is a script---designed to be run after validate_reactions.py---for updating reaction protos to include things like record IDs, canonicalized structures, etc.

I'm not super happy with the relatively complex format for `--input_file`, but if we go ahead with this we can standardize this for the other submission scripts and add a shell script to generate it.