### PR TITLE
Multistep reaction capabilities

### DIFF
--- a/ord_schema/process_dataset.py
+++ b/ord_schema/process_dataset.py
@@ -176,8 +176,8 @@ def main(argv):
         logging.info('nothing else to do; use --update for more')
         return  # Nothing else to do.
     for dataset in datasets.values():
-        for reaction in dataset.reactions:
-            updates.update_reaction(reaction)
+        # Set reaction_ids, resolve names, fix cross-references, etc.
+        updates.update_dataset(dataset)
         # Offload large Data values.
         data_filenames = data_storage.extract_data(dataset,
                                                    FLAGS.root,

--- a/ord_schema/process_dataset.py
+++ b/ord_schema/process_dataset.py
@@ -171,6 +171,7 @@ def main(argv):
         datasets[file_status.filename] = message_helpers.load_message(
             file_status.filename, dataset_pb2.Dataset)
     if FLAGS.validate:
+        # Note: this does not check if IDs are malformed.
         validations.validate_datasets(datasets, FLAGS.write_errors)
     if not FLAGS.update:
         logging.info('nothing else to do; use --update for more')
@@ -188,8 +189,9 @@ def main(argv):
             logging.info('Running command: %s', ' '.join(args))
             subprocess.run(args, check=True)
     combined = _combine_datasets(datasets)
-    # Final validation to make sure we didn't break anything.
-    validations.validate_datasets({'_COMBINED': combined}, FLAGS.write_errors)
+    # Final validation (incl. IDs) to make sure we didn't break anything.
+    validations.validate_datasets({'_COMBINED': combined}, FLAGS.write_errors,
+        validate_ids=True)
     if FLAGS.output:
         output_filename = FLAGS.output
     else:

--- a/ord_schema/proto/reaction.proto
+++ b/ord_schema/proto/reaction.proto
@@ -286,6 +286,8 @@ message CompoundPreparation {
   // The ID of the reaction that produced this species. Note that this ID must
   // be defined within the same Dataset; cross-references cannot exist between
   // multiple datasets. Only to be used with the SYNTHESIZED preparation type.
+  // The referenced reaction should not merely be the procedure that was
+  // followed/reproduced, but the *exact* physical experiment.
   string reaction_id = 3;
 }
 

--- a/ord_schema/proto/reaction.proto
+++ b/ord_schema/proto/reaction.proto
@@ -112,16 +112,17 @@ message ReactionInput {
    * }
    */
   repeated Compound components = 1;
+  repeated CrudeComponent crude_components = 2;
   /**
    * Used to define order of addition. ReactionInputs with the same
    * addition_order were added simultaneously. One ReactionInput with a
    * lower addition_order than another was added earlier in the procedure.
    * This field is 1-indexed.
    */
-  int32 addition_order = 2;
+  int32 addition_order = 3;
   // When the addition event took place in terms of the reaction time (or,
   // in the case of flow chemistry, the residence time).
-  Time addition_time = 3;
+  Time addition_time = 4;
   message AdditionSpeed {
     enum AdditionSpeedType {
       // Unspecified.
@@ -138,11 +139,11 @@ message ReactionInput {
     string details = 2;
   }
   // The qualitative rate of addition.
-  AdditionSpeed addition_speed = 4;
+  AdditionSpeed addition_speed = 5;
   // Quantitatively, how long addition took
-  Time addition_duration = 5;
+  Time addition_duration = 6;
   // For continuous synthesis, we instead specify a flow rate.
-  FlowRate flow_rate = 6;
+  FlowRate flow_rate = 7;
   message AdditionDevice {
     enum AdditionDeviceType {
       UNSPECIFIED = 0;
@@ -157,10 +158,37 @@ message ReactionInput {
     string details = 2;
   }
   // The device used for addition.
-  AdditionDevice addition_device = 7;
+  AdditionDevice addition_device = 8;
   // Specify the temperature of the material being added.
   // E.g., a cooled flask of a stock solution to be added at low temperature.
-  Temperature addition_temperature = 8;
+  Temperature addition_temperature = 9;
+}
+
+/**
+ * Crude components are used in multi-step or multi-stage reactions (no strong 
+ * distinction is made here) where one synthetic process must be described by
+ * multiple "Reaction" messages. In these cases, we often carry the crude
+ * product from one step/stage into the next. This message is only to be used
+ * when there is not complete isolation of an intermediate molecule; if there
+ * is complete isolation, then a regular Compound should be used with the 
+ * SYNTHESIED preparation type.
+ */
+message CrudeComponent {
+  // The ID of the reaction that produced the crude. Note that this ID must be
+  // defined within the same Dataset; cross-references cannot exist between
+  // multiple datasets.
+  string reaction_id = 1;
+  // Whether that reaction's workup and purification steps were performed
+  // prior to addition.
+  optional bool includes_workup = 2;
+  // Whether the amount added in this reaction should be inferred from the
+  // previous step, i.e, if everything was added.
+  optional bool has_derived_amount = 3;
+  // If the entire crude mixture was not used, need to specify an amount.
+  oneof amount {
+    Mass mass = 4;
+    Volume volume = 5;
+  }
 }
 
 message Compound {
@@ -255,6 +283,10 @@ message CompoundPreparation {
   PreparationType type = 1;
   // Full description of how the received compound was prepared.
   string details = 2;
+  // The ID of the reaction that produced this species. Note that this ID must
+  // be defined within the same Dataset; cross-references cannot exist between
+  // multiple datasets. Only to be used with the SYNTHESIZED preparation type.
+  string reaction_id = 3;
 }
 
 /**

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -180,7 +180,7 @@ def update_dataset(dataset):
     # another Reaction in the Dataset. If not validated, this update might
     # raise a KeyError exception.
     for reaction in dataset.reactions:
-        for reaction_input in reaction.inputs:
+        for reaction_input in reaction.inputs.values():
             for component in reaction_input.components:
                 for preparation in component.preparations:
                     if preparation.reaction_id:

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -169,16 +169,17 @@ def update_dataset(dataset):
 
     Args:
         dataset: dataset_pb2.Dataset message.
+
+    Raises:
+        KeyError: if the dataset has not been validated and there exists a
+            cross-referenced reaction_id in any Reaction that is not defined
+            elsewhere in the Dataset.
     """
     # Reaction-level updates
     id_substitutions = {}
     for reaction in dataset.reactions:
         id_substitutions.update(update_reaction(reaction))
     # Dataset-level updates of cross-references
-    # Note: if the Dataset has been validated, then we know that all
-    # cross-referened reaction_ids correspond to placeholder reaction_ids of
-    # another Reaction in the Dataset. If not validated, this update might
-    # raise a KeyError exception.
     for reaction in dataset.reactions:
         for reaction_input in reaction.inputs.values():
             for component in reaction_input.components:

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -57,7 +57,7 @@ class UpdateReactionTest(absltest.TestCase):
     def test_with_no_updates(self):
         message = reaction_pb2.Reaction()
         message.provenance.record_created.time.value = '2020-05-08'
-        message.reaction_id = 'ord-test'
+        message.reaction_id = 'ord-c0bbd41f095a44a78b6221135961d809'
         copied = reaction_pb2.Reaction()
         copied.CopyFrom(message)
         updates.update_reaction(copied)
@@ -83,10 +83,11 @@ class UpdateReactionTest(absltest.TestCase):
 
     def test_keep_existing_reaction_id(self):
         message = reaction_pb2.Reaction()
-        message.reaction_id = 'foo'
+        message.reaction_id = 'ord-c0bbd41f095a44a78b6221135961d809'
         message.provenance.record_created.time.value = '11 am'
         updates.update_reaction(message)
-        self.assertEqual(message.reaction_id, 'foo')
+        self.assertEqual(message.reaction_id,
+                         'ord-c0bbd41f095a44a78b6221135961d809')
         self.assertLen(message.provenance.record_modified, 0)
 
 

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -74,7 +74,7 @@ def _validate_dataset(dataset, label='dataset', validate_ids=False):
     """
 
     errors = []
-    # Reaction-level validation
+    # Reaction-level validation.
     num_bad_reactions = 0
     for i, reaction in enumerate(dataset.reactions):
         reaction_errors = validate_message(reaction,
@@ -89,7 +89,7 @@ def _validate_dataset(dataset, label='dataset', validate_ids=False):
                  label,
                  len(dataset.reactions) - num_bad_reactions,
                  len(dataset.reactions), num_bad_reactions)
-    # Dataset-level validation of cross-references
+    # Dataset-level validation of cross-references.
     dataset_errors = validate_message(dataset,
                                       raise_on_error=False,
                                       recurse=False,

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -406,9 +406,6 @@ def validate_compound(message):
         warnings.warn(
             'Compounds should have more specific identifiers than '
             'NAME whenever possible', ValidationWarning)
-    if not message.HasField('amount'):
-        warnings.warn('Compounds should have an amount specified',
-                      ValidationWarning)
 
 
 def validate_compound_feature(message):

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -70,6 +70,7 @@ def _validate_dataset(filename, dataset):
     """
     basename = os.path.basename(filename)
     errors = []
+    # Reaction-level validation
     num_bad_reactions = 0
     for i, reaction in enumerate(dataset.reactions):
         reaction_errors = validate_message(reaction, raise_on_error=False)
@@ -83,6 +84,9 @@ def _validate_dataset(filename, dataset):
                  basename,
                  len(dataset.reactions) - num_bad_reactions,
                  len(dataset.reactions), num_bad_reactions)
+    # Dataset-level validation of cross-references
+    # TODO
+
     return errors
 
 
@@ -588,7 +592,15 @@ def validate_reaction_outcome(message):
 
 
 def validate_reaction_product(message):
-    del message  # Unused.
+    # pylint: disable=too-many-boolean-expressions
+    if (message.compound.HasField('volume_includes_solutes')
+            or message.compound.HasField('is_limiting')
+            or message.compound.preparations
+            or message.compound.vendor_source
+            or message.compound.vendor_id
+            or message.compound.vendor_lot):
+        warnings.warn('Compounds defined as reaction products should not have'
+                      ' any inapplicable fields defined.', ValidationError)
 
 
 def validate_texture(message):

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -275,7 +275,7 @@ def reaction_needs_internal_standard(message):
 
 
 def validate_dataset(message, validate_id=False):
-    # pylint: disable=too-many-branches
+    # pylint: disable=too-many-branches,too-many-nested-blocks
     if not message.reactions and not message.reaction_ids:
         warnings.warn('Dataset requires reactions or reaction_ids',
                       ValidationError)
@@ -295,14 +295,23 @@ def validate_dataset(message, validate_id=False):
     defined_ids = set()
     for reaction in message.reactions:
         if reaction.reaction_id:
+            if reaction.reaction_id in defined_ids:
+                warnings.warn('Multiple Reactions should never have the same '
+                              'IDs', ValidationError)
             defined_ids.add(reaction.reaction_id)
         for reaction_input in reaction.inputs.values():
             for component in reaction_input.components:
                 for preparation in component.preparations:
                     if preparation.reaction_id:
                         referenced_ids.add(preparation.reaction_id)
+                        if preparation.reaction_id == reaction.reaction_id:
+                            warnings.warn('A Reaction should not reference '
+                                          'its own ID', ValidationError)
             for crude_component in reaction_input.crude_components:
                 referenced_ids.add(crude_component.reaction_id)
+                if crude_component.reaction_id == reaction.reaction_id:
+                    warnings.warn('A Reaction should not reference '
+                                  'its own ID', ValidationError)
     if len(referenced_ids - defined_ids) > 0:
         warnings.warn(
             'Reactions in the Dataset refer to undefined '

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -313,8 +313,9 @@ def validate_dataset(message, validate_id=False):
     for reaction in message.reactions:
         if reaction.reaction_id:
             if reaction.reaction_id in dataset_defined_ids:
-                warnings.warn('Multiple Reactions should never have the same '
-                              'IDs', ValidationError)
+                warnings.warn(
+                    'Multiple Reactions should never have the same '
+                    'IDs', ValidationError)
             dataset_defined_ids.add(reaction.reaction_id)
         referenced_ids = get_referenced_reaction_ids(reaction)
         if any(_id == reaction.reaction_id for _id in referenced_ids):

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -245,7 +245,7 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         _ = message.inputs['test']
         message.outcomes.add()
         with self.assertRaisesRegex(validations.ValidationError, 'malformed'):
-            self._run_validation(message, recurse=False)
+            self._run_validation(message, recurse=False, validate_ids=True)
 
     def test_data(self):
         message = reaction_pb2.Data()
@@ -262,20 +262,20 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
     def test_dataset_bad_reaction_id(self):
         message = dataset_pb2.Dataset(reaction_ids=['foo'])
         with self.assertRaisesRegex(validations.ValidationError, 'malformed'):
-            self._run_validation(message)
+            self._run_validation(message, validate_ids=True)
 
     def test_dataset_records_and_ids(self):
         message = dataset_pb2.Dataset(
             reactions=[reaction_pb2.Reaction()],
             reaction_ids=['ord-c0bbd41f095a44a78b6221135961d809'])
         with self.assertRaisesRegex(validations.ValidationError, 'not both'):
-            self._run_validation(message, recurse=False)
+            self._run_validation(message, recurse=False, validate_ids=True)
 
     def test_dataset_bad_id(self):
         message = dataset_pb2.Dataset(reactions=[reaction_pb2.Reaction()],
                                       dataset_id='foo')
         with self.assertRaisesRegex(validations.ValidationError, 'malformed'):
-            self._run_validation(message, recurse=False)
+            self._run_validation(message, recurse=False, validate_ids=True)
 
     def test_dataset_example(self):
         message = dataset_pb2.DatasetExample()

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -110,7 +110,8 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         self.assertEmpty(self._run_validation(message))
         message = reaction_pb2.CompoundPreparation(
             type='NONE', reaction_id='dummy_reaction_id')
-        with self.assertRaisesRegex(validations.ValidationError, 'IDs'):
+        with self.assertRaisesRegex(validations.ValidationError,
+                                    'only .* when SYNTHESIZED'):
             self._run_validation(message)
 
     def test_crude_component(self):


### PR DESCRIPTION
As a result of our [discussions](https://docs.google.com/document/d/1eO5-2E4RXCpG2bdMGo9R-JnEC92uppPBlswAscVrtlE/edit#) about how to best handle multi-step/stage reactions, this adds that capability.

Use cases are as follows:
1. For a multi-step reaction sequence with complete intermediate isolations and characterizations:
- A string reaction_id field is added to the CompoundPreparation message. This is to be used when the preparation type is SYNTHESIZED and the preparation of that compound is also recorded in the database. Note that this is not to be used when the preparation merely follows a previously described process; the isolated product of the previous reaction should be what is used, physically, in this reaction.
2. For a one-pot reaction sequence with no intermediate isolation:
- For all but the final step (i.e., reaction steps without analysis/characterization of the crude product):
Reactions have a single ReactionOutcome defined at the appropriate reaction_time.
- A putative product structure (key intermediate) can be defined as a ReactionProduct, with no supporting analytical data used to confirm its identity (i.e., analysis_identity is empty); yield, purity, and selectivity would be undefined as well.
3. For all but the first step (i.e., reaction steps that use the output of a previous reaction step without complete isolation and characterization):
- A new repeated CrudeComponent crude_components field is added to the ReactionInput message to indicate that crude (or partially worked up) was used in the reaction.

The key additions in this PR are as follows:
- Addition of a `CrudeComponent` message to the schema and a `repeated CrudeComponent crude_components` field for a `ReactionInput`
- Addition of a `reaction_id` to `CompoundPreparation` to be used when `SYNTHESIZED`
- Validations and validation tests to ensure that cross-referenced reaction IDs are all defined within a single dataset
- Addition of a `validate_ids` keyword argument to `validate_message` so that we can enforce well-formed IDs only after assigning them through `ord_schema.updates`
- Addition of an `update_dataset` function in `updates.py` that is used by `process_dataset.py`, which ensures that when reaction IDs are assigned, we still preserve any cross-references that existed within the `Dataset`.
- Addition of a test for `update_dataset` which confirms that cross-references are preserved.
