### PR TITLE
Name resolve backups

### DIFF
--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -338,8 +338,8 @@ def resolve_compound(identifier_type):
         return ''
     try:
         return flask.jsonify(
-            updates.pubchem_resolve(identifier_type, compound_name))
-    except urllib.error.HTTPError as error:
+            updates.name_resolve(identifier_type, compound_name))
+    except ValueError:
         return ''
 
 

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -43,7 +43,7 @@ def name_resolve(value_type, value):
                 return smiles
         except urllib.error.HTTPError as error:
             logging.info('%s could not resolve %s %s: %s',
-                resolver.__name__, value_type, value, error)
+                         resolver.__name__, value_type, value, error)
     raise ValueError(f'Could not resolve {value_type} {value} to SMILES')
 
 

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -91,7 +91,7 @@ def resolve_names(message):
                     new_identifier = compound.identifiers.add()
                     new_identifier.type = new_identifier.SMILES
                     new_identifier.value = smiles
-                    new_identifier.details = 'NAME resolved by PubChem'
+                    new_identifier.details = 'NAME resolved automatically'
                     modified = True
                     break
                 except ValueError:

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -33,11 +33,34 @@ _COMPOUND_STRUCTURAL_IDENTIFIERS = [
 ]
 
 
-def pubchem_resolve(value_type, value):
+def name_resolve(value_type, value):
+    """Resolves compound identifiers to SMILES via multiple APIs."""
+    smiles = None
+    for resolver in _NAME_RESOLVERS:
+        try:
+            smiles = resolver(value_type, value)
+            if smiles is not None:
+                return smiles
+        except urllib.error.HTTPError as error:
+            logging.info('%s could not resolve %s %s: %s',
+                resolver.__name__, value_type, value, error)
+    raise ValueError(f'Could not resolve {value_type} {value} to SMILES')
+
+
+def _pubchem_resolve(value_type, value):
     """Resolves compound identifiers to SMILES via the PubChem REST API."""
     response = urllib.request.urlopen(
         f'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/{value_type}/'
-        f'/{urllib.parse.quote(value)}/property/IsomericSMILES/txt')
+        f'{urllib.parse.quote(value)}/property/IsomericSMILES/txt')
+    return response.read().decode().strip()
+
+
+def _cactus_resolve(value_type, value):
+    """Resolves compound identifiers to SMILES via the CACTUS API."""
+    del value_type
+    response = urllib.request.urlopen(
+        'https://cactus.nci.nih.gov/chemical/structure/'
+        f'{urllib.parse.quote(value)}/smiles')
     return response.read().decode().strip()
 
 
@@ -64,16 +87,15 @@ def resolve_names(message):
         for identifier in compound.identifiers:
             if identifier.type == identifier.NAME:
                 try:
-                    smiles = pubchem_resolve('name', identifier.value)
+                    smiles = name_resolve('name', identifier.value)
                     new_identifier = compound.identifiers.add()
                     new_identifier.type = new_identifier.SMILES
                     new_identifier.value = smiles
                     new_identifier.details = 'NAME resolved by PubChem'
                     modified = True
                     break
-                except urllib.error.HTTPError as error:
-                    logging.info('PubChem could not resolve NAME %s: %s',
-                                 identifier.value, error)
+                except ValueError:
+                    pass
     return modified
 
 
@@ -190,4 +212,10 @@ def update_dataset(dataset):
 # Standard updates.
 _UPDATES = [
     resolve_names,
+]
+
+# Standard name resolvers.
+_NAME_RESOLVERS = [
+    _pubchem_resolve,
+    _cactus_resolve,
 ]

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -77,7 +77,8 @@ class UpdateReactionTest(absltest.TestCase):
         self.assertEqual(
             component.identifiers[1],
             reaction_pb2.CompoundIdentifier(
-                type='SMILES', value='CCN',
+                type='SMILES',
+                value='CCN',
                 details='NAME resolved automatically'))
 
     def test_add_reaction_id(self):

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -23,16 +23,20 @@ from ord_schema.proto import dataset_pb2
 
 class UpdatesTest(absltest.TestCase):
     def test_resolve_names(self):
+        roundtrip_smi = lambda smi: Chem.MolToSmiles(Chem.MolFromSmiles(smi))
         message = reaction_pb2.Reaction()
         message.inputs['test'].components.add().identifiers.add(
             type='NAME', value='aspirin')
         self.assertTrue(updates.resolve_names(message))
+        resolved_smi = roundtrip_smi(
+            message.inputs['test'].components[0].identifiers[1].value)
+        self.assertEqual(resolved_smi, roundtrip_smi('CC(=O)Oc1ccccc1C(O)=O'))
         self.assertEqual(
-            message.inputs['test'].components[0].identifiers[1],
-            reaction_pb2.CompoundIdentifier(
-                type='SMILES',
-                value='CC(=O)OC1=CC=CC=C1C(=O)O',
-                details='NAME resolved by PubChem'))
+            message.inputs['test'].components[0].identifiers[1].type,
+            reaction_pb2.CompoundIdentifier.IdentifierType.SMILES)
+        self.assertEqual(
+            message.inputs['test'].components[0].identifiers[1].details,
+            'NAME resolved by PubChem')
 
     def test_add_binary_identifiers(self):
         smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O'

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -36,7 +36,7 @@ class UpdatesTest(absltest.TestCase):
             reaction_pb2.CompoundIdentifier.IdentifierType.SMILES)
         self.assertEqual(
             message.inputs['test'].components[0].identifiers[1].details,
-            'NAME resolved by PubChem')
+            'NAME resolved automatically')
 
     def test_add_binary_identifiers(self):
         smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O'
@@ -78,7 +78,7 @@ class UpdateReactionTest(absltest.TestCase):
             component.identifiers[1],
             reaction_pb2.CompoundIdentifier(
                 type='SMILES', value='CCN',
-                details='NAME resolved by PubChem'))
+                details='NAME resolved automatically'))
 
     def test_add_reaction_id(self):
         message = reaction_pb2.Reaction()


### PR DESCRIPTION
PubChem's name resolver API is currently down! 

```
Status: 500
Code: PUGREST.ServerError
Message: Can't see oe_license.txt
```


Highlighted the need for a backup option. Added NIH's cactus resolver. At least our tests will pass now.