### PR TITLE
Remove references to 'dev' branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Excellent! There are a few steps you'll need to follow to get ready to submit ch
    1. Create a fork of `ord-schema` by clicking the "Fork" button at the top-right of this page. 
       Note that you only need to do this once---all of your changes can use the same fork.
    1. Follow the [GitHub flow](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/github-flow)
-      to make changes and send a pull request to the `dev` branch of the official repository. While you are making 
+      to make changes and send a pull request to the official repository. While you are making 
       changes, automated tests will run in your fork after each commit and notify you of any errors encountered in
       validation or syntax.
    
@@ -45,7 +45,7 @@ Excellent! There are a few steps you'll need to follow to get ready to submit ch
    1. Test your changes by rebuilding the package (`python setup.py install`) and running the test script provided
       in the repo (`./run_tests.sh`). This will be performed automatically when you send a pull request to the
       repository, but you can save time by making sure the tests pass locally first.
-   1. Commit your changes, push them to your fork on GitHub, and send a pull request to the `dev` branch of the
+   1. Commit your changes, push them to your fork on GitHub, and send a pull request to the
       official repository.
       
 1. If necessary, update your pull request by adding additional commits to your branch in response to

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Open Reaction Database: Schema (ord-schema)
 
-| `master` | `dev` |
-| -------- | ----- |
-| ![CI](https://github.com/Open-Reaction-Database/ord-schema/workflows/CI/badge.svg?branch=master) | ![CI](https://github.com/Open-Reaction-Database/ord-schema/workflows/CI/badge.svg?branch=dev) |
+![CI](https://github.com/Open-Reaction-Database/ord-schema/workflows/CI/badge.svg?branch=master)
 
 This repository contains the schema for the Open Reaction Database initiative, based in part on survey of importance ([summary](https://docs.google.com/spreadsheets/d/1waPzYvDKlb6TAwgsM7bLc7dhZnJ8G-WtVxJSlMhiVK0/edit)). For more details on the database, please see the documentation at http://open-reaction-database.org.
 


### PR DESCRIPTION
After chatting with Anton, we felt like having two shared branches (`master` and `dev`) was a bit of a headache. Instead, we propose that PRs be merged into `master` and that we use the GitHub Releases mechanism for versioning.

If we need to patch a release off of the `master` branch, we can create a new branch and a new release that points to that branch. This should simplify PRs and merges in the future since there will only be one "trunk" instead of two.

WDYT?