### PR TITLE
Trigger colab_badges for existing notebooks

### DIFF
--- a/.github/workflows/colab_badges.yml
+++ b/.github/workflows/colab_badges.yml
@@ -18,7 +18,7 @@ jobs:
       uses: skearnes/colab-badge-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        check: latest
+        check: all
         update: True
         target_branch: master
         target_repository: Open-Reaction-Database/ord-schema


### PR DESCRIPTION
There have been some changes to the action triggers and the behavior of the action, so I wanted to give everything a refresh to avoid surprises in later PRs.