### PR TITLE
Fix JS linter semicolons

### DIFF
--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -233,7 +233,9 @@ ord.compounds.add = function(root) {
   });
 
   // Add live validation handling.
-  addChangeHandler(node, () => {ord.compounds.validateCompound(node);});
+  addChangeHandler(node, () => {
+    ord.compounds.validateCompound(node);
+  });
 
   return node;
 };

--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -36,7 +36,7 @@ ord.compounds.loadCompound = function(root, compound) {
 ord.compounds.loadIntoCompound = function(node, compound) {
   const reactionRole = compound.getReactionRole();
   setSelector($('.component_reaction_role', node), reactionRole);
-  $('.component_reaction_role', node).trigger('change')
+  $('.component_reaction_role', node).trigger('change');
 
   const isLimiting = compound.hasIsLimiting() ? compound.getIsLimiting() : null;
   setOptionalBool($('.component_limiting', node), isLimiting);
@@ -233,7 +233,7 @@ ord.compounds.add = function(root) {
   });
 
   // Add live validation handling.
-  addChangeHandler(node, () => {ord.compounds.validateCompound(node)});
+  addChangeHandler(node, () => {ord.compounds.validateCompound(node);});
 
   return node;
 };
@@ -280,7 +280,7 @@ ord.compounds.addNameIdentifier = function(node) {
       identifier.setType(proto.ord.CompoundIdentifier.IdentifierType.SMILES);
       identifier.setDetails('NAME resolved by the ' + resolver);
       ord.compounds.loadIdentifier(node, identifier);
-    };
+    }
     ord.compounds.validateCompound(node);
   };
   xhr.send(name);
@@ -327,7 +327,7 @@ ord.compounds.drawIdentifier = function(node) {
           // it.
           ketcherModal.off('shown.bs.modal');
           ketcher.setMolecule(molblock);
-        })
+        });
       }
     }
     // Now that we're done with (trying to) loading the molecule, hide the
@@ -366,7 +366,7 @@ ord.compounds.drawIdentifier = function(node) {
       ord.compounds.loadIdentifier(node, identifier);
     }
     ord.compounds.validateCompound(node);
-  }
+  };
 };
 
 ord.compounds.addPreparation = function(node) {
@@ -385,7 +385,7 @@ ord.compounds.addPreparation = function(node) {
     }
   });
 
-  return PreparationNode
+  return PreparationNode;
 };
 
 // Update the image tag with a drawing of this component.

--- a/editor/js/electro.js
+++ b/editor/js/electro.js
@@ -99,7 +99,7 @@ ord.electro.unload = function() {
     electro.setCell(cell);
   }
 
