### PR TITLE
Move DatasetExample out of Dataset

### DIFF
--- a/editor/html/dataset.html
+++ b/editor/html/dataset.html
@@ -121,28 +121,5 @@ limitations under the License.
       </div>
       <div id="add_other_reaction_id" class="add" onclick="addReactionId();">+ add reaction ID</div>
     </fieldset>
-
-    <div class="spacer"></div>
-
-    <div id="examples">
-      <div id="example_template" class="example" style="display: none;">
-        <fieldset>
-          <legend>Example</legend>
-          <div class="remove" onclick="removeExample(this);" style="float: right;">remove</div>
-          <table>
-            <tr><td align="right">url</td><td><div class="example_url edittext"></div>
-            <tr><td align="right">description</td><td><div class="example_description edittext"></div>
-            <tr><td align="right">time</td><td><div class="example_created_time edittext"></div>
-            <tr><td align="right">username</td><td><div class="example_created_person_username edittext"></div>
-            <tr><td align="right">name</td><td><div class="example_created_person_name edittext"></div>
-            <tr><td align="right">orcid</td><td><div class="example_created_person_orcid edittext"></div>
-            <tr><td align="right">organization</td><td><div class="example_created_person_org edittext"></div>
-            <tr><td align="right">details</td><td><div class="example_created_details edittext"></div>
-          </table>
-        </fieldset>
-        <div class="spacer"></div>
-      </div>
-    </div>
-    <div id="add_example" class="add" onclick="addExample();">+ add example</div>
   </body>
 </html>

--- a/editor/js/dataset.js
+++ b/editor/js/dataset.js
@@ -97,9 +97,6 @@ function loadDataset(dataset) {
   const reactionIds = dataset.getReactionIdsList();
   loadReactionIds(reactionIds);
 
-  const examples = dataset.getExamplesList();
-  loadExamples(examples);
-
   clean();
 }
 
@@ -125,28 +122,6 @@ function loadReactionId(reactionId) {
   $('.other_reaction_id_text', node).text(reactionId);
 }
 
-function loadExamples(examples) {
-  examples.forEach(example => loadExample(example));
-}
-
-function loadExample(example) {
-  const node = addExample();
-  $('.example_url', node).text(example.getUrl());
-  $('.example_description', node).text(example.getDescription());
-  const created = example.getCreated();
-  if (created) {
-    $('.example_created_time', node).text(created.getTime().getValue());
-    $('.example_created_details', node).text(created.getDetails());
-    const person = created.getPerson();
-    if (person) {
-      $('.example_created_person_username', node).text(person.getUsername());
-      $('.example_created_person_name', node).text(person.getName());
-      $('.example_created_person_orcid', node).text(person.getOrcid());
-      $('.example_created_person_org', node).text(person.getOrganization());
-    }
-  }
-}
-
 function unloadDataset() {
   const dataset = session.dataset;
   dataset.setName($('#name').text());
@@ -160,48 +135,8 @@ function unloadDataset() {
     }
   });
   dataset.setReactionIdsList(reactionIds);
-  const examples = [];
-  $('.example').each(function(index, node) {
-    node = $(node);
-    if (!node.attr('id')) {
-      const example = unloadExample(node);
-      examples.push(example);
-    }
-  });
-  dataset.setExamplesList(examples);
   // Do not mutate Reactions. They are edited separately.
   return dataset;
