### PR TITLE
Fix referencing file whose name was changed

### DIFF
--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -25,7 +25,7 @@ limitations under the License.
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.13.1/css/all.min.css">
     <script src="/js/reaction.js"></script>
     <link rel="stylesheet" href="/css/reaction.css">
-    <link rel="stylesheet" href="/css/ketcher-extras.css">
+    <link rel="stylesheet" href="/css/ketcher-bootstrap.css">
     <title>{{ file_name }}:{{ index }}</title>
   </head>
 


### PR DESCRIPTION
Change the `ketcher-extras.css` file to `ketcher-bootstrap.css`; forgot to change it in `reaction.html`, so we couldn't load this file. Fixed in this PR.