### PR TITLE
Add run_tests.sh

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,12 +44,8 @@ jobs:
         python setup.py install
     - name: Run tests
       run: |
-        shopt -s globstar
         cd "${GITHUB_WORKSPACE}"
-        for TEST_FILENAME in ord_schema/**/*_test.py; do \
-          echo "Running tests in ${TEST_FILENAME}"; \
-          python "${TEST_FILENAME}"; \
-        done
+        ./run_tests.sh
     - name: Run pylint
       run: |
         cd "${GITHUB_WORKSPACE}"

--- a/ord_schema/process_dataset_test.py
+++ b/ord_schema/process_dataset_test.py
@@ -21,6 +21,7 @@ import tempfile
 from absl import flags
 from absl.testing import absltest
 from absl.testing import flagsaver
+from rdkit import RDLogger
 
 from ord_schema import message_helpers
 from ord_schema import process_dataset
@@ -32,6 +33,8 @@ from ord_schema.proto import reaction_pb2
 class ProcessDatasetTest(absltest.TestCase):
     def setUp(self):
         super().setUp()
+        # Suppress RDKit warnings to clean up the test output.
+        RDLogger.logger().setLevel(RDLogger.CRITICAL)
         self.test_subdirectory = tempfile.mkdtemp(dir=flags.FLAGS.test_tmpdir)
         reaction1 = reaction_pb2.Reaction()
         dummy_input = reaction1.inputs['dummy_input']

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -31,15 +31,17 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         # other test output.
         original = warnings.showwarning
 
+        # pylint: disable=too-many-arguments
         def _showwarning(message,
                          category,
                          filename,
                          lineno,
                          file=None,
-                         line=None):  # pylint: disable=too-many-arguments
+                         line=None):
             del file  # Unused.
             original(message, category, filename, lineno, sys.stdout, line)
 
+        # pylint: enable=too-many-arguments
         warnings.showwarning = _showwarning
 
     def _run_validation(self, message, **kwargs):

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -36,7 +36,7 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
                          filename,
                          lineno,
                          file=None,
-                         line=None):
+                         line=None):  # pylint: disable=too-many-arguments
             del file  # Unused.
             original(message, category, filename, lineno, sys.stdout, line)
 

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 """Tests for ord_schema.validations."""
 
+import sys
+import warnings
+
 from absl.testing import absltest
 from absl.testing import parameterized
 
@@ -22,6 +25,23 @@ from ord_schema.proto import reaction_pb2
 
 
 class ValidationsTest(parameterized.TestCase, absltest.TestCase):
+    def setUp(self):
+        super().setUp()
+        # Redirect warning messages to stdout so they can be filtered from the
+        # other test output.
+        original = warnings.showwarning
+
+        def _showwarning(message,
+                         category,
+                         filename,
+                         lineno,
+                         file=None,
+                         line=None):
+            del file  # Unused.
+            original(message, category, filename, lineno, sys.stdout, line)
+
+        warnings.showwarning = _showwarning
+
     def _run_validation(self, message, **kwargs):
         original = type(message)()
         original.CopyFrom(message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ protoc-wheel-0>=3.12.0
 python-dateutil>=1.10.0
 jinja2>=2.0.0
 xlrd>=1.0.0
+numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ protoc-wheel-0>=3.12.0
 python-dateutil>=1.10.0
 jinja2>=2.0.0
 xlrd>=1.0.0
-numpy

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright 2020 The Open Reaction Database Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs ord-schema tests.
+find ./ord_schema -name '*_test.py' -print0 \
+  | xargs -t -0 -I '{}' python '{}' --verbosity=-2 > /dev/null


### PR DESCRIPTION
* Adds a script for running all python tests under `ord_schema/`. The script filters out `stdout` and reduces the logging verbosity so the console output is easier to read.
* Spot fixes to remove warning messages to further clean up `stderr` for test outputs.