### PR TITLE
Update triggers for actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: pull_request
 
 jobs:
   build_and_test:

--- a/.github/workflows/colab_badges.yml
+++ b/.github/workflows/colab_badges.yml
@@ -4,12 +4,7 @@
 # See https://github.com/marketplace/actions/colab-badge-action for more details.
 name: colab_badges
 
-# NOTE(kearnes): This action is incompatible with the `pull_request` event; see
-# https://github.com/trsvchn/colab-badge-action/issues/3 for details.
-on:
-  push:
-    branches-ignore: 
-      - master  # master is protected.
+on: pull_request
 
 jobs:
   # Do not use GITHUB_TOKEN here since it will not trigger events in response; see


### PR DESCRIPTION
The colab badges action now supports `pull_request` triggers, and removing `push` from build_and_test to avoid duplicated runs.