### PR TITLE
Update the editor Makefile for easier builds.

### DIFF
--- a/editor/Makefile
+++ b/editor/Makefile
@@ -1,15 +1,27 @@
-protobuf = protobuf-3.12.2
+protobuf = protobuf-3.12.0
+
+protoc_version = $(shell protoc --version | sed 's/.* //')
+protobuf_version = $(shell echo $(protobuf) | sed 's/.*-//')
 
 closure = closure-library-20200517
 
-all : gen js py
+all : prep py js
 
-gen :
+prep :
+	# Ensure output directories exist.
 	mkdir -p gen/py gen/js/ord gen/js/proto/ord
+	# Prevent Closure from compiling test code.
+	rm -rf $(protobuf)/js/binary/*test* $(protobuf)/js/*test* $(protobuf)/js/experimental
+	# Ensure the proto compiler matches the proto runtime JS.
+	if [ $(protoc_version) != $(protobuf_version) ]; then false; fi
 
-js : gen/js/proto/ord/reaction.js gen/js/proto/ord/dataset.js gen/js/ord/reaction.js gen/js/ord/dataset.js
+js : gen/js/proto/ord/dataset.js \
+	   gen/js/proto/ord/reaction.js \
+	   gen/js/ord/dataset.js \
+	   gen/js/ord/reaction.js \
 
-py : gen/py/ord_schema/proto/dataset_pb2.py gen/py/ord_schema/proto/reaction_pb2.py
+py : gen/py/ord_schema/proto/dataset_pb2.py \
+	   gen/py/ord_schema/proto/reaction_pb2.py
 
 gen/js/ord/dataset.js : js/dataset.js gen/js/proto/ord/dataset.js
 	$(closure)/closure/bin/build/closurebuilder.py \
@@ -18,7 +30,9 @@ gen/js/ord/dataset.js : js/dataset.js gen/js/proto/ord/dataset.js
 	  --root=gen/js/proto/ord \
 	  --root=js \
 	  --namespace=ord.dataset \
-	  --output_mode=script > gen/js/ord/dataset.js
+	  --output_mode=script \
+	  --output_file=gen/js/ord/dataset.js \
+	  || (rm -f gen/js/ord/dataset.js && false)
 
 gen/js/ord/reaction.js : js/*.js gen/js/proto/ord/reaction.js
 	$(closure)/closure/bin/build/closurebuilder.py \
@@ -27,17 +41,19 @@ gen/js/ord/reaction.js : js/*.js gen/js/proto/ord/reaction.js
 	  --root=gen/js/proto/ord \
 	  --root=js \
 	  --namespace=ord.reaction \
-	  --output_mode=script > gen/js/ord/reaction.js
+	  --output_mode=script \
+	  --output_file=gen/js/ord/reaction.js \
+	  || (rm -f gen/js/ord/reaction.js && false)
 
-gen/js/proto/ord/%.js : ../../ord-schema/proto/%.proto gen
-	$(protobuf)/src/protoc \
+gen/js/proto/ord/%.js : ../../ord-schema/proto/%.proto
+	protoc \
 	  --experimental_allow_proto3_optional \
 	  --js_out=binary:gen/js/proto/ord \
 	  --proto_path=../.. \
 	  $<
 
-gen/py/ord_schema/proto/%_pb2.py : ../../ord-schema/proto/%.proto gen
-	$(protobuf)/src/protoc \
+gen/py/ord_schema/proto/%_pb2.py : ../../ord-schema/proto/%.proto
+	protoc \
 	  --experimental_allow_proto3_optional \
 	  --python_out=gen/py \
 	  --proto_path=../.. \

--- a/editor/README.md
+++ b/editor/README.md
@@ -16,7 +16,7 @@ This starts service at [http://localhost:5000/](http://localhost:5000/).
 
 The build needs:
 * the `protoc` protobuf compiler;
-* the protobuf runtime libraries for python and Javascript; and
+* the protobuf runtime libraries for Javascript; and
 * the Closure Library for Javascript.
 
 Serving depends on:
@@ -26,36 +26,16 @@ Serving depends on:
 And everything requires Python 3.
 
 The editor has been tested with [protobuf
-3.12.2](https://github.com/protocolbuffers/protobuf/releases) and [Closure
+3.12.0](https://github.com/protocolbuffers/protobuf/releases) and [Closure
 v20200517](https://github.com/google/closure-library/releases/). Unpack these
-in this directory so that make can find them, and compile protobuf to get
-the protoc compiler.
-
-```
-cd protobuf-3.12.2
-./configure && make
-```
-
-(As an alternative, you can edit the Makefile to use a protoc binary you
-already have. But make still needs the protobuf distribution for its JS common
-files.)
+in this directory so that make can find them. The Makefile will look for protoc
+in your PATH so it may not be necessary to compile protobuf.
 
 To install the python packages,
 
 ```
 $ pip install flask
 $ pip install protobuf
-```
-
-The Closure compiler fails to resolve dependencies for test files in the
-protobuf distribution. Feel free to delete any protobuf files Closure doesn't
-like, e.g.
-
-```
-$ rm -rf protobuf-3.12.2/js/*test*
-$ rm -rf protobuf-3.12.2/js/binary/*test*
-$ rm -rf protobuf-3.12.2/js/compatibility_tests
-$ rm -rf protobuf-3.12.2/js/experimental
 ```
 
 ## Testing and Validation


### PR DESCRIPTION
See Issue #183.

* Use pip's protoc for proto compilation to avoid compiling protobuf.

* Reference protobuf version 3.12.0 to match the current pip version.

* Assert that these versions match in a prerequisite make target.

* Prevent Closure from generating empty object files at compiler errors.