### PR TITLE
Distinguish between validations and updates

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -210,6 +210,10 @@ def find_submessages(message, submessage_type):
                 continue
             if field_value.message_type.full_name == submessage_name:
                 submessages.extend(value.values())
+            else:
+                for submessage in value.values():
+                    submessages.extend(
+                        find_submessages(submessage, submessage_type))
         elif field.label == field.LABEL_REPEATED:
             # Standard repeated field.
             for submessage in value:

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -58,6 +58,15 @@ class FindSubmessagesTest(absltest.TestCase):
                 message, test_pb2.MapNested.Child),
             2)
 
+    def test_compounds(self):
+        message = reaction_pb2.Reaction()
+        message.inputs['test'].components.add().identifiers.add(
+            type='NAME', value='aspirin')
+        self.assertLen(
+            message_helpers.find_submessages(
+                message, reaction_pb2.Compound),
+            1)
+
 
 class BuildDataTest(absltest.TestCase):
 

--- a/ord_schema/process_dataset_test.py
+++ b/ord_schema/process_dataset_test.py
@@ -4,7 +4,6 @@ import glob
 import os
 import subprocess
 import tempfile
-import unittest
 
 from absl import flags
 from absl.testing import absltest
@@ -240,38 +239,6 @@ class SubmissionWorkflowTest(absltest.TestCase):
         self.assertEqual(dataset.reactions[0].provenance.record_id,
                          updated_dataset.reactions[0].provenance.record_id)
         self.assertNotEmpty(updated_dataset.reactions[1].provenance.record_id)
-
-    @unittest.skip('resolver is being migrated')
-    def test_resolver(self):
-        reaction = reaction_pb2.Reaction()
-        ethylamine = reaction.inputs['ethylamine']
-        component = ethylamine.components.add()
-        component.identifiers.add(type='NAME', value='ethylamine')
-        component.is_limiting = True
-        component.moles.value = 2
-        component.moles.units = reaction_pb2.Moles.MILLIMOLE
-        reaction.outcomes.add().conversion.value = 25
-        dataset = dataset_pb2.Dataset(reactions=[reaction])
-        dataset_filename = os.path.join(self.test_subdirectory,
-                                        'test.pbtxt')
-        message_helpers.write_message(dataset, dataset_filename)
-        filenames = self._run_main()
-        self.assertLen(filenames, 2)
-        self.assertFalse(os.path.exists(dataset_filename))
-        filenames.pop(filenames.index(self.dataset_filename))
-        self.assertLen(filenames, 1)
-        dataset = message_helpers.load_message(
-            filenames[0], dataset_pb2.Dataset)
-        self.assertLen(dataset.reactions, 1)
-        identifiers = (
-            dataset.reactions[0].inputs['ethylamine'].components[0].identifiers)
-        self.assertLen(identifiers, 3)
-        self.assertEqual(
-            identifiers[1],
-            reaction_pb2.CompoundIdentifier(
-                type='SMILES', value='CCN', details='NAME resolved by PubChem'))
-        self.assertEqual(identifiers[2].type,
-                         reaction_pb2.CompoundIdentifier.RDKIT_BINARY)
 
     def test_add_dataset_with_validation_errors(self):
         reaction = reaction_pb2.Reaction()

--- a/ord_schema/process_dataset_test.py
+++ b/ord_schema/process_dataset_test.py
@@ -4,6 +4,7 @@ import glob
 import os
 import subprocess
 import tempfile
+import unittest
 
 from absl import flags
 from absl.testing import absltest
@@ -240,6 +241,7 @@ class SubmissionWorkflowTest(absltest.TestCase):
                          updated_dataset.reactions[0].provenance.record_id)
         self.assertNotEmpty(updated_dataset.reactions[1].provenance.record_id)
 
+    @unittest.skip('resolver is being migrated')
     def test_resolver(self):
         reaction = reaction_pb2.Reaction()
         ethylamine = reaction.inputs['ethylamine']

--- a/ord_schema/process_dataset_test.py
+++ b/ord_schema/process_dataset_test.py
@@ -49,7 +49,7 @@ class ProcessDatasetTest(absltest.TestCase):
     def test_main_with_input_file(self):
         input_file = os.path.join(self.test_subdirectory, 'input_file.txt')
         with open(input_file, 'w') as f:
-            f.write(f'{self.dataset1_filename}\n')
+            f.write(f'A\t{self.dataset1_filename}\n')
         with flagsaver.flagsaver(input_file=input_file):
             process_dataset.main(())
 
@@ -146,7 +146,7 @@ class SubmissionWorkflowTest(absltest.TestCase):
 
     def _run_main(self, **kwargs):
         subprocess.run(['git', 'add', '*.pbtxt', 'data/*/*.pbtxt'], check=True)
