### PR TITLE
Properly compile and lint Javascript in CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -73,6 +73,20 @@ jobs:
       - name: Run JS linter
         run: |
           cd "${GITHUB_WORKSPACE}"
+          pip install -r requirements.txt
+          conda install -c rdkit rdkit
+          python setup.py install
+          pip install flask
+          cd "${GITHUB_WORKSPACE}/editor"
+          npm install google-protobuf puppeteer
+          wget https://storage.googleapis.com/ord-editor-test/editor_test_protobuf_1dae8fdd.tar
+          tar -xzf editor_test_protobuf_1dae8fdd.tar
+          wget https://github.com/google/closure-library/archive/v20200517.tar.gz
+          tar -xzf v20200517.tar.gz
+          git clone https://github.com/Open-Reaction-Database/ketcher.git
+          make
+
+          cd "${GITHUB_WORKSPACE}"
           # See https://github.com/google/closure-compiler/wiki/Lint-checks.
           npm install google-closure-compiler
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -75,8 +75,11 @@ jobs:
           cd "${GITHUB_WORKSPACE}"
           # See https://github.com/google/closure-compiler/wiki/Lint-checks.
           npm install google-closure-compiler
-          java -jar node_modules/google-closure-compiler-java/compiler.jar \
-            --jscomp_warning=lintChecks editor/js/*.js
+
+          # Build and lint, but supress warnings on anything but our code.
+          java -jar ~/node_modules/google-closure-compiler-java/compiler.jar --js editor/closure-library-20200517 --js editor/protobuf/js --js editor/gen/js/proto/ord  --js editor/js/*.js --checks_only --dependency_mode PRUNE --entry_point ord.reaction --jscomp_warning=lintChecks --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/protobuf/js --hide_warnings_for=gen/js/proto/ord
+
+          java -jar ~/node_modules/google-closure-compiler-java/compiler.jar --js editor/closure-library-20200517 --js editor/protobuf/js --js editor/gen/js/proto/ord  --js editor/js/dataset.js --checks_only --dependency_mode PRUNE --entry_point ord.dataset --jscomp_warning=lintChecks --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/protobuf/js --hide_warnings_for=gen/js/proto/ord
 
   test_notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -77,9 +77,9 @@ jobs:
           npm install google-closure-compiler
 
           # Build and lint, but supress warnings on anything but our code.
-          java -jar ~/node_modules/google-closure-compiler-java/compiler.jar --js editor/closure-library-20200517 --js editor/protobuf/js --js editor/gen/js/proto/ord  --js editor/js/*.js --checks_only --dependency_mode PRUNE --entry_point ord.reaction --jscomp_warning=lintChecks --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/protobuf/js --hide_warnings_for=gen/js/proto/ord
+          java -jar node_modules/google-closure-compiler-java/compiler.jar --js editor/closure-library-20200517 --js editor/protobuf/js --js editor/gen/js/proto/ord  --js editor/js/*.js --checks_only --dependency_mode PRUNE --entry_point ord.reaction --jscomp_warning=lintChecks --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/protobuf/js --hide_warnings_for=gen/js/proto/ord
 
-          java -jar ~/node_modules/google-closure-compiler-java/compiler.jar --js editor/closure-library-20200517 --js editor/protobuf/js --js editor/gen/js/proto/ord  --js editor/js/dataset.js --checks_only --dependency_mode PRUNE --entry_point ord.dataset --jscomp_warning=lintChecks --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/protobuf/js --hide_warnings_for=gen/js/proto/ord
+          java -jar node_modules/google-closure-compiler-java/compiler.jar --js editor/closure-library-20200517 --js editor/protobuf/js --js editor/gen/js/proto/ord  --js editor/js/dataset.js --checks_only --dependency_mode PRUNE --entry_point ord.dataset --jscomp_warning=lintChecks --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/protobuf/js --hide_warnings_for=gen/js/proto/ord
 
   test_notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -95,35 +95,35 @@ jobs:
           make
       - name: Run JS linter
         run: |
-          cd "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}/editor"
           # See https://github.com/google/closure-compiler/wiki/Lint-checks.
           npm install google-closure-compiler
 
           # Build and lint, but supress warnings on anything but our code.
           java -jar node_modules/google-closure-compiler-java/compiler.jar \
             --entry_point ord.reaction \
-            --js 'editor/closure-library-20200517/**.js' \
-            --js 'editor/protobuf/js/**.js' \
-            --js 'editor/gen/js/proto/ord/**.js'  \
-            --js editor/js/*.js \
+            --js 'closure-library-20200517/**.js' \
+            --js 'protobuf/js/**.js' \
+            --js 'gen/js/proto/ord/**.js'  \
+            --js js/*.js \
             --dependency_mode PRUNE \
             --checks_only \
             --jscomp_warning=lintChecks \
-            --hide_warnings_for=editor/closure-library-20200517 \
-            --hide_warnings_for=editor/protobuf/js \
+            --hide_warnings_for=closure-library-20200517 \
+            --hide_warnings_for=protobuf/js \
             --hide_warnings_for=gen/js/proto/ord
 
           java -jar node_modules/google-closure-compiler-java/compiler.jar \
             --entry_point ord.dataset \
-            --js 'editor/closure-library-20200517/**.js' \
-            --js 'editor/protobuf/js/**.js' \
-            --js 'editor/gen/js/proto/ord/**.js'  \
-            --js editor/js/*.js \
+            --js 'closure-library-20200517/**.js' \
+            --js 'protobuf/js/**.js' \
+            --js 'gen/js/proto/ord/**.js'  \
+            --js js/*.js \
             --dependency_mode PRUNE \
             --checks_only \
             --jscomp_warning=lintChecks \
-            --hide_warnings_for=editor/closure-library-20200517 \
-            --hide_warnings_for=editor/protobuf/js \
+            --hide_warnings_for=closure-library-20200517 \
+            --hide_warnings_for=protobuf/js \
             --hide_warnings_for=gen/js/proto/ord
 
   test_notebooks:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -99,40 +99,8 @@ jobs:
           # See https://github.com/google/closure-compiler/wiki/Lint-checks.
           npm install google-closure-compiler
 
-          # Run the closure compiler, having it lint code and produce warnings during compilation.
-          # In order to compile properly, we must provide all the source files necessary, 
-          # and make sure the compiler skips over files that aren't needed as dependencies.
-          # Because we are only checking code, we skip generating output and running optimizations.
-          # We also produce warnings only for our written source code 
-          # (by suppressing warnings for third-party libraries or machine generated code).
-
-          # Check reaction.js.
-          java -jar node_modules/google-closure-compiler-java/compiler.jar \
-            --entry_point ord.reaction \
-            --js 'closure-library-20200517/**.js' \
-            --js 'protobuf/js/**.js' \
-            --js 'gen/js/proto/ord/**.js'  \
-            --js 'js/**.js' \
-            --dependency_mode PRUNE \
-            --checks_only \
-            --jscomp_warning lintChecks \
-            --hide_warnings_for closure-library-20200517 \
-            --hide_warnings_for protobuf/js \
-            --hide_warnings_for gen/js/proto/ord
-
-          # Check dataset.js.
-          java -jar node_modules/google-closure-compiler-java/compiler.jar \
-            --entry_point ord.dataset \
-            --js 'closure-library-20200517/**.js' \
-            --js 'protobuf/js/**.js' \
-            --js 'gen/js/proto/ord/**.js'  \
-            --js 'js/**.js' \
-            --dependency_mode PRUNE \
-            --checks_only \
-            --jscomp_warning lintChecks \
-            --hide_warnings_for closure-library-20200517 \
-            --hide_warnings_for protobuf/js \
-            --hide_warnings_for gen/js/proto/ord
+          # Run the compiler; see the shell script for more info.
+          ../actions/lint_js.sh
 
   test_notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -99,7 +99,14 @@ jobs:
           # See https://github.com/google/closure-compiler/wiki/Lint-checks.
           npm install google-closure-compiler
 
-          # Build and lint, but supress warnings on anything but our code.
+          # Run the closure compiler, having it lint code and produce warnings during compilation.
+          # In order to compile properly, we must provide all the source files necessary, 
+          # and make sure the compiler skips over files that aren't needed as dependencies.
+          # Because we are only checking code, we skip generating output and running optimizations.
+          # We also produce warnings only for our written source code 
+          # (by suppressing warnings for third-party libraries or machine generated code).
+
+          # Check reaction.js.
           java -jar node_modules/google-closure-compiler-java/compiler.jar \
             --entry_point ord.reaction \
             --js 'closure-library-20200517/**.js' \
@@ -113,6 +120,7 @@ jobs:
             --hide_warnings_for protobuf/js \
             --hide_warnings_for gen/js/proto/ord
 
+          # Check dataset.js.
           java -jar node_modules/google-closure-compiler-java/compiler.jar \
             --entry_point ord.dataset \
             --js 'closure-library-20200517/**.js' \

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -105,26 +105,26 @@ jobs:
             --js 'closure-library-20200517/**.js' \
             --js 'protobuf/js/**.js' \
             --js 'gen/js/proto/ord/**.js'  \
-            --js js/*.js \
+            --js 'js/**.js' \
             --dependency_mode PRUNE \
             --checks_only \
-            --jscomp_warning=lintChecks \
-            --hide_warnings_for=closure-library-20200517 \
-            --hide_warnings_for=protobuf/js \
-            --hide_warnings_for=gen/js/proto/ord
+            --jscomp_warning lintChecks \
+            --hide_warnings_for closure-library-20200517 \
+            --hide_warnings_for protobuf/js \
+            --hide_warnings_for gen/js/proto/ord
 
           java -jar node_modules/google-closure-compiler-java/compiler.jar \
             --entry_point ord.dataset \
             --js 'closure-library-20200517/**.js' \
             --js 'protobuf/js/**.js' \
             --js 'gen/js/proto/ord/**.js'  \
-            --js js/*.js \
+            --js 'js/**.js' \
             --dependency_mode PRUNE \
             --checks_only \
-            --jscomp_warning=lintChecks \
-            --hide_warnings_for=closure-library-20200517 \
-            --hide_warnings_for=protobuf/js \
-            --hide_warnings_for=gen/js/proto/ord
+            --jscomp_warning lintChecks \
+            --hide_warnings_for closure-library-20200517 \
+            --hide_warnings_for protobuf/js \
+            --hide_warnings_for gen/js/proto/ord
 
   test_notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -73,22 +73,28 @@ jobs:
         with:
           java-version: 1.8
       - uses: actions/setup-node@v1
-      - name: Run JS linter
+      - name: Install ord_schema
         run: |
           cd "${GITHUB_WORKSPACE}"
           pip install -r requirements.txt
           conda install -c rdkit rdkit
           python setup.py install
-          pip install flask
+      - name: Install editor dependencies
+        run: |
           cd "${GITHUB_WORKSPACE}/editor"
+          pip install flask
           npm install google-protobuf puppeteer
           wget https://storage.googleapis.com/ord-editor-test/editor_test_protobuf_1dae8fdd.tar
           tar -xzf editor_test_protobuf_1dae8fdd.tar
           wget https://github.com/google/closure-library/archive/v20200517.tar.gz
           tar -xzf v20200517.tar.gz
           git clone https://github.com/Open-Reaction-Database/ketcher.git
+      - name: Build editor JS
+        run: |
+          cd "${GITHUB_WORKSPACE}/editor"
           make
-
+      - name: Run JS linter
+        run: |
           cd "${GITHUB_WORKSPACE}"
           # See https://github.com/google/closure-compiler/wiki/Lint-checks.
           npm install google-closure-compiler

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -100,9 +100,33 @@ jobs:
           npm install google-closure-compiler
 
           # Build and lint, but supress warnings on anything but our code.
-          java -jar node_modules/google-closure-compiler-java/compiler.jar --js 'editor/closure-library-20200517/**.js' --js 'editor/protobuf/js/**.js' --js 'editor/gen/js/proto/ord/**.js'  --js editor/js/*.js --checks_only --dependency_mode PRUNE --entry_point ord.reaction --jscomp_warning=lintChecks --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/protobuf/js --hide_warnings_for=gen/js/proto/ord
+          java -jar node_modules/google-closure-compiler-java/compiler.jar \
+            --entry_point ord.reaction \
+            --js 'editor/closure-library-20200517/**.js' \ 
+            --js 'editor/protobuf/js/**.js' \ 
+            --js 'editor/gen/js/proto/ord/**.js'  \
+            --js editor/js/*.js \
+            --dependency_mode PRUNE \
+            --checks_only \
+            --jscomp_warning=lintChecks \
+            --hide_warnings_for=editor/closure-library-20200517 \
+            --hide_warnings_for=editor/closure-library-20200517 \
+            --hide_warnings_for=editor/protobuf/js \
+            --hide_warnings_for=gen/js/proto/ord
 
-          java -jar node_modules/google-closure-compiler-java/compiler.jar --js 'editor/closure-library-20200517/**.js' --js 'editor/protobuf/js/**.js' --js 'editor/gen/js/proto/ord/**.js'  --js editor/js/*.js --checks_only --dependency_mode PRUNE --entry_point ord.dataset --jscomp_warning=lintChecks --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/protobuf/js --hide_warnings_for=gen/js/proto/ord
+          java -jar node_modules/google-closure-compiler-java/compiler.jar \
+            --entry_point ord.dataset \
+            --js 'editor/closure-library-20200517/**.js' \ 
+            --js 'editor/protobuf/js/**.js' \ 
+            --js 'editor/gen/js/proto/ord/**.js'  \
+            --js editor/js/*.js \
+            --dependency_mode PRUNE \
+            --checks_only \
+            --jscomp_warning=lintChecks \
+            --hide_warnings_for=editor/closure-library-20200517 \
+            --hide_warnings_for=editor/closure-library-20200517 \
+            --hide_warnings_for=editor/protobuf/js \
+            --hide_warnings_for=gen/js/proto/ord
 
   test_notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -77,9 +77,9 @@ jobs:
           npm install google-closure-compiler
 
           # Build and lint, but supress warnings on anything but our code.
-          java -jar node_modules/google-closure-compiler-java/compiler.jar --js editor/closure-library-20200517 --js editor/protobuf/js --js editor/gen/js/proto/ord  --js editor/js/*.js --checks_only --dependency_mode PRUNE --entry_point ord.reaction --jscomp_warning=lintChecks --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/protobuf/js --hide_warnings_for=gen/js/proto/ord
+          java -jar node_modules/google-closure-compiler-java/compiler.jar --js 'editor/closure-library-20200517/**.js' --js 'editor/protobuf/js/**.js' --js 'editor/gen/js/proto/ord/**.js'  --js editor/js/*.js --checks_only --dependency_mode PRUNE --entry_point ord.reaction --jscomp_warning=lintChecks --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/protobuf/js --hide_warnings_for=gen/js/proto/ord
 
-          java -jar node_modules/google-closure-compiler-java/compiler.jar --js editor/closure-library-20200517 --js editor/protobuf/js --js editor/gen/js/proto/ord  --js editor/js/dataset.js --checks_only --dependency_mode PRUNE --entry_point ord.dataset --jscomp_warning=lintChecks --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/protobuf/js --hide_warnings_for=gen/js/proto/ord
+          java -jar node_modules/google-closure-compiler-java/compiler.jar --js 'editor/closure-library-20200517/**.js' --js 'editor/protobuf/js/**.js' --js 'editor/gen/js/proto/ord/**.js'  --js editor/js/*.js --checks_only --dependency_mode PRUNE --entry_point ord.dataset --jscomp_warning=lintChecks --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/closure-library-20200517 --hide_warnings_for=editor/protobuf/js --hide_warnings_for=gen/js/proto/ord
 
   test_notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -102,8 +102,8 @@ jobs:
           # Build and lint, but supress warnings on anything but our code.
           java -jar node_modules/google-closure-compiler-java/compiler.jar \
             --entry_point ord.reaction \
-            --js 'editor/closure-library-20200517/**.js' \ 
-            --js 'editor/protobuf/js/**.js' \ 
+            --js 'editor/closure-library-20200517/**.js' \
+            --js 'editor/protobuf/js/**.js' \
             --js 'editor/gen/js/proto/ord/**.js'  \
             --js editor/js/*.js \
             --dependency_mode PRUNE \
@@ -115,8 +115,8 @@ jobs:
 
           java -jar node_modules/google-closure-compiler-java/compiler.jar \
             --entry_point ord.dataset \
-            --js 'editor/closure-library-20200517/**.js' \ 
-            --js 'editor/protobuf/js/**.js' \ 
+            --js 'editor/closure-library-20200517/**.js' \
+            --js 'editor/protobuf/js/**.js' \
             --js 'editor/gen/js/proto/ord/**.js'  \
             --js editor/js/*.js \
             --dependency_mode PRUNE \

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -66,6 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: s-weigand/setup-conda@v1
+        with:
+          python-version: 3.7
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -100,7 +100,8 @@ jobs:
           npm install google-closure-compiler
 
           # Run the compiler; see the shell script for more info.
-          ../actions/lint_js.sh
+          ../actions/lint_js.sh ord.reaction
+          ../actions/lint_js.sh ord.dataset
 
   test_notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -110,7 +110,6 @@ jobs:
             --checks_only \
             --jscomp_warning=lintChecks \
             --hide_warnings_for=editor/closure-library-20200517 \
-            --hide_warnings_for=editor/closure-library-20200517 \
             --hide_warnings_for=editor/protobuf/js \
             --hide_warnings_for=gen/js/proto/ord
 
@@ -123,7 +122,6 @@ jobs:
             --dependency_mode PRUNE \
             --checks_only \
             --jscomp_warning=lintChecks \
-            --hide_warnings_for=editor/closure-library-20200517 \
             --hide_warnings_for=editor/closure-library-20200517 \
             --hide_warnings_for=editor/protobuf/js \
             --hide_warnings_for=gen/js/proto/ord

--- a/actions/lint_js.sh
+++ b/actions/lint_js.sh
@@ -1,0 +1,36 @@
+# Run the closure compiler, having it lint code and produce warnings during compilation.
+# Assumes that all prerequisite Javascript has been generated, 
+# and that the Google Closure compiler has been installed as a Node package,
+# all in the directory that this script is run from.
+
+# In order to compile properly, we must provide all the source files necessary, 
+# and make sure the compiler skips over files that aren't needed as dependencies.
+# Because we are only checking code, we skip generating output and running optimizations.
+# We also produce warnings only for our written source code 
+# (by suppressing warnings for third-party libraries or machine generated code).
+
+java -jar node_modules/google-closure-compiler-java/compiler.jar \
+    --entry_point ord.reaction \
+    --js 'closure-library-20200517/**.js' \
+    --js 'protobuf/js/**.js' \
+    --js 'gen/js/proto/ord/**.js'  \
+    --js 'js/**.js' \
+    --dependency_mode PRUNE \
+    --checks_only \
+    --jscomp_warning lintChecks \
+    --hide_warnings_for closure-library-20200517 \
+    --hide_warnings_for protobuf/js \
+    --hide_warnings_for gen/js/proto/ord
+
+java -jar node_modules/google-closure-compiler-java/compiler.jar \
+    --entry_point ord.dataset \
+    --js 'closure-library-20200517/**.js' \
+    --js 'protobuf/js/**.js' \
+    --js 'gen/js/proto/ord/**.js'  \
+    --js 'js/**.js' \
+    --dependency_mode PRUNE \
+    --checks_only \
+    --jscomp_warning lintChecks \
+    --hide_warnings_for closure-library-20200517 \
+    --hide_warnings_for protobuf/js \
+    --hide_warnings_for gen/js/proto/ord

--- a/actions/lint_js.sh
+++ b/actions/lint_js.sh
@@ -1,4 +1,5 @@
 # Run the closure compiler, having it lint code and produce warnings during compilation.
+# Takes in one argument: the entry point for the compiler.
 # Assumes that all prerequisite Javascript has been generated, 
 # and that the Google Closure compiler has been installed as a Node package,
 # all in the directory that this script is run from.
@@ -9,21 +10,14 @@
 # We also produce warnings only for our written source code 
 # (by suppressing warnings for third-party libraries or machine generated code).
 
-java -jar node_modules/google-closure-compiler-java/compiler.jar \
-    --entry_point ord.reaction \
-    --js 'closure-library-20200517/**.js' \
-    --js 'protobuf/js/**.js' \
-    --js 'gen/js/proto/ord/**.js'  \
-    --js 'js/**.js' \
-    --dependency_mode PRUNE \
-    --checks_only \
-    --jscomp_warning lintChecks \
-    --hide_warnings_for closure-library-20200517 \
-    --hide_warnings_for protobuf/js \
-    --hide_warnings_for gen/js/proto/ord
+if [ "$#" -ne 1 ]; then
+  echo "entry point required"
+  exit 1
+fi
+ENTRY_POINT="$1"
 
 java -jar node_modules/google-closure-compiler-java/compiler.jar \
-    --entry_point ord.dataset \
+    --entry_point $ENTRY_POINT \
     --js 'closure-library-20200517/**.js' \
     --js 'protobuf/js/**.js' \
     --js 'gen/js/proto/ord/**.js'  \

--- a/actions/lint_js.sh
+++ b/actions/lint_js.sh
@@ -1,3 +1,17 @@
+# Copyright 2020 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Run the closure compiler, having it lint code and produce warnings during compilation.
 # Takes in one argument: the entry point for the compiler.
 # Assumes that all prerequisite Javascript has been generated, 


### PR DESCRIPTION
Fixes #277. In short, emulates the proper build/compile process found in the Makefile, and only shows warnings for our own written code.

Works how (I think) we want it to, see results of `lint_javascript` [in this CI run](https://github.com/Open-Reaction-Database/ord-schema/runs/960097580). However, the commands look horrific right now -- will clean up.