### PR TITLE
Use best practices for SQL queries

### DIFF
--- a/ord_schema/interface/build_database.py
+++ b/ord_schema/interface/build_database.py
@@ -62,6 +62,9 @@ _TABLES = {
         ]),
 }
 
+# Schema name for tables with RDKit cartridge functionality.
+_SCHEMA = 'rdk'
+
 
 class Tables:
     """Holds file handles and CSV writers for database table files."""
@@ -176,7 +179,7 @@ def create_database():
             command = sql.SQL('DROP TABLE IF EXISTS {}')
             cursor.execute(command.format(sql.Identifier(table)))
     cursor.execute(sql.SQL('CREATE EXTENSION IF NOT EXISTS rdkit'))
-    cursor.execute(sql.SQL('CREATE SCHEMA rdk'))
+    cursor.execute(sql.SQL('CREATE SCHEMA {}').format(sql.Identifier(_SCHEMA)))
     for table, columns in _TABLES.items():
         dtypes = []
         for column, dtype in columns.items():
@@ -228,18 +231,18 @@ def _rdkit_reaction_smiles(cursor, table):
         SELECT reaction_id,
                r,
                reaction_difference_fp(r) AS rdfp 
-        INTO rdk.{} FROM (
+        INTO {} FROM (
             SELECT reaction_id, 
                    reaction_from_smiles(reaction_smiles::cstring) AS r
             FROM {}) tmp
-        WHERE r IS NOT NULL""").format(sql.Identifier(table),
+        WHERE r IS NOT NULL""").format(sql.Identifier(_SCHEMA, table),
                                        sql.Identifier(table)))
     cursor.execute(
-        sql.SQL('CREATE INDEX {} ON rdk.{} USING gist(r)').format(
-            sql.Identifier(f'{table}_r'), sql.Identifier(table)))
+        sql.SQL('CREATE INDEX {} ON {} USING gist(r)').format(
+            sql.Identifier(f'{table}_r'), sql.Identifier(_SCHEMA, table)))
     cursor.execute(
-        sql.SQL('CREATE INDEX {} ON rdk.{} USING gist(rdfp)').format(
-            sql.Identifier(f'{table}_rdfp'), sql.Identifier(table)))
+        sql.SQL('CREATE INDEX {} ON {} USING gist(rdfp)').format(
+            sql.Identifier(f'{table}_rdfp'), sql.Identifier(_SCHEMA, table)))
 
 
 def _rdkit_smiles(cursor, table):
@@ -260,18 +263,18 @@ def _rdkit_smiles(cursor, table):
         SELECT reaction_id,
                m,
                morganbv_fp(m) AS mfp2 
-        INTO rdk.{} FROM (
+        INTO {} FROM (
             SELECT reaction_id, 
                    mol_from_smiles(smiles::cstring) AS m
             FROM {}) tmp
-        WHERE m IS NOT NULL""").format(sql.Identifier(table),
+        WHERE m IS NOT NULL""").format(sql.Identifier(_SCHEMA, table),
                                        sql.Identifier(table)))
     cursor.execute(
-        sql.SQL('CREATE INDEX {} ON rdk.{} USING gist(m)').format(
-            sql.Identifier(f'{table}_m'), sql.Identifier(table)))
+        sql.SQL('CREATE INDEX {} ON {} USING gist(m)').format(
+            sql.Identifier(f'{table}_m'), sql.Identifier(_SCHEMA, table)))
     cursor.execute(
-        sql.SQL('CREATE INDEX {} ON rdk.{} USING gist(mfp2)').format(
-            sql.Identifier(f'{table}_mfp2'), sql.Identifier(table)))
+        sql.SQL('CREATE INDEX {} ON {} USING gist(mfp2)').format(
+            sql.Identifier(f'{table}_mfp2'), sql.Identifier(_SCHEMA, table)))
 
 
 def main(argv):

--- a/ord_schema/interface/build_database.py
+++ b/ord_schema/interface/build_database.py
@@ -26,6 +26,7 @@ from absl import app
 from absl import flags
 from absl import logging
 import psycopg2
+from psycopg2 import sql
 
 from ord_schema import message_helpers
 from ord_schema.proto import dataset_pb2
@@ -170,20 +171,37 @@ def create_database():
                           port=FLAGS.port)
     cursor = db.cursor()
     if FLAGS.overwrite:
