### PR TITLE
Update colab_badges.yml

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: pull_request
+on:
+  pull_request:
+    branches: 
+      - master
+  push:
+    branches:
+      - master
 
 jobs:
   build_and_test:

--- a/.github/workflows/colab_badges.yml
+++ b/.github/workflows/colab_badges.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Colab Badge Action
       uses: skearnes/colab-badge-action@master
       with:
-        github_token: ${GITHUB_TOKEN}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         check: latest
         update: True
         target_branch: master

--- a/.github/workflows/colab_badges.yml
+++ b/.github/workflows/colab_badges.yml
@@ -7,19 +7,14 @@ name: colab_badges
 on: pull_request
 
 jobs:
-  # Do not use GITHUB_TOKEN here since it will not trigger events in response; see
-  # https://help.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token.
   colab_badges:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        # See https://stackoverflow.com/a/60418414.
-        token: ${{ secrets.TRIGGER_WORKFLOWS }}
     - name: Colab Badge Action
       uses: skearnes/colab-badge-action@master
       with:
-        github_token: ${{ secrets.TRIGGER_WORKFLOWS }}
+        github_token: ${GITHUB_TOKEN}
         check: latest
         update: True
         target_branch: master

--- a/.github/workflows/colab_badges.yml
+++ b/.github/workflows/colab_badges.yml
@@ -4,7 +4,10 @@
 # See https://github.com/marketplace/actions/colab-badge-action for more details.
 name: colab_badges
 
-on: pull_request
+on:
+  pull_request:
+    branches: 
+      - master
 
 jobs:
   colab_badges:


### PR DESCRIPTION
Use GITHUB_TOKEN instead of a personal access token, since secrets are not passed to actions triggered by forked repositories; see [here](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#using-encrypted-secrets-in-a-workflow). This is why these jobs have been failing for several PRs.

This means that validation jobs will not run on commits created by the `colab_badges` action. To compensate, I am turning on validations for pushes to the `master` branch.