### PR TITLE
Dataset-level change statistics

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,6 +25,7 @@ jobs:
     - name: Install ord_schema
       run: |
         cd "${GITHUB_WORKSPACE}"
+        apt update && apt install git
         pip install -r requirements.txt
         pip install -r test_requirements.txt
         conda install -c rdkit rdkit

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install ord_schema
       run: |
         cd "${GITHUB_WORKSPACE}"
-        apt update && apt install git
+        sudo apt update && sudo apt install -y git
         pip install -r requirements.txt
         pip install -r test_requirements.txt
         conda install -c rdkit rdkit

--- a/ord_schema/process_dataset.py
+++ b/ord_schema/process_dataset.py
@@ -191,7 +191,9 @@ def _load_base_dataset(file_status, base):
     else:
         args.append(f'{base}:{file_status.filename}')
     logging.info('Running command: %s', ' '.join(args))
-    dataset_pbtxt = subprocess.run(args, capture_output=True, check=True,
+    dataset_pbtxt = subprocess.run(args,
+                                   capture_output=True,
+                                   check=True,
                                    text=True)
     return text_format.Parse(dataset_pbtxt.stdout, dataset_pb2.Dataset())
 
@@ -223,7 +225,7 @@ def main(argv):
     inputs = sorted(_get_inputs())
     if not inputs:
         logging.info('nothing to do')
-        return set(), set() # Nothing to do.
+        return set(), set()  # Nothing to do.
     datasets = {}
     for file_status in inputs:
         if file_status.status == 'D':
@@ -243,7 +245,7 @@ def main(argv):
             f'Summary: +{len(added)} -{len(removed)} reaction IDs')
     if not FLAGS.update:
         logging.info('nothing else to do; use --update for more')
-        return added, removed # Nothing else to do.
+        return added, removed  # Nothing else to do.
     for dataset in datasets.values():
         # Set reaction_ids, resolve names, fix cross-references, etc.
         updates.update_dataset(dataset)

--- a/ord_schema/process_dataset.py
+++ b/ord_schema/process_dataset.py
@@ -47,6 +47,8 @@ import uuid
 from absl import app
 from absl import flags
 from absl import logging
+import github
+from google.protobuf import text_format
 
 from ord_schema import data_storage
 from ord_schema import message_helpers
@@ -70,6 +72,11 @@ flags.DEFINE_float('min_size', 0.1,
                    'Minimum size (in MB) for offloading Data values.')
 flags.DEFINE_float('max_size', 100.0,
                    'Maximum size (in MB) for offloading Data values.')
+flags.DEFINE_string('base', 'main', 'Git branch to diff against.')
+flags.DEFINE_integer(
+    'issue', None,
+    'GitHub pull request number. If provided, a comment will be added.')
+flags.DEFINE_string('token', None, 'GitHub authentication token.')
 
 
 @dataclasses.dataclass(eq=True, frozen=True, order=True)
@@ -77,6 +84,7 @@ class FileStatus:
     """A filename and its status in Git."""
     filename: str
     status: str
+    original_filename: str
 
     def __post_init__(self):
         if self.status[0] not in ['A', 'D', 'M', 'R']:
@@ -88,6 +96,9 @@ def _get_inputs():
 
     Returns:
         List of FileStatus objects.
