### PR TITLE
Add validation tracing

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -255,7 +255,7 @@ indent-string='    '
 max-line-length=80
 
 # Maximum number of lines in a module.
-max-module-lines=1000
+max-module-lines=1500
 
 # List of optional constructs for which whitespace checking is disabled. `dict-
 # separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.

--- a/ord_schema/process_dataset_test.py
+++ b/ord_schema/process_dataset_test.py
@@ -77,8 +77,8 @@ class ProcessDatasetTest(absltest.TestCase):
         error_filename = f'{self.dataset2_filename}.error'
         self.assertTrue(os.path.exists(error_filename))
         expected_output = [
-            'Reactions should have at least 1 reaction input\n',
-            'Reactions should have at least 1 reaction outcome\n',
+            'Reaction: Reactions should have at least 1 reaction input\n',
+            'Reaction: Reactions should have at least 1 reaction outcome\n',
         ]
         with open(error_filename) as f:
             self.assertEqual(f.readlines(), expected_output)

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -101,12 +101,11 @@ def _validate_dataset(dataset, label='dataset', validate_ids=False):
     return errors
 
 
-# pylint: disable=too-many-branches
-# pylint: disable=too-many-nested-blocks
 def validate_message(message,
                      recurse=True,
                      raise_on_error=True,
-                     validate_ids=False):
+                     validate_ids=False,
+                     trace=None):
     """Template function for validating custom messages in the reaction_pb2.
 
     Messages are not validated to check enum values, since these are enforced
@@ -127,6 +126,8 @@ def validate_message(message,
             value to identify validation errors.
         validate_ids: A boolean that controls whether the IDs of Reactions or
             Datasets should be checked for validity. Defaults to False.
+        trace: Tuple containing a string "stack trace" to track the position of
+            the current message relative to the recursion root.
 
     Returns:
         List of text validation errors, if any.
@@ -134,35 +135,19 @@ def validate_message(message,
     Raises:
         ValidationError: If any fields are invalid.
     """
+    if trace is None:
+        trace = (message.DESCRIPTOR.name, )
     errors = []
     # Recurse through submessages
     if recurse:
         for field, value in message.ListFields():
             if field.type == field.TYPE_MESSAGE:  # need to recurse
-                if field.label == field.LABEL_REPEATED:
-                    if field.message_type.GetOptions().map_entry:  # map
-                        # value is message
-                        if field.message_type.fields_by_name['value'].type == \
-                                field.TYPE_MESSAGE:
-                            for submessage in value.values():
-                                errors.extend(
-                                    validate_message(
-                                        submessage,
-                                        raise_on_error=raise_on_error,
-                                        validate_ids=validate_ids))
-                        else:  # value is a primitive
-                            pass
-                    else:  # Just a repeated message
-                        for submessage in value:
-                            errors.extend(
-                                validate_message(submessage,
-                                                 raise_on_error=raise_on_error,
-                                                 validate_ids=validate_ids))
-                else:  # no recursion needed
-                    errors.extend(
-                        validate_message(value,
-                                         raise_on_error=raise_on_error,
-                                         validate_ids=validate_ids))
+                _validate_message(field=field,
+                                  value=value,
+                                  errors=errors,
+                                  raise_on_error=raise_on_error,
+                                  validate_ids=validate_ids,
+                                  trace=trace)
 
     # Message-specific validation
     if not isinstance(message, tuple(_VALIDATOR_SWITCH.keys())):
@@ -180,18 +165,63 @@ def validate_message(message,
             _VALIDATOR_SWITCH[type(message)](message, validate_id=True)
         else:
             _VALIDATOR_SWITCH[type(message)](message)
+    stack = '.'.join(trace)
     for warning in tape:
+        message = f'{stack}: {warning.message}'
         if issubclass(warning.category, ValidationError):
             if raise_on_error:
-                raise warning.message
-            errors.append(str(warning.message))
+                raise ValidationError(message)
+            errors.append(message)
         else:
-            warnings.warn(warning.message)
+            warnings.warn(message)
     return errors
 
 
-# pylint: enable=too-many-branches
-# pylint: enable=too-many-nested-blocks
+def _validate_message(field, value, errors, raise_on_error, validate_ids,
+                      trace):
+    """Validates a single message field and its children.
+
+    Args:
+        field: FieldDescriptor instance.
+        value: The value of the current message field.
+        errors: List of text error messages.
+        raise_on_error: If True, raises a ValidationError exception when errors
+            are encountered. If False, the user must manually check the return
+            value to identify validation errors.
+        validate_ids: A boolean that controls whether the IDs of Reactions or
+            Datasets should be checked for validity. Defaults to False.
+        trace: Tuple containing a string "stack trace" to track the position of
+            the current message relative to the recursion root.
+    """
+    if field.label == field.LABEL_REPEATED:
+        if field.message_type.GetOptions().map_entry:  # map
+            # value is message
+            if field.message_type.fields_by_name['value'].type == \
+                    field.TYPE_MESSAGE:
+                for key, submessage in value.items():
+                    this_trace = trace + (f'{field.name}["{key}"]', )
+                    errors.extend(
+                        validate_message(submessage,
+                                         raise_on_error=raise_on_error,
+                                         validate_ids=validate_ids,
+                                         trace=this_trace))
+            else:  # value is a primitive
+                pass
+        else:  # Just a repeated message
+            for index, submessage in enumerate(value):
+                this_trace = trace + (f'{field.name}[{index}]', )
+                errors.extend(
+                    validate_message(submessage,
+                                     raise_on_error=raise_on_error,
+                                     validate_ids=validate_ids,
+                                     trace=this_trace))
+    else:  # no recursion needed
+        this_trace = trace + (field.name, )
+        errors.extend(
+            validate_message(value,
+                             raise_on_error=raise_on_error,
+                             validate_ids=validate_ids,
+                             trace=this_trace))
 
 
 class ValidationError(Warning):

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -406,7 +406,7 @@ def validate_reaction_input(message):
                       ValidationError)
     for component in message.components:
         if not component.WhichOneof('amount'):
-            warnings.warn('Reaction input\'s components require an amount',
+            warnings.warn('Reaction input components require an amount',
                           ValidationError)
 
 

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -211,9 +211,11 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         message.inputs['dummy_input'].components.add()
         errors = self._run_validation(message, raise_on_error=False)
         expected = [
-            'Compounds must have at least one identifier',
-            "Reaction input's components require an amount",
-            'Reactions should have at least 1 reaction outcome',
+            ('Reaction.inputs["dummy_input"].components[0]: '
+             'Compounds must have at least one identifier'),
+            ('Reaction.inputs["dummy_input"]: '
+             'Reaction input components require an amount'),
+            'Reaction: Reactions should have at least 1 reaction outcome',
         ]
         self.assertEqual(errors, expected)
 


### PR DESCRIPTION
Fixes #240 

...at least for most cases. There are some edge cases; for example, `validate_reaction_input` loops over the components rather than allowing `validate_component` to do the job (since `amount` is not always required).

Also refactors the behemoth that was `validate_message` to separate the recursive logic into a new function.