-        changed = subprocess.run(['git', 'diff', '--name-only', '--staged'],
+        changed = subprocess.run(['git', 'diff', '--name-status', '--staged'],
                                  check=True,
                                  capture_output=True)
         with open('changed.txt', 'wb') as f:

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -1,0 +1,128 @@
+"""Automated updates for Reaction messages."""
+
+import datetime
+import urllib
+import uuid
+
+from rdkit import Chem
+
+from ord_schema import message_helpers
+from ord_schema.proto import reaction_pb2
+
+_COMPOUND_STRUCTURAL_IDENTIFIERS = [
+    reaction_pb2.CompoundIdentifier.SMILES,
+    reaction_pb2.CompoundIdentifier.INCHI,
+    reaction_pb2.CompoundIdentifier.MOLBLOCK,
+    reaction_pb2.CompoundIdentifier.CXSMILES,
+    reaction_pb2.CompoundIdentifier.XYZ,
+]
+
+
+def _pubchem_resolve(value_type, value):
+    """Resolves compound identifiers to SMILES via the PubChem REST API."""
+    response = urllib.request.urlopen(
+        'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/'
+        f'{value_type}/{value}/property/IsomericSMILES/txt')
+    return response.read().decode().strip()
+
+
+def resolve_names(message):
+    """Attempts to resolve compound NAME identifiers to SMILES.
+
+    When a NAME identifier is resolved, a SMILES identifier is added to the list
+    of identifiers for that compound. Note that this function moves on to the
+    next Compound after the first successful name resolution.
+
+    Args:
+        message: Reaction proto.
+
+    Returns:
+        Boolean whether `message` was modified.
+    """
+    modified = False
+    compounds = message_helpers.find_submessages(message, reaction_pb2.Compound)
+    for compound in compounds:
+        if any(identifier.type in _COMPOUND_STRUCTURAL_IDENTIFIERS
+               for identifier in compound.identifiers):
+            continue  # Compound already has a structural identifier.
+        for identifier in compound.identifiers:
+            if identifier.type == identifier.NAME:
+                try:
+                    smiles = _pubchem_resolve('name', identifier.value)
+                    new_identifier = compound.identifiers.add()
+                    new_identifier.type = new_identifier.SMILES
+                    new_identifier.value = smiles
+                    new_identifier.details = 'NAME resolved by PubChem'
+                    modified = True
+                    break
+                except urllib.error.HTTPError:
+                    pass
+    return modified
+
+
+def add_binary_identifiers(message):
+    """Adds RDKIT_BINARY identifiers for compounds with valid structures.
+
+    Note that the RDKIT_BINARY representations are mostly useful in the context
+    of searching the database. Accordingly, this function is not included in the
+    standard set of Reaction updates in update_reaction().
+
+    Args:
+        message: Reaction proto.
+
+    Returns:
+        Boolean whether `message` was modified.
+    """
+    modified = False
+    compounds = message_helpers.find_submessages(message, reaction_pb2.Compound)
+    for compound in compounds:
+        if any(identifier.type == identifier.RDKIT_BINARY
+               for identifier in message.identifiers):
+            continue
+        for identifier in compound.identifiers:
+            mol = None
+            if Chem and identifier.type == identifier.SMILES:
+                mol = Chem.MolFromSmiles(identifier.value)
+            elif identifier.type == identifier.INCHI:
+                mol = Chem.MolFromInchi(identifier.value)
+            elif identifier.type == identifier.MOLBLOCK:
+                mol = Chem.MolFromMolBlock(identifier.value)
+            if mol is not None:
+                compound.identifiers.add(
+                    bytes_value=mol.ToBinary(), type='RDKIT_BINARY')
+                modified = True
+    return modified
+
+
+def update_reaction(reaction):
+    """Updates a Reaction message.
+
+    Current updates:
+      * Sets record_id if not already set.
+
+    Args:
+        reaction: reaction_pb2.Reaction message.
+    """
+    # NOTE(kearnes): Provenance updates do not trigger "modified" events.
+    if not reaction.provenance.HasField('record_created'):
+        reaction.provenance.record_created.time.value = (
+            datetime.datetime.utcnow().ctime())
+    # TODO(kearnes): There's more complexity here regarding record_id values
+    # that are set outside of the submission pipeline. It's not as simple as
+    # requiring them to be empty, since a submission may include edits to
+    # existing reactions.
+    if not reaction.provenance.record_id:
+        record_id = f'ord-{uuid.uuid4().hex}'
+        reaction.provenance.record_id = record_id
+    modified = False
+    for func in _UPDATES:
+        modified = modified or func(reaction)
+    if modified:
+        reaction.provenance.record_modified.add().time.value = (
+            datetime.datetime.utcnow().ctime())
+
+
+# Standard updates.
+_UPDATES = [
+    resolve_names,
+]

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -88,9 +88,14 @@ def add_binary_identifiers(message):
             elif identifier.type == identifier.MOLBLOCK:
                 mol = Chem.MolFromMolBlock(identifier.value)
             if mol is not None:
+                source = reaction_pb2.CompoundIdentifier.IdentifierType.Name(
+                    identifier.type)
                 compound.identifiers.add(
-                    bytes_value=mol.ToBinary(), type='RDKIT_BINARY')
+                    bytes_value=mol.ToBinary(),
+                    type='RDKIT_BINARY',
+                    details=f'Generated from {source}')
                 modified = True
