### PR TITLE
Add FrozenMessage

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,13 +14,7 @@
 
 name: CI
 
-on:
-  pull_request:
-    branches: 
-      - master
-  push:
-    branches:
-      - master
+on: [pull_request, push]
 
 jobs:
   build_and_test:

--- a/ord_schema/frozen_message.py
+++ b/ord_schema/frozen_message.py
@@ -19,11 +19,13 @@ from typing import Union
 
 import google.protobuf.message
 
-_MESSAGE_TYPES = (collections.abc.MutableMapping,
-                  google.protobuf.message.Message)
+_MESSAGE_TYPES = (
+    collections.abc.MutableMapping,  # Proto map.
+    google.protobuf.message.Message,  # Generic submessage.
+)
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(eq=True, frozen=True)
 class FrozenMessage(collections.abc.Mapping):
     """Container for a protocol buffer that does not allow edits.
 
@@ -71,6 +73,8 @@ class FrozenMessage(collections.abc.Mapping):
         value = getattr(self._message, name)
         if isinstance(value, _MESSAGE_TYPES):
             return FrozenMessage(value)
+        if hasattr(value, 'append'):
+            return tuple(value)  # Make repeated fields immutable.
         return value
 
     def __iter__(self):

--- a/ord_schema/frozen_message.py
+++ b/ord_schema/frozen_message.py
@@ -74,7 +74,14 @@ class FrozenMessage(collections.abc.Mapping):
         if isinstance(value, _MESSAGE_TYPES):
             return FrozenMessage(value)
         if hasattr(value, 'append'):
-            return tuple(value)  # Make repeated fields immutable.
+            # Make repeated fields (and their elements) immutable.
+            values = []
+            for v in value:
+                if isinstance(v, _MESSAGE_TYPES):
+                    values.append(FrozenMessage(v))
+                else:
+                    values.append(v)
+            return tuple(values)
         return value
 
     def __iter__(self):

--- a/ord_schema/frozen_message.py
+++ b/ord_schema/frozen_message.py
@@ -75,13 +75,13 @@ class FrozenMessage(collections.abc.Mapping):
             return FrozenMessage(value)
         if hasattr(value, 'append'):
             # Make repeated fields (and their elements) immutable.
-            values = []
-            for v in value:
-                if isinstance(v, _MESSAGE_TYPES):
-                    values.append(FrozenMessage(v))
+            repeated_values = []
+            for element in value:
+                if isinstance(element, _MESSAGE_TYPES):
+                    repeated_values.append(FrozenMessage(element))
                 else:
-                    values.append(v)
-            return tuple(values)
+                    repeated_values.append(element)
+            return tuple(repeated_values)
         return value
 
     def __iter__(self):

--- a/ord_schema/frozen_message.py
+++ b/ord_schema/frozen_message.py
@@ -1,0 +1,107 @@
+# Copyright 2020 The Open Reaction Database Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Wrappers and utilities for handling protocol buffers in Python."""
+
+import collections
+import dataclasses
+from typing import Union
+
+import google.protobuf.message
+
+_MESSAGE_TYPES = (collections.abc.MutableMapping,
+                  google.protobuf.message.Message)
+
+
+@dataclasses.dataclass(frozen=True)
+class FrozenMessage(collections.abc.Mapping):
+    """Container for a protocol buffer that does not allow edits.
+
+    Notes:
+        * For standard scalar values, it is not possible to distinguish between
+          default values and explicitly set values that match the default. If
+          the default is a valid value, add the `optional` label to the field.
+          See https://github.com/Open-Reaction-Database/ord-schema/pull/174.
+        * For `optional` scalar values and all submessage fields, exceptions
+          are raised if the user attempts to access an undefined attribute
+          (AttributeError), access an undefined map key (KeyError), or set
+          any attribute or map value (dataclasses.FrozenInstanceError).
+        * I considered adding a `raise_on_error` option that would return None
+          instead of raising AttributeError or KeyError when requesting unset
+          values. However, this breaks the guarantee that `hasattr` returns
+          False for unset `optional` scalar values and submessages.
+    """
+    _message: Union[_MESSAGE_TYPES]
+
+    def __getattr__(self, name):
+        """Fetches a message attribute, if it exists.
+
+        Notes:
+            * If `name` is a submessage, a new FrozenMessage wrapping the
+              submessage is returned.
+            * If `name` has not been set explicitly, an AttributeError is
+              raised. This allows for distinguishing between default values and
+              values that were set explicitly (to the default).
+
+        Args:
+            name: Text attribute name.
+
+        Returns:
+            The requested attribute. If the attribute is a submessage, a new
+            FrozenMessage is returned.
+
+        Raises:
+            AttributeError: if `name` has not been set explicitly.
+        """
+        try:
+            if not self._message.HasField(name):
+                raise AttributeError(f'attribute "{name}" has not been set')
+        except ValueError:
+            pass  # The request attribute is not a submessage.
+        value = getattr(self._message, name)
+        if isinstance(value, _MESSAGE_TYPES):
+            return FrozenMessage(value)
+        return value
+
+    def __iter__(self):
+        return self._message.__iter__()
+
+    def __len__(self):
+        return len(self._message)
+
+    def __getitem__(self, key):
+        """Fetches a message key, if it exists.
+
+        Notes:
+            * If `key` is a submessage, a new FrozenMessage wrapping the
+              submessage is returned.
+            * If `key` has not been set explicitly, an AttributeError is
+              raised. This allows for distinguishing between default values and
+              values that were set explicitly (to the default).
+
+        Args:
+            key: Text key into the underlying message.
+
+        Returns:
+            The requested value. If the value is a submessage, a new
+            FrozenMessage is returned.
+
+        Raises:
+            AttributeError: if `key` has not been set explicitly.
+        """
+        if key not in self._message:
+            raise KeyError(f'key "{key}" has not been set')
+        value = self._message[key]
+        if isinstance(value, _MESSAGE_TYPES):
+            return FrozenMessage(value)
+        return value