+        logging.info('Removing existing tables')
         for table in _TABLES:
-            cursor.execute(f'DROP TABLE IF EXISTS {table};')
-    cursor.execute('CREATE EXTENSION IF NOT EXISTS rdkit;')
-    cursor.execute('CREATE SCHEMA rdk;')
+            command = sql.SQL('DROP TABLE IF EXISTS {}')
+            cursor.execute(command.format(sql.Identifier(table)))
+    cursor.execute(sql.SQL('CREATE EXTENSION IF NOT EXISTS rdkit'))
+    cursor.execute(sql.SQL('CREATE SCHEMA rdk'))
     for table, columns in _TABLES.items():
-        dtypes = ',\n'.join(
-            [f'\t{column}\t{dtype}' for column, dtype in columns.items()])
-        command = f'CREATE TABLE {table} (\n{dtypes}\n);'
-        logging.info('Running:\n%s', command)
+        dtypes = []
+        for column, dtype in columns.items():
+            if table == 'reactions' and column == 'reaction_id':
+                component = sql.SQL('{} {} PRIMARY KEY')
+            else:
+                component = sql.SQL('{} {}')
+            # NOTE(kearnes): sql.Identifier(dtype) does not work for the
+            # 'double precision' type.
+            dtypes.append(
+                component.format(sql.Identifier(column), sql.SQL(dtype)))
+        command = sql.Composed([
+            sql.SQL('CREATE TABLE {} (').format(sql.Identifier(table)),
+            sql.Composed(dtypes).join(', '),
+            sql.SQL(')')
+        ])
+        logging.info('Running:\n%s', command.as_string(cursor))
         cursor.execute(command)
         logging.info('Running COPY')
         with open(os.path.join(FLAGS.output, f'{table}.csv')) as f:
             cursor.copy_expert(
-                f'COPY {table} FROM STDIN DELIMITER \',\' CSV HEADER;', f)
+                sql.SQL(
+                    'COPY {} FROM STDIN WITH CSV HEADER').format(
+                    sql.Identifier(table)),
+                f)
         logging.info('Adding RDKit cartridge functionality')
         if 'reaction_smiles' in columns:
             _rdkit_reaction_smiles(cursor, table)
@@ -207,18 +225,22 @@ def _rdkit_reaction_smiles(cursor, table):
         cursor: psycopg2 Cursor.
         table: Text table name.
     """
-    cursor.execute(f"""
+    cursor.execute(sql.SQL("""
         SELECT reaction_id,
                r,
                reaction_difference_fp(r) AS rdfp 
-        INTO rdk.{table} FROM (
+        INTO rdk.{} FROM (
             SELECT reaction_id, 
                    reaction_from_smiles(reaction_smiles::cstring) AS r
-            FROM {table}) tmp
-        WHERE r IS NOT NULL;""")
-    cursor.execute(f'CREATE INDEX {table}_r ON rdk.{table} USING gist(r);')
+            FROM {}) tmp
+        WHERE r IS NOT NULL""").format(sql.Identifier(table),
+                                       sql.Identifier(table)))
     cursor.execute(
-        f'CREATE INDEX {table}_rdfp ON rdk.{table} USING gist(rdfp);')
+        sql.SQL('CREATE INDEX {} ON rdk.{} USING gist(r)').format(
+            sql.Identifier(f'{table}_r'), sql.Identifier(table)))
+    cursor.execute(
+        sql.SQL('CREATE INDEX {} ON rdk.{} USING gist(rdfp)').format(
+            sql.Identifier(f'{table}_rdfp'), sql.Identifier(table)))
 
 
 def _rdkit_smiles(cursor, table):
@@ -234,18 +256,22 @@ def _rdkit_smiles(cursor, table):
         cursor: psycopg2 Cursor.
         table: Text table name.
     """