-  const measurements = []
+  const measurements = [];
   $('.electro_measurement').each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {

--- a/editor/js/inputs.js
+++ b/editor/js/inputs.js
@@ -147,7 +147,9 @@ ord.inputs.unloadInputUnnamed = function(node) {
 ord.inputs.add = function(root) {
   const node = addSlowly('#input_template', root);
   // Add live validation handling.
-  addChangeHandler(node, () => {ord.inputs.validateInput(node);});
+  addChangeHandler(node, () => {
+    ord.inputs.validateInput(node);
+  });
   return node;
 };
 

--- a/editor/js/inputs.js
+++ b/editor/js/inputs.js
@@ -147,7 +147,7 @@ ord.inputs.unloadInputUnnamed = function(node) {
 ord.inputs.add = function(root) {
   const node = addSlowly('#input_template', root);
   // Add live validation handling.
-  addChangeHandler(node, () => {ord.inputs.validateInput(node)});
+  addChangeHandler(node, () => {ord.inputs.validateInput(node);});
   return node;
 };
 

--- a/editor/js/observations.js
+++ b/editor/js/observations.js
@@ -143,7 +143,9 @@ ord.observations.add = function() {
   ord.uploads.initialize(node);
 
   // Add live validation handling.
-  addChangeHandler(node, () => {ord.observations.validateObservation(node);});
+  addChangeHandler(node, () => {
+    ord.observations.validateObservation(node);
+  });
 
   return node;
 };

--- a/editor/js/observations.js
+++ b/editor/js/observations.js
@@ -143,7 +143,7 @@ ord.observations.add = function() {
   ord.uploads.initialize(node);
 
   // Add live validation handling.
-  addChangeHandler(node, () => {ord.observations.validateObservation(node)});
+  addChangeHandler(node, () => {ord.observations.validateObservation(node);});
 
   return node;
 };

--- a/editor/js/outcomes.js
+++ b/editor/js/outcomes.js
@@ -328,7 +328,7 @@ ord.outcomes.unloadRaw = function(node, raws) {
 ord.outcomes.add = function() {
   const node = addSlowly('#outcome_template', '#outcomes');
   // Add live validation handling.
-  addChangeHandler(node, () => {ord.outcomes.validateOutcome(node)});
+  addChangeHandler(node, () => {ord.outcomes.validateOutcome(node);});
   return node;
 };
 
@@ -337,7 +337,7 @@ ord.outcomes.addAnalysis = function(node) {
       addSlowly('#outcome_analysis_template', $('.outcome_analyses', node));
 
   // Handle name changes.
-  const nameNode = $('.outcome_analysis_name', analysisNode)
+  const nameNode = $('.outcome_analysis_name', analysisNode);
   nameNode.on('focusin', function() {
     // Store old value in val attribute.
     nameNode.data('val', nameNode.text());
@@ -366,7 +366,7 @@ ord.outcomes.addAnalysis = function(node) {
 
   // Add live validation handling.
   addChangeHandler(
-      analysisNode, () => {ord.outcomes.validateAnalysis(analysisNode)});
+      analysisNode, () => {ord.outcomes.validateAnalysis(analysisNode);});
   return analysisNode;
 };
 

--- a/editor/js/outcomes.js
+++ b/editor/js/outcomes.js
@@ -328,7 +328,9 @@ ord.outcomes.unloadRaw = function(node, raws) {
 ord.outcomes.add = function() {
   const node = addSlowly('#outcome_template', '#outcomes');
   // Add live validation handling.
-  addChangeHandler(node, () => {ord.outcomes.validateOutcome(node);});
+  addChangeHandler(node, () => {
+    ord.outcomes.validateOutcome(node);
+  });
   return node;
 };
 
@@ -365,8 +367,9 @@ ord.outcomes.addAnalysis = function(node) {
   });
 
   // Add live validation handling.
-  addChangeHandler(
-      analysisNode, () => {ord.outcomes.validateAnalysis(analysisNode);});
+  addChangeHandler(analysisNode, () => {
+    ord.outcomes.validateAnalysis(analysisNode);
+  });
   return analysisNode;
 };
 

--- a/editor/js/products.js
+++ b/editor/js/products.js
@@ -207,7 +207,7 @@ ord.products.add = function(node) {
 
   // Add live validation handling.
   addChangeHandler(
-      productNode, () => {ord.products.validateProduct(productNode)});
+      productNode, () => {ord.products.validateProduct(productNode);});
   return productNode;
 };
 

--- a/editor/js/products.js
+++ b/editor/js/products.js
@@ -206,8 +206,9 @@ ord.products.add = function(node) {
   $('.component .vendor', productNode).hide();
 
   // Add live validation handling.
-  addChangeHandler(
-      productNode, () => {ord.products.validateProduct(productNode);});
+  addChangeHandler(productNode, () => {
+    ord.products.validateProduct(productNode);
+  });
   return productNode;
 };
 

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -592,53 +592,63 @@ function initValidateNode(oldNode) {
 function initValidateHandlers() {
   // For setup
   var setupNode = $('#section_setup');
-  addChangeHandler(setupNode, () => {ord.setups.validateSetup(setupNode);});
+  addChangeHandler(setupNode, () => {
+    ord.setups.validateSetup(setupNode);
+  });
 
   // For conditions
   var conditionNode = $('#section_conditions');
-  addChangeHandler(
-      conditionNode, () => {ord.conditions.validateConditions(conditionNode);});
+  addChangeHandler(conditionNode, () => {
+    ord.conditions.validateConditions(conditionNode);
+  });
 
   // For temperature
   var temperatureNode = $('#section_conditions_temperature');
-  addChangeHandler(
-      temperatureNode,
-      () => {ord.temperature.validateTemperature(temperatureNode);});
+  addChangeHandler(temperatureNode, () => {
+    ord.temperature.validateTemperature(temperatureNode);
+  });
 
   // For pressure
   var pressureNode = $('#section_conditions_pressure');
-  addChangeHandler(
-      pressureNode, () => {ord.pressure.validatePressure(pressureNode);});
+  addChangeHandler(pressureNode, () => {
+    ord.pressure.validatePressure(pressureNode);
+  });
 
   // For stirring
   var stirringNode = $('#section_conditions_stirring');
-  addChangeHandler(
-      stirringNode, () => {ord.stirring.validateStirring(stirringNode);});
+  addChangeHandler(stirringNode, () => {
+    ord.stirring.validateStirring(stirringNode);
+  });
 
   // For illumination
   var illuminationNode = $('#section_conditions_illumination');
-  addChangeHandler(
-      illuminationNode,
-      () => {ord.illumination.validateIllumination(illuminationNode);});
+  addChangeHandler(illuminationNode, () => {
+    ord.illumination.validateIllumination(illuminationNode);
+  });
 
   // For electro
   var electroNode = $('#section_conditions_electro');
-  addChangeHandler(
-      electroNode, () => {ord.electro.validateElectro(electroNode);});
+  addChangeHandler(electroNode, () => {
+    ord.electro.validateElectro(electroNode);
+  });
 
   // For flow
   var flowNode = $('#section_conditions_flow');
-  addChangeHandler(flowNode, () => {ord.flows.validateFlow(flowNode);});
+  addChangeHandler(flowNode, () => {
+    ord.flows.validateFlow(flowNode);
+  });
 
   // For notes
   var notesNode = $('#section_notes');
-  addChangeHandler(notesNode, () => {ord.notes.validateNotes(notesNode);});
+  addChangeHandler(notesNode, () => {
+    ord.notes.validateNotes(notesNode);
+  });
 
   // For provenance
   var provenanceNode = $('#section_provenance');
-  addChangeHandler(
-      provenanceNode,
-      () => {ord.provenance.validateProvenance(provenanceNode);});
+  addChangeHandler(provenanceNode, () => {
+    ord.provenance.validateProvenance(provenanceNode);
+  });
 }
 
 // Convert a Message_Field name from a data-proto attribute into a proto class.

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -129,7 +129,7 @@ function validate(message, messageTypeString, validateNode) {
     statusNode.css('backgroundColor', null);
     statusNode.text('');
     if (errors.length) {
-      statusNode.addClass('fa fa-exclamation-triangle')
+      statusNode.addClass('fa fa-exclamation-triangle');
       statusNode.css('color', 'red');
       statusNode.text(' ' + errors.length);
 
@@ -142,7 +142,7 @@ function validate(message, messageTypeString, validateNode) {
       }
       messageNode.css('backgroundColor', 'pink');
     } else {
-      statusNode.addClass('fa fa-check')
+      statusNode.addClass('fa fa-check');
       statusNode.css('color', 'green');
 
       messageNode.html('');
@@ -398,7 +398,7 @@ function removeSlowly(button, pattern) {
   node.parents('fieldset').each(function() {
     buttonsToClick =
         buttonsToClick.add($(this).children('legend').find('.validate_button'));
-  })
+  });
   node.hide('slow', function() {
     node.remove();
     buttonsToClick.trigger('click');
@@ -480,7 +480,7 @@ function setTextFromFile(identifierNode, valueClass) {
     reader.onload = readerEvent => {
       const contents = readerEvent.target.result;
       $('.' + valueClass, identifierNode).text(contents);
-    }
+    };
   });
   input.click();
 }
@@ -592,53 +592,53 @@ function initValidateNode(oldNode) {
 function initValidateHandlers() {
   // For setup
   var setupNode = $('#section_setup');
-  addChangeHandler(setupNode, () => {ord.setups.validateSetup(setupNode)});
+  addChangeHandler(setupNode, () => {ord.setups.validateSetup(setupNode);});
 
   // For conditions
   var conditionNode = $('#section_conditions');
   addChangeHandler(
-      conditionNode, () => {ord.conditions.validateConditions(conditionNode)});
+      conditionNode, () => {ord.conditions.validateConditions(conditionNode);});
 
   // For temperature
   var temperatureNode = $('#section_conditions_temperature');
   addChangeHandler(
       temperatureNode,
-      () => {ord.temperature.validateTemperature(temperatureNode)});
+      () => {ord.temperature.validateTemperature(temperatureNode);});
 
   // For pressure
   var pressureNode = $('#section_conditions_pressure');
   addChangeHandler(
-      pressureNode, () => {ord.pressure.validatePressure(pressureNode)});
+      pressureNode, () => {ord.pressure.validatePressure(pressureNode);});
 
   // For stirring
   var stirringNode = $('#section_conditions_stirring');
   addChangeHandler(
-      stirringNode, () => {ord.stirring.validateStirring(stirringNode)});
+      stirringNode, () => {ord.stirring.validateStirring(stirringNode);});
 
   // For illumination
   var illuminationNode = $('#section_conditions_illumination');
   addChangeHandler(
       illuminationNode,
-      () => {ord.illumination.validateIllumination(illuminationNode)});
+      () => {ord.illumination.validateIllumination(illuminationNode);});
 
   // For electro
   var electroNode = $('#section_conditions_electro');
   addChangeHandler(
-      electroNode, () => {ord.electro.validateElectro(electroNode)});
+      electroNode, () => {ord.electro.validateElectro(electroNode);});
 
   // For flow
   var flowNode = $('#section_conditions_flow');
-  addChangeHandler(flowNode, () => {ord.flows.validateFlow(flowNode)});
+  addChangeHandler(flowNode, () => {ord.flows.validateFlow(flowNode);});
 
   // For notes
   var notesNode = $('#section_notes');
-  addChangeHandler(notesNode, () => {ord.notes.validateNotes(notesNode)});
+  addChangeHandler(notesNode, () => {ord.notes.validateNotes(notesNode);});
 
   // For provenance
   var provenanceNode = $('#section_provenance');
   addChangeHandler(
       provenanceNode,
-      () => {ord.provenance.validateProvenance(provenanceNode)});
+      () => {ord.provenance.validateProvenance(provenanceNode);});
 }
 
 // Convert a Message_Field name from a data-proto attribute into a proto class.

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -163,7 +163,7 @@ function toggleValidateMessage(node) {
       messageNode.css('visibility', 'visible');
       break;
   }
