### PR TITLE
Remove rdkit binary

### DIFF
--- a/editor/db/test/full.pbtxt
+++ b/editor/db/test/full.pbtxt
@@ -9,7 +9,7 @@ reactions {
   identifiers {
     type: REACTION_SMILES
     details: "3"
-    bytes_value: "123\n"
+    value: "123\n"
   }
   inputs {
     value {
@@ -446,6 +446,12 @@ reactions {
             float_value: 140.0
             description: "141"
             format: "142"
+          }
+        }
+        raw_data {
+          key: "byte_data"
+          value {
+            bytes_value: "bytestring"
           }
         }
         instrument_manufacturer: "133"

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -84,13 +84,6 @@ limitations under the License.
             <div class="remove" onclick="removeSlowly(this, '.reaction_identifier');">remove</div>
             <br>
             details <div class="reaction_identifier_details edittext"></div>
-            <div style="display: none;"><input type="checkbox" class="reaction_identifier_upload"> upload</div>
-            <div class="uploader" data-token="" style="display: none;">
-              <input class="uploader_chooser_file uploadertext" type="file">
-              <div class="uploader_chooser_button uploadertext">Choose...</div>
-              <div class="uploader_file_name uploadertext"></div>
-              <div class="uploader_file_retrieve uploadertext" onclick="ord.uploads.retrieve($(this).closest('.uploader'));" style="display: none;">retrieve</div>
-            </div>
           </div>
         </div>
         <div onclick="ord.identifiers.add();" class="add">+ add identifier</div>
@@ -252,13 +245,6 @@ limitations under the License.
               <span class="fa fa-upload text_upload" aria-hidden="true" style="cursor:pointer;" onclick="setTextFromFile($(this).closest('.component_identifier'), 'component_identifier_value');"></span>
               <div onclick="removeSlowly(this, '.component_identifier');" class="remove">remove</div>
               <br>details <div class="component_identifier_details edittext longtext"></div>
-              <div style="display: none;"><input type="checkbox" class="component_identifier_upload"> upload</div>
-              <div class="uploader" data-token="" style="display: none;">
-                <input class="uploader_chooser_file uploadertext" type="file">
-                <div class="uploader_chooser_button uploadertext">Choose...</div>
-                <div class="uploader_file_name uploadertext"></div>
-                <div class="uploader_file_retrieve uploadertext" onclick="ord.uploads.retrieve($(this).closest('.uploader'));" style="display: none;">retrieve</div>
-              </div>
             </div>
 
             <div id="component_preparation_template" class="component_preparation" style="display: none;">

--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -70,16 +70,8 @@ ord.compounds.loadIntoCompound = function (node, compound) {
 
 ord.compounds.loadIdentifier = function (compoundNode, identifier) {
   const node = ord.compounds.addIdentifier(compoundNode);
-  const bytesValue = identifier.getBytesValue();
-  if (bytesValue) {
-    $('.component_identifier_upload', node).prop('checked', true);
-    $('.component_identifier_value', node).hide();
-    $('.text_upload', node).hide();
-    ord.uploads.load(node, bytesValue);
-  } else {
-    const value = identifier.getValue();
-    $('.component_identifier_value', node).text(value);
-  }
+  const value = identifier.getValue();
+  $('.component_identifier_value', node).text(value);
   setSelector(node, identifier.getType());
   $('.component_identifier_details', node).text(identifier.getDetails());
 };
@@ -176,16 +168,9 @@ ord.compounds.unloadIdentifiers = function (node) {
 ord.compounds.unloadIdentifier = function (node) {
   const identifier = new proto.ord.CompoundIdentifier();
 
-  if ($('.component_identifier_upload', node).is(':checked')) {
-    const bytesValue = ord.uploads.unload(node);
-    if (!isEmptyMessage(bytesValue)) {
-      identifier.setBytesValue(bytesValue);
-    }
-  } else {
-    const value = $('.component_identifier_value', node).text();
-    if (!isEmptyMessage(value)) {
-      identifier.setValue(value);
-    }
+  const value = $('.component_identifier_value', node).text();
+  if (!isEmptyMessage(value)) {
+    identifier.setValue(value);
   }
   const type = getSelector(node);
   identifier.setType(type);

--- a/editor/js/identifiers.js
+++ b/editor/js/identifiers.js
@@ -28,16 +28,8 @@ ord.identifiers.load = function (identifiers) {
 
 ord.identifiers.loadIdentifier = function (identifier) {
   const node = ord.identifiers.add();
-  const bytesValue = identifier.getBytesValue();
-  if (bytesValue) {
-    $('.reaction_identifier_upload', node).prop('checked', true);
-    $('.reaction_identifier_value', node).hide();
-    $('.text_upload', node).hide();
-    ord.uploads.load(node, bytesValue);
-  } else {
-    const value = identifier.getValue();
-    $('.reaction_identifier_value', node).text(value);
-  }
+  const value = identifier.getValue();
+  $('.reaction_identifier_value', node).text(value);
   setSelector(node, identifier.getType());
   $('.reaction_identifier_details', node).text(identifier.getDetails());
 };
@@ -60,18 +52,11 @@ ord.identifiers.unload = function () {
 ord.identifiers.unloadIdentifier = function (node) {
   const identifier = new proto.ord.ReactionIdentifier();
 
-  if ($('.reaction_identifier_upload', node).is(':checked')) {
-    const bytesValue = ord.uploads.unload(node);
-    if (!isEmptyMessage(bytesValue)) {
-      identifier.setBytesValue(bytesValue);
-    }
+  const value = $('.reaction_identifier_value', node).text();
+  if (!isEmptyMessage(value)) {
+    identifier.setValue(value);
   }
-  else {
-    const value = $('.reaction_identifier_value', node).text();
-    if (!isEmptyMessage(value)) {
-      identifier.setValue(value);
-    }
-  }
+
   const type = getSelector(node);
   if (!isEmptyMessage(type)) {
     identifier.setType(type);

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -478,10 +478,6 @@ function initSelector(node) {
     if (options[i] == 'UNSPECIFIED') {
       option.attr('selected', 'selected');
     }
-    // Don't let users directly select/enter RDKIT_BINARY identifiers.
-    if (options[i] == 'RDKIT_BINARY') {
-      option.attr('disabled', true);
-    }
     select.append(option);
   }
   node.append(select);

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -275,8 +275,6 @@ def smiles_from_compound(compound):
 def mol_from_compound(compound, return_identifier=False):
     """Creates an RDKit Mol from a Compound message.
 
-    Note that this function prefers RDKIT_BINARY identifiers over any others.
-
     Args:
         compound: reaction_pb2.Compound message.
         return_identifier: If True, return the CompoundIdentifier used to
@@ -291,13 +289,6 @@ def mol_from_compound(compound, return_identifier=False):
         ValueError: If no structural identifier is available, or if the
             resulting Mol object is invalid.
     """
-    # Prefer RDKIT_BINARY identifiers when available.
-    for identifier in compound.identifiers:
-        if identifier.type == reaction_pb2.CompoundIdentifier.RDKIT_BINARY:
-            mol = Chem.Mol(identifier.bytes_value)
-            if return_identifier:
-                return mol, identifier
-            return mol
     for identifier in compound.identifiers:
         if identifier.type in _COMPOUND_IDENTIFIER_LOADERS:
             mol = _COMPOUND_IDENTIFIER_LOADERS[identifier.type](
@@ -327,9 +318,7 @@ def check_compound_identifiers(compound):
     """
     smiles = set()
     for identifier in compound.identifiers:
-        if identifier.type == reaction_pb2.CompoundIdentifier.RDKIT_BINARY:
-            mol = Chem.Mol(identifier.bytes_value)
-        elif identifier.type in _COMPOUND_IDENTIFIER_LOADERS:
+        if identifier.type in _COMPOUND_IDENTIFIER_LOADERS:
             mol = _COMPOUND_IDENTIFIER_LOADERS[identifier.type](
                 identifier.value)
         else:

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -107,6 +107,9 @@ class MessageHelpersTest(parameterized.TestCase, absltest.TestCase):
         compound.identifiers.add(value='InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H',
                                  type='INCHI')
         message_helpers.check_compound_identifiers(compound)
+        compound.identifiers.add(value='c1ccc(O)cc1', type='SMILES')
+        with self.assertRaisesRegex(ValueError, 'inconsistent'):
+            message_helpers.check_compound_identifiers(compound)
 
     def test_get_reaction_smiles(self):
         reaction = reaction_pb2.Reaction()

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -80,15 +80,10 @@ class MessageHelpersTest(parameterized.TestCase, absltest.TestCase):
     @parameterized.named_parameters(
         ('SMILES', 'c1ccccc1', 'SMILES', 'c1ccccc1'),
         ('INCHI', 'InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H', 'INCHI', 'c1ccccc1'),
-        ('MOLBLOCK', _BENZENE_MOLBLOCK, 'MOLBLOCK', 'c1ccccc1'),
-        ('RDKIT_BINARY', Chem.MolFromSmiles('c1ccccc1').ToBinary(),
-         'RDKIT_BINARY', 'c1ccccc1'))
+        ('MOLBLOCK', _BENZENE_MOLBLOCK, 'MOLBLOCK', 'c1ccccc1'))
     def test_mol_from_compound(self, value, identifier_type, expected):
         compound = reaction_pb2.Compound()
-        if identifier_type == 'RDKIT_BINARY':
-            compound.identifiers.add(bytes_value=value, type=identifier_type)
-        else:
-            compound.identifiers.add(value=value, type=identifier_type)
+        compound.identifiers.add(value=value, type=identifier_type)
         mol = message_helpers.mol_from_compound(compound)
         self.assertEqual(Chem.MolToSmiles(mol), expected)
         mol, identifier = message_helpers.mol_from_compound(
@@ -112,11 +107,6 @@ class MessageHelpersTest(parameterized.TestCase, absltest.TestCase):
         compound.identifiers.add(value='InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H',
                                  type='INCHI')
         message_helpers.check_compound_identifiers(compound)
-        compound.identifiers.add(
-            bytes_value=Chem.MolFromSmiles('C').ToBinary(),
-            type='RDKIT_BINARY')
-        with self.assertRaisesRegex(ValueError, 'inconsistent'):
-            message_helpers.check_compound_identifiers(compound)
 
     def test_get_reaction_smiles(self):
         reaction = reaction_pb2.Reaction()

--- a/ord_schema/proto/reaction.proto
+++ b/ord_schema/proto/reaction.proto
@@ -68,14 +68,10 @@ message ReactionIdentifier {
     RDFILE = 3;  // Reaction data file.
     RINCHI = 4;  // Reaction InChI.
     NAME = 5;  // Named reaction or reaction category.
-    RDKIT_BINARY = 6;  // RDKit binary format (for fast loading).
   }
   IdentifierType type = 1;
   string details = 2;
-  oneof kind {
-    string value = 3;
-    bytes bytes_value = 4;
-  }
+  string value = 3;
   // Whether identifier contains atom-to-atom mapping information. When True,
   // we encourage users to specify how that mapping was obtained in the
   // details field (e.g., manually, using NameRXN, using ChemDraw).
@@ -334,17 +330,12 @@ message CompoundIdentifier {
     UNIPROT_ID = 13;
     // Protein data bank ID (for enzymes)
     PDB_ID = 14;
-    // RDKit binary format (for fast loading)
-    RDKIT_BINARY = 15;
   }
   IdentifierType type = 1;
   string details = 2;
   // Value of the compound identifier; certain types (e.g., PUBCHEM_CID) may
   // cast the string as an integer for downstream processing and validation.
-  oneof kind {
-    string value = 3;
-    bytes bytes_value = 4;
-  }
+  string value = 3;
 }
 
 /**

--- a/ord_schema/proto/reaction_pb2_test.py
+++ b/ord_schema/proto/reaction_pb2_test.py
@@ -34,14 +34,6 @@ class ReactionPb2Test(absltest.TestCase):
                                     'Reaction has no field not_a_field'):
             reaction.HasField('not_a_field')
 
-    @absltest.skipIf(Chem is None, 'no rdkit')
-    def test_rdkit_binary_compound_identifier(self):
-        mol = Chem.MolFromSmiles('COO')
-        identifier = reaction_pb2.CompoundIdentifier(
-            type='RDKIT_BINARY', bytes_value=mol.ToBinary())
-        self.assertEqual(Chem.MolToSmiles(mol),
-                         Chem.MolToSmiles(Chem.Mol(identifier.bytes_value)))
-
 
 if __name__ == '__main__':
     absltest.main()

--- a/ord_schema/proto/reaction_pb2_test.py
+++ b/ord_schema/proto/reaction_pb2_test.py
@@ -14,10 +14,6 @@
 """Tests for ord_schema.proto.reaction_pb2."""
 
 from absl.testing import absltest
-try:
-    from rdkit import Chem
-except ImportError:
-    Chem = None
 
 from ord_schema.proto import reaction_pb2
 

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -99,40 +99,6 @@ def resolve_names(message):
     return modified
 
 
-def add_binary_identifiers(message):
-    """Adds RDKIT_BINARY identifiers for compounds with valid structures.
-
-    Note that the RDKIT_BINARY representations are mostly useful in the context
-    of searching the database. Accordingly, this function is not included in the
-    standard set of Reaction updates in update_reaction().
-
-    Args:
-        message: Reaction proto.
-
-    Returns:
-        Boolean whether `message` was modified.
-    """
-    modified = False
-    compounds = message_helpers.find_submessages(message,
-                                                 reaction_pb2.Compound)
-    for compound in compounds:
-        if any(identifier.type == identifier.RDKIT_BINARY
-               for identifier in message.identifiers):
-            continue
-        try:
-            mol, identifier = message_helpers.mol_from_compound(
-                compound, return_identifier=True)
-            source = reaction_pb2.CompoundIdentifier.IdentifierType.Name(
-                identifier.type)
-            compound.identifiers.add(bytes_value=mol.ToBinary(),
-                                     type='RDKIT_BINARY',
-                                     details=f'Generated from {source}')
-            modified = True
-        except ValueError:
-            pass
-    return modified
-
-
 def update_reaction(reaction):
     """Updates a Reaction message.
 

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -38,19 +38,6 @@ class UpdatesTest(absltest.TestCase):
             message.inputs['test'].components[0].identifiers[1].details,
             'NAME resolved')
 
-    def test_add_binary_identifiers(self):
-        smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O'
-        mol = Chem.MolFromSmiles(smiles)
-        message = reaction_pb2.Reaction()
-        message.inputs['test'].components.add().identifiers.add(type='SMILES',
-                                                                value=smiles)
-        self.assertTrue(updates.add_binary_identifiers(message))
-        self.assertEqual(
-            message.inputs['test'].components[0].identifiers[1],
-            reaction_pb2.CompoundIdentifier(type='RDKIT_BINARY',
-                                            bytes_value=mol.ToBinary(),
-                                            details='Generated from SMILES'))
-
 
 class UpdateReactionTest(absltest.TestCase):
     def test_with_updates_simple(self):

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -397,8 +397,8 @@ def validate_reaction(message, validate_id=False):
 
 def validate_reaction_identifier(message):
     check_type_and_details(message)
-    if not message.value and not message.bytes_value:
-        warnings.warn('{bytes_}value must be set', ValidationError)
+    if not message.value:
+        warnings.warn('value must be set', ValidationError)
 
 
 def validate_reaction_input(message):
@@ -465,8 +465,8 @@ def validate_compound_preparation(message):
 
 def validate_compound_identifier(message):
     check_type_and_details(message)
-    if not message.value and not message.bytes_value:
-        warnings.warn('{bytes_}value must be set', ValidationError)
+    if not message.value:
+        warnings.warn('value must be set', ValidationError)
     if Chem and message.type == message.SMILES:
         mol = Chem.MolFromSmiles(message.value)
         if mol is None:
@@ -485,12 +485,6 @@ def validate_compound_identifier(message):
             warnings.warn(
                 f'RDKit {RDKIT_VERSION} could not validate'
                 ' MolBlock identifier', ValidationError)
-    elif message.type == message.RDKIT_BINARY:
-        mol = Chem.Mol(message.bytes_value)
-        if mol is None:
-            warnings.warn(
-                f'RDKit {RDKIT_VERSION} could not validate'
-                ' RDKit Binary identifier', ValidationError)
 
 
 def validate_vessel(message):

--- a/ord_schema/visualization/filters.py
+++ b/ord_schema/visualization/filters.py
@@ -342,7 +342,7 @@ def _analysis_format(analysis):
 def _compound_svg(compound):
     """Returns an SVG string for the given compound.
 
-    If the compound does not have an RDKIT_BINARY identifier, a sentinel value
+    If the compound does not have a structural identifier, a sentinel value
     is returned instead.
 
     Args:
@@ -354,13 +354,13 @@ def _compound_svg(compound):
     mol = message_helpers.mol_from_compound(compound)
     if mol:
         return drawing.mol_to_svg(mol)
-    return 'no RDKIT_BINARY'
+    return 'no structural identifiers'
 
 
 def _compound_png(compound):
     """Returns a PNG string for the given compound.
 
-    If the compound does not have an RDKIT_BINARY identifier, a sentinel value
+    If the compound does not have a structural identifier, a sentinel value
     is returned instead.
 
     Args:
@@ -372,7 +372,7 @@ def _compound_png(compound):
     mol = message_helpers.mol_from_compound(compound)
     if mol:
         return drawing.mol_to_png(mol)
-    return 'no RDKIT_BINARY'
+    return 'no structural identifiers'
 
 
 def _compound_amount(compound):


### PR DESCRIPTION
Addresses #247 

- No more bytes_value fields in proto for identifiers
- Validation updated to require that "string value" be defined
- Tests, helper functions updated
- Update function to assign binary now irrelevant
- Editor changed to remove upload boxes around compound and
  reaction identifiers
- load/unload of identifiers in webform simplified
- `full.pbtxt` dataset example updated to not use bytes_value in reaction identifier