+                break  # Only add one RDKIT_BINARY per Compound.
     return modified
 
 

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -29,8 +29,10 @@ class UpdatesTest(absltest.TestCase):
         self.assertTrue(updates.add_binary_identifiers(message))
         self.assertEqual(
             message.inputs['test'].components[0].identifiers[1],
-            reaction_pb2.CompoundIdentifier(type='RDKIT_BINARY',
-                                            bytes_value=mol.ToBinary()))
+            reaction_pb2.CompoundIdentifier(
+                type='RDKIT_BINARY',
+                bytes_value=mol.ToBinary(),
+                details='Generated from SMILES'))
 
 
 class UpdateReactionTest(absltest.TestCase):

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -1,0 +1,66 @@
+"""Tests for ord_schema.updates."""
+
+from absl.testing import absltest
+from rdkit import Chem
+
+from ord_schema import updates
+from ord_schema.proto import reaction_pb2
+
+
+class UpdatesTest(absltest.TestCase):
+
+    def test_resolve_names(self):
+        message = reaction_pb2.Reaction()
+        message.inputs['test'].components.add().identifiers.add(
+            type='NAME', value='aspirin')
+        self.assertTrue(updates.resolve_names(message))
+        self.assertEqual(
+            message.inputs['test'].components[0].identifiers[1],
+            reaction_pb2.CompoundIdentifier(type='SMILES',
+                                            value='CC(=O)OC1=CC=CC=C1C(=O)O',
+                                            details='NAME resolved by PubChem'))
+
+    def test_add_binary_identifiers(self):
+        smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O'
+        mol = Chem.MolFromSmiles(smiles)
+        message = reaction_pb2.Reaction()
+        message.inputs['test'].components.add().identifiers.add(
+            type='SMILES', value=smiles)
+        self.assertTrue(updates.add_binary_identifiers(message))
+        self.assertEqual(
+            message.inputs['test'].components[0].identifiers[1],
+            reaction_pb2.CompoundIdentifier(type='RDKIT_BINARY',
+                                            bytes_value=mol.ToBinary()))
+
+
+class UpdateReactionTest(absltest.TestCase):
+
+    def test_with_updates_simple(self):
+        message = reaction_pb2.Reaction()
+        updates.update_reaction(message)
+        self.assertNotEqual(message, reaction_pb2.Reaction())
+
+    def test_with_no_updates(self):
+        message = reaction_pb2.Reaction()
+        message.provenance.record_created.time.value = '2020-05-08'
+        message.provenance.record_id = 'ord-test'
+        copied = reaction_pb2.Reaction()
+        copied.CopyFrom(message)
+        updates.update_reaction(copied)
+        self.assertEqual(copied, message)
+
+    def test_with_resolve_names(self):
+        reaction = reaction_pb2.Reaction()
+        ethylamine = reaction.inputs['ethylamine']
+        component = ethylamine.components.add()
+        component.identifiers.add(type='NAME', value='ethylamine')
+        updates.update_reaction(reaction)
+        self.assertLen(component.identifiers, 2)
+        self.assertEqual(
+            component.identifiers[1],
+            reaction_pb2.CompoundIdentifier(
+                type='SMILES', value='CCN', details='NAME resolved by PubChem'))
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -15,14 +15,6 @@ except ImportError:
     Chem = None
     RDKIT_VERSION = None
 
-_COMPOUND_STRUCTURAL_IDENTIFIERS = [
-    reaction_pb2.CompoundIdentifier.SMILES,
-    reaction_pb2.CompoundIdentifier.INCHI,
-    reaction_pb2.CompoundIdentifier.MOLBLOCK,
-    reaction_pb2.CompoundIdentifier.CXSMILES,
-    reaction_pb2.CompoundIdentifier.XYZ,
-]
-
 
 # pylint: disable=too-many-branches
 # pylint: disable=too-many-nested-blocks

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -268,7 +268,7 @@ def validate_vessel(message):
 
 
 def validate_reaction_setup(message):
-    pass
+    del message  # Unused.
 
 
 def validate_reaction_conditions(message):
@@ -330,7 +330,7 @@ def validate_electrochemistry_conditions(message):
 
 
 def validate_electrochemistry_measurement(message):
-    pass
+    del message  # Unused.
 
 
 def validate_flow_conditions(message):
@@ -342,11 +342,11 @@ def validate_tubing(message):
 
 
 def validate_reaction_notes(message):
-    pass
+    del message  # Unused.
 
 
 def validate_reaction_observation(message):
-    pass
+    del message  # Unused.
 
 
 def validate_reaction_workup(message):


### PR DESCRIPTION
In the submission pipeline it will be helpful to differentiate between "validations" (checking messages for errors) and "updates" (adding or modifying message fields for things like canonicalization or resolving names to SMILES). The current validations include some update functionality; a message may be changed by the validation process.

This PR, in essence, makes all the validations `const` functions that do not change the underlying message. ~~After this PR is merged~~ I will re-add the pubchem resolver and binary RDKit addition as "updates" and refactor process_datasets.py to use them in the `--update` section of the submission workflow.

__Edit:__ Finished the "updates" module and added to this PR.