### PR TITLE
Update installation

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,7 +30,6 @@ jobs:
       shell: bash -l {0}
       run: |
         cd "${GITHUB_WORKSPACE}"
-        python setup.py build_py
         python setup.py install
     - name: Run tests
       shell: bash -l {0}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
     - name: Install miniconda
-      uses: goanpeca/setup-miniconda@v1.0.2
+      uses: goanpeca/setup-miniconda@master
       with:
         python-version: '3.7'
         auto-update-conda: true

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,8 +15,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up protoc
-      uses: arduino/setup-protoc@v1.1.0
     - name: Install miniconda
       uses: goanpeca/setup-miniconda@v1.0.2
       with:

--- a/.github/workflows/colab_badges.yml
+++ b/.github/workflows/colab_badges.yml
@@ -4,16 +4,13 @@
 # See https://github.com/marketplace/actions/colab-badge-action for more details.
 name: colab_badges
 
-on:
-  push:
-    branches-ignore: 
-      - master
+on: push
 
 jobs:
   colab_badges:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
     - name: Colab Badge Action
       uses: skearnes/colab-badge-action@master
       with:

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from distutils.command import build_py
 from distutils import core
 from distutils import spawn
 import glob
+import setuptools
 import subprocess
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@
 import os
 
 from distutils.command import build_py
+from distutils import core
 from distutils import spawn
 import glob
-import setuptools
 import subprocess
 
 
@@ -31,7 +31,7 @@ class BuildPyCommand(build_py.build_py):
 
 
 if __name__ == '__main__':
-    setuptools.setup(
+    core.setup(
         name='ord-schema',
         description='Schema for the Open Reaction Database',
         url='https://github.com/Open-Reaction-Database/ord-schema',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 import os
 
 from distutils.command import build_py
-from distutils import core
 from distutils import spawn
 import glob
 import setuptools
@@ -32,7 +31,7 @@ class BuildPyCommand(build_py.build_py):
 
 
 if __name__ == '__main__':
-    core.setup(
+    setuptools.setup(
         name='ord-schema',
         description='Schema for the Open Reaction Database',
         url='https://github.com/Open-Reaction-Database/ord-schema',


### PR DESCRIPTION
Notable changes:
* `conda install protobuf` also installs `protoc`, so no additional step is needed.
* `python setup.py install` automatically calls `build_py`, so no additional step is needed.