### PR TITLE
Fix "cleanup" failure on master

### DIFF
--- a/editor/serve.sh
+++ b/editor/serve.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2020 The Open Reaction Database Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 export PYTHONPATH=py:gen/py
 export FLASK_APP=serve.py


### PR DESCRIPTION
Adds missing license header from #180 