### PR TITLE
Fix relative time values

### DIFF
--- a/ord_schema/process_dataset_test.py
+++ b/ord_schema/process_dataset_test.py
@@ -47,7 +47,7 @@ class ProcessDatasetTest(absltest.TestCase):
         dummy_component.mass.value = 1
         dummy_component.mass.units = reaction_pb2.Mass.GRAM
         reaction1.outcomes.add().conversion.value = 75
-        reaction1.provenance.record_created.time.value = '11 am'
+        reaction1.provenance.record_created.time.value = '2020-01-01'
         reaction1.provenance.record_created.person.username = 'test'
         reaction1.provenance.record_created.person.email = 'test@example.com'
         dataset1 = dataset_pb2.Dataset(reactions=[reaction1])
@@ -263,7 +263,7 @@ class SubmissionWorkflowTest(absltest.TestCase):
         reaction.outcomes.add().conversion.value = 25
         reaction_id = 'ord-10aed8b5dffe41fab09f5b2cc9c58ad9'
         reaction.reaction_id = reaction_id
-        reaction.provenance.record_created.time.value = '2020-01-01 11 am'
+        reaction.provenance.record_created.time.value = '2020-01-01'
         reaction.provenance.record_created.person.username = 'test'
         reaction.provenance.record_created.person.email = 'test@example.com'
         dataset = dataset_pb2.Dataset(reactions=[reaction])

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -75,7 +75,7 @@ class UpdateReactionTest(absltest.TestCase):
     def test_keep_existing_reaction_id(self):
         message = reaction_pb2.Reaction()
         message.reaction_id = 'ord-c0bbd41f095a44a78b6221135961d809'
-        message.provenance.record_created.time.value = '11 am'
+        message.provenance.record_created.time.value = '2020-01-01'
         updates.update_reaction(message)
         self.assertEqual(message.reaction_id,
                          'ord-c0bbd41f095a44a78b6221135961d809')

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -237,13 +237,13 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
 
     def test_datetimes(self):
         message = reaction_pb2.ReactionProvenance()
-        message.experiment_start.value = '11 am'
-        message.record_created.time.value = '10 am'
+        message.experiment_start.value = '2020-01-02'
+        message.record_created.time.value = '2020-01-01'
         message.record_created.person.name = 'test'
         message.record_created.person.email = 'test@example.com'
         with self.assertRaisesRegex(validations.ValidationError, 'after'):
             self._run_validation(message)
-        message.record_created.time.value = '11:15 am'
+        message.record_created.time.value = '2020-01-03'
         self.assertEmpty(self._run_validation(message))
 
     def test_reaction_id(self):


### PR DESCRIPTION
Tests are failing because I introduced a relative time (`'11 am'`) in #271 that doesn't play well with UTC in the before/after validations.