### PR TITLE
Restore the editor test.

### DIFF
--- a/editor/.gitignore
+++ b/editor/.gitignore
@@ -7,3 +7,4 @@ gen
 node_modules
 package
 package-lock.json
+protobuf

--- a/editor/css/reaction.css
+++ b/editor/css/reaction.css
@@ -23,7 +23,7 @@ body {
 #top_buttons {
   text-align: center;
 }
-.edittext, .selector {
+.edittext, .selector, .optional_bool {
   padding: 2px;
   margin: 2px;
   display: inline-block;

--- a/editor/db/empty.pbtxt
+++ b/editor/db/empty.pbtxt
@@ -10,6 +10,7 @@ reactions {
         precision: 0.0
       }
     }
+    is_automated: false
     environment {
     }
   }
@@ -78,9 +79,18 @@ reactions {
         }
       }
     }
+    reflux: false
     pH: 0.0
+    conditions_are_dynamic: false
   }
   notes {
+    is_heterogeneous: false
+    forms_precipitate: false
+    is_exothermic: false
+    offgasses: false
+    is_sensitive_to_moisture: false
+    is_sensitive_to_oxygen: false
+    is_sensitive_to_light: false
   }
   provenance {
     experimenter {

--- a/editor/db/empty.pbtxt
+++ b/editor/db/empty.pbtxt
@@ -6,11 +6,8 @@ reactions {
       material {
       }
       volume {
-        value: 0.0
-        precision: 0.0
       }
     }
-    is_automated: false
     environment {
     }
   }
@@ -19,16 +16,12 @@ reactions {
       control {
       }
       setpoint {
-        value: 0.0
-        precision: 0.0
       }
     }
     pressure {
       control {
       }
       setpoint {
-        value: 0.0
-        precision: 0.0
       }
       atmosphere {
       }
@@ -43,28 +36,18 @@ reactions {
       type {
       }
       peak_wavelength {
-        value: 0.0
-        precision: 0.0
       }
       distance_to_vessel {
-        value: 0.0
-        precision: 0.0
       }
     }
     electrochemistry {
       electrochemistry_type {
       }
       current {
-        value: 0.0
-        precision: 0.0
       }
       voltage {
-        value: 0.0
-        precision: 0.0
       }
       electrode_separation {
-        value: 0.0
-        precision: 0.0
       }
       cell {
       }
@@ -74,23 +57,11 @@ reactions {
       }
       tubing {
         diameter {
-          value: 0.0
-          precision: 0.0
         }
       }
     }
-    reflux: false
-    pH: 0.0
-    conditions_are_dynamic: false
   }
   notes {
-    is_heterogeneous: false
-    forms_precipitate: false
-    is_exothermic: false
-    offgasses: false
-    is_sensitive_to_moisture: false
-    is_sensitive_to_oxygen: false
-    is_sensitive_to_light: false
   }
   provenance {
     experimenter {

--- a/editor/db/full.pbtxt
+++ b/editor/db/full.pbtxt
@@ -67,6 +67,7 @@ reactions {
           float_value: 14.0
           how_computed: "15"
         }
+        volume_includes_solutes: false
       }
       addition_order: 16
       addition_time {
@@ -118,7 +119,7 @@ reactions {
         units: MILLILITER
       }
     }
-    is_automated: false
+    is_automated: true
     automation_platform: "29"
     automation_code {
       key: "33"
@@ -259,19 +260,17 @@ reactions {
         }
       }
     }
-    reflux: false
+    reflux: true
     pH: 78.0
     conditions_are_dynamic: false
     details: "79"
   }
   notes {
-    is_heterogeneous: false
+    is_heterogeneous: true
     forms_precipitate: false
-    is_exothermic: false
-    offgasses: false
+    offgasses: true
     is_sensitive_to_moisture: false
-    is_sensitive_to_oxygen: false
-    is_sensitive_to_light: false
+    is_sensitive_to_light: true
     safety_notes: "80"
     procedure_details: "81"
   }