-};
+}
 
 // Update the visual summary of this reaction.
 function renderReaction(reaction) {

--- a/editor/js/temperature.js
+++ b/editor/js/temperature.js
@@ -67,7 +67,7 @@ ord.temperature.unload = function() {
 
   const measurements = [];
   $('.temperature_measurement').each(function(index, node) {
-    node = $(node)
+    node = $(node);
     if (!node.attr('id')) {
       const measurement = ord.temperature.unloadMeasurement(node);
       if (!isEmptyMessage(measurement)) {

--- a/editor/js/workups.js
+++ b/editor/js/workups.js
@@ -233,7 +233,7 @@ ord.workups.add = function() {
   $('.remove', inputNode).hide();
 
   // Add live validation handling.
-  addChangeHandler(workupNode, () => {ord.workups.validateWorkup(workupNode)});
+  addChangeHandler(workupNode, () => {ord.workups.validateWorkup(workupNode);});
 
   return workupNode;
 };

--- a/editor/js/workups.js
+++ b/editor/js/workups.js
@@ -233,7 +233,9 @@ ord.workups.add = function() {
   $('.remove', inputNode).hide();
 
   // Add live validation handling.
-  addChangeHandler(workupNode, () => {ord.workups.validateWorkup(workupNode);});
+  addChangeHandler(workupNode, () => {
+    ord.workups.validateWorkup(workupNode);
+  });
 
   return workupNode;
 };


### PR DESCRIPTION
Fixes some issues regarding semicolons that the linter has with our code. (yes, misleading branch name -- whoops)

TODO in other PRs: use goog.module; add JSDocs; change linter to throw errors rather than warnings 