+
+    Raises:
+        ValueError: If a git-diff status is not one of {'A', 'D', 'M', 'R'}.
     """
     if FLAGS.input_pattern and FLAGS.input_file:
         raise ValueError(
@@ -95,22 +106,24 @@ def _get_inputs():
     if FLAGS.input_pattern:
         # Setting recursive=True allows recursive matching with '**'.
         filenames = glob.glob(FLAGS.input_pattern, recursive=True)
-        return [FileStatus(filename, 'A') for filename in filenames]
+        return [FileStatus(filename, 'A', '') for filename in filenames]
     if FLAGS.input_file:
         inputs = []
         with open(FLAGS.input_file) as f:
             for line in f:
                 fields = line.strip().split()
                 if len(fields) == 3:
-                    status, _, filename = fields
+                    status, original_filename, filename = fields
                     if not status.startswith('R'):
                         raise ValueError(
                             f'malformed status line: {line.strip()}')
                 else:
                     status, filename = fields
-                if status == 'D':
-                    continue  # Nothing to do for deleted files.
-                inputs.append(FileStatus(filename, status))
+                    if not status.startswith(('A', 'D', 'M')):
+                        raise ValueError(
+                            f'unsupported git-diff statue: {status}')
+                    original_filename = ''
+                inputs.append(FileStatus(filename, status, original_filename))
         return inputs
     raise ValueError('one of --input_pattern or --input_file is required')
 
@@ -160,22 +173,77 @@ def cleanup(inputs, output_filename):
         subprocess.run(args, check=True)
 
 
+def _get_reaction_ids(dataset):
+    """Returns a list of reaction IDs in a Dataset."""
+    reaction_ids = []
+    for reaction in dataset.reactions:
+        reaction_ids.append(reaction.reaction_id)
+    return reaction_ids
+
+
+def _load_base_dataset(file_status, base):
+    """Loads a Dataset message from another branch."""
+    if file_status.status.startswith('A'):
+        return None  # Dataset only exists in the submission.
+    args = ['git', 'show']
+    if file_status.status.startswith('R'):
+        args.append(f'{base}:{file_status.original_filename}')
+    else:
+        args.append(f'{base}:{file_status.filename}')
+    logging.info('Running command: %s', ' '.join(args))
+    dataset_pbtxt = subprocess.run(args, capture_output=True, check=True,
+                                   text=True)
+    return text_format.Parse(dataset_pbtxt.stdout, dataset_pb2.Dataset())
+
+
+def get_change_stats(datasets, inputs, base):
+    """Computes diff statistics for the submission.
+
+    Args:
+        datasets: Dict mapping filenames to Dataset messages.
+        inputs: List of FileStatus objects.
+        base: Git branch to diff against.
+
+    Returns:
+        added: Set of added reaction IDs.
+        removed: Set of deleted reaction IDs.
+    """
+    old, new = set(), set()
+    for file_status in inputs:
+        if not file_status.status.startswith('D'):
+            new.update(_get_reaction_ids(datasets[file_status.filename]))
+        dataset = _load_base_dataset(file_status, base)
+        if dataset is not None:
+            old.update(_get_reaction_ids(dataset))
+    return new - old, old - new
+
+
 def main(argv):
     del argv  # Only used by app.run().
     inputs = sorted(_get_inputs())
     if not inputs:
         logging.info('nothing to do')
-        return  # Nothing to do.
+        return set(), set() # Nothing to do.
     datasets = {}
     for file_status in inputs:
+        if file_status.status == 'D':
+            continue  # Nothing to do for deleted files.
         datasets[file_status.filename] = message_helpers.load_message(
             file_status.filename, dataset_pb2.Dataset)
     if FLAGS.validate:
         # Note: this does not check if IDs are malformed.
         validations.validate_datasets(datasets, FLAGS.write_errors)
+    added, removed = get_change_stats(datasets, inputs, base=FLAGS.base)
+    logging.info(f'Summary: +%d -%d reaction IDs', len(added), len(removed))
+    if FLAGS.issue and FLAGS.token:
+        client = github.Github(FLAGS.token)
+        repo = client.get_repo(os.environ['GITHUB_REPOSITORY'])
+        issue = repo.get_issue(FLAGS.issue)
+        issue.create_comment(
+            f'Summary: +{len(added)} -{len(removed)} reaction IDs')
     if not FLAGS.update:
         logging.info('nothing else to do; use --update for more')
-        return  # Nothing else to do.
+        return added, removed # Nothing else to do.
     for dataset in datasets.values():
         # Set reaction_ids, resolve names, fix cross-references, etc.
         updates.update_dataset(dataset)
@@ -205,6 +273,7 @@ def main(argv):
         cleanup(inputs, output_filename)
     logging.info('writing combined Dataset to %s', output_filename)
     message_helpers.write_message(combined, output_filename)
+    return added, removed
 
 
 if __name__ == '__main__':

--- a/ord_schema/process_dataset_test.py
+++ b/ord_schema/process_dataset_test.py
@@ -177,9 +177,9 @@ class SubmissionWorkflowTest(absltest.TestCase):
         run_flags.update(kwargs)
         with flagsaver.flagsaver(**run_flags):
             added, removed = process_dataset.main(())
-        filenames = glob.glob(
-            os.path.join(self.test_subdirectory, '**/*.pbtxt'),
-            recursive=True)
+        filenames = glob.glob(os.path.join(self.test_subdirectory,
+                                           '**/*.pbtxt'),
+                              recursive=True)
         return added, removed, filenames
 
     def test_add_dataset(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pandas>=1.0.4
 protobuf>=3.12.0
 protoc-wheel-0>=3.12.0
 psycopg2-binary>=2.8.5
+pygithub>=1.51
 python-dateutil>=1.10.0
 jinja2>=2.0.0
 xlrd>=1.0.0


### PR DESCRIPTION
Replaces #258 

Adds new features to `process_dataset.py`:

* The sets of added and removed reaction IDs are computed by comparing to the branch specified by `--base`. Specifically, we load the `Dataset` messages from the base branch and compare to the `Dataset` messages loaded from the current HEAD.
* Tests now use a new branch instead of just a new commit to better simulate real-world use.