@@ -360,7 +359,7 @@ reactions {
       }
     }
     target_ph: 89.0
-    is_automated: false
+    is_automated: true
   }
   outcomes {
     reaction_time {
@@ -373,7 +372,7 @@ reactions {
       precision: 116.0
     }
     products {
-      is_desired_product: false
+      is_desired_product: true
       compound_yield {
         value: 117.0
         precision: 118.0
@@ -424,7 +423,7 @@ reactions {
         instrument_last_calibrated {
           value: "134"
         }
-        uses_internal_standard: false
+        uses_internal_standard: true
         uses_authentic_standard: false
       }
     }

--- a/editor/db/full.pbtxt
+++ b/editor/db/full.pbtxt
@@ -54,7 +54,7 @@ reactions {
           units: MILLIMOLE
         }
         reaction_role: REACTANT
-        is_limiting: TRUE
+        is_limiting: true
         preparations {
           type: REPURIFIED
           details: "9"
@@ -118,7 +118,7 @@ reactions {
         units: MILLILITER
       }
     }
-    is_automated: TRUE
+    is_automated: false
     automation_platform: "29"
     automation_code {
       key: "33"
@@ -259,17 +259,19 @@ reactions {
         }
       }
     }
-    reflux: TRUE
+    reflux: false
     pH: 78.0
-    conditions_are_dynamic: FALSE
+    conditions_are_dynamic: false
     details: "79"
   }
   notes {
-    is_heterogeneous: TRUE
-    forms_precipitate: FALSE
-    offgasses: TRUE
-    is_sensitive_to_moisture: FALSE
-    is_sensitive_to_light: TRUE
+    is_heterogeneous: false
+    forms_precipitate: false
+    is_exothermic: false
+    offgasses: false
+    is_sensitive_to_moisture: false
+    is_sensitive_to_oxygen: false
+    is_sensitive_to_light: false
     safety_notes: "80"
     procedure_details: "81"
   }
@@ -358,7 +360,7 @@ reactions {
       }
     }
     target_ph: 89.0
