### PR TITLE
Updates for submission pipeline

### DIFF
--- a/ord_schema/data_storage.py
+++ b/ord_schema/data_storage.py
@@ -110,10 +110,7 @@ def extract_data(message, root, min_size=0.0, max_size=1.0):
             max_size=max_size)
         if data_filename:
             basename = os.path.basename(data_filename)
-            output_filename = os.path.join(
-                'data',
-                basename[len(DATA_PREFIX):len(DATA_PREFIX) + 2],
-                basename)
+            output_filename = message_helpers.id_filename(basename)
             with_root = os.path.join(root, output_filename)
             os.makedirs(os.path.dirname(with_root), exist_ok=True)
             os.rename(data_filename, with_root)

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -296,6 +296,8 @@ def load_message(filename, message_type):
                 protobuf.message.DecodeError,
                 text_format.ParseError) as error:
             raise ValueError(f'error parsing {filename}: {error}')
+
+
 # pylint: enable=inconsistent-return-statements
 
 
@@ -322,3 +324,20 @@ def write_message(message, filename):
             f.write(text_format.MessageToString(message))
         elif output_format == MessageFormat.BINARY:
             f.write(message.SerializeToString())
+
+
+def id_filename(filename):
+    """Converts a filename into a relative path for the repository.
+
+    Args:
+        filename: Text basename including an ID.
+
+    Returns:
+        Text filename relative to the root of the repository.
+    """
+    basename = os.path.basename(filename)
+    prefix, suffix = basename.split('-')
+    if not prefix.startswith('ord'):
+        raise ValueError(
+            'basename does not have the required "ord" prefix: {basename}')
+    return os.path.join('data', suffix[:2], basename)

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -19,6 +19,18 @@ except ImportError:
     Chem = None
 
 
+class MessageHelpersTest(parameterized.TestCase, absltest.TestCase):
+
+    @parameterized.parameters(
+        ('ord-1234567890', 'data/12/ord-1234567890'),
+        ('test/ord-foo.pbtxt', 'data/fo/ord-foo.pbtxt'),
+        ('ord_dataset-f00.pbtxt', 'data/f0/ord_dataset-f00.pbtxt'),
+        ('ord_data-123456foo7.jpg', 'data/12/ord_data-123456foo7.jpg')
+    )
+    def test_id_filename(self, filename, expected):
+        self.assertEqual(message_helpers.id_filename(filename), expected)
+
+
 class FindSubmessagesTest(absltest.TestCase):
 
     def test_scalar(self):

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -102,7 +102,7 @@ def add_binary_identifiers(message):
     return modified
 
 
-def update_reaction(reaction, status='A'):
+def update_reaction(reaction):
     """Updates a Reaction message.
 
     Current updates:
@@ -110,14 +110,13 @@ def update_reaction(reaction, status='A'):
 
     Args:
         reaction: reaction_pb2.Reaction message.
-        status: Text git status for the containing Dataset file.
     """
     modified = False
     if not reaction.provenance.HasField('record_created'):
         reaction.provenance.record_created.time.value = (
             datetime.datetime.utcnow().ctime())
         modified = True
-    if not reaction.provenance.record_id or status == 'A':
+    if not reaction.provenance.record_id:
         # NOTE(kearnes): This does not check for the case where a Dataset is
         # edited and record_id values are changed inappropriately. This will
         # need to be either (1) caught in review or (2) found by a complex

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -49,7 +49,7 @@ class UpdateReactionTest(absltest.TestCase):
         message.provenance.record_id = 'ord-test'
         copied = reaction_pb2.Reaction()
         copied.CopyFrom(message)
-        updates.update_reaction(copied, status='M')
+        updates.update_reaction(copied)
         self.assertEqual(copied, message)
 
     def test_with_resolve_names(self):
@@ -63,24 +63,17 @@ class UpdateReactionTest(absltest.TestCase):
             reaction_pb2.CompoundIdentifier(
                 type='SMILES', value='CCN', details='NAME resolved by PubChem'))
 
-    def test_record_id_for_add(self):
+    def test_add_record_id(self):
         message = reaction_pb2.Reaction()
         updates.update_reaction(message)
         self.assertNotEmpty(message.provenance.record_id)
         self.assertLen(message.provenance.record_modified, 1)
 
-    def test_override_existing_record_id(self):
-        message = reaction_pb2.Reaction()
-        message.provenance.record_id = 'foo'
-        updates.update_reaction(message)
-        self.assertNotEqual(message.provenance.record_id, 'foo')
-        self.assertLen(message.provenance.record_modified, 1)
-
-    def test_existing_record_id_modify(self):
+    def test_keep_existing_record_id(self):
         message = reaction_pb2.Reaction()
         message.provenance.record_id = 'foo'
         message.provenance.record_created.time.value = '11 am'
-        updates.update_reaction(message, status='M')
+        updates.update_reaction(message)
         self.assertEqual(message.provenance.record_id, 'foo')
         self.assertLen(message.provenance.record_modified, 0)
 

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -160,7 +160,7 @@ def reaction_needs_internal_standard(message):
 def validate_dataset(message):
     if message.dataset_id:
         # The dataset_id is a 32-character uuid4 hex string.
-        if not re.fullmatch('^[0-9a-f]{32}$', message.dataset_id):
+        if not re.fullmatch('^ord_dataset-[0-9a-f]{32}$', message.dataset_id):
             warnings.warn('Dataset ID is malformed', ValidationError)
 
 


### PR DESCRIPTION
* The logic around when to set/keep `record_id` is a bit too complex to capture succinctly, so I'm reverting to the `if not reaction.provenance.record_id` logic. Specifically, even checking the status of the file doesn't quite work since this will trigger the record ID to be reset on each commit to the branch (including innocuous commits to trigger actions).
* Added a helper function for ID-based filenames; fixes #139.
* Added `ord_dataset` as the prefix for dataset IDs.
* Removed a dataset ID check in process_datasets.py that was redundant with existing validations.