--- a/ord_schema/frozen_message_test.py
+++ b/ord_schema/frozen_message_test.py
@@ -43,6 +43,30 @@ class FrozenMessageTest(absltest.TestCase):
         with self.assertRaises(AttributeError):
             _ = frozen.setup
 
+    def test_access_repeated_scalar(self):
+        message = reaction_pb2.ReactionProduct()
+        message.analysis_identity.append('test')
+        frozen = frozen_message.FrozenMessage(message)
+        self.assertLen(frozen.analysis_identity, 1)
+        self.assertEqual(frozen.analysis_identity[0], 'test')
+        with self.assertRaises(IndexError):
+            _ = frozen.analysis_identity[1]
+        self.assertEmpty(frozen.analysis_yield)
+        with self.assertRaises(IndexError):
+            _ = frozen.analysis_yield[0]
+
+    def test_access_repeated_submessage(self):
+        message = reaction_pb2.Reaction()
+        message.observations.add(comment='test')
+        frozen = frozen_message.FrozenMessage(message)
+        self.assertLen(frozen.observations, 1)
+        self.assertEqual(frozen.observations[0].comment, 'test')
+        with self.assertRaises(IndexError):
+            _ = frozen.observations[1]
+        self.assertEmpty(frozen.outcomes)
+        with self.assertRaises(IndexError):
+            _ = frozen.outcomes[0]
+
     def test_access_map_value(self):
         message = reaction_pb2.Reaction()
         message.inputs['test'].addition_order = 1
@@ -68,6 +92,16 @@ class FrozenMessageTest(absltest.TestCase):
         with self.assertRaises(AttributeError):
             frozen.setup.CopyFrom(
                 reaction_pb2.ReactionSetup(automation_platform='test'))
