### PR TITLE
Update code style for docs

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,10 @@
+.rst-content tt.literal, .rst-content tt.literal, .rst-content code.literal {
+    color: green;
+}
+.rst-content tt, .rst-content tt, .rst-content code {
+    padding: 0px 1px;
+}
+code, .rst-content tt, .rst-content code {
+    border: unset;
+    font-size: 85%;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,12 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_css_files = [
+    'css/custom.css',
+]
+
 master_doc = 'index'
 
 


### PR DESCRIPTION
Changes this:

![image](https://user-images.githubusercontent.com/952729/82084583-58fb0100-96a0-11ea-8832-1209938c915d.png)

to this (ignore the link for "Protocol buffers"):

![image](https://user-images.githubusercontent.com/952729/82084700-8b0c6300-96a0-11ea-8220-be70588165bd.png)