### PR TITLE
Add support for similarity searching

### DIFF
--- a/ord_schema/interface/query.py
+++ b/ord_schema/interface/query.py
@@ -101,6 +101,9 @@ class OrdPostgres:
             table: Text SQL table name.
             limit: Integer maximum number of matches to return.
             threshold: Float similarity threshold.
+
+        Returns:
+            Dataset proto containing matched Reactions.
         """
         if 'reactions' in table:
             column = 'rdfp'


### PR DESCRIPTION
Also refactors the usage of OrdPostgres to remove an extra layer of context managers and adds an explicit `rollback()` call in transactions to (hopefully) avoid any persistent changes to cartridge options.