-    cursor.execute(f"""
+    cursor.execute(sql.SQL("""
         SELECT reaction_id,
                m,
                morganbv_fp(m) AS mfp2 
-        INTO rdk.{table} FROM (
+        INTO rdk.{} FROM (
             SELECT reaction_id, 
                    mol_from_smiles(smiles::cstring) AS m
-            FROM {table}) tmp
-        WHERE m IS NOT NULL;""")
-    cursor.execute(f'CREATE INDEX {table}_m ON rdk.{table} USING gist(m);')
+            FROM {}) tmp
+        WHERE m IS NOT NULL""").format(sql.Identifier(table),
+                                       sql.Identifier(table)))
     cursor.execute(
-        f'CREATE INDEX {table}_mfp2 ON rdk.{table} USING gist(mfp2);')
+        sql.SQL('CREATE INDEX {} ON rdk.{} USING gist(m)').format(
+            sql.Identifier(f'{table}_m'), sql.Identifier(table)))
+    cursor.execute(
+        sql.SQL('CREATE INDEX {} ON rdk.{} USING gist(mfp2)').format(
+            sql.Identifier(f'{table}_mfp2'), sql.Identifier(table)))
 
 
 def main(argv):

--- a/ord_schema/interface/build_database.py
+++ b/ord_schema/interface/build_database.py
@@ -26,7 +26,6 @@ from absl import app
 from absl import flags
 from absl import logging
 import psycopg2
-from psycopg2 import sql
 
 from ord_schema import message_helpers
 from ord_schema.proto import dataset_pb2
@@ -171,37 +170,20 @@ def create_database():
                           port=FLAGS.port)
     cursor = db.cursor()
     if FLAGS.overwrite:
-        logging.info('Removing existing tables')
         for table in _TABLES:
-            command = sql.SQL('DROP TABLE IF EXISTS {}')
-            cursor.execute(command.format(sql.Identifier(table)))
-    cursor.execute(sql.SQL('CREATE EXTENSION IF NOT EXISTS rdkit'))
-    cursor.execute(sql.SQL('CREATE SCHEMA rdk'))
+            cursor.execute(f'DROP TABLE IF EXISTS {table};')
+    cursor.execute('CREATE EXTENSION IF NOT EXISTS rdkit;')
+    cursor.execute('CREATE SCHEMA rdk;')
     for table, columns in _TABLES.items():
-        dtypes = []
-        for column, dtype in columns.items():
-            if table == 'reactions' and column == 'reaction_id':
-                component = sql.SQL('{} {} PRIMARY KEY')
-            else:
-                component = sql.SQL('{} {}')
-            # NOTE(kearnes): sql.Identifier(dtype) does not work for the
-            # 'double precision' type.
-            dtypes.append(
-                component.format(sql.Identifier(column), sql.SQL(dtype)))
-        command = sql.Composed([
-            sql.SQL('CREATE TABLE {} (').format(sql.Identifier(table)),
-            sql.Composed(dtypes).join(', '),
-            sql.SQL(')')
-        ])
-        logging.info('Running:\n%s', command.as_string(cursor))
+        dtypes = ',\n'.join(
+            [f'\t{column}\t{dtype}' for column, dtype in columns.items()])
+        command = f'CREATE TABLE {table} (\n{dtypes}\n);'
+        logging.info('Running:\n%s', command)
         cursor.execute(command)
         logging.info('Running COPY')
         with open(os.path.join(FLAGS.output, f'{table}.csv')) as f:
             cursor.copy_expert(
-                sql.SQL(
-                    'COPY {} FROM STDIN WITH CSV HEADER').format(
-                    sql.Identifier(table)),
-                f)
+                f'COPY {table} FROM STDIN DELIMITER \',\' CSV HEADER;', f)
         logging.info('Adding RDKit cartridge functionality')
         if 'reaction_smiles' in columns:
             _rdkit_reaction_smiles(cursor, table)