-    is_automated: FALSE
+    is_automated: false
   }
   outcomes {
     reaction_time {
@@ -371,7 +373,7 @@ reactions {
       precision: 116.0
     }
     products {
-      is_desired_product: FALSE
+      is_desired_product: false
       compound_yield {
         value: 117.0
         precision: 118.0
@@ -422,8 +424,8 @@ reactions {
         instrument_last_calibrated {
           value: "134"
         }
-        uses_internal_standard: TRUE
-        uses_authentic_standard: FALSE
+        uses_internal_standard: false
+        uses_authentic_standard: false
       }
     }
   }

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -118,8 +118,11 @@ limitations under the License.
             <div id="component_template" class="component" style="display: none;">
               <fieldset>
                 <legend>Component</legend>
-                reaction role <div class="component_reaction_role selector" data-proto="Compound_ReactionRole_ReactionRoleType"></div>
-                limiting reactant? <input type="checkbox" class="component_limiting">
+                <table>
+                  <tr><td>reaction role</td><td><div class="component_reaction_role selector" data-proto="Compound_ReactionRole_ReactionRoleType"></div></td></tr>
+                  <tr><td>limiting reactant?</td><td><div class="component_limiting optional_bool"></div></td></tr>
+                  <tr><td>includes solutes?</td><td><div class="component_includes_solutes optional_bool"></div></td></tr>
+                </table>
                 <div onclick="removeSlowly(this, '.component');" class="remove">remove</div>
                 <div>
                   <fieldset>
@@ -202,7 +205,7 @@ limitations under the License.
           <tr><td align="right">volume</td><td><div id="setup_vessel_volume_value" class="edittext"></div>
                                                <div id="setup_vessel_volume_units" class="selector" data-proto="Volume_VolumeUnit"></div>
                                                +/- <div id="setup_vessel_volume_precision" class="edittext"></div></td></tr>
-          <tr><td align="right">automated</td><td><div id="setup_automated" class="selector" data-proto="Boolean_BooleanValue"></div></td></tr>
+          <tr><td align="right">automated</td><td><div id="setup_automated" class="optional_bool"></div></td></tr>
           <tr><td align="right">platform</td><td><div id="setup_platform" class="edittext"></div></td></tr>
           <tr><td align="right">environment</td><td><div id="setup_environment_type" class="selector" data-proto="ReactionSetup_ReactionEnvironment_ReactionEnvironmentType"></div>
                                                     details <div id="setup_environment_details" class="edittext"></div></td></tr>
@@ -405,9 +408,9 @@ limitations under the License.
           </table>
         </fieldset>
         <table>
-          <tr><td align="right">reflux</td><td><div id="condition_reflux" class="selector" data-proto="Boolean_BooleanValue"></div></td></tr>
+          <tr><td align="right">reflux</td><td><div id="condition_reflux" class="optional_bool"></div></td></tr>
           <tr><td align="right">pH</td><td><div id="condition_ph" class="edittext"></div></td></tr>
-          <tr><td align="right">dynamic conditions</td><td><div id="condition_dynamic" class="selector" data-proto="Boolean_BooleanValue"></div></td></tr>
+          <tr><td align="right">dynamic conditions</td><td><div id="condition_dynamic" class="optional_bool"></div></td></tr>
           <tr><td align="right">details</td><td><div id="condition_details" class="edittext"></div></td></tr>
         </table>
       </fieldset>
@@ -415,13 +418,13 @@ limitations under the License.
       <fieldset id="section_notes" class="section">
         <legend>Notes</legend>
         <table>
-          <tr><td align="right">is heterogeneous</td><td><div id="notes_heterogeneous" class="selector" data-proto="Boolean_BooleanValue"></div></td></tr>
-          <tr><td align="right">forms precipitate</td><td><div id="notes_precipitate" class="selector" data-proto="Boolean_BooleanValue"></div></td></tr>
-          <tr><td align="right">is exothermic</td><td><div id="notes_exothermic" class="selector" data-proto="Boolean_BooleanValue"></div></td></tr>
-          <tr><td align="right">offgasses</td><td><div id="notes_offgas" class="selector" data-proto="Boolean_BooleanValue"></div></td></tr>
-          <tr><td align="right">moisure sensitive</td><td><div id="notes_moisture" class="selector" data-proto="Boolean_BooleanValue"></div></td></tr>
-          <tr><td align="right">oxygen sensitive</td><td><div id="notes_oxygen" class="selector" data-proto="Boolean_BooleanValue"></div></td></tr>
-          <tr><td align="right">light sensitive</td><td><div id="notes_light" class="selector" data-proto="Boolean_BooleanValue"></div></td></tr>
+          <tr><td align="right">is heterogeneous</td><td><div id="notes_heterogeneous" class="optional_bool"></div></td></tr>
+          <tr><td align="right">forms precipitate</td><td><div id="notes_precipitate" class="optional_bool"></div></td></tr>
+          <tr><td align="right">is exothermic</td><td><div id="notes_exothermic" class="optional_bool"></div></td></tr>
+          <tr><td align="right">offgasses</td><td><div id="notes_offgas" class="optional_bool"></div></td></tr>
+          <tr><td align="right">moisure sensitive</td><td><div id="notes_moisture" class="optional_bool"></div></td></tr>
+          <tr><td align="right">oxygen sensitive</td><td><div id="notes_oxygen" class="optional_bool"></div></td></tr>
+          <tr><td align="right">light sensitive</td><td><div id="notes_light" class="optional_bool"></div></td></tr>
           <tr><td align="right">safety notes</td><td><div id="notes_safety" class="edittext"></div></td></tr>
           <tr><td align="right">procedure details</td><td><div id="notes_details" class="edittext"></div></td></tr>
         </table>
@@ -476,7 +479,7 @@ limitations under the License.
               <tr><td align="right">duration</td><td><div class="workup_duration_value edittext"></div>
                                                      <div class="workup_duration_units selector" data-proto="Time_TimeUnit"></div>
                                                      +/- <div class="workup_duration_precision edittext"></div></td></tr>
-              <tr><td align="right">automated</td><td><div class="workup_automated selector" data-proto="Boolean_BooleanValue"></div></td></tr>
+              <tr><td align="right">automated</td><td><div class="workup_automated optional_bool"></div></td></tr>
               <tr><td align="right">details</td><td><div class="workup_details edittext"></div></td></tr>
             </table>
             <div class="workup_input">
@@ -561,7 +564,7 @@ limitations under the License.
             <div onclick="removeSlowly(this, '.outcome_product');" class="remove">remove</div>
 
             <table>
-              <tr><td align="right">desired</td><td><div class="outcome_product_desired selector" data-proto="Boolean_BooleanValue"></div></td>
+              <tr><td align="right">desired</td><td><div class="outcome_product_desired optional_bool"></div></td>
               <tr><td align="right">yield</td><td><div class="outcome_product_yield_value edittext"></div>
                                                   +/- <div class="outcome_product_yield_precision edittext"></div></td></tr>
               <tr><td align="right">purity</td><td><div class="outcome_product_purity_value edittext"></div>
@@ -635,8 +638,8 @@ limitations under the License.
                 <tr><td align="right">details</td><td><div class="outcome_analysis_details edittext"></div></td></tr>
                 <tr><td align="right">instrument manufacturer</td><td><div class="outcome_analysis_manufacturer edittext"></div></td></tr>
                 <tr><td align="right">calibrated</td><td><div class="outcome_analysis_calibrated edittext"></div></td></tr>
-                <tr><td align="right">internal standard</td><td><div class="outcome_analysis_internal_standard selector" data-proto="Boolean_BooleanValue"></div></td></tr>
-                <tr><td align="right">authentic standard</td><td><div class="outcome_analysis_authentic_standard selector" data-proto="Boolean_BooleanValue"></div></td></tr>
+                <tr><td align="right">internal standard</td><td><div class="outcome_analysis_internal_standard optional_bool"></div></td></tr>
+                <tr><td align="right">authentic standard</td><td><div class="outcome_analysis_authentic_standard optional_bool"></div></td></tr>
               </table>
 
               <div>

--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -34,8 +34,12 @@ ord.compounds.loadCompound = function (root, compound) {
   const reactionRole = compound.getReactionRole();
   setSelector($('.component_reaction_role', node), reactionRole);
 
-  const isLimiting = compound.getIsLimiting();
-  $('.component_limiting', node).prop('checked', isLimiting);
+  const isLimiting = compound.hasIsLimiting() ? compound.getIsLimiting() : null;
+  setOptionalBool($('.component_limiting', node), isLimiting);
+
+  const solutes = compound.hasVolumeIncludesSolutes() ?
+      compound.getVolumeIncludesSolutes() : null;
+  setOptionalBool($('.component_includes_solutes', node), solutes);
 
   const identifiers = compound.getIdentifiersList();
   identifiers.forEach(
@@ -109,8 +113,11 @@ ord.compounds.unloadCompound = function (node) {
   const reactionRole = getSelector($('.component_reaction_role', node));
   compound.setReactionRole(reactionRole);
 
-  const isLimiting = $('.component_limiting', node).is(':checked');
+  const isLimiting = getOptionalBool($('.component_limiting', node));
   compound.setIsLimiting(isLimiting);
+
+  const solutes = getOptionalBool($('.component_includes_solutes', node));
+  compound.setVolumeIncludesSolutes(solutes);
 
   const identifiers = ord.compounds.unloadIdentifiers(node);
   compound.setIdentifiersList(identifiers);

--- a/editor/js/conditions.js
+++ b/editor/js/conditions.js
@@ -51,7 +51,9 @@ ord.conditions.load = function (conditions) {
   }
   const reflux = conditions.hasReflux() ? conditions.getReflux() : null;
   setOptionalBool($('#condition_reflux'), reflux);
-  $('#condition_ph').text(conditions.getPh());
+  if (conditions.hasPh()) {
+    $('#condition_ph').text(conditions.getPh());
+  }
   const dynamic = conditions.hasConditionsAreDynamic() ?
       conditions.getConditionsAreDynamic() : null;
   setOptionalBool($('#condition_dynamic'), dynamic);

--- a/editor/js/conditions.js
+++ b/editor/js/conditions.js
@@ -49,9 +49,12 @@ ord.conditions.load = function (conditions) {
   if (flow) {
     ord.flows.load(flow);
   }
-  setSelector($('#condition_reflux'), conditions.getReflux());
+  const reflux = conditions.hasReflux() ? conditions.getReflux() : null;
+  setOptionalBool($('#condition_reflux'), reflux);
   $('#condition_ph').text(conditions.getPh());
-  setSelector($('#condition_dynamic'), conditions.getConditionsAreDynamic());
+  const dynamic = conditions.hasConditionsAreDynamic() ?
+      conditions.getConditionsAreDynamic() : null;
+  setOptionalBool($('#condition_dynamic'), dynamic);
   $('#condition_details').text(conditions.getDetails());
 };
 
@@ -69,13 +72,13 @@ ord.conditions.unload = function () {
   conditions.setElectrochemistry(electro);
   const flow = ord.flows.unload();
   conditions.setFlow(flow);
-  const reflux = getSelector($('#condition_reflux'));
+  const reflux = getOptionalBool($('#condition_reflux'));
   conditions.setReflux(reflux);
   const ph = parseFloat($('#condition_ph').text());
   if (!isNaN(ph)) {
     conditions.setPh(ph);
   }
-  const dynamic = getSelector($('#condition_dynamic'));
+  const dynamic = getOptionalBool($('#condition_dynamic'));
   conditions.setConditionsAreDynamic(dynamic);
   const details = $('#condition_details').text();
   conditions.setDetails(details);

--- a/editor/js/enums.js
+++ b/editor/js/enums.js
@@ -17,7 +17,6 @@
 goog.provide('ord.enums');
 
 // Proto enums are referenced by reflection from "data-proto" HTML attributes.
-goog.require('proto.ord.Boolean.BooleanValue');
 goog.require('proto.ord.Compound.ReactionRole.ReactionRoleType');
 goog.require('proto.ord.CompoundIdentifier.IdentifierType');
 goog.require('proto.ord.CompoundPreparation.PreparationType');

--- a/editor/js/notes.js
+++ b/editor/js/notes.js
@@ -19,26 +19,34 @@ goog.provide('ord.notes');
 goog.require('proto.ord.ReactionNotes');
 
 ord.notes.load = function (notes) {
-  setSelector($('#notes_heterogeneous'), notes.getIsHeterogeneous());
-  setSelector($('#notes_precipitate'), notes.getFormsPrecipitate());
-  setSelector($('#notes_exothermic'), notes.getIsExothermic());
-  setSelector($('#notes_offgas'), notes.getOffgasses());
-  setSelector($('#notes_moisture'), notes.getIsSensitiveToMoisture());
-  setSelector($('#notes_oxygen'), notes.getIsSensitiveToOxygen());
-  setSelector($('#notes_light'), notes.getIsSensitiveToLight());
+  setOptionalBool($('#notes_heterogeneous'), 
+      notes.hasIsHeterogeneous() ? notes.getIsHeterogeneous() : null);
+  setOptionalBool($('#notes_precipitate'),
+      notes.hasFormsPrecipitate() ? notes.getFormsPrecipitate() : null);
+  setOptionalBool($('#notes_exothermic'),
+      notes.hasIsExothermic() ? notes.getIsExothermic() : null);
+  setOptionalBool($('#notes_offgas'),
+      notes.hasOffgasses() ? notes.getOffgasses() : null);
+  setOptionalBool($('#notes_moisture'),
+      notes.hasIsSensitiveToMoisture() ?
+          notes.getIsSensitiveToMoisture() : null);
+  setOptionalBool($('#notes_oxygen'),
+      notes.hasIsSensitiveToOxygen() ? notes.getIsSensitiveToOxygen() : null);
+  setOptionalBool($('#notes_light'),
+      notes.hasIsSensitiveToLight() ? notes.getIsSensitiveToLight() : null);
   $('#notes_safety').text(notes.getSafetyNotes());
   $('#notes_details').text(notes.getProcedureDetails());
 };
 
 ord.notes.unload = function () {
   const notes = new proto.ord.ReactionNotes();
-  notes.setIsHeterogeneous(getSelector($('#notes_heterogeneous')));
-  notes.setFormsPrecipitate(getSelector($('#notes_precipitate')));
-  notes.setIsExothermic(getSelector($('#notes_exothermic')));
-  notes.setOffgasses(getSelector($('#notes_offgas')));
-  notes.setIsSensitiveToMoisture(getSelector($('#notes_moisture')));
-  notes.setIsSensitiveToOxygen(getSelector($('#notes_oxygen')));
-  notes.setIsSensitiveToLight(getSelector($('#notes_light')));
+  notes.setIsHeterogeneous(getOptionalBool($('#notes_heterogeneous')));
+  notes.setFormsPrecipitate(getOptionalBool($('#notes_precipitate')));
+  notes.setIsExothermic(getOptionalBool($('#notes_exothermic')));
+  notes.setOffgasses(getOptionalBool($('#notes_offgas')));
+  notes.setIsSensitiveToMoisture(getOptionalBool($('#notes_moisture')));
+  notes.setIsSensitiveToOxygen(getOptionalBool($('#notes_oxygen')));
+  notes.setIsSensitiveToLight(getOptionalBool($('#notes_light')));
   notes.setSafetyNotes($('#notes_safety').text());
   notes.setProcedureDetails($('#notes_details').text());
   return notes;

--- a/editor/js/outcomes.js
+++ b/editor/js/outcomes.js
@@ -79,12 +79,14 @@ ord.outcomes.loadAnalysis = function (analysesNode, name, analysis) {
   if (calibrated) {
     $('.outcome_analysis_calibrated', node).text(calibrated.getValue());
   }
-  setSelector(
+  setOptionalBool(
       $('.outcome_analysis_internal_standard', node),
-      analysis.getUsesInternalStandard());
-  setSelector(
+      analysis.hasUsesInternalStandard() ?
+          analysis.getUsesInternalStandard() : null);
+  setOptionalBool(
       $('.outcome_analysis_authentic_standard', node),
-      analysis.getUsesAuthenticStandard());
+      analysis.hasUsesAuthenticStandard() ?
+          analysis.getUsesAuthenticStandard() : null);
 };
 
 ord.outcomes.loadProcess = function (node, name, process) {
@@ -225,9 +227,9 @@ ord.outcomes.unloadAnalysis = function (analysisNode, analyses) {
   calibrated.setValue($('.outcome_analysis_calibrated', analysisNode).text());
   analysis.setInstrumentLastCalibrated(calibrated);
   analysis.setUsesInternalStandard(
-      getSelector($('.outcome_analysis_internal_standard', analysisNode)));
+      getOptionalBool($('.outcome_analysis_internal_standard', analysisNode)));
   analysis.setUsesAuthenticStandard(
-      getSelector($('.outcome_analysis_authentic_standard', analysisNode)));
+      getOptionalBool($('.outcome_analysis_authentic_standard', analysisNode)));
 
   analyses.set(name, analysis);
 };

--- a/editor/js/products.js
+++ b/editor/js/products.js
@@ -46,11 +46,14 @@ ord.products.loadProduct = function (outcomeNode, product) {
       $('.outcome_product_selectivity_type', node), selectivity.getType());
   $('.outcome_product_selectivity_details', node)
       .text(selectivity.getDetails());
-  $('.outcome_product_selectivity_value', node)
-      .text(selectivity.getValue());
-  $('.outcome_product_selectivity_precision', node)
-      .text(selectivity.getPrecision());
-
+  if (selectivity.hasValue()) {
+    $('.outcome_product_selectivity_value', node)
+        .text(selectivity.getValue());
+  }
+  if (selectivity.hasPrecision()) {
+    $('.outcome_product_selectivity_precision', node)
+        .text(selectivity.getPrecision());
+  }
   const identities = product.getAnalysisIdentityList();
   identities.forEach(identity => {
     const analysisNode = ord.products.addIdentity(node);

--- a/editor/js/products.js
+++ b/editor/js/products.js
@@ -33,8 +33,9 @@ ord.products.loadProduct = function (outcomeNode, product) {
     // ReactionComponents should not be added or removed.
     $('.component .remove', node).hide();
   }
-  setSelector(
-      $('.outcome_product_desired', node), product.getIsDesiredProduct());
+  setOptionalBool(
+      $('.outcome_product_desired', node),
+      product.hasIsDesiredProduct() ? product.getIsDesiredProduct() : null);
 
   writeMetric('.outcome_product_yield', product.getCompoundYield(), node);
 
@@ -100,7 +101,8 @@ ord.products.unloadProduct = function (node) {
   if (compounds) {
     product.setCompound(compounds[0]);
   }
-  product.setIsDesiredProduct(getSelector($('.outcome_product_desired', node)));
+  product.setIsDesiredProduct(
+      getOptionalBool($('.outcome_product_desired', node)));
 
   const yeild =
       readMetric('.outcome_product_yield', new proto.ord.Percentage(), node);

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -227,12 +227,16 @@ function readMetric(prefix, proto, node) {
 
 // Pack a value/units/precision triple into the elements specified.
 function writeMetric(prefix, proto, node) {
-  $(prefix + '_value', node).text(proto.getValue());
+  if (proto.hasValue()) {
+    $(prefix + '_value', node).text(proto.getValue());
+  }
   if (proto.getUnits) {
     // proto.ord.Percentage doesn't have units.
     setSelector($(prefix + '_units', node), proto.getUnits());
   }
-  $(prefix + '_precision', node).text(proto.getPrecision());
+  if (proto.hasPrecision()) {
+    $(prefix + '_precision', node).text(proto.getPrecision());
+  }
 }
 
 // Populate a <select/> node according to its data-proto type declaration.

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -39,7 +39,8 @@ async function init(fileName, index) {
   session.fileName = fileName;
   session.index = index;
   // Initialize all the template popup menus.
-  $('.selector').each((index, node)  => initSelector($(node)));
+  $('.selector').each((index, node) => initSelector($(node)));
+  $('.optional_bool').each((index, node) => initOptionalBool($(node)));
   // Enable all the editable text fields.
   $('.edittext').attr('contentEditable', 'true');
   // Show "save" on modifications.
@@ -61,6 +62,7 @@ function ready() {
 function listen(node) {
   $('.edittext', node).on('input', dirty);
   $('.selector', node).on('input', dirty);
+  $('.optional_bool', node).on('input', dirty);
   $('input').on('input', dirty);
   $('.edittext').on('focus', event => selectText(event.target));
 }
@@ -262,6 +264,45 @@ function setSelector(node, value) {
 // Find the selected <option/> and map its text onto a proto Enum.
 function getSelector(node) {
   return parseInt($('select', node).val());
+}
+
+// Set up the three-way popup, "true"/"false"/"unspecified".
+function initOptionalBool(node) {
+  const select = $('<select>');
+  const options = ['UNSPECIFIED', 'TRUE', 'FALSE'];
+  for (let i = 0; i < options.length; i++) {
+    const option = $('<option>').text(options[i]);
+    option.attr('value', options[i]);
+    if (options[i] == 'UNSPECIFIED') {
+      option.attr('selected', 'selected');
+    }
+    select.append(option);
+  }
+  node.append(select);
+}
+
+function setOptionalBool(node, value) {
+  $('option', node).removeAttr('selected');
+  if (value == true) {
+    $('option[value=TRUE]', node).attr('selected', 'selected');
+  }
+  if (value == false) {
+    $('option[value=FALSE]', node).attr('selected', 'selected');
+  }
+  if (value == null) {
+    $('option[value=UNSPECIFIED]', node).attr('selected', 'selected');
+  }
+}
+
+function getOptionalBool(node) {
+  const value = $('select', node).val();
+  if (value == 'TRUE') {
+    return true;
+  }
+  if (value == 'FALSE') {
+    return false;
+  }
+  return null;
 }
 
 // Convert a Message_Field name from a data-proto attribute into a proto class.

--- a/editor/js/setups.js
+++ b/editor/js/setups.js
@@ -67,8 +67,8 @@ ord.setups.loadVessel = function (vessel) {
         $('.setup_vessel_attachment_type', node), attachment.getType());
     $('.setup_vessel_attachment_details', node).text(attachment.getDetails());
   });
-  const volume = vessel.getVolume();
-  if (volume) {
+  if (vessel.hasVolume()) {
+    const volume = vessel.getVolume();
     writeMetric('#setup_vessel_volume', volume);
   }
 };

--- a/editor/js/setups.js
+++ b/editor/js/setups.js
@@ -26,8 +26,8 @@ ord.setups.load = function (setup) {
   if (vessel) {
     ord.setups.loadVessel(vessel);
   }
-  const isAutomated = setup.getIsAutomated();
-  setSelector($('#setup_automated'), isAutomated);
+  const isAutomated = setup.hasIsAutomated() ? setup.getIsAutomated() : null;
+  setOptionalBool($('#setup_automated'), isAutomated);
 
   const platform = setup.getAutomationPlatform();
   $('#setup_platform').text(platform);
@@ -79,7 +79,7 @@ ord.setups.unload = function () {
   const vessel = ord.setups.unloadVessel();
   setup.setVessel(vessel);
 
-  const isAutomated = getSelector($('#setup_automated'));
+  const isAutomated = getOptionalBool($('#setup_automated'));
   setup.setIsAutomated(isAutomated);
 
   const platform = $('#setup_platform').text();

--- a/editor/js/workups.js
+++ b/editor/js/workups.js
@@ -60,7 +60,8 @@ ord.workups.loadWorkup = function (workup) {
   }
   $('.workup_target_ph', node).text(workup.getTargetPh());
 
-  setSelector($('.workup_automated', node), workup.getIsAutomated());
+  setOptionalBool($('.workup_automated', node),
+      workup.hasIsAutomated() ? workup.getIsAutomated() : null);
 };
 
 ord.workups.loadMeasurement = function (workupNode, measurement) {
@@ -149,7 +150,7 @@ ord.workups.unloadWorkup = function (node) {
   if (!isNaN(targetPh)) {
     workup.setTargetPh(targetPh);
   }
-  workup.setIsAutomated(getSelector($('.workup_automated', node)));
+  workup.setIsAutomated(getOptionalBool($('.workup_automated', node)));
   return workup;
 };
 

--- a/editor/js/workups.js
+++ b/editor/js/workups.js
@@ -58,8 +58,9 @@ ord.workups.loadWorkup = function (workup) {
     $('.workup_stirring_rate_details', node).text(rate.getDetails());
     $('.workup_stirring_rate_rpm', node).text(rate.getRpm());
   }
-  $('.workup_target_ph', node).text(workup.getTargetPh());
-
+  if (workup.hasTargetPh()) {
+    $('.workup_target_ph', node).text(workup.getTargetPh());
+  }
   setOptionalBool($('.workup_automated', node),
       workup.hasIsAutomated() ? workup.getIsAutomated() : null);
 };


### PR DESCRIPTION
This adds expression in the editor for the new proto3 "optional" field semantics.

In the case of "optional bool", the fields are represented as before by a three-way popup, "TRUE / FALSE / UNSPECIFIED". In the case of "optional float", the load logic first checks whether the field is defined before initializing its text, and the unload logic treats the empty string as an absent field.

The editor test is again passing.