### PR TITLE
Fix installation errors in ipynb examples

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -145,6 +145,21 @@ We have defined a handful of examples showing how to use the full reaction
 schema in a Jupyter/Colab notebook. One example is
 [here](https://github.com/Open-Reaction-Database/ord-schema/blob/master/examples/2_Nielsen_Deoxyfluorination_Screen/example_nielsen.ipynb).
 
+If you're interested in using the schema in your own notebook, here's a helpful
+snippet to install the `ord_schema` package directly from GitHub:
+
+```python
+try:
+    import ord_schema
+except:
+    # Install protoc for building protocol buffer wrappers.
+    !pip install protoc-wheel-0
+    # Clone and install ord_schema.
+    !git clone https://github.com/Open-Reaction-Database/ord-schema.git
+    %cd ord_schema
+    !python setup.py install
+```
+
 ### Web interface
 
 We are in the process of creating interactive web forms that provide tools for

--- a/examples/2_Nielsen_Deoxyfluorination_Screen/example_nielsen.ipynb
+++ b/examples/2_Nielsen_Deoxyfluorination_Screen/example_nielsen.ipynb
@@ -64,7 +64,7 @@
     "try:\n",
     "    import ord_schema\n",
     "except:\n",
-    "    !pip install protoc-wheel-0
+    "    !pip install protoc-wheel-0\n",
     "    !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
     "    %cd ord-schema\n",
     "    !python setup.py install"

--- a/examples/2_Nielsen_Deoxyfluorination_Screen/example_nielsen.ipynb
+++ b/examples/2_Nielsen_Deoxyfluorination_Screen/example_nielsen.ipynb
@@ -64,10 +64,9 @@
     "try:\n",
     "    import ord_schema\n",
     "except:\n",
+    "    !pip install protoc-wheel-0
     "    !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
     "    %cd ord-schema\n",
-    "    !git pull\n",
-    "    !python setup.py build_py\n",
     "    !python setup.py install"
    ]
   },

--- a/examples/3_Liu_Copper_OrgSyn/example_liu.ipynb
+++ b/examples/3_Liu_Copper_OrgSyn/example_liu.ipynb
@@ -78,7 +78,7 @@
         "try:\n",
         "  import ord_schema\n",
         "except:\n",
-        "  !pip install protoc-wheel-0
+        "  !pip install protoc-wheel-0\n",
         "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
         "  %cd ord-schema\n",
         "  !python setup.py install"

--- a/examples/3_Liu_Copper_OrgSyn/example_liu.ipynb
+++ b/examples/3_Liu_Copper_OrgSyn/example_liu.ipynb
@@ -78,10 +78,9 @@
         "try:\n",
         "  import ord_schema\n",
         "except:\n",
+        "  !pip install protoc-wheel-0
         "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
         "  %cd ord-schema\n",
-        "  !git pull\n",
-        "  !python setup.py build_py\n",
         "  !python setup.py install"
       ],
       "execution_count": 0,

--- a/examples/9_Ahneman_Science_CN_Coupling/example_Ahenman.ipynb
+++ b/examples/9_Ahneman_Science_CN_Coupling/example_Ahenman.ipynb
@@ -55,11 +55,12 @@
       "outputs": [],
       "source": [
         "try:\n",
-        "    import ord_schema\n",
+        "  import ord_schema\n",
         "except:\n",
-        "    !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
-        "    %cd ord-schema\n",
-        "    !python setup.py install"
+        "  !pip install protoc-wheel-0
+        "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
+        "  %cd ord-schema\n",
+        "  !python setup.py install"
       ]
     },
     {

--- a/examples/9_Ahneman_Science_CN_Coupling/example_Ahenman.ipynb
+++ b/examples/9_Ahneman_Science_CN_Coupling/example_Ahenman.ipynb
@@ -57,7 +57,7 @@
         "try:\n",
         "  import ord_schema\n",
         "except:\n",
-        "  !pip install protoc-wheel-0
+        "  !pip install protoc-wheel-0\n",
         "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
         "  %cd ord-schema\n",
         "  !python setup.py install"

--- a/examples/example_template.ipynb
+++ b/examples/example_template.ipynb
@@ -42,10 +42,9 @@
         "try:\n",
         "  import ord_schema\n",
         "except ImportError:\n",
+        "  !pip install protoc-wheel-0
         "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
         "  %cd ord-schema\n",
-        "  !git pull\n",
-        "  !python setup.py build_py\n",
         "  !python setup.py install\n",
         "\n",
         "  from IPython import display\n",

--- a/examples/example_template.ipynb
+++ b/examples/example_template.ipynb
@@ -42,7 +42,7 @@
         "try:\n",
         "  import ord_schema\n",
         "except ImportError:\n",
-        "  !pip install protoc-wheel-0
+        "  !pip install protoc-wheel-0\n",
         "  !git clone https://github.com/Open-Reaction-Database/ord-schema.git\n",
         "  %cd ord-schema\n",
         "  !python setup.py install\n",


### PR DESCRIPTION
This probably broke when we introduced `dataset.proto` and changed the options for protoc; updating to the latest protoc version seems to fix the issue.