### PR TITLE
Updates for serving the editor on GCP

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3
+FROM continuumio/miniconda3
 WORKDIR /usr/src/app
 
+RUN conda install -c rdkit rdkit
+COPY package/ord/requirements.txt .
+RUN pip install -r requirements.txt
 RUN pip install Flask protobuf
 
 # First run "make package".

--- a/editor/Makefile
+++ b/editor/Makefile
@@ -79,6 +79,7 @@ package : all
 	  serve.sh \
 	  package/ord
 
+	cp ../requirements.txt package/ord
 	cp -r ../build/lib/ord_schema package/ord/py
 
 	mkdir package/ord/db


### PR DESCRIPTION
Procedure:

```shell
# Install and build the package.
cd ord-schema
python setup.py install
cd editor
git clone https://github.com/Open-Reaction-Database/ketcher.git
cd ketcher
npm install && npm run build
cd ..
make package
# Build and deploy the container.
docker build -t openreactiondatabase/ord-editor .
docker push openreactiondatabase/ord-editor
```

On GCP:

1. Create a new VM to host the container ([instructions](https://cloud.google.com/compute/docs/containers/deploying-containers#deploying_a_container_on_a_new_vm_instance); use `docker.io/openreactiondatabase/ord-editor` as the container image)
2. Add the `ord-editor` tag to the VM (used in the next step)
3. Create a custom firewall rule to expose port 5000 on VMs with the `ord-editor` tag ([instructions](https://cloud.google.com/vpc/docs/using-firewalls#creating_firewall_rules))
4. Get the IP address from the instance dashboard and connect on port 5000 in a browser

*Edit:* Note that updates to the container image can be deployed simply by restarting the VM after pushing the new image to Docker Hub.

*Edit:* Added Ketcher installation.