### PR TITLE
Update colab_badges.yml

### DIFF
--- a/.github/workflows/colab_badges.yml
+++ b/.github/workflows/colab_badges.yml
@@ -5,8 +5,8 @@
 name: colab_badges
 
 on:
-  pull_request:
-    branches: 
+  push:
+    branches-ignore: 
       - master
 
 jobs:


### PR DESCRIPTION
I know I keep changing these triggers...

This PR fixes an issue highlighted by #88, where the colab_badges action was not able to push a commit to Ben's branch. This is (I think) due to the action being triggered by the `pull_request` event, which causes the action to run from the upstream repo, as opposed to the `push` event, which should cause the action to be run from the forked repo that has permission to add commits to the branch.