-}
-
-function unloadExample(node) {
-  const example = new proto.ord.DatasetExample();
-  const url = $('.example_url', node).text();
-  example.setUrl(url);
-  const description = $('.example_description', node).text();
-  example.setDescription(description);
-
-  const created = new proto.ord.RecordEvent();
-  const timeValue = $('.example_created_time', node).text();
-  time = new proto.ord.DateTime();
-  time.setValue(timeValue);
-  created.setTime(time);
-  const details = $('.example_created_details', node).text();
-  created.setDetails(details);
-
-  const person = new proto.ord.Person();
-  const username = $('.example_created_person_username', node).text();
-  person.setUsername(username);
-  const name = $('.example_created_person_name', node).text();
-  person.setName(name);
-  const orcid = $('.example_created_person_orcid', node).text();
-  person.setOrcid(orcid);
-  const org = $('.example_created_person_org', node).text();
-  person.setOrganization(org);
-
-  created.setPerson(person);
-  example.setCreated(created);
-
-  return example;
 }
 
 function addReaction(index) {
@@ -229,17 +164,6 @@ function addReactionId() {
   return node;
 }
 
-function addExample() {
-  const node = $('#example_template').clone();
-  node.removeAttr('id');
-  const root = $('#examples');
-  root.append(node);
-  node.show('slow');
-  listenDirty(node);
-  dirty();
-  return node;
-}
-
 function newReaction() {
   // Load the Reaction editor immediately without waiting for "save".
   window.location.href = '/dataset/' + session.fileName + '/new/reaction';
@@ -255,10 +179,6 @@ function deleteReaction(button) {
 
 function removeReactionId(button) {
   removeSlowly(button, '.other_reaction_id');
-}
-
-function removeExample(button) {
-  removeSlowly(button, '.example');
 }
 
 function removeSlowly(button, pattern) {

--- a/ord_schema/proto/dataset.proto
+++ b/ord_schema/proto/dataset.proto
@@ -37,17 +37,16 @@ message Dataset {
   // datasets. For example, a collection of all reactions of a certain type
   // across multiple datasets.
   repeated string reaction_ids = 4;
-  // Examples of how to use the Dataset, e.g. in downstream applications.
-  repeated DatasetExample examples = 5;
   // Dataset ID assigned during the submission process.
-  string dataset_id = 6;
+  string dataset_id = 5;
 }
 
 // Metadata for an example of using a Dataset. For example, a DatasetExample
 // might include a URL for a colab/jupyter notebook or a blog post showing how
 // to use the Dataset in a downstream machine learning application.
 message DatasetExample {
-  string description = 1;
-  string url = 2;
-  RecordEvent created = 3;
+  string dataset_id = 1;
+  string description = 2;
+  string url = 3;
+  RecordEvent created = 4;
 }

--- a/ord_schema/proto/dataset_pb2_test.py
+++ b/ord_schema/proto/dataset_pb2_test.py
@@ -34,14 +34,9 @@ class DatasetPb2Test(absltest.TestCase):
         reaction2 = reaction_pb2.Reaction()
         reaction2.identifiers.add(value='amide coupling', type='NAME')
         dataset.reactions.add().CopyFrom(reaction2)
-        # Add an example.
-        example = dataset.examples.add()
-        example.description = 'test example'
-        example.url = 'example.com'
-        example.created.time.value = '11 am'
         self.dataset_pb = dataset.SerializeToString()
 
-    def test_simple(self):
+    def test_dataset(self):
         dataset = dataset_pb2.Dataset.FromString(self.dataset_pb)
         self.assertEqual(dataset.name, 'test')
         self.assertEqual(dataset.description, 'test dataset')
@@ -50,10 +45,6 @@ class DatasetPb2Test(absltest.TestCase):
                          reaction_pb2.ReactionIdentifier.REACTION_SMILES)
         self.assertEqual(dataset.reactions[1].identifiers[0].type,
                          reaction_pb2.ReactionIdentifier.NAME)
-        self.assertLen(dataset.examples, 1)
-        self.assertEqual(dataset.examples[0].description, 'test example')
-        self.assertEqual(dataset.examples[0].url, 'example.com')
-        self.assertEqual(dataset.examples[0].created.time.value, '11 am')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It's awkward to edit a `Dataset` to add a `DatasetExample`; instead we should just have a `dataset_id` pointer in `DatasetExample` and take it out of `Dataset`.