@@ -225,22 +207,18 @@ def _rdkit_reaction_smiles(cursor, table):
         cursor: psycopg2 Cursor.
         table: Text table name.
     """
-    cursor.execute(sql.SQL("""
+    cursor.execute(f"""
         SELECT reaction_id,
                r,
                reaction_difference_fp(r) AS rdfp 
-        INTO rdk.{} FROM (
+        INTO rdk.{table} FROM (
             SELECT reaction_id, 
                    reaction_from_smiles(reaction_smiles::cstring) AS r
-            FROM {}) tmp
-        WHERE r IS NOT NULL""").format(sql.Identifier(table),
-                                       sql.Identifier(table)))
+            FROM {table}) tmp
+        WHERE r IS NOT NULL;""")
+    cursor.execute(f'CREATE INDEX {table}_r ON rdk.{table} USING gist(r);')
     cursor.execute(
-        sql.SQL('CREATE INDEX {} ON rdk.{} USING gist(r)').format(
-            sql.Identifier(f'{table}_r'), sql.Identifier(table)))
-    cursor.execute(
-        sql.SQL('CREATE INDEX {} ON rdk.{} USING gist(rdfp)').format(
-            sql.Identifier(f'{table}_rdfp'), sql.Identifier(table)))
+        f'CREATE INDEX {table}_rdfp ON rdk.{table} USING gist(rdfp);')
 
 
 def _rdkit_smiles(cursor, table):
@@ -256,22 +234,18 @@ def _rdkit_smiles(cursor, table):
         cursor: psycopg2 Cursor.
         table: Text table name.
     """
-    cursor.execute(sql.SQL("""
+    cursor.execute(f"""
         SELECT reaction_id,
                m,
                morganbv_fp(m) AS mfp2 
-        INTO rdk.{} FROM (
+        INTO rdk.{table} FROM (
             SELECT reaction_id, 
                    mol_from_smiles(smiles::cstring) AS m
-            FROM {}) tmp
-        WHERE m IS NOT NULL""").format(sql.Identifier(table),
-                                       sql.Identifier(table)))
+            FROM {table}) tmp
+        WHERE m IS NOT NULL;""")
+    cursor.execute(f'CREATE INDEX {table}_m ON rdk.{table} USING gist(m);')
     cursor.execute(
-        sql.SQL('CREATE INDEX {} ON rdk.{} USING gist(m)').format(
-            sql.Identifier(f'{table}_m'), sql.Identifier(table)))
-    cursor.execute(
-        sql.SQL('CREATE INDEX {} ON rdk.{} USING gist(mfp2)').format(
-            sql.Identifier(f'{table}_mfp2'), sql.Identifier(table)))
+        f'CREATE INDEX {table}_mfp2 ON rdk.{table} USING gist(mfp2);')
 
 
 def main(argv):

--- a/ord_schema/interface/build_database_longtest.py
+++ b/ord_schema/interface/build_database_longtest.py
@@ -51,7 +51,8 @@ class BuildDatabaseTest(absltest.TestCase):
     def test_main(self):
         input_pattern = os.path.join(self.test_subdirectory, '*.pbtxt')
         output_dir = os.path.join(self.test_subdirectory, 'tables')
-        with flagsaver.flagsaver(input=input_pattern, output=output_dir):
+        with flagsaver.flagsaver(input=input_pattern, output=output_dir,
+                                 database=True):
             build_database.main(())
         with open(os.path.join(output_dir, 'reactions.csv')) as f:
             df = pd.read_csv(f)

--- a/ord_schema/interface/build_database_longtest.py
+++ b/ord_schema/interface/build_database_longtest.py
@@ -48,7 +48,8 @@ class BuildDatabaseTest(absltest.TestCase):
             remove=True)
         while True:
             try:
-                psycopg2.connect(host='localhost', port=_POSTGRES_PORT,
+                psycopg2.connect(host='localhost',
+                                 port=_POSTGRES_PORT,
                                  user='postgres',
                                  password='postgres')
                 break
@@ -83,10 +84,13 @@ class BuildDatabaseTest(absltest.TestCase):
     def test_main(self):
         input_pattern = os.path.join(self.test_subdirectory, '*.pbtxt')
         output_dir = os.path.join(self.test_subdirectory, 'tables')
-        with flagsaver.flagsaver(input=input_pattern, output=output_dir,
-                                 database='postgres', host='localhost',
+        with flagsaver.flagsaver(input=input_pattern,
+                                 output=output_dir,
+                                 database='postgres',
+                                 host='localhost',
                                  port=_POSTGRES_PORT,
-                                 user='postgres', password='postgres'):
+                                 user='postgres',
+                                 password='postgres'):
             build_database.main(())
         with open(os.path.join(output_dir, 'reactions.csv')) as f:
             df = pd.read_csv(f)

--- a/ord_schema/interface/query.py
+++ b/ord_schema/interface/query.py
@@ -75,6 +75,9 @@ class OrdPostgres:
             column = 'r'
         else:
             column = 'm'
+        # NOTE(kearnes): We use table.split('.') because "rdk"."inputs" is a
+        # valid identifier but "rdk.inputs" is not. See
+        # https://www.psycopg.org/docs/sql.html#psycopg2.sql.Identifier.
         components = [
             sql.SQL("""
                 SELECT DISTINCT A.reaction_id, A.serialized 

--- a/ord_schema/interface/query.py
+++ b/ord_schema/interface/query.py
@@ -22,6 +22,8 @@ from psycopg2 import sql
 from ord_schema.proto import dataset_pb2
 from ord_schema.proto import reaction_pb2
 
+# pylint: disable=too-many-locals
+
 
 class OrdPostgres:
     """Class for performing SQL queries on the ORD."""
@@ -75,11 +77,11 @@ class OrdPostgres:
             column = 'm'
         components = [
             sql.SQL("""
-            SELECT DISTINCT A.reaction_id, A.serialized 
-            FROM reactions A 
-            INNER JOIN {} B ON A.reaction_id = B.reaction_id
-            WHERE B.{}@>%s""").format(sql.Identifier(*table.split('.')),
-                                      sql.Identifier(column))
+                SELECT DISTINCT A.reaction_id, A.serialized 
+                FROM reactions A 
+                INNER JOIN {} B ON A.reaction_id = B.reaction_id
+                WHERE B.{}@>%s""").format(sql.Identifier(*table.split('.')),
+                                          sql.Identifier(column))
         ]
         args = [pattern]
         if use_smarts:
@@ -125,12 +127,12 @@ class OrdPostgres:
             function = 'morganbv_fp'
         components = [
             sql.SQL("""
-                    SELECT DISTINCT A.reaction_id, A.serialized 
-                    FROM reactions A 
-                    INNER JOIN {} B ON A.reaction_id = B.reaction_id
-                    WHERE B.{}%%{}(%s)""").format(
-                sql.Identifier(*table.split('.')), sql.Identifier(column),
-                sql.Identifier(function))
+                SELECT DISTINCT A.reaction_id, A.serialized 
+                FROM reactions A 
+                INNER JOIN {} B ON A.reaction_id = B.reaction_id
+                WHERE B.{}%%{}(%s)""").format(sql.Identifier(*table.split('.')),
+                                              sql.Identifier(column),
+                                              sql.Identifier(function))
         ]
         args = [smiles]
         if limit:

--- a/ord_schema/interface/query_longtest.py
+++ b/ord_schema/interface/query_longtest.py
@@ -24,7 +24,7 @@ import psycopg2
 
 from ord_schema.interface import query
 
-# Avoid conflicts with any running PostgreSQL server(s).
+# Avoid conflicts with any existing PostgreSQL server.
 _POSTGRES_PORT = 5430
 
 
@@ -33,12 +33,12 @@ class QueryTest(parameterized.TestCase, absltest.TestCase):
     @classmethod
     def setUpClass(cls):
         client = docker.from_env()
-        # TODO(kearnes): Use a smaller test image if needed.
         client.images.pull('openreactiondatabase/ord-postgres')
         cls._container = client.containers.run(
             'openreactiondatabase/ord-postgres',
             ports={'5432/tcp': _POSTGRES_PORT},
-            detach=True)
+            detach=True,
+            remove=True)
 
     @classmethod
     def tearDownClass(cls):
@@ -51,8 +51,8 @@ class QueryTest(parameterized.TestCase, absltest.TestCase):
                 self.postgres = query.OrdPostgres(host='localhost',
                                                   port=_POSTGRES_PORT)
                 break
-            except psycopg2.OperationalError:
-                logging.info('waiting for database to be ready')
+            except psycopg2.OperationalError as error:
+                logging.info('waiting for database to be ready: %s', error)
                 time.sleep(1)
                 continue
 


### PR DESCRIPTION
From the [psycopg2 documenation](https://www.psycopg.org/docs/usage.html#the-problem-with-the-query-parameters):

> Never, __never__, __NEVER__ use Python string concatenation (+) or string parameters interpolation (%) to pass variables to a SQL query string. Not even at gunpoint.

* Updates queries to use `psycopg2.sql` classes. The changes to `build_database.py` are probably not strictly necessary since that script doesn't take any untrusted inputs.
* Updates tests to clean up after themselves and provide better logging.