### PR TITLE
Fix the "retrieve" button.

### DIFF
--- a/editor/css/reaction.css
+++ b/editor/css/reaction.css
@@ -130,6 +130,7 @@ fieldset {
 .uploader_chooser_file {
   opacity: 0;
   position: absolute;
+  width: 100px;
 }
 .uploader_chooser_button {
   width: 99px;


### PR DESCRIPTION
The div was obstructed by the invisible file-chooser button. This change reduces the width of the invisible button so it matches its visible affordance.