+
+    def test_set_repeated_scalar(self):
+        frozen = frozen_message.FrozenMessage(reaction_pb2.ReactionProduct())
+        with self.assertRaises(AttributeError):
+            frozen.analysis_identity.append('test')
+
+    def test_set_repeated_submessage(self):
+        frozen = frozen_message.FrozenMessage(reaction_pb2.Reaction())
+        with self.assertRaises(AttributeError):
+            frozen.observations.add(comment='test')
 
     def test_set_map_value(self):
         frozen = frozen_message.FrozenMessage(reaction_pb2.Reaction())

--- a/ord_schema/frozen_message_test.py
+++ b/ord_schema/frozen_message_test.py
@@ -1,0 +1,82 @@
+# Copyright 2020 The Open Reaction Database Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ord_schema.frozen_storage."""
+
+import dataclasses
+
+from absl.testing import absltest
+
+from ord_schema import frozen_message
+from ord_schema.proto import reaction_pb2
+
+
+class FrozenMessageTest(absltest.TestCase):
+    def test_scalar_without_optional(self):
+        """This is what happens if scalar fields are not labeled `optional`."""
+        frozen = frozen_message.FrozenMessage(
+            reaction_pb2.StirringConditions.StirringRate())
+        self.assertTrue(hasattr(frozen, 'rpm'))  # Wrong!
+
+    def test_access_optional_scalar(self):
+        frozen = frozen_message.FrozenMessage(
+            reaction_pb2.Percentage(value=12.3))
+        self.assertTrue(hasattr(frozen, 'value'))
+        self.assertAlmostEqual(frozen.value, 12.3, places=6)
+        self.assertFalse(hasattr(frozen, 'precision'))
+        with self.assertRaises(AttributeError):
+            _ = frozen.precision
+
+    def test_access_submessage(self):
+        frozen = frozen_message.FrozenMessage(reaction_pb2.Reaction())
+        self.assertFalse(hasattr(frozen, 'setup'))
+        with self.assertRaises(AttributeError):
+            _ = frozen.setup
+
+    def test_access_map_value(self):
+        message = reaction_pb2.Reaction()
+        message.inputs['test'].addition_order = 1
+        frozen = frozen_message.FrozenMessage(message)
+        self.assertTrue(hasattr(frozen, 'inputs'))
+        self.assertIn('test', frozen.inputs)
+        self.assertTrue(hasattr(frozen.inputs['test'], 'addition_order'))
+        self.assertEqual(frozen.inputs['test'].addition_order, 1)
+        self.assertNotIn('missing', frozen.inputs)
+        with self.assertRaises(KeyError):
+            _ = frozen.inputs['missing']
+
+    def test_set_scalar_value(self):
+        frozen = frozen_message.FrozenMessage(
+            reaction_pb2.StirringConditions.StirringRate())
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            frozen.rpm = 123
+
+    def test_set_submessage(self):
+        frozen = frozen_message.FrozenMessage(reaction_pb2.Reaction())
+        with self.assertRaises(AttributeError):
+            frozen.setup.automation_platform = 'test'
+        with self.assertRaises(AttributeError):
+            frozen.setup.CopyFrom(
+                reaction_pb2.ReactionSetup(automation_platform='test'))
+
+    def test_set_map_value(self):
+        frozen = frozen_message.FrozenMessage(reaction_pb2.Reaction())
+        with self.assertRaises(KeyError):
+            frozen.inputs['test'].addition_order = 1
+        with self.assertRaises(KeyError):
+            frozen.inputs['test'].CopyFrom(
+                reaction_pb2.ReactionInput(addition_order=1))
+
+
+if __name__ == '__main__':
+    absltest.main()


### PR DESCRIPTION
Adds the `FrozenMessage` class, which does not allow for assignment to message fields. When used with `optional` field labels (see #174), this avoids many of the issues with ambiguous defaults raised in #156.

Question: Raising exceptions is relatively safe but also noisy. Will this match your target use case or would you prefer something that will require fewer try/except blocks? (See my note in the FrozenMessage docstring about returning None values.)