### PR TITLE
Fix python version to 3.7 in CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: s-weigand/setup-conda@v1
+      with:
+        python-version: 3.7
     - name: Install ord_schema
       run: |
         cd "${GITHUB_WORKSPACE}"
@@ -44,6 +46,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: s-weigand/setup-conda@v1
+      with:
+        python-version: 3.7
     - name: Install ord_schema
       run: |
         cd "${GITHUB_WORKSPACE}"
@@ -63,6 +67,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: s-weigand/setup-conda@v1
+        with:
+          python-version: 3.7
       - name: Install ord_schema
         run: |
           cd "${GITHUB_WORKSPACE}"
@@ -80,6 +86,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: s-weigand/setup-conda@v1
+      with:
+        python-version: 3.7
     - uses: actions/setup-node@v1.4.2
     - name: Install dependencies
       run: |


### PR DESCRIPTION
The default python version in conda just switched to 3.8, and our tests are failing because conda RDKit doesn't support 3.8 yet.

See https://github.com/Open-Reaction-Database/ord-schema/pull/246/checks?check_run_id=955493897