### PR TITLE
Unloading inputs should not include workup inputs

### DIFF
--- a/editor/js/inputs.js
+++ b/editor/js/inputs.js
@@ -75,7 +75,7 @@ ord.inputs.loadInputUnnamed = function(node, input) {
 };
 
 ord.inputs.unload = function(inputs) {
-  $('.input').each(function(index, node) {
+  $('#inputs > div.input').each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
       // Not a template.


### PR DESCRIPTION
Noticed that saving a reaction.pbtxt for the Nielsen example where there is a Workup input caused that input to be included in the "main" reaction inputs in addition to the workup inputs.