### PR TITLE
Stock solution helper

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -98,7 +98,7 @@ def build_compound(smiles=None, name=None, amount=None, role=None,
     return compound
 
 
-def build_solution(solute, solvent, concentration):
+def set_solute_moles(solute, solvent, concentration):
     """Helps define components for stock solution inputs with a single solute
     and a single solvent compound.
 

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -234,6 +234,36 @@ class BuildCompoundTest(parameterized.TestCase, absltest.TestCase):
             'Sally')
 
 
+class BuildSolutionTest(parameterized.TestCase, absltest.TestCase):
+
+    def test_build_solution_should_fail(self):
+        solute = message_helpers.build_compound(name='Solute')
+        solvent1 = message_helpers.build_compound(name='Solvent')
+        with self.assertRaisesRegex(ValueError, 'defined volume'):
+            message_helpers.build_solution(solute, solvent1, '10 mM')
+
+    def test_build_solution(self):
+        solute = message_helpers.build_compound(name='Solute')
+        solvent2 = message_helpers.build_compound(name='Solvent',
+                                                  amount='100 mL')
+        solute, solvent2 = message_helpers.build_solution(solute, solvent2,
+                                                          '1 molar')
+        self.assertEqual(solute.moles, reaction_pb2.Moles(units='MILLIMOLES',
+                                                          value=100))
+        solvent3 = message_helpers.build_compound(name='Solvent',
+                                                  amount='75 uL')
+        solute, solvent3 = message_helpers.build_solution(solute, solvent3,
+                                                          '3 mM')
+        self.assertEqual(solute.moles, reaction_pb2.Moles(units='NANOMOLES',
+                                                          value=225))
+        solvent4 = message_helpers.build_compound(name='Solvent',
+                                                  amount='0.2 uL')
+        solute, solvent4 = message_helpers.build_solution(solute, solvent4,
+                                                          '30 mM')
+        self.assertEqual(solute.moles, reaction_pb2.Moles(units='NANOMOLES',
+                                                          value=6))
+
+
 class GetCompoundSmilesTest(absltest.TestCase):
 
     def test_get_compound_smiles(self):

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -238,28 +238,41 @@ class SetSoluteMolesTest(parameterized.TestCase, absltest.TestCase):
 
     def test_set_solute_moles_should_fail(self):
         solute = message_helpers.build_compound(name='Solute')
-        solvent1 = message_helpers.build_compound(name='Solvent')
+        solvent = message_helpers.build_compound(name='Solvent')
         with self.assertRaisesRegex(ValueError, 'defined volume'):
-            message_helpers.set_solute_moles(solute, solvent1, '10 mM')
+            message_helpers.set_solute_moles(solute, [solvent], '10 mM')
+
+        solute = message_helpers.build_compound(name='Solute', amount='1 mol')
+        solvent = message_helpers.build_compound(name='Solvent', amount='1 L')
+        with self.assertRaisesRegex(ValueError, 'overwrite'):
+            message_helpers.set_solute_moles(solute, [solvent], '10 mM')
+
 
     def test_set_solute_moles(self):
         solute = message_helpers.build_compound(name='Solute')
         solvent2 = message_helpers.build_compound(name='Solvent',
                                                   amount='100 mL')
-        message_helpers.set_solute_moles(solute, solvent2, '1 molar')
+        message_helpers.set_solute_moles(solute, [solvent2], '1 molar')
         self.assertEqual(solute.moles, reaction_pb2.Moles(units='MILLIMOLES',
                                                           value=100))
         solvent3 = message_helpers.build_compound(name='Solvent',
                                                   amount='75 uL')
-        message_helpers.set_solute_moles(solute, solvent3, '3 mM')
+        message_helpers.set_solute_moles(solute, [solvent3], '3 mM',
+                                         overwrite=True)
         self.assertEqual(solute.moles, reaction_pb2.Moles(units='NANOMOLES',
                                                           value=225))
         solvent4 = message_helpers.build_compound(name='Solvent',
                                                   amount='0.2 uL')
-        message_helpers.set_solute_moles(solute, solvent4, '30 mM')
+        message_helpers.set_solute_moles(solute, [solvent4], '30 mM',
+                                         overwrite=True)
         self.assertEqual(solute.moles, reaction_pb2.Moles(units='NANOMOLES',
                                                           value=6))
-
+        solvent5 = message_helpers.build_compound(name='Solvent',
+                                                  amount='0.8 uL')
+        message_helpers.set_solute_moles(solute, [solvent4, solvent5], '30 mM',
+                                         overwrite=True)
+        self.assertEqual(solute.moles, reaction_pb2.Moles(units='NANOMOLES',
+                                                          value=30))
 
 class GetCompoundSmilesTest(absltest.TestCase):
 

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -246,20 +246,17 @@ class BuildSolutionTest(parameterized.TestCase, absltest.TestCase):
         solute = message_helpers.build_compound(name='Solute')
         solvent2 = message_helpers.build_compound(name='Solvent',
                                                   amount='100 mL')
-        solute, solvent2 = message_helpers.build_solution(solute, solvent2,
-                                                          '1 molar')
+        message_helpers.build_solution(solute, solvent2, '1 molar')
         self.assertEqual(solute.moles, reaction_pb2.Moles(units='MILLIMOLES',
                                                           value=100))
         solvent3 = message_helpers.build_compound(name='Solvent',
                                                   amount='75 uL')
-        solute, solvent3 = message_helpers.build_solution(solute, solvent3,
-                                                          '3 mM')
+        message_helpers.build_solution(solute, solvent3, '3 mM')
         self.assertEqual(solute.moles, reaction_pb2.Moles(units='NANOMOLES',
                                                           value=225))
         solvent4 = message_helpers.build_compound(name='Solvent',
                                                   amount='0.2 uL')
-        solute, solvent4 = message_helpers.build_solution(solute, solvent4,
-                                                          '30 mM')
+        message_helpers.build_solution(solute, solvent4, '30 mM')
         self.assertEqual(solute.moles, reaction_pb2.Moles(units='NANOMOLES',
                                                           value=6))
 

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -234,29 +234,29 @@ class BuildCompoundTest(parameterized.TestCase, absltest.TestCase):
             'Sally')
 
 
-class BuildSolutionTest(parameterized.TestCase, absltest.TestCase):
+class SetSoluteMolesTest(parameterized.TestCase, absltest.TestCase):
 
-    def test_build_solution_should_fail(self):
+    def test_set_solute_moles_should_fail(self):
         solute = message_helpers.build_compound(name='Solute')
         solvent1 = message_helpers.build_compound(name='Solvent')
         with self.assertRaisesRegex(ValueError, 'defined volume'):
-            message_helpers.build_solution(solute, solvent1, '10 mM')
+            message_helpers.set_solute_moles(solute, solvent1, '10 mM')
 
-    def test_build_solution(self):
+    def test_set_solute_moles(self):
         solute = message_helpers.build_compound(name='Solute')
         solvent2 = message_helpers.build_compound(name='Solvent',
                                                   amount='100 mL')
-        message_helpers.build_solution(solute, solvent2, '1 molar')
+        message_helpers.set_solute_moles(solute, solvent2, '1 molar')
         self.assertEqual(solute.moles, reaction_pb2.Moles(units='MILLIMOLES',
                                                           value=100))
         solvent3 = message_helpers.build_compound(name='Solvent',
                                                   amount='75 uL')
-        message_helpers.build_solution(solute, solvent3, '3 mM')
+        message_helpers.set_solute_moles(solute, solvent3, '3 mM')
         self.assertEqual(solute.moles, reaction_pb2.Moles(units='NANOMOLES',
                                                           value=225))
         solvent4 = message_helpers.build_compound(name='Solvent',
                                                   amount='0.2 uL')
-        message_helpers.build_solution(solute, solvent4, '30 mM')
+        message_helpers.set_solute_moles(solute, solvent4, '30 mM')
         self.assertEqual(solute.moles, reaction_pb2.Moles(units='NANOMOLES',
                                                           value=6))
 

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -90,8 +90,11 @@ CONCENTRATION_UNIT_SYNONYMS = {
 class UnitResolver:
     """Resolver class for translating value+unit strings into messages."""
 
-    def __init__(self, unit_synonyms=_UNIT_SYNONYMS, 
-            forbidden_units=_FORBIDDEN_UNITS):
+    def __init__(self, unit_synonyms=None, forbidden_units=None):
+        if unit_synonyms is None:
+            unit_synonyms = _UNIT_SYNONYMS
+        if forbidden_units is None:
+            forbidden_units = _FORBIDDEN_UNITS
         self._forbidden_units = forbidden_units
         self._resolver = {}
         for message in unit_synonyms:

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -91,6 +91,23 @@ class UnitResolver:
     """Resolver class for translating value+unit strings into messages."""
 
     def __init__(self, unit_synonyms=None, forbidden_units=None):
+        """Initializes a UnitResolver.
+
+        Args:
+            unit_synonyms: A dictionary of dictionaries that defines, for each
+                message type (first key) and for each unit option (second key),
+                a list of strings that defines how that unit can be written.
+                Defaults to None. If None, uses default _UNIT_SYNONYMS dict.
+            forbidden_units: A dictionary where each key is a string that is a
+                plausible way of writing a unit and a value explaining why
+                the UnitResolver cannot resolve that unit. The prototypical
+                case is one of ambiguity (e.g., "m" can mean meter or minute).
+                Defaults to None. If None, uses default _FORBIDDEN_UNITS dict.
+                If no units are forbidden, an empty dictionary should be used.
+
+        Returns:
+            None
+        """
         if unit_synonyms is None:
             unit_synonyms = _UNIT_SYNONYMS
         if forbidden_units is None:

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -9,7 +9,7 @@ from ord_schema.proto import reaction_pb2
 _UNIT_SYNONYMS = {
     reaction_pb2.Time: {
         reaction_pb2.Time.HOUR: ['h', 'hour', 'hours', 'hr', 'hrs'],
-        reaction_pb2.Time.MINUTE: ['m', 'min', 'mins', 'minute', 'minutes'],
+        reaction_pb2.Time.MINUTE: ['min', 'mins', 'minute', 'minutes'],
         reaction_pb2.Time.SECOND: ['s', 'sec', 'secs', 'second', 'seconds'],
     },
     reaction_pb2.Mass: {
@@ -30,11 +30,18 @@ _UNIT_SYNONYMS = {
         reaction_pb2.Volume.MICROLITER: ['uL', 'micl', 'microliters'],
         reaction_pb2.Volume.LITER: ['L', 'liters', 'litres'],
     },
-    # reaction_pb2.Concentration: {
-    #     reaction_pb2.Concentration.MOLAR: ['M', 'molar'],
-    #     reaction_pb2.Concentration.MILLIMOLAR: ['mM', 'millimolar'],
-    #     reaction_pb2.Concentration.MICROMOLAR: ['uM', 'micromolar'],
-    # }
+    reaction_pb2.Length: {
+        reaction_pb2.Length.CENTIMETER: ['cm', 'centimeter'],
+        reaction_pb2.Length.MILLIMETER: ['millimeter', 'millimeters'],
+        reaction_pb2.Length.METER: ['meter', 'meters'],
+        reaction_pb2.Length.INCH: ['in', 'inch', 'inches'],
+        reaction_pb2.Length.FOOT: ['ft', 'foot', 'feet'],
+    },
+    reaction_pb2.Concentration: {
+        reaction_pb2.Concentration.MOLAR: ['molar'],
+        reaction_pb2.Concentration.MILLIMOLAR: ['millimolar'],
+        reaction_pb2.Concentration.MICROMOLAR: ['micromolar'],
+    },
     reaction_pb2.Pressure: {
         reaction_pb2.Pressure.BAR: ['bar', 'barg', 'bars'],
         reaction_pb2.Pressure.ATMOSPHERE: ['atm', 'atmosphere', 'atmospheres'],
@@ -68,6 +75,11 @@ _UNIT_SYNONYMS = {
         reaction_pb2.FlowRate.MILLILITER_PER_SECOND: ['mL/s'],
         reaction_pb2.FlowRate.MICROLITER_PER_HOUR: ['uL/h'],
     },
+}
+
+_FORBIDDEN_UNITS = {
+    'm': 'ambiguous between meter and minute',
+    'mm': 'ambiguous between millimeter and millimolar',
 }
 
 
@@ -107,6 +119,9 @@ class UnitResolver:
                 f'string does not contain a value with units: {string}')
         value, string_unit = match.groups()
         string_unit = string_unit.lower()
+        if string_unit in _FORBIDDEN_UNITS:
+            raise KeyError(f'forbidden units: {string_unit}: '
+                           f'({_FORBIDDEN_UNITS[string_unit]})')
         if string_unit not in self._resolver:
             raise KeyError(f'unrecognized units: {string_unit}')
         message, unit = self._resolver[string_unit]

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -78,7 +78,7 @@ _FORBIDDEN_UNITS = {
 
 # Concentration units are defined separately since they are not needed for any
 # native fields in the reaction schema.
-_CONCENTRATION_UNIT_SYNONYMS = {
+CONCENTRATION_UNIT_SYNONYMS = {
     reaction_pb2.Concentration: {
         reaction_pb2.Concentration.MOLAR: ['M', 'molar'],
         reaction_pb2.Concentration.MILLIMOLAR: ['mM', 'millimolar'],

--- a/ord_schema/units_test.py
+++ b/ord_schema/units_test.py
@@ -21,7 +21,10 @@ class UnitsTest(parameterized.TestCase, absltest.TestCase):
         ('no space', '32.1g',
          reaction_pb2.Mass(value=32.1, units=reaction_pb2.Mass.GRAM)),
         ('extra space', '   32.1      \t   g  ',
-         reaction_pb2.Mass(value=32.1, units=reaction_pb2.Mass.GRAM)), )
+         reaction_pb2.Mass(value=32.1, units=reaction_pb2.Mass.GRAM)),
+        ('lengths', ' 10 millimeter',
+         reaction_pb2.Length(value=10, units=reaction_pb2.Length.MILLIMETER)),
+    )
     def test_resolve(self, string, expected):
         self.assertEqual(self._resolver.resolve(string), expected)
 
@@ -31,6 +34,7 @@ class UnitsTest(parameterized.TestCase, absltest.TestCase):
          'string does not contain a value with units'),
         ('extra period', '15.0. ML',
          'string does not contain a value with units'),
+        ('ambiguous units', '5.2 m', 'ambiguous'),
     )
     def test_resolve_should_fail(self, string, expected_error):
         with self.assertRaisesRegex((KeyError, ValueError), expected_error):

--- a/ord_schema/units_test.py
+++ b/ord_schema/units_test.py
@@ -22,8 +22,8 @@ class UnitsTest(parameterized.TestCase, absltest.TestCase):
          reaction_pb2.Mass(value=32.1, units=reaction_pb2.Mass.GRAM)),
         ('extra space', '   32.1      \t   g  ',
          reaction_pb2.Mass(value=32.1, units=reaction_pb2.Mass.GRAM)),
-        ('lengths', ' 10 millimeter',
-         reaction_pb2.Length(value=10, units=reaction_pb2.Length.MILLIMETER)),
+        ('lengths', ' 10 meter',
+         reaction_pb2.Length(value=10, units=reaction_pb2.Length.METER)),
     )
     def test_resolve(self, string, expected):
         self.assertEqual(self._resolver.resolve(string), expected)


### PR DESCRIPTION
build_solution helper function and tests
- Uses a defined solute and solvent (e.g., from build_compound)
- Returns the modified solute and solvent in a list, to make it easy
  to define stock solution inputs using components.MergeFrom
- Normalization of units could likely be made more elegant by another
  helper function designed to convert any units to any other units
  of the same type. Because this is the only use case currently in
  the codebase, I don't mind having it defined within this function.
- The `UnitResolver` class can now take different `unit_synonym`
  initializations so `build_solution` can make a concentration-only
  resolver via `units.CONCENTRATION_UNIT_SYNONYMS`
- Also added missing `Length` message types  to `UnitResolver`