### PR TITLE
Use goog.module for Closure modules

### DIFF
--- a/editor/html/dataset.html
+++ b/editor/html/dataset.html
@@ -66,14 +66,14 @@ limitations under the License.
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="/js/dataset.js"></script>
   </head>
-  <body onload="init('{{ file_name }}');">
+  <body onload="ord.dataset.init('{{ file_name }}');">
 
     <center>
       <h1><a href="/">Dataset</a>: {{ file_name }}.pbtxt</h1>
     </center>
     <div id="top_buttons">
-      <div id="download" onclick="download();">download</div>
-      <div id="save" onclick="commit();" style="visibility: hidden;">save</div>
+      <div id="download" onclick="ord.dataset.download();">download</div>
+      <div id="save" onclick="ord.dataset.commit();" style="visibility: hidden;">save</div>
     </div>
 
     <div class="spacer"></div>
@@ -103,10 +103,10 @@ limitations under the License.
         <div id="reaction_template" class="reaction" style="display: none;">
           <a class="reaction_index"></a>
           <div class="reaction_id"></div>
-          <div class="remove" onclick="deleteReaction(this);">remove</div>
+          <div class="remove" onclick="ord.dataset.deleteReaction(this);">remove</div>
         </div>
       </div>
-      <div id="add_reaction" class="add" onclick="newReaction();">+ add reaction</div>
+      <div id="add_reaction" class="add" onclick="ord.dataset.newReaction();">+ add reaction</div>
     </fieldset>
 
     <div class="spacer"></div>
@@ -116,10 +116,10 @@ limitations under the License.
       <div id="other_reaction_ids">
         <div id="other_reaction_id_template" class="other_reaction_id" style="display: none;">
           <div class="other_reaction_id_text edittext"></div>
-          <div class="remove" onclick="removeReactionId(this);">remove</div>
+          <div class="remove" onclick="ord.dataset.removeReactionId(this);">remove</div>
         </div>
       </div>
-      <div id="add_other_reaction_id" class="add" onclick="addReactionId();">+ add reaction ID</div>
+      <div id="add_other_reaction_id" class="add" onclick="ord.dataset.addReactionId();">+ add reaction ID</div>
     </fieldset>
   </body>
 </html>

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -68,7 +68,7 @@ limitations under the License.
       <span id="validate_template" style="display: none">
         <span class="validate_button" aria-hidden="true">validate</span>
         <span class="validate_status-message">
-          <span onmouseenter="toggleValidateMessage($(this).closest('.validate'))" onmouseleave="toggleValidateMessage($(this).closest('.validate'))"  class="validate_status">unvalidated</span>
+          <span onmouseenter="ord.reaction.toggleValidateMessage($(this).closest('.validate'))" onmouseleave="ord.reaction.toggleValidateMessage($(this).closest('.validate'))"  class="validate_status">unvalidated</span>
           <span class="validate_message"></span>
         </span>
       </span>

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -29,20 +29,20 @@ limitations under the License.
     <title>{{ file_name }}:{{ index }}</title>
   </head>
 
-  <body onload="init('{{ file_name }}', {{ index }});">
+  <body onload="ord.reaction.init('{{ file_name }}', {{ index }});">
 
     <center>
       <h1><a href="/dataset/{{ file_name }}">{{ file_name }}</a>: {{ index }}</h1>
     </center>
 
     <div id="top_buttons">
-      <div id="download" onclick="commit(); downloadReaction();">download</div>
+      <div id="download" onclick="ord.reaction.commit(); ord.reaction.downloadReaction();">download</div>
       <div>
         <div class="add" onclick="location.href='/dataset/{{ file_name }}/clone/{{ index }}';">+ clone</div>
-        <div id="save" onclick="commit();" style="visibility: hidden;">save</div>
+        <div id="save" onclick="ord.reaction.commit();" style="visibility: hidden;">save</div>
         <div id="delete" class="remove" style="float: none;" onclick="location.href='/dataset/{{ file_name }}/delete/reaction/{{ index }}';">delete</div>
       </div>
-      <span id="reaction_validate" class="validate" button-onclick="validateReaction()"></span>
+      <span id="reaction_validate" class="validate" button-onclick="ord.reaction.validateReaction()"></span>
     </div>
 
     <div id="reaction_render_wrapper" style="text-align: center">
@@ -85,8 +85,8 @@ limitations under the License.
           <div id="reaction_identifier_template" class="reaction_identifier" style="display: none;">
             type <div class="reaction_identifier_type selector" data-proto="ReactionIdentifier_IdentifierType"></div>
             value <div class="reaction_identifier_value edittext longtext"></div>
-            <span class="fa fa-upload text_upload" aria-hidden="true" style="cursor:pointer;" onclick="setTextFromFile($(this).closest('.reaction_identifier'), 'reaction_identifier_value');"></span>
-            <div class="remove" onclick="removeSlowly(this, '.reaction_identifier');">remove</div>
+            <span class="fa fa-upload text_upload" aria-hidden="true" style="cursor:pointer;" onclick="ord.reaction.setTextFromFile($(this).closest('.reaction_identifier'), 'reaction_identifier_value');"></span>
+            <div class="remove" onclick="ord.reaction.removeSlowly(this, '.reaction_identifier');">remove</div>
             <br>
             details <div class="reaction_identifier_details edittext"></div>
           </div>
@@ -113,7 +113,7 @@ limitations under the License.
                   <span class="validate" button-onclick="ord.inputs.validateInput($(this).closest('.input'))"></span>
                </legend>
                 
-                <div onclick="removeSlowly(this, '.input');" class="remove">remove</div>
+                <div onclick="ord.reaction.removeSlowly(this, '.input');" class="remove">remove</div>
                 <div>
                   <div class="components"></div>
                   <div onclick="ord.compounds.add($(this).closest('.input'));" class="add">+ add component</div>
@@ -175,7 +175,7 @@ limitations under the License.
                   Component
                   <span class="validate" button-onclick="ord.compounds.validateCompound($(this).closest('.component'))"></span>
                 </legend>
-                <div onclick="removeSlowly(this, '.component');" class="remove">remove</div>
+                <div onclick="ord.reaction.removeSlowly(this, '.component');" class="remove">remove</div>
                 <table class="component_role_limiting">
                   <tr><td>reaction role</td><td><div class="component_reaction_role selector" data-proto="Compound_ReactionRole_ReactionRoleType"></div></td></tr>
                   <tr class="limiting_reactant"><td>limiting reactant?</td><td><div class="component_limiting optional_bool"></div></td></tr>
@@ -251,8 +251,8 @@ limitations under the License.
             <div id="component_identifier_template" class="component_identifier" style="display: none; padding-bottom:10px">
               type <div class="component_identifier_type selector" data-proto="CompoundIdentifier_IdentifierType"></div>
               value <div class="component_identifier_value edittext longtext"></div>
-              <span class="fa fa-upload text_upload" aria-hidden="true" style="cursor:pointer;" onclick="setTextFromFile($(this).closest('.component_identifier'), 'component_identifier_value');"></span>
-              <div onclick="removeSlowly(this, '.component_identifier');" class="remove">remove</div>
+              <span class="fa fa-upload text_upload" aria-hidden="true" style="cursor:pointer;" onclick="ord.reaction.setTextFromFile($(this).closest('.component_identifier'), 'component_identifier_value');"></span>
+              <div onclick="ord.reaction.removeSlowly(this, '.component_identifier');" class="remove">remove</div>
               <br>details <div class="component_identifier_details edittext longtext"></div>
             </div>
 
@@ -261,14 +261,14 @@ limitations under the License.
               details <div class="component_compound_preparation_details edittext"></div>
               <span class="component_compound_preparation_reaction_id">reaction ID</span>
               <div class="component_compound_preparation_reaction component_compound_preparation_reaction_id edittext"></div>
-              <div onclick="removeSlowly(this, '.component_preparation');" class="remove">remove</div>
+              <div onclick="ord.reaction.removeSlowly(this, '.component_preparation');" class="remove">remove</div>
             </div>
 
             <div id="component_feature_template" class="component_feature" style="display: none;">
               name <div class="component_feature_name edittext"></div>
               value <div class="component_feature_value edittext"></div>
               how computed <div class="component_feature_how edittext"></div>
-              <div onclick="removeSlowly(this, '.component_feature');" class="remove">remove</div>
+              <div onclick="ord.reaction.removeSlowly(this, '.component_feature');" class="remove">remove</div>
             </div>
 
             <div id="crude_template" class="crude" style="display: none;">
@@ -297,7 +297,7 @@ limitations under the License.
                   <div class="crude_amount_units_mass selector" data-proto="Mass_MassUnit"></div>
                   <div class="crude_amount_units_volume selector" data-proto="Volume_VolumeUnit" style="display: none;"></div>
                 </fieldset>
-                <div onclick="removeSlowly(this, '.crude');" class="remove">remove</div>
+                <div onclick="ord.reaction.removeSlowly(this, '.crude');" class="remove">remove</div>
               </fieldset>
             </div>
 
@@ -333,7 +333,7 @@ limitations under the License.
           </legend>
           <div id="setup_vessel_preparations">
             <div id="setup_vessel_preparation_template" class="setup_vessel_preparation" style="display: none;">
-              <div onclick="removeSlowly(this, '.setup_vessel_preparation');" class="remove">remove</div>
+              <div onclick="ord.reaction.removeSlowly(this, '.setup_vessel_preparation');" class="remove">remove</div>
               preparation<div class="setup_vessel_preparation_type selector" data-proto="VesselPreparation_VesselPreparationType"></div>
               details <div class="setup_vessel_preparation_details edittext"></div>
             </div>
@@ -347,7 +347,7 @@ limitations under the License.
           </legend>
           <div id="setup_vessel_attachments">
             <div id="setup_vessel_attachment_template" class="setup_vessel_attachment" style="display: none;">
-              <div onclick="removeSlowly(this, '.setup_vessel_attachment');" class="remove">remove</div>
+              <div onclick="ord.reaction.removeSlowly(this, '.setup_vessel_attachment');" class="remove">remove</div>
               attachment<div class="setup_vessel_attachment_type selector" data-proto="VesselAttachment_VesselAttachmentType"></div>
               details <div class="setup_vessel_attachment_details edittext"></div>
             </div>
@@ -364,7 +364,7 @@ limitations under the License.
                   <span class="fa fa-question-circle" aria-hidden="true"></span>
                 </span>
               </legend>
-              <div onclick="removeSlowly(this, '.setup_code');" class="remove">remove</div>
+              <div onclick="ord.reaction.removeSlowly(this, '.setup_code');" class="remove">remove</div>
               <table>
                 <tr><td align="right">name</td><td><div class="setup_code_name edittext"></div></td></tr>
                 <tr>
@@ -423,7 +423,7 @@ limitations under the License.
                   <span class="collapse"></span>
                   Measurement
                 </legend>
-                <div onclick="removeSlowly(this, '.temperature_measurement');" class="remove">remove</div>
+                <div onclick="ord.reaction.removeSlowly(this, '.temperature_measurement');" class="remove">remove</div>
                 <table>
                   <tr><td align="right">type</td><td><div class="temperature_measurement_type selector" data-proto="TemperatureConditions_Measurement_MeasurementType"></div></td></tr>
                   <tr><td align="right">temperature</td><td><div class="temperature_measurement_temperature_value edittext shorttext"></div>
@@ -461,7 +461,7 @@ limitations under the License.
                   <span class="collapse"></span>
                   Measurement
                 </legend>
-                <div onclick="removeSlowly(this, '.pressure_measurement');" class="remove">remove</div>
+                <div onclick="ord.reaction.removeSlowly(this, '.pressure_measurement');" class="remove">remove</div>
                 <table>
                   <tr><td align="right">type</td><td><div class="pressure_measurement_type selector" data-proto="PressureConditions_Measurement_MeasurementType"></div></td></tr>
                   <tr><td align="right">pressure</td><td><div class="pressure_measurement_pressure_value edittext shorttext"></div>
@@ -539,7 +539,7 @@ limitations under the License.
                   <span class="collapse"></span>
                   Measurement
                 </legend>
-                <div onclick="removeSlowly(this, '.electro_measurement');" class="remove">remove</div>
+                <div onclick="ord.reaction.removeSlowly(this, '.electro_measurement');" class="remove">remove</div>
                 <input type="radio" class="electro_measurement_current" value="current" checked> current
                 <input type="radio" class="electro_measurement_voltage" value="voltage"> voltage
                 <table>
@@ -628,7 +628,7 @@ limitations under the License.
                 Observation
                 <span class="validate" button-onclick="ord.observations.validateObservation($(this).closest('.observation'))"></span>
               </legend>
-              <div onclick="removeSlowly(this, '.observation');" class="remove">remove</div>
+              <div onclick="ord.reaction.removeSlowly(this, '.observation');" class="remove">remove</div>
               <table>
                 <tr><td align="right">time</td><td><div class="observation_time_value edittext shorttext"></div>
                                                    <div class="observation_time_units selector" data-proto="Time_TimeUnit"></div>
@@ -680,7 +680,7 @@ limitations under the License.
               Workup
               <span class="validate" button-onclick="ord.workups.validateWorkup($(this).closest('.workup'))"></span>
             </legend>
-            <div onclick="removeSlowly(this, '.workup');" class="remove">remove</div>
+            <div onclick="ord.reaction.removeSlowly(this, '.workup');" class="remove">remove</div>
             <table>
               <tr><td align="right">type</td><td><div class="workup_type selector" data-proto="ReactionWorkup_WorkupType"></div></td></tr>
               <tr><td align="right">keep phase</td><td><div class="workup_keep_phase edittext"></div></td></tr>
@@ -738,7 +738,7 @@ limitations under the License.
                 <span class="collapse"></span>
                 Temperature measurement
               </legend>
-              <div onclick="removeSlowly(this, '.workup_temperature_measurement');" class="remove">remove</div>
+              <div onclick="ord.reaction.removeSlowly(this, '.workup_temperature_measurement');" class="remove">remove</div>
               <table>
                 <tr><td align="right">type</td><td><div class="workup_temperature_measurement_type selector" data-proto="TemperatureConditions_Measurement_MeasurementType"></div></td></tr>
                 <tr><td align="right">time</td><td><div class="workup_temperature_measurement_time_value edittext"></div>
@@ -774,7 +774,7 @@ limitations under the License.
               Outcome
               <span class="validate" button-onclick="ord.outcomes.validateOutcome($(this).closest('.outcome'))"></span>
             </legend>
-            <div onclick="removeSlowly(this, '.outcome');" class="remove">remove</div>
+            <div onclick="ord.reaction.removeSlowly(this, '.outcome');" class="remove">remove</div>
             <table>
               <tr><td align="right">time 
                 <span data-toggle="tooltip" data-placement="right" title="The reaction time at which this analysis/characterization was performed.">
@@ -808,7 +808,7 @@ limitations under the License.
                 Product
                 <span class="validate" button-onclick="ord.products.validateProduct($(this).closest('.outcome_product')"></span>
               </legend>
-            <div onclick="removeSlowly(this, '.outcome_product');" class="remove">remove</div>
+            <div onclick="ord.reaction.removeSlowly(this, '.outcome_product');" class="remove">remove</div>
 
             <div class="outcome_product_compound components"></div>
             <!-- Shares "#component_template" with ".components" in the input section. -->
@@ -897,25 +897,25 @@ limitations under the License.
             <select class="analysis_key_selector">
               <option disabled selected value="">-- select an analysis label --</option>
             </select>
-            <div onclick="removeSlowly(this, '.outcome_product_analysis_identity');" class="remove">remove</div>
+            <div onclick="ord.reaction.removeSlowly(this, '.outcome_product_analysis_identity');" class="remove">remove</div>
           </div>
           <div id="outcome_product_analysis_yield_template" class="outcome_product_analysis_yield" style="display: none;">
             <select class="analysis_key_selector">
               <option disabled selected value="">-- select an analysis label --</option>
             </select>
-            <div onclick="removeSlowly(this, '.outcome_product_analysis_yield');" class="remove">remove</div>
+            <div onclick="ord.reaction.removeSlowly(this, '.outcome_product_analysis_yield');" class="remove">remove</div>
           </div>
           <div id="outcome_product_analysis_purity_template" class="outcome_product_analysis_purity" style="display: none;">
             <select class="analysis_key_selector">
               <option disabled selected value="">-- select an analysis label --</option>
             </select>
-            <div onclick="removeSlowly(this, '.outcome_product_analysis_purity');" class="remove">remove</div>
+            <div onclick="ord.reaction.removeSlowly(this, '.outcome_product_analysis_purity');" class="remove">remove</div>
           </div>
           <div id="outcome_product_analysis_selectivity_template" class="outcome_product_analysis_selectivity" style="display: none;">
             <select class="analysis_key_selector">
               <option disabled selected value="">-- select an analysis label --</option>
             </select>
-            <div onclick="removeSlowly(this, '.outcome_product_analysis_selectivity');" class="remove">remove</div>
+            <div onclick="ord.reaction.removeSlowly(this, '.outcome_product_analysis_selectivity');" class="remove">remove</div>
           </div>
 
           <div id="outcome_analysis_template" class="outcome_analysis" style="display: none;">
@@ -926,7 +926,7 @@ limitations under the License.
                 <span class="analysis_name_label">label: </span><div class="outcome_analysis_name edittext"></div>
                 <span class="validate" button-onclick="ord.outcomes.validateAnalysis($(this).closest('.outcome_analysis'))" ></span>
               </legend>
-              <div onclick="removeSlowly(this, '.outcome_analysis');" class="remove">remove</div>
+              <div onclick="ord.reaction.removeSlowly(this, '.outcome_analysis');" class="remove">remove</div>
               <table>
                 <tr><td align="right">type</td><td><div class="outcome_analysis_type selector" data-proto="ReactionAnalysis_AnalysisType"></div></td></tr>
                 <tr><td align="right">details</td><td><div class="outcome_analysis_details edittext"></div></td></tr>
@@ -966,7 +966,7 @@ limitations under the License.
                 <span class="collapse"></span>
                 Processed analytical data
               </legend>
-              <div onclick="removeSlowly(this, '.outcome_process');" class="remove">remove</div>
+              <div onclick="ord.reaction.removeSlowly(this, '.outcome_process');" class="remove">remove</div>
               <table>
                 <tr><td align="right">name</td><td><div class="outcome_process_name edittext"></div></td></tr>
                 <tr>
@@ -1002,7 +1002,7 @@ limitations under the License.
                 <span class="collapse"></span>
                 Raw analytical data
               </legend>
-              <div onclick="removeSlowly(this, '.outcome_raw');" class="remove">remove</div>
+              <div onclick="ord.reaction.removeSlowly(this, '.outcome_raw');" class="remove">remove</div>
               <table>
                 <tr><td align="right">name</td><td><div class="outcome_raw_name edittext"></div></td></tr>
                 <tr>
@@ -1092,7 +1092,7 @@ limitations under the License.
                 <span class="fa fa-question-circle" aria-hidden="true"></span>
               </span>
               </legend>
-              <div onclick="removeSlowly(this, '.provenance_modified');" class="remove">remove</div>
+              <div onclick="ord.reaction.removeSlowly(this, '.provenance_modified');" class="remove">remove</div>
               <table>
                 <tr><td align="right">time</td><td>
                   <div class="provenance_time edittext"></div>

--- a/editor/js/amounts.js
+++ b/editor/js/amounts.js
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-goog.provide('ord.amounts');
+goog.module('ord.amounts');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, unloadVolume};
 
 goog.require('proto.ord.Mass');
 goog.require('proto.ord.Moles');
 goog.require('proto.ord.Volume');
 
-ord.amounts.load = function(node, mass, moles, volume) {
+function load (node, mass, moles, volume) {
   const amount = $('.amount', node);
   $('.component_amount_units_mass', node).hide();
   $('.component_amount_units_moles', node).hide();
@@ -63,12 +65,12 @@ ord.amounts.load = function(node, mass, moles, volume) {
     ord.reaction.setSelector(
         $('.component_amount_units_volume', amount), volume.getUnits());
   }
-};
+}
 
-ord.amounts.unload = function(node, compound) {
-  const mass = ord.amounts.unloadMass(node);
-  const moles = ord.amounts.unloadMoles(node);
-  const volume = ord.amounts.unloadVolume(node);
+function unload(node, compound) {
+  const mass = unloadMass(node);
+  const moles = unloadMoles(node);
+  const volume = unloadVolume(node);
   if (mass) {
     if (!ord.reaction.isEmptyMessage(mass)) {
       compound.setMass(mass);
@@ -84,9 +86,9 @@ ord.amounts.unload = function(node, compound) {
       compound.setVolume(volume);
     }
   }
-};
+}
 
-ord.amounts.unloadMass = function(node) {
+function unloadMass(node) {
   if (!$('.component_amount_mass', node).is(':checked')) {
     return null;
   }
@@ -103,9 +105,9 @@ ord.amounts.unloadMass = function(node) {
     mass.setPrecision(precision);
   }
   return mass;
-};
+}
 
-ord.amounts.unloadMoles = function(node) {
+function unloadMoles(node) {
   if (!$('.component_amount_moles', node).is(':checked')) {
     return null;
   }
@@ -122,9 +124,9 @@ ord.amounts.unloadMoles = function(node) {
     moles.setPrecision(precision);
   }
   return moles;
-};
+}
 
-ord.amounts.unloadVolume = function(node) {
+function unloadVolume(node) {
   if (!$('.component_amount_volume', node).is(':checked')) {
     return null;
   }
@@ -141,4 +143,4 @@ ord.amounts.unloadVolume = function(node) {
     volume.setPrecision(precision);
   }
   return volume;
-};
+}

--- a/editor/js/amounts.js
+++ b/editor/js/amounts.js
@@ -16,13 +16,17 @@
 
 goog.module('ord.amounts');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, unloadVolume};
+exports = {
+  load,
+  unload,
+  unloadVolume
+};
 
 goog.require('proto.ord.Mass');
 goog.require('proto.ord.Moles');
 goog.require('proto.ord.Volume');
 
-function load (node, mass, moles, volume) {
+function load(node, mass, moles, volume) {
   const amount = $('.amount', node);
   $('.component_amount_units_mass', node).hide();
   $('.component_amount_units_moles', node).hide();

--- a/editor/js/amounts.js
+++ b/editor/js/amounts.js
@@ -35,7 +35,8 @@ ord.amounts.load = function(node, mass, moles, volume) {
       $('.component_amount_precision', node).text(mass.getPrecision());
     }
     $('.component_amount_units_mass', node).show();
-    setSelector($('.component_amount_units_mass', amount), mass.getUnits());
+    ord.reaction.setSelector(
+        $('.component_amount_units_mass', amount), mass.getUnits());
   }
   if (moles) {
     $('input[value=\'moles\']', amount).prop('checked', true);
@@ -46,7 +47,8 @@ ord.amounts.load = function(node, mass, moles, volume) {
       $('.component_amount_precision', node).text(moles.getPrecision());
     }
     $('.component_amount_units_moles', node).show();
-    setSelector($('.component_amount_units_moles', amount), moles.getUnits());
+    ord.reaction.setSelector(
+        $('.component_amount_units_moles', amount), moles.getUnits());
   }
   if (volume) {
     $('input[value=\'volume\']', amount).prop('checked', true);
@@ -58,7 +60,8 @@ ord.amounts.load = function(node, mass, moles, volume) {
     }
     $('.component_amount_units_volume', node).show();
     $('.includes_solutes', node).show().css('display', 'inline-block');
-    setSelector($('.component_amount_units_volume', amount), volume.getUnits());
+    ord.reaction.setSelector(
+        $('.component_amount_units_volume', amount), volume.getUnits());
   }
 };
 
@@ -67,17 +70,17 @@ ord.amounts.unload = function(node, compound) {
   const moles = ord.amounts.unloadMoles(node);
   const volume = ord.amounts.unloadVolume(node);
   if (mass) {
-    if (!isEmptyMessage(mass)) {
+    if (!ord.reaction.isEmptyMessage(mass)) {
       compound.setMass(mass);
     }
   }
   if (moles) {
-    if (!isEmptyMessage(moles)) {
+    if (!ord.reaction.isEmptyMessage(moles)) {
       compound.setMoles(moles);
     }
   }
   if (volume) {
-    if (!isEmptyMessage(volume)) {
+    if (!ord.reaction.isEmptyMessage(volume)) {
       compound.setVolume(volume);
     }
   }
@@ -92,7 +95,8 @@ ord.amounts.unloadMass = function(node) {
   if (!isNaN(value)) {
     mass.setValue(value);
   }
-  const units = getSelector($('.component_amount_units_mass', node));
+  const units =
+      ord.reaction.getSelector($('.component_amount_units_mass', node));
   mass.setUnits(units);
   const precision = parseFloat($('.component_amount_precision', node).text());
   if (!isNaN(precision)) {
@@ -110,7 +114,8 @@ ord.amounts.unloadMoles = function(node) {
   if (!isNaN(value)) {
     moles.setValue(value);
   }
-  const units = getSelector($('.component_amount_units_moles', node));
+  const units =
+      ord.reaction.getSelector($('.component_amount_units_moles', node));
   moles.setUnits(units);
   const precision = parseFloat($('.component_amount_precision', node).text());
   if (!isNaN(precision)) {
@@ -128,7 +133,8 @@ ord.amounts.unloadVolume = function(node) {
   if (!isNaN(value)) {
     volume.setValue(value);
   }
-  const units = getSelector($('.component_amount_units_volume', node));
+  const units =
+      ord.reaction.getSelector($('.component_amount_units_volume', node));
   volume.setUnits(units);
   const precision = parseFloat($('.component_amount_precision', node).text());
   if (!isNaN(precision)) {

--- a/editor/js/amountsCrudes.js
+++ b/editor/js/amountsCrudes.js
@@ -32,7 +32,8 @@ ord.amountsCrudes.load = function(node, mass, volume) {
       $('.crude_amount_precision', node).text(mass.getPrecision());
     }
     $('.crude_amount_units_mass', node).show();
-    setSelector($('.crude_amount_units_mass', amount), mass.getUnits());
+    ord.reaction.setSelector(
+        $('.crude_amount_units_mass', amount), mass.getUnits());
   }
   if (volume) {
     $('input[value=\'volume\']', amount).prop('checked', true);
@@ -43,7 +44,8 @@ ord.amountsCrudes.load = function(node, mass, volume) {
       $('.crude_amount_precision', node).text(volume.getPrecision());
     }
     $('.crude_amount_units_volume', node).show();
-    setSelector($('.crude_amount_units_volume', amount), volume.getUnits());
+    ord.reaction.setSelector(
+        $('.crude_amount_units_volume', amount), volume.getUnits());
   }
 };
 
@@ -51,12 +53,12 @@ ord.amountsCrudes.unload = function(node, crude) {
   const mass = ord.amountsCrudes.unloadMass(node);
   const volume = ord.amountsCrudes.unloadVolume(node);
   if (mass) {
-    if (!isEmptyMessage(mass)) {
+    if (!ord.reaction.isEmptyMessage(mass)) {
       crude.setMass(mass);
     }
   }
   if (volume) {
-    if (!isEmptyMessage(volume)) {
+    if (!ord.reaction.isEmptyMessage(volume)) {
       crude.setVolume(volume);
     }
   }
@@ -71,7 +73,7 @@ ord.amountsCrudes.unloadMass = function(node) {
   if (!isNaN(value)) {
     mass.setValue(value);
   }
-  const units = getSelector($('.crude_amount_units_mass', node));
+  const units = ord.reaction.getSelector($('.crude_amount_units_mass', node));
   mass.setUnits(units);
   const precision = parseFloat($('.crude_amount_precision', node).text());
   if (!isNaN(precision)) {
@@ -89,7 +91,7 @@ ord.amountsCrudes.unloadVolume = function(node) {
   if (!isNaN(value)) {
     volume.setValue(value);
   }
-  const units = getSelector($('.crude_amount_units_volume', node));
+  const units = ord.reaction.getSelector($('.crude_amount_units_volume', node));
   volume.setUnits(units);
   const precision = parseFloat($('.crude_amount_precision', node).text());
   if (!isNaN(precision)) {

--- a/editor/js/amountsCrudes.js
+++ b/editor/js/amountsCrudes.js
@@ -16,12 +16,15 @@
 
 goog.module('ord.amountsCrudes');
 goog.module.declareLegacyNamespace();
-exports = {load, unload};
+exports = {
+  load,
+  unload
+};
 
 goog.require('proto.ord.Mass');
 goog.require('proto.ord.Volume');
 
-function load (node, mass, volume) {
+function load(node, mass, volume) {
   const amount = $('.amount', node);
   $('.crude_amount_units_mass', node).hide();
   $('.crude_amount_units_volume', node).hide();

--- a/editor/js/amountsCrudes.js
+++ b/editor/js/amountsCrudes.js
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-goog.provide('ord.amountsCrudes');
+goog.module('ord.amountsCrudes');
+goog.module.declareLegacyNamespace();
+exports = {load, unload};
 
 goog.require('proto.ord.Mass');
 goog.require('proto.ord.Volume');
 
-ord.amountsCrudes.load = function(node, mass, volume) {
+function load (node, mass, volume) {
   const amount = $('.amount', node);
   $('.crude_amount_units_mass', node).hide();
   $('.crude_amount_units_volume', node).hide();
@@ -47,11 +49,11 @@ ord.amountsCrudes.load = function(node, mass, volume) {
     ord.reaction.setSelector(
         $('.crude_amount_units_volume', amount), volume.getUnits());
   }
-};
+}
 
-ord.amountsCrudes.unload = function(node, crude) {
-  const mass = ord.amountsCrudes.unloadMass(node);
-  const volume = ord.amountsCrudes.unloadVolume(node);
+function unload(node, crude) {
+  const mass = unloadMass(node);
+  const volume = unloadVolume(node);
   if (mass) {
     if (!ord.reaction.isEmptyMessage(mass)) {
       crude.setMass(mass);
@@ -62,9 +64,9 @@ ord.amountsCrudes.unload = function(node, crude) {
       crude.setVolume(volume);
     }
   }
-};
+}
 
-ord.amountsCrudes.unloadMass = function(node) {
+function unloadMass(node) {
   if (!$('.crude_amount_mass', node).is(':checked')) {
     return null;
   }
@@ -80,9 +82,9 @@ ord.amountsCrudes.unloadMass = function(node) {
     mass.setPrecision(precision);
   }
   return mass;
-};
+}
 
-ord.amountsCrudes.unloadVolume = function(node) {
+function unloadVolume(node) {
   if (!$('.crude_amount_volume', node).is(':checked')) {
     return null;
   }
@@ -98,4 +100,4 @@ ord.amountsCrudes.unloadVolume = function(node) {
     volume.setPrecision(precision);
   }
   return volume;
-};
+}

--- a/editor/js/codes.js
+++ b/editor/js/codes.js
@@ -16,7 +16,11 @@
 
 goog.module('ord.codes');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, addCode};
+exports = {
+  load,
+  unload,
+  addCode
+};
 
 goog.require('proto.ord.Data');
 

--- a/editor/js/codes.js
+++ b/editor/js/codes.js
@@ -14,23 +14,25 @@
  * limitations under the License.
  */
 
-goog.provide('ord.codes');
+goog.module('ord.codes');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, addCode};
 
 goog.require('proto.ord.Data');
 
 // Freely create radio button groups by generating new input names.
-ord.codes.radioGroupCounter = 0;
+let radioGroupCounter = 0;
 
-ord.codes.load = function(codes) {
+function load(codes) {
   const names = codes.stringKeys_();
   names.forEach(function(name) {
     const code = codes.get(name);
-    ord.codes.loadCode(name, code);
+    loadCode(name, code);
   });
-};
+}
 
-ord.codes.loadCode = function(name, code) {
-  const node = ord.codes.addCode();
+function loadCode(name, code) {
+  const node = addCode();
   $('.setup_code_name', node).text(name);
   $('.setup_code_description', node).text(code.getDescription());
   $('.setup_code_format', node).text(code.getFormat());
@@ -63,18 +65,18 @@ ord.codes.loadCode = function(name, code) {
     $('.setup_code_text', node).text(url);
     $('input[value=\'url\']', node).prop('checked', true);
   }
-};
+}
 
-ord.codes.unload = function(codes) {
+function unload(codes) {
   $('.setup_code').each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
-      ord.codes.unloadCode(codes, node);
+      unloadCode(codes, node);
     }
   });
-};
+}
 
-ord.codes.unloadCode = function(codes, node) {
+function unloadCode(codes, node) {
   const name = $('.setup_code_name', node).text();
 
   const code = new proto.ord.Data();
@@ -112,13 +114,13 @@ ord.codes.unloadCode = function(codes, node) {
       !ord.reaction.isEmptyMessage(code)) {
     codes.set(name, code);
   }
-};
+}
 
-ord.codes.addCode = function() {
+function addCode() {
   const node = ord.reaction.addSlowly('#setup_code_template', '#setup_codes');
 
   const typeButtons = $('input[type=\'radio\']', node);
-  typeButtons.attr('name', 'codes_' + ord.codes.radioGroupCounter++);
+  typeButtons.attr('name', 'codes_' + radioGroupCounter++);
   typeButtons.change(function() {
     if ((this.value == 'text') || (this.value == 'number') ||
         (this.value == 'url')) {
@@ -131,4 +133,4 @@ ord.codes.addCode = function() {
   });
   ord.uploads.initialize(node);
   return node;
-};
+}

--- a/editor/js/codes.js
+++ b/editor/js/codes.js
@@ -86,7 +86,7 @@ ord.codes.unloadCode = function(codes, node) {
 
   if ($('input[value=\'text\']', node).is(':checked')) {
     const stringValue = $('.setup_code_text', node).text();
-    if (!isEmptyMessage(stringValue)) {
+    if (!ord.reaction.isEmptyMessage(stringValue)) {
       code.setStringValue(stringValue);
     }
   }
@@ -98,23 +98,24 @@ ord.codes.unloadCode = function(codes, node) {
   }
   if ($('input[value=\'upload\']', node).is(':checked')) {
     const bytesValue = ord.uploads.unload(node);
-    if (!isEmptyMessage(bytesValue)) {
+    if (!ord.reaction.isEmptyMessage(bytesValue)) {
       code.setBytesValue(bytesValue);
     }
   }
   if ($('input[value=\'url\']', node).is(':checked')) {
     const url = $('.setup_code_text', node).text();
-    if (!isEmptyMessage(url)) {
+    if (!ord.reaction.isEmptyMessage(url)) {
       code.setUrl(url);
     }
   }
-  if (!isEmptyMessage(name) || !isEmptyMessage(code)) {
+  if (!ord.reaction.isEmptyMessage(name) ||
+      !ord.reaction.isEmptyMessage(code)) {
     codes.set(name, code);
   }
 };
 
 ord.codes.addCode = function() {
-  const node = addSlowly('#setup_code_template', '#setup_codes');
+  const node = ord.reaction.addSlowly('#setup_code_template', '#setup_codes');
 
   const typeButtons = $('input[type=\'radio\']', node);
   typeButtons.attr('name', 'codes_' + ord.codes.radioGroupCounter++);

--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-goog.provide('ord.compounds');
+goog.module('ord.compounds');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, unloadCompound, loadIntoCompound, add, validateCompound, drawIdentifier, addNameIdentifier, addIdentifier, addPreparation};
 
 goog.require('ord.amounts');
 goog.require('ord.features');
@@ -22,18 +24,18 @@ goog.require('proto.ord.Compound');
 goog.require('proto.ord.CompoundIdentifier');
 
 // Freely create radio button groups by generating new input names.
-ord.compounds.radioGroupCounter = 0;
+let radioGroupCounter = 0;
 
-ord.compounds.load = function(node, compounds) {
-  compounds.forEach(compound => ord.compounds.loadCompound(node, compound));
-};
+function load(node, compounds) {
+  compounds.forEach(compound => loadCompound(node, compound));
+}
 
-ord.compounds.loadCompound = function(root, compound) {
-  const node = ord.compounds.add(root);
-  ord.compounds.loadIntoCompound(node, compound);
-};
+function loadCompound(root, compound) {
+  const node = add(root);
+  loadIntoCompound(node, compound);
+}
 
-ord.compounds.loadIntoCompound = function(node, compound) {
+function loadIntoCompound(node, compound) {
   const reactionRole = compound.getReactionRole();
   ord.reaction.setSelector($('.component_reaction_role', node), reactionRole);
   $('.component_reaction_role', node).trigger('change');
@@ -48,7 +50,7 @@ ord.compounds.loadIntoCompound = function(node, compound) {
 
   const identifiers = compound.getIdentifiersList();
   identifiers.forEach(
-      identifier => ord.compounds.loadIdentifier(node, identifier));
+      identifier => loadIdentifier(node, identifier));
 
   const mass = compound.getMass();
   const moles = compound.getMoles();
@@ -57,27 +59,27 @@ ord.compounds.loadIntoCompound = function(node, compound) {
 
   const preparations = compound.getPreparationsList();
   preparations.forEach(preparation => {
-    const preparationNode = ord.compounds.addPreparation(node);
-    ord.compounds.loadPreparation(preparationNode, preparation);
+    const preparationNode = addPreparation(node);
+    loadPreparation(preparationNode, preparation);
   });
   const vendorSource = compound.getVendorSource();
   const vendorLot = compound.getVendorLot();
   const vendorId = compound.getVendorId();
-  ord.compounds.loadVendor(node, vendorSource, vendorLot, vendorId);
+  loadVendor(node, vendorSource, vendorLot, vendorId);
 
   const features = compound.getFeaturesList();
   ord.features.load(node, features);
-};
+}
 
-ord.compounds.loadIdentifier = function(compoundNode, identifier) {
-  const node = ord.compounds.addIdentifier(compoundNode);
+function loadIdentifier(compoundNode, identifier) {
+  const node = addIdentifier(compoundNode);
   const value = identifier.getValue();
   $('.component_identifier_value', node).text(value);
   ord.reaction.setSelector(node, identifier.getType());
   $('.component_identifier_details', node).text(identifier.getDetails());
-};
+}
 
-ord.compounds.loadPreparation = function(node, preparation) {
+function loadPreparation(node, preparation) {
   const type = preparation.getType();
   ord.reaction.setSelector(
       $('.component_compound_preparation_type', node), type);
@@ -85,32 +87,32 @@ ord.compounds.loadPreparation = function(node, preparation) {
   $('.component_compound_preparation_details', node).text(details);
   const reaction = preparation.getReactionId();
   $('.component_compound_preparation_reaction', node).text(reaction);
-};
+}
 
-ord.compounds.loadVendor = function(
+function loadVendor(
     compoundNode, vendorSource, vendorLot, vendorId) {
   const node = $('fieldset.vendor', compoundNode);
   $('.component_vendor_source', node).text(vendorSource);
   $('.component_vendor_lot', node).text(vendorLot);
   $('.component_vendor_id', node).text(vendorId);
-};
+}
 
-ord.compounds.unload = function(node) {
+function unload(node) {
   const compounds = [];
   $('.component', node).each(function(index, compoundNode) {
     compoundNode = $(compoundNode);
     if (!compoundNode.attr('id')) {
       // Not a template.
-      const compound = ord.compounds.unloadCompound(compoundNode);
+      const compound = unloadCompound(compoundNode);
       if (!ord.reaction.isEmptyMessage(compound)) {
         compounds.push(compound);
       }
     }
   });
   return compounds;
-};
+}
 
-ord.compounds.unloadCompound = function(node) {
+function unloadCompound(node) {
   const compound = new proto.ord.Compound();
 
   const reactionRole =
@@ -132,7 +134,7 @@ ord.compounds.unloadCompound = function(node) {
     compound.setVolumeIncludesSolutes(solutes);
   }
 
-  const identifiers = ord.compounds.unloadIdentifiers(node);
+  const identifiers = unloadIdentifiers(node);
   if (!ord.reaction.isEmptyMessage(identifiers)) {
     compound.setIdentifiersList(identifiers);
   }
@@ -141,37 +143,37 @@ ord.compounds.unloadCompound = function(node) {
 
   const preparations = [];
   $('.component_preparation', node).each(function(index, preparationNode) {
-    const preparation = ord.compounds.unloadPreparation(preparationNode);
+    const preparation = unloadPreparation(preparationNode);
     if (!ord.reaction.isEmptyMessage(preparation)) {
       preparations.push(preparation);
     }
   });
   compound.setPreparationsList(preparations);
 
-  ord.compounds.unloadVendor(node, compound);
+  unloadVendor(node, compound);
 
   const features = ord.features.unload(node);
   compound.setFeaturesList(features);
 
   return compound;
-};
+}
 
-ord.compounds.unloadIdentifiers = function(node) {
+function unloadIdentifiers(node) {
   const identifiers = [];
   $('.component_identifier', node).each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
       // Not a template.
-      const identifier = ord.compounds.unloadIdentifier(node);
+      const identifier = unloadIdentifier(node);
       if (!ord.reaction.isEmptyMessage(identifier)) {
         identifiers.push(identifier);
       }
     }
   });
   return identifiers;
-};
+}
 
-ord.compounds.unloadIdentifier = function(node) {
+function unloadIdentifier(node) {
   const identifier = new proto.ord.CompoundIdentifier();
 
   const value = $('.component_identifier_value', node).text();
@@ -183,9 +185,9 @@ ord.compounds.unloadIdentifier = function(node) {
   const details = $('.component_identifier_details', node).text();
   identifier.setDetails(details);
   return identifier;
-};
+}
 
-ord.compounds.unloadPreparation = function(node) {
+function unloadPreparation (node) {
   const preparation = new proto.ord.CompoundPreparation();
   const type =
       ord.reaction.getSelector($('.component_compound_preparation_type', node));
@@ -195,20 +197,19 @@ ord.compounds.unloadPreparation = function(node) {
   const reaction = $('.component_compound_preparation_reaction', node).text();
   preparation.setReactionId(reaction);
   return preparation;
-};
+}
 
-ord.compounds.unloadVendor = function(node, compound) {
+function unloadVendor (node, compound) {
   const vendorSource = $('.component_vendor_source', node).text();
   compound.setVendorSource(vendorSource);
   const vendorLot = $('.component_vendor_lot', node).text();
   compound.setVendorLot(vendorLot);
   const vendorId = $('.component_vendor_id', node).text();
   compound.setVendorId(vendorId);
-};
+}
 
-ord.compounds.add = function(root) {
-  const node =
-      ord.reaction.addSlowly('#component_template', $('.components', root));
+function add (root) {
+  const node = ord.reaction.addSlowly('#component_template', $('.components', root));
 
   // Connect reaction role selection to limiting reactant field.
   const roleSelector = $('.component_reaction_role', node);
@@ -222,7 +223,7 @@ ord.compounds.add = function(root) {
 
   // Create an "amount" radio button group and connect it to the unit selectors.
   const amountButtons = $('.amount input', node);
-  amountButtons.attr('name', 'compounds_' + ord.compounds.radioGroupCounter++);
+  amountButtons.attr('name', 'compounds_' + radioGroupCounter++);
   amountButtons.change(function() {
     $('.amount .selector', node).hide();
     if (this.value == 'mass') {
@@ -240,16 +241,14 @@ ord.compounds.add = function(root) {
   });
 
   // Add live validation handling.
-  ord.reaction.addChangeHandler(node, () => {
-    ord.compounds.validateCompound(node);
-  });
+  ord.reaction.addChangeHandler(node, () => {validateCompound(node)});
 
   return node;
-};
+}
 
-ord.compounds.addIdentifier = function(node) {
-  const identifierNode = ord.reaction.addSlowly(
-      '#component_identifier_template', $('.identifiers', node));
+function addIdentifier(node) {
+  const identifierNode =
+      ord.reaction.addSlowly('#component_identifier_template', $('.identifiers', node));
 
   const uploadButton = $('.component_identifier_upload', identifierNode);
   uploadButton.change(function() {
@@ -264,10 +263,10 @@ ord.compounds.addIdentifier = function(node) {
   });
   ord.uploads.initialize(identifierNode);
   return identifierNode;
-};
+}
 
 // Shortcut to add an identifier based on name.
-ord.compounds.addNameIdentifier = function(node) {
+function addNameIdentifier (node) {
   var name = prompt('Compound name: ');
   if (!(name)) {
     return;
@@ -275,7 +274,7 @@ ord.compounds.addNameIdentifier = function(node) {
   const identifier = new proto.ord.CompoundIdentifier();
   identifier.setValue(name);
   identifier.setType(proto.ord.CompoundIdentifier.IdentifierType.NAME);
-  ord.compounds.loadIdentifier(node, identifier);
+  loadIdentifier(node, identifier);
 
   const xhr = new XMLHttpRequest();
   xhr.open('POST', '/resolve/name');
@@ -288,15 +287,15 @@ ord.compounds.addNameIdentifier = function(node) {
       identifier.setValue(smiles);
       identifier.setType(proto.ord.CompoundIdentifier.IdentifierType.SMILES);
       identifier.setDetails('NAME resolved by the ' + resolver);
-      ord.compounds.loadIdentifier(node, identifier);
-    }
-    ord.compounds.validateCompound(node);
+      loadIdentifier(node, identifier);
+    };
+    validateCompound(node);
   };
   xhr.send(name);
-};
+}
 
 // Shortcut to add an identifier by drawing.
-ord.compounds.drawIdentifier = function(node) {
+function drawIdentifier (node) {
   // Get a reference to Ketcher, and to look nice, clear any old drawings.
   const ketcher =
       document.getElementById('ketcher-iframe').contentWindow.ketcher;
@@ -306,7 +305,7 @@ ord.compounds.drawIdentifier = function(node) {
 
   // First, pack the current Compound into a message.
   const compound = new proto.ord.Compound();
-  const identifiers = ord.compounds.unloadIdentifiers(node);
+  const identifiers = unloadIdentifiers(node);
   if (!ord.reaction.isEmptyMessage(identifiers)) {
     compound.setIdentifiersList(identifiers);
   }
@@ -354,7 +353,7 @@ ord.compounds.drawIdentifier = function(node) {
       node = $(node);
       if (!node.attr('id')) {
         // Not a template.
-        const identifier = ord.compounds.unloadIdentifier(node);
+        const identifier = unloadIdentifier(node);
         if ((identifier.getType() ===
              proto.ord.CompoundIdentifier.IdentifierType.SMILES) ||
             (identifier.getType() ===
@@ -369,18 +368,18 @@ ord.compounds.drawIdentifier = function(node) {
       identifier.setType(proto.ord.CompoundIdentifier.IdentifierType.SMILES);
       identifier.setValue(ketcher.getSmiles());
       identifier.setDetails('Drawn with Ketcher');
-      ord.compounds.loadIdentifier(node, identifier);
+      loadIdentifier(node, identifier);
       identifier.setType(proto.ord.CompoundIdentifier.IdentifierType.MOLBLOCK);
       identifier.setValue(ketcher.getMolfile());
-      ord.compounds.loadIdentifier(node, identifier);
+      loadIdentifier(node, identifier);
     }
-    ord.compounds.validateCompound(node);
-  };
-};
+    validateCompound(node);
+  }
+}
 
-ord.compounds.addPreparation = function(node) {
-  const PreparationNode = ord.reaction.addSlowly(
-      '#component_preparation_template', $('.preparations', node));
+function addPreparation (node) {
+  const PreparationNode =
+      ord.reaction.addSlowly('#component_preparation_template', $('.preparations', node));
 
   const typeSelector =
       $('.component_compound_preparation_type', PreparationNode);
@@ -398,7 +397,7 @@ ord.compounds.addPreparation = function(node) {
 };
 
 // Update the image tag with a drawing of this component.
-ord.compounds.renderCompound = function(node, compound) {
+function renderCompound (node, compound) {
   const xhr = new XMLHttpRequest();
   xhr.open('POST', '/render/compound');
   const binary = compound.serializeBinary();
@@ -412,10 +411,10 @@ ord.compounds.renderCompound = function(node, compound) {
     }
   };
   xhr.send(binary);
-};
+}
 
-ord.compounds.validateCompound = function(node, validateNode) {
-  const compound = ord.compounds.unloadCompound(node);
+function validateCompound (node, validateNode) {
+  const compound = unloadCompound(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
@@ -424,5 +423,5 @@ ord.compounds.validateCompound = function(node, validateNode) {
   // Try to resolve compound structural identifiers. This is tied to
   // validation so the same trigger is used and we only have to unload the
   // compound once per update.
-  ord.compounds.renderCompound(node, compound);
-};
+  renderCompound(node, compound);
+}

--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -251,7 +251,9 @@ function add(root) {
   });
 
   // Add live validation handling.
-  ord.reaction.addChangeHandler(node, () => {validateCompound(node)});
+  ord.reaction.addChangeHandler(node, () => {
+    validateCompound(node);
+  });
 
   return node;
 }
@@ -298,7 +300,7 @@ function addNameIdentifier(node) {
       identifier.setType(proto.ord.CompoundIdentifier.IdentifierType.SMILES);
       identifier.setDetails('NAME resolved by the ' + resolver);
       loadIdentifier(node, identifier);
-    };
+    }
     validateCompound(node);
   };
   xhr.send(name);
@@ -384,7 +386,7 @@ function drawIdentifier(node) {
       loadIdentifier(node, identifier);
     }
     validateCompound(node);
-  }
+  };
 }
 
 function addPreparation(node) {
@@ -404,7 +406,7 @@ function addPreparation(node) {
   });
 
   return PreparationNode;
-};
+}
 
 // Update the image tag with a drawing of this component.
 function renderCompound(node, compound) {

--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -35,16 +35,16 @@ ord.compounds.loadCompound = function(root, compound) {
 
 ord.compounds.loadIntoCompound = function(node, compound) {
   const reactionRole = compound.getReactionRole();
-  setSelector($('.component_reaction_role', node), reactionRole);
+  ord.reaction.setSelector($('.component_reaction_role', node), reactionRole);
   $('.component_reaction_role', node).trigger('change');
 
   const isLimiting = compound.hasIsLimiting() ? compound.getIsLimiting() : null;
-  setOptionalBool($('.component_limiting', node), isLimiting);
+  ord.reaction.setOptionalBool($('.component_limiting', node), isLimiting);
 
   const solutes = compound.hasVolumeIncludesSolutes() ?
       compound.getVolumeIncludesSolutes() :
       null;
-  setOptionalBool($('.component_includes_solutes', node), solutes);
+  ord.reaction.setOptionalBool($('.component_includes_solutes', node), solutes);
 
   const identifiers = compound.getIdentifiersList();
   identifiers.forEach(
@@ -73,13 +73,14 @@ ord.compounds.loadIdentifier = function(compoundNode, identifier) {
   const node = ord.compounds.addIdentifier(compoundNode);
   const value = identifier.getValue();
   $('.component_identifier_value', node).text(value);
-  setSelector(node, identifier.getType());
+  ord.reaction.setSelector(node, identifier.getType());
   $('.component_identifier_details', node).text(identifier.getDetails());
 };
 
 ord.compounds.loadPreparation = function(node, preparation) {
   const type = preparation.getType();
-  setSelector($('.component_compound_preparation_type', node), type);
+  ord.reaction.setSelector(
+      $('.component_compound_preparation_type', node), type);
   const details = preparation.getDetails();
   $('.component_compound_preparation_details', node).text(details);
   const reaction = preparation.getReactionId();
@@ -101,7 +102,7 @@ ord.compounds.unload = function(node) {
     if (!compoundNode.attr('id')) {
       // Not a template.
       const compound = ord.compounds.unloadCompound(compoundNode);
-      if (!isEmptyMessage(compound)) {
+      if (!ord.reaction.isEmptyMessage(compound)) {
         compounds.push(compound);
       }
     }
@@ -112,23 +113,27 @@ ord.compounds.unload = function(node) {
 ord.compounds.unloadCompound = function(node) {
   const compound = new proto.ord.Compound();
 
-  const reactionRole = getSelector($('.component_reaction_role', node));
+  const reactionRole =
+      ord.reaction.getSelector($('.component_reaction_role', node));
   compound.setReactionRole(reactionRole);
 
   // Only call setIsLimiting if this is a reactant Compound.
-  if (getSelectorText($('.component_reaction_role', node)[0]) === 'REACTANT') {
-    const isLimiting = getOptionalBool($('.component_limiting', node));
+  if (ord.reaction.getSelectorText($('.component_reaction_role', node)[0]) ===
+      'REACTANT') {
+    const isLimiting =
+        ord.reaction.getOptionalBool($('.component_limiting', node));
     compound.setIsLimiting(isLimiting);
   }
 
   // Only call setVolumeIncludesSolutes if the amount is defined as a volume.
   if (ord.amounts.unloadVolume(node)) {
-    const solutes = getOptionalBool($('.component_includes_solutes', node));
+    const solutes =
+        ord.reaction.getOptionalBool($('.component_includes_solutes', node));
     compound.setVolumeIncludesSolutes(solutes);
   }
 
   const identifiers = ord.compounds.unloadIdentifiers(node);
-  if (!isEmptyMessage(identifiers)) {
+  if (!ord.reaction.isEmptyMessage(identifiers)) {
     compound.setIdentifiersList(identifiers);
   }
 
@@ -137,7 +142,7 @@ ord.compounds.unloadCompound = function(node) {
   const preparations = [];
   $('.component_preparation', node).each(function(index, preparationNode) {
     const preparation = ord.compounds.unloadPreparation(preparationNode);
-    if (!isEmptyMessage(preparation)) {
+    if (!ord.reaction.isEmptyMessage(preparation)) {
       preparations.push(preparation);
     }
   });
@@ -158,7 +163,7 @@ ord.compounds.unloadIdentifiers = function(node) {
     if (!node.attr('id')) {
       // Not a template.
       const identifier = ord.compounds.unloadIdentifier(node);
-      if (!isEmptyMessage(identifier)) {
+      if (!ord.reaction.isEmptyMessage(identifier)) {
         identifiers.push(identifier);
       }
     }
@@ -170,10 +175,10 @@ ord.compounds.unloadIdentifier = function(node) {
   const identifier = new proto.ord.CompoundIdentifier();
 
   const value = $('.component_identifier_value', node).text();
-  if (!isEmptyMessage(value)) {
+  if (!ord.reaction.isEmptyMessage(value)) {
     identifier.setValue(value);
   }
-  const type = getSelector(node);
+  const type = ord.reaction.getSelector(node);
   identifier.setType(type);
   const details = $('.component_identifier_details', node).text();
   identifier.setDetails(details);
@@ -182,7 +187,8 @@ ord.compounds.unloadIdentifier = function(node) {
 
 ord.compounds.unloadPreparation = function(node) {
   const preparation = new proto.ord.CompoundPreparation();
-  const type = getSelector($('.component_compound_preparation_type', node));
+  const type =
+      ord.reaction.getSelector($('.component_compound_preparation_type', node));
   preparation.setType(type);
   const details = $('.component_compound_preparation_details', node).text();
   preparation.setDetails(details);
@@ -201,12 +207,13 @@ ord.compounds.unloadVendor = function(node, compound) {
 };
 
 ord.compounds.add = function(root) {
-  const node = addSlowly('#component_template', $('.components', root));
+  const node =
+      ord.reaction.addSlowly('#component_template', $('.components', root));
 
   // Connect reaction role selection to limiting reactant field.
   const roleSelector = $('.component_reaction_role', node);
   roleSelector.change(function() {
-    if (getSelectorText(this) === 'REACTANT') {
+    if (ord.reaction.getSelectorText(this) === 'REACTANT') {
       $('.limiting_reactant', node).show();
     } else {
       $('.limiting_reactant', node).hide();
@@ -233,7 +240,7 @@ ord.compounds.add = function(root) {
   });
 
   // Add live validation handling.
-  addChangeHandler(node, () => {
+  ord.reaction.addChangeHandler(node, () => {
     ord.compounds.validateCompound(node);
   });
 
@@ -241,8 +248,8 @@ ord.compounds.add = function(root) {
 };
 
 ord.compounds.addIdentifier = function(node) {
-  const identifierNode =
-      addSlowly('#component_identifier_template', $('.identifiers', node));
+  const identifierNode = ord.reaction.addSlowly(
+      '#component_identifier_template', $('.identifiers', node));
 
   const uploadButton = $('.component_identifier_upload', identifierNode);
   uploadButton.change(function() {
@@ -300,7 +307,7 @@ ord.compounds.drawIdentifier = function(node) {
   // First, pack the current Compound into a message.
   const compound = new proto.ord.Compound();
   const identifiers = ord.compounds.unloadIdentifiers(node);
-  if (!isEmptyMessage(identifiers)) {
+  if (!ord.reaction.isEmptyMessage(identifiers)) {
     compound.setIdentifiersList(identifiers);
   }
   // Then, try to resolve compound into a MolBlock.
@@ -352,7 +359,7 @@ ord.compounds.drawIdentifier = function(node) {
              proto.ord.CompoundIdentifier.IdentifierType.SMILES) ||
             (identifier.getType() ===
              proto.ord.CompoundIdentifier.IdentifierType.MOLBLOCK)) {
-          removeSlowly(node, '.component_identifier');
+          ord.reaction.removeSlowly(node, '.component_identifier');
         }
       }
     });
@@ -372,13 +379,13 @@ ord.compounds.drawIdentifier = function(node) {
 };
 
 ord.compounds.addPreparation = function(node) {
-  const PreparationNode =
-      addSlowly('#component_preparation_template', $('.preparations', node));
+  const PreparationNode = ord.reaction.addSlowly(
+      '#component_preparation_template', $('.preparations', node));
 
   const typeSelector =
       $('.component_compound_preparation_type', PreparationNode);
   typeSelector.change(function() {
-    if (getSelectorText(this) == 'SYNTHESIZED') {
+    if (ord.reaction.getSelectorText(this) == 'SYNTHESIZED') {
       $('.component_compound_preparation_reaction_id', PreparationNode)
           .css('display', 'inline-block');
     } else {
@@ -412,7 +419,7 @@ ord.compounds.validateCompound = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(compound, 'Compound', validateNode);
+  ord.reaction.validate(compound, 'Compound', validateNode);
 
   // Try to resolve compound structural identifiers. This is tied to
   // validation so the same trigger is used and we only have to unload the

--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -16,7 +16,18 @@
 
 goog.module('ord.compounds');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, unloadCompound, loadIntoCompound, add, validateCompound, drawIdentifier, addNameIdentifier, addIdentifier, addPreparation};
+exports = {
+  load,
+  unload,
+  unloadCompound,
+  loadIntoCompound,
+  add,
+  validateCompound,
+  drawIdentifier,
+  addNameIdentifier,
+  addIdentifier,
+  addPreparation
+};
 
 goog.require('ord.amounts');
 goog.require('ord.features');
@@ -49,8 +60,7 @@ function loadIntoCompound(node, compound) {
   ord.reaction.setOptionalBool($('.component_includes_solutes', node), solutes);
 
   const identifiers = compound.getIdentifiersList();
-  identifiers.forEach(
-      identifier => loadIdentifier(node, identifier));
+  identifiers.forEach(identifier => loadIdentifier(node, identifier));
 
   const mass = compound.getMass();
   const moles = compound.getMoles();
@@ -89,8 +99,7 @@ function loadPreparation(node, preparation) {
   $('.component_compound_preparation_reaction', node).text(reaction);
 }
 
-function loadVendor(
-    compoundNode, vendorSource, vendorLot, vendorId) {
+function loadVendor(compoundNode, vendorSource, vendorLot, vendorId) {
   const node = $('fieldset.vendor', compoundNode);
   $('.component_vendor_source', node).text(vendorSource);
   $('.component_vendor_lot', node).text(vendorLot);
@@ -187,7 +196,7 @@ function unloadIdentifier(node) {
   return identifier;
 }
 
-function unloadPreparation (node) {
+function unloadPreparation(node) {
   const preparation = new proto.ord.CompoundPreparation();
   const type =
       ord.reaction.getSelector($('.component_compound_preparation_type', node));
@@ -199,7 +208,7 @@ function unloadPreparation (node) {
   return preparation;
 }
 
-function unloadVendor (node, compound) {
+function unloadVendor(node, compound) {
   const vendorSource = $('.component_vendor_source', node).text();
   compound.setVendorSource(vendorSource);
   const vendorLot = $('.component_vendor_lot', node).text();
@@ -208,8 +217,9 @@ function unloadVendor (node, compound) {
   compound.setVendorId(vendorId);
 }
 
-function add (root) {
-  const node = ord.reaction.addSlowly('#component_template', $('.components', root));
+function add(root) {
+  const node =
+      ord.reaction.addSlowly('#component_template', $('.components', root));
 
   // Connect reaction role selection to limiting reactant field.
   const roleSelector = $('.component_reaction_role', node);
@@ -247,8 +257,8 @@ function add (root) {
 }
 
 function addIdentifier(node) {
-  const identifierNode =
-      ord.reaction.addSlowly('#component_identifier_template', $('.identifiers', node));
+  const identifierNode = ord.reaction.addSlowly(
+      '#component_identifier_template', $('.identifiers', node));
 
   const uploadButton = $('.component_identifier_upload', identifierNode);
   uploadButton.change(function() {
@@ -266,7 +276,7 @@ function addIdentifier(node) {
 }
 
 // Shortcut to add an identifier based on name.
-function addNameIdentifier (node) {
+function addNameIdentifier(node) {
   var name = prompt('Compound name: ');
   if (!(name)) {
     return;
@@ -295,7 +305,7 @@ function addNameIdentifier (node) {
 }
 
 // Shortcut to add an identifier by drawing.
-function drawIdentifier (node) {
+function drawIdentifier(node) {
   // Get a reference to Ketcher, and to look nice, clear any old drawings.
   const ketcher =
       document.getElementById('ketcher-iframe').contentWindow.ketcher;
@@ -377,9 +387,9 @@ function drawIdentifier (node) {
   }
 }
 
-function addPreparation (node) {
-  const PreparationNode =
-      ord.reaction.addSlowly('#component_preparation_template', $('.preparations', node));
+function addPreparation(node) {
+  const PreparationNode = ord.reaction.addSlowly(
+      '#component_preparation_template', $('.preparations', node));
 
   const typeSelector =
       $('.component_compound_preparation_type', PreparationNode);
@@ -397,7 +407,7 @@ function addPreparation (node) {
 };
 
 // Update the image tag with a drawing of this component.
-function renderCompound (node, compound) {
+function renderCompound(node, compound) {
   const xhr = new XMLHttpRequest();
   xhr.open('POST', '/render/compound');
   const binary = compound.serializeBinary();
@@ -413,7 +423,7 @@ function renderCompound (node, compound) {
   xhr.send(binary);
 }
 
-function validateCompound (node, validateNode) {
+function validateCompound(node, validateNode) {
   const compound = unloadCompound(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();

--- a/editor/js/conditions.js
+++ b/editor/js/conditions.js
@@ -65,7 +65,7 @@ function load(conditions) {
       null;
   ord.reaction.setOptionalBool($('#condition_dynamic'), dynamic);
   $('#condition_details').text(conditions.getDetails());
-};
+}
 
 function unload() {
   const conditions = new proto.ord.ReactionConditions();
@@ -105,7 +105,7 @@ function unload() {
   const details = $('#condition_details').text();
   conditions.setDetails(details);
   return conditions;
-};
+}
 
 function validateConditions(node, validateNode) {
   const condition = unload();
@@ -113,4 +113,4 @@ function validateConditions(node, validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(condition, 'ReactionConditions', validateNode);
-};
+}

--- a/editor/js/conditions.js
+++ b/editor/js/conditions.js
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-goog.provide('ord.conditions');
+goog.module('ord.conditions');
+goog.module.declareLegacyNamespace();
+exports = {
+  load,
+  unload,
+  validateConditions
+};
 
 goog.require('ord.electro');
 goog.require('ord.flows');
@@ -24,7 +30,7 @@ goog.require('ord.stirring');
 goog.require('ord.temperature');
 goog.require('proto.ord.ReactionConditions');
 
-ord.conditions.load = function(conditions) {
+function load(conditions) {
   const temperature = conditions.getTemperature();
   if (temperature) {
     ord.temperature.load(temperature);
@@ -61,7 +67,7 @@ ord.conditions.load = function(conditions) {
   $('#condition_details').text(conditions.getDetails());
 };
 
-ord.conditions.unload = function() {
+function unload() {
   const conditions = new proto.ord.ReactionConditions();
   const temperature = ord.temperature.unload();
   if (!ord.reaction.isEmptyMessage(temperature)) {
@@ -101,8 +107,8 @@ ord.conditions.unload = function() {
   return conditions;
 };
 
-ord.conditions.validateConditions = function(node, validateNode) {
-  const condition = ord.conditions.unload();
+function validateConditions(node, validateNode) {
+  const condition = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/conditions.js
+++ b/editor/js/conditions.js
@@ -50,51 +50,51 @@ ord.conditions.load = function(conditions) {
     ord.flows.load(flow);
   }
   const reflux = conditions.hasReflux() ? conditions.getReflux() : null;
-  setOptionalBool($('#condition_reflux'), reflux);
+  ord.reaction.setOptionalBool($('#condition_reflux'), reflux);
   if (conditions.hasPh()) {
     $('#condition_ph').text(conditions.getPh());
   }
   const dynamic = conditions.hasConditionsAreDynamic() ?
       conditions.getConditionsAreDynamic() :
       null;
-  setOptionalBool($('#condition_dynamic'), dynamic);
+  ord.reaction.setOptionalBool($('#condition_dynamic'), dynamic);
   $('#condition_details').text(conditions.getDetails());
 };
 
 ord.conditions.unload = function() {
   const conditions = new proto.ord.ReactionConditions();
   const temperature = ord.temperature.unload();
-  if (!isEmptyMessage(temperature)) {
+  if (!ord.reaction.isEmptyMessage(temperature)) {
     conditions.setTemperature(temperature);
   }
   const pressure = ord.pressure.unload();
-  if (!isEmptyMessage(pressure)) {
+  if (!ord.reaction.isEmptyMessage(pressure)) {
     conditions.setPressure(pressure);
   }
   const stirring = ord.stirring.unload();
-  if (!isEmptyMessage(stirring)) {
+  if (!ord.reaction.isEmptyMessage(stirring)) {
     conditions.setStirring(stirring);
   }
   const illumination = ord.illumination.unload();
-  if (!isEmptyMessage(illumination)) {
+  if (!ord.reaction.isEmptyMessage(illumination)) {
     conditions.setIllumination(illumination);
   }
   const electro = ord.electro.unload();
-  if (!isEmptyMessage(electro)) {
+  if (!ord.reaction.isEmptyMessage(electro)) {
     conditions.setElectrochemistry(electro);
   }
   const flow = ord.flows.unload();
-  if (!isEmptyMessage(flow)) {
+  if (!ord.reaction.isEmptyMessage(flow)) {
     conditions.setFlow(flow);
   }
 
-  const reflux = getOptionalBool($('#condition_reflux'));
+  const reflux = ord.reaction.getOptionalBool($('#condition_reflux'));
   conditions.setReflux(reflux);
   const ph = parseFloat($('#condition_ph').text());
   if (!isNaN(ph)) {
     conditions.setPh(ph);
   }
-  const dynamic = getOptionalBool($('#condition_dynamic'));
+  const dynamic = ord.reaction.getOptionalBool($('#condition_dynamic'));
   conditions.setConditionsAreDynamic(dynamic);
   const details = $('#condition_details').text();
   conditions.setDetails(details);
@@ -106,5 +106,5 @@ ord.conditions.validateConditions = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(condition, 'ReactionConditions', validateNode);
+  ord.reaction.validate(condition, 'ReactionConditions', validateNode);
 };

--- a/editor/js/crudes.js
+++ b/editor/js/crudes.js
@@ -33,11 +33,11 @@ ord.crudes.loadCrude = function(root, crude) {
   $('.crude_reaction', node).text(reactionId);
 
   const workup = crude.hasIncludesWorkup() ? crude.getIncludesWorkup() : null;
-  setOptionalBool($('.crude_includes_workup', node), workup);
+  ord.reaction.setOptionalBool($('.crude_includes_workup', node), workup);
 
   const derived =
       crude.hasHasDerivedAmount() ? crude.getHasDerivedAmount() : null;
-  setOptionalBool($('.crude_has_derived', node), derived);
+  ord.reaction.setOptionalBool($('.crude_has_derived', node), derived);
 
   const mass = crude.getMass();
   const volume = crude.getVolume();
@@ -51,7 +51,7 @@ ord.crudes.unload = function(node) {
     if (!crudeNode.attr('id')) {
       // Not a template.
       const crude = ord.crudes.unloadCrude(crudeNode);
-      if (!isEmptyMessage(crude)) {
+      if (!ord.reaction.isEmptyMessage(crude)) {
         crudes.push(crude);
       }
     }
@@ -65,10 +65,11 @@ ord.crudes.unloadCrude = function(node) {
   const reactionId = $('.crude_reaction', node).text();
   crude.setReactionId(reactionId);
 
-  const workup = getOptionalBool($('.crude_includes_workup', node));
+  const workup =
+      ord.reaction.getOptionalBool($('.crude_includes_workup', node));
   crude.setIncludesWorkup(workup);
 
-  const derived = getOptionalBool($('.crude_has_derived', node));
+  const derived = ord.reaction.getOptionalBool($('.crude_has_derived', node));
   crude.setHasDerivedAmount(derived);
 
   ord.amountsCrudes.unload(node, crude);
@@ -77,7 +78,7 @@ ord.crudes.unloadCrude = function(node) {
 };
 
 ord.crudes.add = function(root) {
-  const node = addSlowly('#crude_template', $('.crudes', root));
+  const node = ord.reaction.addSlowly('#crude_template', $('.crudes', root));
 
   // Create an "amount" radio button group and connect it to the unit selectors.
   const amountButtons = $('.amount input', node);

--- a/editor/js/crudes.js
+++ b/editor/js/crudes.js
@@ -16,7 +16,11 @@
 
 goog.module('ord.crudes');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, add};
+exports = {
+  load,
+  unload,
+  add
+};
 
 goog.require('ord.amountsCrudes');
 goog.require('proto.ord.CrudeComponent');
@@ -24,11 +28,11 @@ goog.require('proto.ord.CrudeComponent');
 // Freely create radio button groups by generating new input names.
 let radioGroupCounter = 0;
 
-function load (node, crudes) {
+function load(node, crudes) {
   crudes.forEach(crude => loadCrude(node, crude));
-};
+}
 
-function loadCrude (root, crude) {
+function loadCrude(root, crude) {
   const node = add(root);
 
   const reactionId = crude.getReactionId();
@@ -44,9 +48,9 @@ function loadCrude (root, crude) {
   const mass = crude.getMass();
   const volume = crude.getVolume();
   ord.amountsCrudes.load(node, mass, volume);
-};
+}
 
-function unload (node) {
+function unload(node) {
   const crudes = [];
   $('.crude', node).each(function(index, crudeNode) {
     crudeNode = $(crudeNode);
@@ -59,9 +63,9 @@ function unload (node) {
     }
   });
   return crudes;
-};
+}
 
-function unloadCrude (node) {
+function unloadCrude(node) {
   const crude = new proto.ord.CrudeComponent();
 
   const reactionId = $('.crude_reaction', node).text();
@@ -77,9 +81,9 @@ function unloadCrude (node) {
   ord.amountsCrudes.unload(node, crude);
 
   return crude;
-};
+}
 
-function add (root) {
+function add(root) {
   const node = ord.reaction.addSlowly('#crude_template', $('.crudes', root));
 
   // Create an "amount" radio button group and connect it to the unit selectors.
@@ -98,4 +102,4 @@ function add (root) {
     }
   });
   return node;
-};
+}

--- a/editor/js/crudes.js
+++ b/editor/js/crudes.js
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 
-goog.provide('ord.crudes');
+goog.module('ord.crudes');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, add};
 
 goog.require('ord.amountsCrudes');
 goog.require('proto.ord.CrudeComponent');
 
 // Freely create radio button groups by generating new input names.
-ord.crudes.radioGroupCounter = 0;
+let radioGroupCounter = 0;
 
-ord.crudes.load = function(node, crudes) {
-  crudes.forEach(crude => ord.crudes.loadCrude(node, crude));
+function load (node, crudes) {
+  crudes.forEach(crude => loadCrude(node, crude));
 };
 
-ord.crudes.loadCrude = function(root, crude) {
-  const node = ord.crudes.add(root);
+function loadCrude (root, crude) {
+  const node = add(root);
 
   const reactionId = crude.getReactionId();
   $('.crude_reaction', node).text(reactionId);
@@ -44,13 +46,13 @@ ord.crudes.loadCrude = function(root, crude) {
   ord.amountsCrudes.load(node, mass, volume);
 };
 
-ord.crudes.unload = function(node) {
+function unload (node) {
   const crudes = [];
   $('.crude', node).each(function(index, crudeNode) {
     crudeNode = $(crudeNode);
     if (!crudeNode.attr('id')) {
       // Not a template.
-      const crude = ord.crudes.unloadCrude(crudeNode);
+      const crude = unloadCrude(crudeNode);
       if (!ord.reaction.isEmptyMessage(crude)) {
         crudes.push(crude);
       }
@@ -59,7 +61,7 @@ ord.crudes.unload = function(node) {
   return crudes;
 };
 
-ord.crudes.unloadCrude = function(node) {
+function unloadCrude (node) {
   const crude = new proto.ord.CrudeComponent();
 
   const reactionId = $('.crude_reaction', node).text();
@@ -77,12 +79,12 @@ ord.crudes.unloadCrude = function(node) {
   return crude;
 };
 
-ord.crudes.add = function(root) {
+function add (root) {
   const node = ord.reaction.addSlowly('#crude_template', $('.crudes', root));
 
   // Create an "amount" radio button group and connect it to the unit selectors.
   const amountButtons = $('.amount input', node);
-  amountButtons.attr('name', 'crudes_' + ord.crudes.radioGroupCounter++);
+  amountButtons.attr('name', 'crudes_' + radioGroupCounter++);
   amountButtons.change(function() {
     $('.amount .selector', node).hide();
     if (this.value == 'mass') {

--- a/editor/js/dataset.js
+++ b/editor/js/dataset.js
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-goog.provide('ord.dataset');
+goog.module('ord.dataset');
+goog.module.declareLegacyNamespace();
+exports = {init, download, commit, deleteReaction, newReaction, removeReactionId, addReactionId};
 
 goog.require('proto.ord.Dataset');
 

--- a/editor/js/dataset.js
+++ b/editor/js/dataset.js
@@ -16,7 +16,15 @@
 
 goog.module('ord.dataset');
 goog.module.declareLegacyNamespace();
-exports = {init, download, commit, deleteReaction, newReaction, removeReactionId, addReactionId};
+exports = {
+  init,
+  download,
+  commit,
+  deleteReaction,
+  newReaction,
+  removeReactionId,
+  addReactionId
+};
 
 goog.require('proto.ord.Dataset');
 

--- a/editor/js/electro.js
+++ b/editor/js/electro.js
@@ -14,15 +14,17 @@
  * limitations under the License.
  */
 
-goog.provide('ord.electro');
+goog.module('ord.electro');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, addMeasurement, validateElectro};
 
 goog.require('proto.ord.ElectrochemistryConditions');
 goog.require('proto.ord.ElectrochemistryConditions.Measurement');
 
 // Freely create radio button groups by generating new input names.
-ord.electro.radioGroupCounter = 0;
+let radioGroupCounter = 0;
 
-ord.electro.load = function(electro) {
+function load (electro) {
   const type = electro.getElectrochemistryType();
   if (type) {
     ord.reaction.setSelector($('#electro_type'), type.getType());
@@ -41,12 +43,12 @@ ord.electro.load = function(electro) {
     $('#electro_cell_details').text(cell.getDetails());
   }
   electro.getMeasurementsList().forEach(function(measurement) {
-    const node = ord.electro.addMeasurement();
-    ord.electro.loadMeasurement(node, measurement);
+    const node = addMeasurement();
+    loadMeasurement(node, measurement);
   });
 };
 
-ord.electro.loadMeasurement = function(node, measurement) {
+function loadMeasurement (node, measurement) {
   const time = measurement.getTime();
   if (time) {
     ord.reaction.writeMetric('.electro_measurement_time', time, node);
@@ -67,7 +69,7 @@ ord.electro.loadMeasurement = function(node, measurement) {
   }
 };
 
-ord.electro.unload = function() {
+function unload () {
   const electro = new proto.ord.ElectrochemistryConditions();
 
   const type = new proto.ord.ElectrochemistryConditions.ElectrochemistryType();
@@ -106,7 +108,7 @@ ord.electro.unload = function() {
   $('.electro_measurement').each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
-      const measurement = ord.electro.unloadMeasurement(node);
+      const measurement = unloadMeasurement(node);
       if (!ord.reaction.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
@@ -116,7 +118,7 @@ ord.electro.unload = function() {
   return electro;
 };
 
-ord.electro.unloadMeasurement = function(node) {
+function unloadMeasurement (node) {
   const measurement = new proto.ord.ElectrochemistryConditions.Measurement();
   const time = ord.reaction.readMetric(
       '.electro_measurement_time', new proto.ord.Time(), node);
@@ -141,12 +143,12 @@ ord.electro.unloadMeasurement = function(node) {
   return measurement;
 };
 
-ord.electro.addMeasurement = function() {
+function addMeasurement () {
   const node = ord.reaction.addSlowly(
       '#electro_measurement_template', '#electro_measurements');
 
   const metricButtons = $('input', node);
-  metricButtons.attr('name', 'electro_' + ord.electro.radioGroupCounter++);
+  metricButtons.attr('name', 'electro_' + radioGroupCounter++);
   metricButtons.change(function() {
     if (this.value == 'current') {
       $('.electro_measurement_current_fields', node).show();
@@ -161,8 +163,8 @@ ord.electro.addMeasurement = function() {
   return node;
 };
 
-ord.electro.validateElectro = function(node, validateNode) {
-  const electro = ord.electro.unload();
+function validateElectro (node, validateNode) {
+  const electro = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/electro.js
+++ b/editor/js/electro.js
@@ -25,18 +25,19 @@ ord.electro.radioGroupCounter = 0;
 ord.electro.load = function(electro) {
   const type = electro.getElectrochemistryType();
   if (type) {
-    setSelector($('#electro_type'), type.getType());
+    ord.reaction.setSelector($('#electro_type'), type.getType());
     $('#electro_details').text(type.getDetails());
   }
-  writeMetric('#electro_current', electro.getCurrent());
-  writeMetric('#electro_voltage', electro.getVoltage());
+  ord.reaction.writeMetric('#electro_current', electro.getCurrent());
+  ord.reaction.writeMetric('#electro_voltage', electro.getVoltage());
   $('#electro_anode').text(electro.getAnodeMaterial());
   $('#electro_cathode').text(electro.getCathodeMaterial());
-  writeMetric('#electro_separation', electro.getElectrodeSeparation());
+  ord.reaction.writeMetric(
+      '#electro_separation', electro.getElectrodeSeparation());
 
   const cell = electro.getCell();
   if (cell) {
-    setSelector($('#electro_cell_type'), cell.getType());
+    ord.reaction.setSelector($('#electro_cell_type'), cell.getType());
     $('#electro_cell_details').text(cell.getDetails());
   }
   electro.getMeasurementsList().forEach(function(measurement) {
@@ -48,19 +49,19 @@ ord.electro.load = function(electro) {
 ord.electro.loadMeasurement = function(node, measurement) {
   const time = measurement.getTime();
   if (time) {
-    writeMetric('.electro_measurement_time', time, node);
+    ord.reaction.writeMetric('.electro_measurement_time', time, node);
   }
   const current = measurement.getCurrent();
   const voltage = measurement.getVoltage();
   if (current) {
-    writeMetric('.electro_measurement_current', current, node);
+    ord.reaction.writeMetric('.electro_measurement_current', current, node);
     $('input[value=\'current\']', node).prop('checked', true);
     $('.electro_measurement_current_fields', node).show();
     $('.electro_measurement_voltage_fields', node).hide();
   }
   if (voltage) {
     $('input[value=\'voltage\']', node).prop('checked', true);
-    writeMetric('.electro_measurement_voltage', voltage, node);
+    ord.reaction.writeMetric('.electro_measurement_voltage', voltage, node);
     $('.electro_measurement_current_fields', node).hide();
     $('.electro_measurement_voltage_fields', node).show();
   }
@@ -70,32 +71,34 @@ ord.electro.unload = function() {
   const electro = new proto.ord.ElectrochemistryConditions();
 
   const type = new proto.ord.ElectrochemistryConditions.ElectrochemistryType();
-  type.setType(getSelector($('#electro_type')));
+  type.setType(ord.reaction.getSelector($('#electro_type')));
   type.setDetails($('#electro_details').text());
-  if (!isEmptyMessage(type)) {
+  if (!ord.reaction.isEmptyMessage(type)) {
     electro.setElectrochemistryType(type);
   }
 
-  const current = readMetric('#electro_current', new proto.ord.Current());
-  if (!isEmptyMessage(current)) {
+  const current =
+      ord.reaction.readMetric('#electro_current', new proto.ord.Current());
+  if (!ord.reaction.isEmptyMessage(current)) {
     electro.setCurrent(current);
   }
-  const voltage = readMetric('#electro_voltage', new proto.ord.Voltage());
-  if (!isEmptyMessage(voltage)) {
+  const voltage =
+      ord.reaction.readMetric('#electro_voltage', new proto.ord.Voltage());
+  if (!ord.reaction.isEmptyMessage(voltage)) {
     electro.setVoltage(voltage);
   }
   electro.setAnodeMaterial($('#electro_anode').text());
   electro.setCathodeMaterial($('#electro_cathode').text());
   const electrodeSeparation =
-      readMetric('#electro_separation', new proto.ord.Length());
-  if (!isEmptyMessage(electrodeSeparation)) {
+      ord.reaction.readMetric('#electro_separation', new proto.ord.Length());
+  if (!ord.reaction.isEmptyMessage(electrodeSeparation)) {
     electro.setElectrodeSeparation(electrodeSeparation);
   }
 
   const cell = new proto.ord.ElectrochemistryConditions.ElectrochemistryCell();
-  cell.setType(getSelector($('#electro_cell_type')));
+  cell.setType(ord.reaction.getSelector($('#electro_cell_type')));
   cell.setDetails($('#electro_cell_details').text());
-  if (!isEmptyMessage(cell)) {
+  if (!ord.reaction.isEmptyMessage(cell)) {
     electro.setCell(cell);
   }
 
@@ -104,7 +107,7 @@ ord.electro.unload = function() {
     node = $(node);
     if (!node.attr('id')) {
       const measurement = ord.electro.unloadMeasurement(node);
-      if (!isEmptyMessage(measurement)) {
+      if (!ord.reaction.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
     }
@@ -115,23 +118,23 @@ ord.electro.unload = function() {
 
 ord.electro.unloadMeasurement = function(node) {
   const measurement = new proto.ord.ElectrochemistryConditions.Measurement();
-  const time =
-      readMetric('.electro_measurement_time', new proto.ord.Time(), node);
-  if (!isEmptyMessage(time)) {
+  const time = ord.reaction.readMetric(
+      '.electro_measurement_time', new proto.ord.Time(), node);
+  if (!ord.reaction.isEmptyMessage(time)) {
     measurement.setTime(time);
   }
 
   if ($('.electro_measurement_current', node).is(':checked')) {
-    const current = readMetric(
+    const current = ord.reaction.readMetric(
         '.electro_measurement_current', new proto.ord.Current(), node);
-    if (!isEmptyMessage(current)) {
+    if (!ord.reaction.isEmptyMessage(current)) {
       measurement.setCurrent(current);
     }
   }
   if ($('.electro_measurement_voltage', node).is(':checked')) {
-    const voltage = readMetric(
+    const voltage = ord.reaction.readMetric(
         '.electro_measurement_voltage', new proto.ord.Voltage(), node);
-    if (!isEmptyMessage(voltage)) {
+    if (!ord.reaction.isEmptyMessage(voltage)) {
       measurement.setVoltage(voltage);
     }
   }
@@ -139,8 +142,8 @@ ord.electro.unloadMeasurement = function(node) {
 };
 
 ord.electro.addMeasurement = function() {
-  const node =
-      addSlowly('#electro_measurement_template', '#electro_measurements');
+  const node = ord.reaction.addSlowly(
+      '#electro_measurement_template', '#electro_measurements');
 
   const metricButtons = $('input', node);
   metricButtons.attr('name', 'electro_' + ord.electro.radioGroupCounter++);
@@ -163,5 +166,5 @@ ord.electro.validateElectro = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(electro, 'ElectrochemistryConditions', validateNode);
+  ord.reaction.validate(electro, 'ElectrochemistryConditions', validateNode);
 };

--- a/editor/js/electro.js
+++ b/editor/js/electro.js
@@ -16,7 +16,12 @@
 
 goog.module('ord.electro');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, addMeasurement, validateElectro};
+exports = {
+  load,
+  unload,
+  addMeasurement,
+  validateElectro
+};
 
 goog.require('proto.ord.ElectrochemistryConditions');
 goog.require('proto.ord.ElectrochemistryConditions.Measurement');
@@ -24,7 +29,7 @@ goog.require('proto.ord.ElectrochemistryConditions.Measurement');
 // Freely create radio button groups by generating new input names.
 let radioGroupCounter = 0;
 
-function load (electro) {
+function load(electro) {
   const type = electro.getElectrochemistryType();
   if (type) {
     ord.reaction.setSelector($('#electro_type'), type.getType());
@@ -46,9 +51,9 @@ function load (electro) {
     const node = addMeasurement();
     loadMeasurement(node, measurement);
   });
-};
+}
 
-function loadMeasurement (node, measurement) {
+function loadMeasurement(node, measurement) {
   const time = measurement.getTime();
   if (time) {
     ord.reaction.writeMetric('.electro_measurement_time', time, node);
@@ -67,9 +72,9 @@ function loadMeasurement (node, measurement) {
     $('.electro_measurement_current_fields', node).hide();
     $('.electro_measurement_voltage_fields', node).show();
   }
-};
+}
 
-function unload () {
+function unload() {
   const electro = new proto.ord.ElectrochemistryConditions();
 
   const type = new proto.ord.ElectrochemistryConditions.ElectrochemistryType();
@@ -116,9 +121,9 @@ function unload () {
   });
   electro.setMeasurementsList(measurements);
   return electro;
-};
+}
 
-function unloadMeasurement (node) {
+function unloadMeasurement(node) {
   const measurement = new proto.ord.ElectrochemistryConditions.Measurement();
   const time = ord.reaction.readMetric(
       '.electro_measurement_time', new proto.ord.Time(), node);
@@ -141,9 +146,9 @@ function unloadMeasurement (node) {
     }
   }
   return measurement;
-};
+}
 
-function addMeasurement () {
+function addMeasurement() {
   const node = ord.reaction.addSlowly(
       '#electro_measurement_template', '#electro_measurements');
 
@@ -161,12 +166,12 @@ function addMeasurement () {
   });
 
   return node;
-};
+}
 
-function validateElectro (node, validateNode) {
+function validateElectro(node, validateNode) {
   const electro = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(electro, 'ElectrochemistryConditions', validateNode);
-};
+}

--- a/editor/js/enums.js
+++ b/editor/js/enums.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-goog.provide('ord.enums');
+goog.module('ord.enums');
+goog.module.declareLegacyNamespace();
 
 // Proto enums are referenced by reflection from "data-proto" HTML attributes.
 goog.require('proto.ord.Compound.ReactionRole.ReactionRoleType');

--- a/editor/js/features.js
+++ b/editor/js/features.js
@@ -16,13 +16,17 @@
 
 goog.module('ord.features');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, add};
+exports = {
+  load,
+  unload,
+  add
+};
 
 goog.require('proto.ord.Compound.Feature');
 
 function load(node, features) {
   features.forEach(feature => loadFeature(node, feature));
-};
+}
 
 function loadFeature(compoundNode, feature) {
   const node = add(compoundNode);
@@ -38,9 +42,9 @@ function loadFeature(compoundNode, feature) {
   }
   const how = feature.getHowComputed();
   $('.component_feature_how', node).text(how);
-};
+}
 
-function unload (compoundNode) {
+function unload(compoundNode) {
   const features = [];
   $('.component_feature', compoundNode).each(function(index, node) {
     node = $(node);
@@ -52,7 +56,7 @@ function unload (compoundNode) {
     }
   });
   return features;
-};
+}
 
 function unloadFeature(node) {
   const feature = new proto.ord.Compound.Feature();
@@ -73,9 +77,9 @@ function unloadFeature(node) {
   const how = $('.component_feature_how', node).text();
   feature.setHowComputed(how);
   return feature;
-};
+}
 
 function add(compoundNode) {
   return ord.reaction.addSlowly(
       '#component_feature_template', $('.features', compoundNode));
-};
+}

--- a/editor/js/features.js
+++ b/editor/js/features.js
@@ -44,7 +44,7 @@ ord.features.unload = function(compoundNode) {
     node = $(node);
     if (!node.attr('id')) {
       const feature = ord.features.unloadFeature(node);
-      if (!isEmptyMessage(feature)) {
+      if (!ord.reaction.isEmptyMessage(feature)) {
         features.push(feature);
       }
     }
@@ -60,11 +60,11 @@ ord.features.unloadFeature = function(node) {
   const valueText = $('.component_feature_value', node).text();
   const valueFloat = parseFloat(valueText);
   if (isNaN(valueFloat)) {
-    if (!isEmptyMessage(valueText)) {
+    if (!ord.reaction.isEmptyMessage(valueText)) {
       feature.setStringValue(valueText);
     }
   } else {
-    if (!isEmptyMessage(valueFloat)) {
+    if (!ord.reaction.isEmptyMessage(valueFloat)) {
       feature.setFloatValue(valueFloat);
     }
   }
@@ -74,5 +74,6 @@ ord.features.unloadFeature = function(node) {
 };
 
 ord.features.add = function(compoundNode) {
-  return addSlowly('#component_feature_template', $('.features', compoundNode));
+  return ord.reaction.addSlowly(
+      '#component_feature_template', $('.features', compoundNode));
 };

--- a/editor/js/features.js
+++ b/editor/js/features.js
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-goog.provide('ord.features');
+goog.module('ord.features');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, add};
 
 goog.require('proto.ord.Compound.Feature');
 
-ord.features.load = function(node, features) {
-  features.forEach(feature => ord.features.loadFeature(node, feature));
+function load(node, features) {
+  features.forEach(feature => loadFeature(node, feature));
 };
 
-ord.features.loadFeature = function(compoundNode, feature) {
-  const node = ord.features.add(compoundNode);
+function loadFeature(compoundNode, feature) {
+  const node = add(compoundNode);
   const name = feature.getName();
   $('.component_feature_name', node).text(name);
   const valueText = feature.getStringValue();
@@ -38,12 +40,12 @@ ord.features.loadFeature = function(compoundNode, feature) {
   $('.component_feature_how', node).text(how);
 };
 
-ord.features.unload = function(compoundNode) {
+function unload (compoundNode) {
   const features = [];
   $('.component_feature', compoundNode).each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
-      const feature = ord.features.unloadFeature(node);
+      const feature = unloadFeature(node);
       if (!ord.reaction.isEmptyMessage(feature)) {
         features.push(feature);
       }
@@ -52,7 +54,7 @@ ord.features.unload = function(compoundNode) {
   return features;
 };
 
-ord.features.unloadFeature = function(node) {
+function unloadFeature(node) {
   const feature = new proto.ord.Compound.Feature();
   const name = $('.component_feature_name', node).text();
   feature.setName(name);
@@ -73,7 +75,7 @@ ord.features.unloadFeature = function(node) {
   return feature;
 };
 
-ord.features.add = function(compoundNode) {
+function add(compoundNode) {
   return ord.reaction.addSlowly(
       '#component_feature_template', $('.features', compoundNode));
 };

--- a/editor/js/flow.js
+++ b/editor/js/flow.js
@@ -16,7 +16,11 @@
 
 goog.module('ord.flows');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, validateFlow};
+exports = {
+  load,
+  unload,
+  validateFlow
+};
 
 goog.require('proto.ord.FlowConditions');
 goog.require('proto.ord.FlowConditions.Tubing');
@@ -24,38 +28,39 @@ goog.require('proto.ord.FlowConditions.Tubing');
 function load(flow) {
   const type = flow.getFlowType();
   if (type) {
-    setSelector($('#flow_type'), type.getType());
+    ord.reaction.setSelector($('#flow_type'), type.getType());
     $('#flow_details').text(type.getDetails());
   }
   $('#flow_pump').text(flow.getPumpType());
 
   const tubing = flow.getTubing();
-  setSelector($('#flow_tubing_type'), tubing.getType());
+  ord.reaction.setSelector($('#flow_tubing_type'), tubing.getType());
   $('#flow_tubing_details').text(tubing.getDetails());
-  writeMetric('#flow_tubing', tubing.getDiameter());
+  ord.reaction.writeMetric('#flow_tubing', tubing.getDiameter());
 };
 
 function unload() {
   const flow = new proto.ord.FlowConditions();
 
   const type = new proto.ord.FlowConditions.FlowType();
-  type.setType(getSelector('#flow_type'));
+  type.setType(ord.reaction.getSelector('#flow_type'));
   type.setDetails($('#flow_details').text());
-  if (!isEmptyMessage(type)) {
+  if (!ord.reaction.isEmptyMessage(type)) {
     flow.setFlowType(type);
   }
 
   flow.setPumpType($('#flow_pump').text());
 
   const tubing = new proto.ord.FlowConditions.Tubing();
-  tubing.setType(getSelector('#flow_tubing_type'));
+  tubing.setType(ord.reaction.getSelector('#flow_tubing_type'));
   tubing.setDetails($('#flow_tubing_details').text());
-  const diameter = readMetric('#flow_tubing', new proto.ord.Length());
-  if (!isEmptyMessage(diameter)) {
+  const diameter =
+      ord.reaction.readMetric('#flow_tubing', new proto.ord.Length());
+  if (!ord.reaction.isEmptyMessage(diameter)) {
     tubing.setDiameter(diameter);
   }
 
-  if (!isEmptyMessage(tubing)) {
+  if (!ord.reaction.isEmptyMessage(tubing)) {
     flow.setTubing(tubing);
   }
   return flow;
@@ -66,5 +71,5 @@ function validateFlow(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(flow, 'FlowConditions', validateNode);
+  ord.reaction.validate(flow, 'FlowConditions', validateNode);
 };

--- a/editor/js/flow.js
+++ b/editor/js/flow.js
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-goog.provide('ord.flows');
+goog.module('ord.flows');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, validateFlow};
 
 goog.require('proto.ord.FlowConditions');
 goog.require('proto.ord.FlowConditions.Tubing');
 
-ord.flows.load = function(flow) {
+function load(flow) {
   const type = flow.getFlowType();
   if (type) {
     setSelector($('#flow_type'), type.getType());
@@ -33,7 +35,7 @@ ord.flows.load = function(flow) {
   writeMetric('#flow_tubing', tubing.getDiameter());
 };
 
-ord.flows.unload = function() {
+function unload() {
   const flow = new proto.ord.FlowConditions();
 
   const type = new proto.ord.FlowConditions.FlowType();
@@ -59,8 +61,8 @@ ord.flows.unload = function() {
   return flow;
 };
 
-ord.flows.validateFlow = function(node, validateNode) {
-  const flow = ord.flows.unload();
+function validateFlow(node, validateNode) {
+  const flow = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/flow.js
+++ b/editor/js/flow.js
@@ -37,7 +37,7 @@ function load(flow) {
   ord.reaction.setSelector($('#flow_tubing_type'), tubing.getType());
   $('#flow_tubing_details').text(tubing.getDetails());
   ord.reaction.writeMetric('#flow_tubing', tubing.getDiameter());
-};
+}
 
 function unload() {
   const flow = new proto.ord.FlowConditions();
@@ -64,7 +64,7 @@ function unload() {
     flow.setTubing(tubing);
   }
   return flow;
-};
+}
 
 function validateFlow(node, validateNode) {
   const flow = unload();
@@ -72,4 +72,4 @@ function validateFlow(node, validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(flow, 'FlowConditions', validateNode);
-};
+}

--- a/editor/js/identifiers.js
+++ b/editor/js/identifiers.js
@@ -14,33 +14,35 @@
  * limitations under the License.
  */
 
-goog.provide('ord.identifiers');
+goog.module('ord.identifiers');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, add};
 
 goog.require('ord.uploads');
 goog.require('proto.ord.ReactionIdentifier');
 
-ord.identifiers.load = function(identifiers) {
-  identifiers.forEach(identifier => ord.identifiers.loadIdentifier(identifier));
+function load(identifiers) {
+  identifiers.forEach(identifier => loadIdentifier(identifier));
   if (!(identifiers.length)) {
-    ord.identifiers.add();
+    add();
   }
 };
 
-ord.identifiers.loadIdentifier = function(identifier) {
-  const node = ord.identifiers.add();
+function loadIdentifier(identifier) {
+  const node = add();
   const value = identifier.getValue();
   $('.reaction_identifier_value', node).text(value);
   ord.reaction.setSelector(node, identifier.getType());
   $('.reaction_identifier_details', node).text(identifier.getDetails());
 };
 
-ord.identifiers.unload = function() {
+function unload () {
   const identifiers = [];
   $('.reaction_identifier').each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
       // Not a template.
-      const identifier = ord.identifiers.unloadIdentifier(node);
+      const identifier = unloadIdentifier(node);
       if (!ord.reaction.isEmptyMessage(identifier)) {
         identifiers.push(identifier);
       }
@@ -49,7 +51,7 @@ ord.identifiers.unload = function() {
   return identifiers;
 };
 
-ord.identifiers.unloadIdentifier = function(node) {
+function unloadIdentifier (node) {
   const identifier = new proto.ord.ReactionIdentifier();
 
   const value = $('.reaction_identifier_value', node).text();
@@ -68,7 +70,7 @@ ord.identifiers.unloadIdentifier = function(node) {
   return identifier;
 };
 
-ord.identifiers.add = function() {
+function add () {
   const node =
       ord.reaction.addSlowly('#reaction_identifier_template', '#identifiers');
 

--- a/editor/js/identifiers.js
+++ b/editor/js/identifiers.js
@@ -16,7 +16,11 @@
 
 goog.module('ord.identifiers');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, add};
+exports = {
+  load,
+  unload,
+  add
+};
 
 goog.require('ord.uploads');
 goog.require('proto.ord.ReactionIdentifier');
@@ -26,7 +30,7 @@ function load(identifiers) {
   if (!(identifiers.length)) {
     add();
   }
-};
+}
 
 function loadIdentifier(identifier) {
   const node = add();
@@ -34,9 +38,9 @@ function loadIdentifier(identifier) {
   $('.reaction_identifier_value', node).text(value);
   ord.reaction.setSelector(node, identifier.getType());
   $('.reaction_identifier_details', node).text(identifier.getDetails());
-};
+}
 
-function unload () {
+function unload() {
   const identifiers = [];
   $('.reaction_identifier').each(function(index, node) {
     node = $(node);
@@ -49,9 +53,9 @@ function unload () {
     }
   });
   return identifiers;
-};
+}
 
-function unloadIdentifier (node) {
+function unloadIdentifier(node) {
   const identifier = new proto.ord.ReactionIdentifier();
 
   const value = $('.reaction_identifier_value', node).text();
@@ -68,9 +72,9 @@ function unloadIdentifier (node) {
     identifier.setDetails(details);
   }
   return identifier;
-};
+}
 
-function add () {
+function add() {
   const node =
       ord.reaction.addSlowly('#reaction_identifier_template', '#identifiers');
 
@@ -87,4 +91,4 @@ function add () {
   });
   ord.uploads.initialize(node);
   return node;
-};
+}

--- a/editor/js/identifiers.js
+++ b/editor/js/identifiers.js
@@ -30,7 +30,7 @@ ord.identifiers.loadIdentifier = function(identifier) {
   const node = ord.identifiers.add();
   const value = identifier.getValue();
   $('.reaction_identifier_value', node).text(value);
-  setSelector(node, identifier.getType());
+  ord.reaction.setSelector(node, identifier.getType());
   $('.reaction_identifier_details', node).text(identifier.getDetails());
 };
 
@@ -41,7 +41,7 @@ ord.identifiers.unload = function() {
     if (!node.attr('id')) {
       // Not a template.
       const identifier = ord.identifiers.unloadIdentifier(node);
-      if (!isEmptyMessage(identifier)) {
+      if (!ord.reaction.isEmptyMessage(identifier)) {
         identifiers.push(identifier);
       }
     }
@@ -53,23 +53,24 @@ ord.identifiers.unloadIdentifier = function(node) {
   const identifier = new proto.ord.ReactionIdentifier();
 
   const value = $('.reaction_identifier_value', node).text();
-  if (!isEmptyMessage(value)) {
+  if (!ord.reaction.isEmptyMessage(value)) {
     identifier.setValue(value);
   }
 
-  const type = getSelector(node);
-  if (!isEmptyMessage(type)) {
+  const type = ord.reaction.getSelector(node);
+  if (!ord.reaction.isEmptyMessage(type)) {
     identifier.setType(type);
   }
   const details = $('.reaction_identifier_details', node).text();
-  if (!isEmptyMessage(details)) {
+  if (!ord.reaction.isEmptyMessage(details)) {
     identifier.setDetails(details);
   }
   return identifier;
 };
 
 ord.identifiers.add = function() {
-  const node = addSlowly('#reaction_identifier_template', '#identifiers');
+  const node =
+      ord.reaction.addSlowly('#reaction_identifier_template', '#identifiers');
 
   const uploadButton = $('.reaction_identifier_upload', node);
   uploadButton.change(function() {

--- a/editor/js/illumination.js
+++ b/editor/js/illumination.js
@@ -14,13 +14,15 @@
  * limitations under the License.
  */
 
-goog.provide('ord.illumination');
+goog.module('ord.illumination');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, validateIllumination};
 
 goog.require('proto.ord.IlluminationConditions');
 goog.require('proto.ord.Length');
 goog.require('proto.ord.Wavelength');
 
-ord.illumination.load = function(illumination) {
+function load (illumination) {
   const type = illumination.getType();
   if (type) {
     ord.reaction.setSelector($('#illumination_type'), type.getType());
@@ -33,7 +35,7 @@ ord.illumination.load = function(illumination) {
   ord.reaction.writeMetric('#illumination_distance', distance);
 };
 
-ord.illumination.unload = function() {
+function unload () {
   const illumination = new proto.ord.IlluminationConditions();
 
   const type = new proto.ord.IlluminationConditions.IlluminationType();
@@ -57,8 +59,8 @@ ord.illumination.unload = function() {
   return illumination;
 };
 
-ord.illumination.validateIllumination = function(node, validateNode) {
-  const illumination = ord.illumination.unload();
+function validateIllumination (node, validateNode) {
+  const illumination = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/illumination.js
+++ b/editor/js/illumination.js
@@ -23,34 +23,35 @@ goog.require('proto.ord.Wavelength');
 ord.illumination.load = function(illumination) {
   const type = illumination.getType();
   if (type) {
-    setSelector($('#illumination_type'), type.getType());
+    ord.reaction.setSelector($('#illumination_type'), type.getType());
     $('#illumination_details').text(type.getDetails());
   }
   const wavelength = illumination.getPeakWavelength();
-  writeMetric('#illumination_wavelength', wavelength);
+  ord.reaction.writeMetric('#illumination_wavelength', wavelength);
   $('#illumination_color').text(illumination.getColor());
   const distance = illumination.getDistanceToVessel();
-  writeMetric('#illumination_distance', distance);
+  ord.reaction.writeMetric('#illumination_distance', distance);
 };
 
 ord.illumination.unload = function() {
   const illumination = new proto.ord.IlluminationConditions();
 
   const type = new proto.ord.IlluminationConditions.IlluminationType();
-  type.setType(getSelector($('#illumination_type')));
+  type.setType(ord.reaction.getSelector($('#illumination_type')));
   type.setDetails($('#illumination_details').text());
-  if (!isEmptyMessage(type)) {
+  if (!ord.reaction.isEmptyMessage(type)) {
     illumination.setType(type);
   }
 
-  const wavelength =
-      readMetric('#illumination_wavelength', new proto.ord.Wavelength());
-  if (!isEmptyMessage(wavelength)) {
+  const wavelength = ord.reaction.readMetric(
+      '#illumination_wavelength', new proto.ord.Wavelength());
+  if (!ord.reaction.isEmptyMessage(wavelength)) {
     illumination.setPeakWavelength(wavelength);
   }
   illumination.setColor($('#illumination_color').text());
-  const distance = readMetric('#illumination_distance', new proto.ord.Length());
-  if (!isEmptyMessage(distance)) {
+  const distance =
+      ord.reaction.readMetric('#illumination_distance', new proto.ord.Length());
+  if (!ord.reaction.isEmptyMessage(distance)) {
     illumination.setDistanceToVessel(distance);
   }
   return illumination;
@@ -61,5 +62,5 @@ ord.illumination.validateIllumination = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(illumination, 'IlluminationConditions', validateNode);
+  ord.reaction.validate(illumination, 'IlluminationConditions', validateNode);
 };

--- a/editor/js/illumination.js
+++ b/editor/js/illumination.js
@@ -16,13 +16,17 @@
 
 goog.module('ord.illumination');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, validateIllumination};
+exports = {
+  load,
+  unload,
+  validateIllumination
+};
 
 goog.require('proto.ord.IlluminationConditions');
 goog.require('proto.ord.Length');
 goog.require('proto.ord.Wavelength');
 
-function load (illumination) {
+function load(illumination) {
   const type = illumination.getType();
   if (type) {
     ord.reaction.setSelector($('#illumination_type'), type.getType());
@@ -33,9 +37,9 @@ function load (illumination) {
   $('#illumination_color').text(illumination.getColor());
   const distance = illumination.getDistanceToVessel();
   ord.reaction.writeMetric('#illumination_distance', distance);
-};
+}
 
-function unload () {
+function unload() {
   const illumination = new proto.ord.IlluminationConditions();
 
   const type = new proto.ord.IlluminationConditions.IlluminationType();
@@ -57,12 +61,12 @@ function unload () {
     illumination.setDistanceToVessel(distance);
   }
   return illumination;
-};
+}
 
-function validateIllumination (node, validateNode) {
+function validateIllumination(node, validateNode) {
   const illumination = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(illumination, 'IlluminationConditions', validateNode);
-};
+}

--- a/editor/js/inputs.js
+++ b/editor/js/inputs.js
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-goog.provide('ord.inputs');
+goog.module('ord.inputs');
+goog.module.declareLegacyNamespace();
+exports = {load, loadInputUnnamed, unload, unloadInputUnnamed, add, validateInput};
 
 goog.require('ord.compounds');
 goog.require('ord.crudes');
@@ -22,21 +24,21 @@ goog.require('proto.ord.FlowRate');
 goog.require('proto.ord.ReactionInput');
 goog.require('proto.ord.Time');
 
-ord.inputs.load = function(inputs) {
+function load (inputs) {
   const names = inputs.stringKeys_();
   names.forEach(function(name) {
     const input = inputs.get(name);
-    ord.inputs.loadInput('#inputs', name, input);
+    loadInput('#inputs', name, input);
   });
 };
 
-ord.inputs.loadInput = function(root, name, input) {
-  const node = ord.inputs.add(root);
-  ord.inputs.loadInputUnnamed(node, input);
+function loadInput (root, name, input) {
+  const node = add(root);
+  loadInputUnnamed(node, input);
   $('.input_name', node).text(name);
 };
 
-ord.inputs.loadInputUnnamed = function(node, input) {
+function loadInputUnnamed (node, input) {
   const compounds = input.getComponentsList();
   ord.compounds.load(node, compounds);
 
@@ -75,26 +77,26 @@ ord.inputs.loadInputUnnamed = function(node, input) {
   return node;
 };
 
-ord.inputs.unload = function(inputs) {
+function unload (inputs) {
   $('#inputs > div.input').each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
       // Not a template.
-      ord.inputs.unloadInput(inputs, node);
+      unloadInput(inputs, node);
     }
   });
 };
 
-ord.inputs.unloadInput = function(inputs, node) {
+function unloadInput (inputs, node) {
   const name = $('.input_name', node).text();
-  const input = ord.inputs.unloadInputUnnamed(node);
+  const input = unloadInputUnnamed(node);
   if (!ord.reaction.isEmptyMessage(input) ||
       !ord.reaction.isEmptyMessage(name)) {
     inputs.set(name, input);
   }
 };
 
-ord.inputs.unloadInputUnnamed = function(node) {
+function unloadInputUnnamed (node) {
   const input = new proto.ord.ReactionInput();
 
   const compounds = ord.compounds.unload(node);
@@ -148,17 +150,17 @@ ord.inputs.unloadInputUnnamed = function(node) {
   return input;
 };
 
-ord.inputs.add = function(root) {
+function add (root) {
   const node = ord.reaction.addSlowly('#input_template', root);
   // Add live validation handling.
   ord.reaction.addChangeHandler(node, () => {
-    ord.inputs.validateInput(node);
+    validateInput(node);
   });
   return node;
 };
 
-ord.inputs.validateInput = function(node, validateNode) {
-  const input = ord.inputs.unloadInputUnnamed(node);
+function validateInput (node, validateNode) {
+  const input = unloadInputUnnamed(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/inputs.js
+++ b/editor/js/inputs.js
@@ -16,7 +16,14 @@
 
 goog.module('ord.inputs');
 goog.module.declareLegacyNamespace();
-exports = {load, loadInputUnnamed, unload, unloadInputUnnamed, add, validateInput};
+exports = {
+  load,
+  loadInputUnnamed,
+  unload,
+  unloadInputUnnamed,
+  add,
+  validateInput
+};
 
 goog.require('ord.compounds');
 goog.require('ord.crudes');
@@ -24,21 +31,21 @@ goog.require('proto.ord.FlowRate');
 goog.require('proto.ord.ReactionInput');
 goog.require('proto.ord.Time');
 
-function load (inputs) {
+function load(inputs) {
   const names = inputs.stringKeys_();
   names.forEach(function(name) {
     const input = inputs.get(name);
     loadInput('#inputs', name, input);
   });
-};
+}
 
-function loadInput (root, name, input) {
+function loadInput(root, name, input) {
   const node = add(root);
   loadInputUnnamed(node, input);
   $('.input_name', node).text(name);
-};
+}
 
-function loadInputUnnamed (node, input) {
+function loadInputUnnamed(node, input) {
   const compounds = input.getComponentsList();
   ord.compounds.load(node, compounds);
 
@@ -75,9 +82,9 @@ function loadInputUnnamed (node, input) {
     ord.reaction.writeMetric('.input_flow_rate', flowRate, node);
   }
   return node;
-};
+}
 
-function unload (inputs) {
+function unload(inputs) {
   $('#inputs > div.input').each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
@@ -85,18 +92,18 @@ function unload (inputs) {
       unloadInput(inputs, node);
     }
   });
-};
+}
 
-function unloadInput (inputs, node) {
+function unloadInput(inputs, node) {
   const name = $('.input_name', node).text();
   const input = unloadInputUnnamed(node);
   if (!ord.reaction.isEmptyMessage(input) ||
       !ord.reaction.isEmptyMessage(name)) {
     inputs.set(name, input);
   }
-};
+}
 
-function unloadInputUnnamed (node) {
+function unloadInputUnnamed(node) {
   const input = new proto.ord.ReactionInput();
 
   const compounds = ord.compounds.unload(node);
@@ -148,21 +155,21 @@ function unloadInputUnnamed (node) {
   }
 
   return input;
-};
+}
 
-function add (root) {
+function add(root) {
   const node = ord.reaction.addSlowly('#input_template', root);
   // Add live validation handling.
   ord.reaction.addChangeHandler(node, () => {
     validateInput(node);
   });
   return node;
-};
+}
 
-function validateInput (node, validateNode) {
+function validateInput(node, validateNode) {
   const input = unloadInputUnnamed(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(input, 'ReactionInput', validateNode);
-};
+}

--- a/editor/js/inputs.js
+++ b/editor/js/inputs.js
@@ -50,26 +50,27 @@ ord.inputs.loadInputUnnamed = function(node, input) {
 
   const additionTime = input.getAdditionTime();
   if (additionTime) {
-    writeMetric('.input_addition_time', additionTime, node);
+    ord.reaction.writeMetric('.input_addition_time', additionTime, node);
   }
   const additionSpeed = input.getAdditionSpeed();
   if (additionSpeed) {
-    setSelector($('.input_addition_speed_type', node), additionSpeed.getType());
+    ord.reaction.setSelector(
+        $('.input_addition_speed_type', node), additionSpeed.getType());
     $('.input_addition_speed_details', node).text(additionSpeed.getDetails());
   }
   const additionDevice = input.getAdditionDevice();
   if (additionDevice) {
-    setSelector(
+    ord.reaction.setSelector(
         $('.input_addition_device_type', node), additionDevice.getType());
     $('.input_addition_device_details', node).text(additionDevice.getDetails());
   }
   const duration = input.getAdditionDuration();
   if (duration) {
-    writeMetric('.input_addition_duration', duration, node);
+    ord.reaction.writeMetric('.input_addition_duration', duration, node);
   }
   const flowRate = input.getFlowRate();
   if (flowRate) {
-    writeMetric('.input_flow_rate', flowRate, node);
+    ord.reaction.writeMetric('.input_flow_rate', flowRate, node);
   }
   return node;
 };
@@ -87,7 +88,8 @@ ord.inputs.unload = function(inputs) {
 ord.inputs.unloadInput = function(inputs, node) {
   const name = $('.input_name', node).text();
   const input = ord.inputs.unloadInputUnnamed(node);
-  if (!isEmptyMessage(input) || !isEmptyMessage(name)) {
+  if (!ord.reaction.isEmptyMessage(input) ||
+      !ord.reaction.isEmptyMessage(name)) {
     inputs.set(name, input);
   }
 };
@@ -96,12 +98,12 @@ ord.inputs.unloadInputUnnamed = function(node) {
   const input = new proto.ord.ReactionInput();
 
   const compounds = ord.compounds.unload(node);
-  if (!isEmptyMessage(compounds)) {
+  if (!ord.reaction.isEmptyMessage(compounds)) {
     input.setComponentsList(compounds);
   }
 
   const crudes = ord.crudes.unload(node);
-  if (!isEmptyMessage(crudes)) {
+  if (!ord.reaction.isEmptyMessage(crudes)) {
     input.setCrudeComponentsList(crudes);
   }
 
@@ -109,35 +111,37 @@ ord.inputs.unloadInputUnnamed = function(node) {
   if (!isNaN(additionOrder)) {
     input.setAdditionOrder(additionOrder);
   }
-  const additionTime =
-      readMetric('.input_addition_time', new proto.ord.Time(), node);
-  if (!isEmptyMessage(additionTime)) {
+  const additionTime = ord.reaction.readMetric(
+      '.input_addition_time', new proto.ord.Time(), node);
+  if (!ord.reaction.isEmptyMessage(additionTime)) {
     input.setAdditionTime(additionTime);
   }
 
   const additionSpeed = new proto.ord.ReactionInput.AdditionSpeed();
-  additionSpeed.setType(getSelector($('.input_addition_speed_type', node)));
+  additionSpeed.setType(
+      ord.reaction.getSelector($('.input_addition_speed_type', node)));
   additionSpeed.setDetails($('.input_addition_speed_details', node).text());
-  if (!isEmptyMessage(additionSpeed)) {
+  if (!ord.reaction.isEmptyMessage(additionSpeed)) {
     input.setAdditionSpeed(additionSpeed);
   }
 
   const additionDevice = new proto.ord.ReactionInput.AdditionDevice();
-  additionDevice.setType(getSelector($('.input_addition_device_type', node)));
+  additionDevice.setType(
+      ord.reaction.getSelector($('.input_addition_device_type', node)));
   additionDevice.setDetails($('.input_addition_device_details', node).text());
-  if (!isEmptyMessage(additionDevice)) {
+  if (!ord.reaction.isEmptyMessage(additionDevice)) {
     input.setAdditionDevice(additionDevice);
   }
 
-  const additionDuration =
-      readMetric('.input_addition_duration', new proto.ord.Time(), node);
-  if (!isEmptyMessage(additionDuration)) {
+  const additionDuration = ord.reaction.readMetric(
+      '.input_addition_duration', new proto.ord.Time(), node);
+  if (!ord.reaction.isEmptyMessage(additionDuration)) {
     input.setAdditionDuration(additionDuration);
   }
 
-  const flowRate =
-      readMetric('.input_flow_rate', new proto.ord.FlowRate(), node);
-  if (!isEmptyMessage(flowRate)) {
+  const flowRate = ord.reaction.readMetric(
+      '.input_flow_rate', new proto.ord.FlowRate(), node);
+  if (!ord.reaction.isEmptyMessage(flowRate)) {
     input.setFlowRate(flowRate);
   }
 
@@ -145,9 +149,9 @@ ord.inputs.unloadInputUnnamed = function(node) {
 };
 
 ord.inputs.add = function(root) {
-  const node = addSlowly('#input_template', root);
+  const node = ord.reaction.addSlowly('#input_template', root);
   // Add live validation handling.
-  addChangeHandler(node, () => {
+  ord.reaction.addChangeHandler(node, () => {
     ord.inputs.validateInput(node);
   });
   return node;
@@ -158,5 +162,5 @@ ord.inputs.validateInput = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(input, 'ReactionInput', validateNode);
+  ord.reaction.validate(input, 'ReactionInput', validateNode);
 };

--- a/editor/js/notes.js
+++ b/editor/js/notes.js
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-goog.provide('ord.notes');
+goog.module('ord.notes');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, validateNotes};
 
 goog.require('proto.ord.ReactionNotes');
 
-ord.notes.load = function(notes) {
+function load (notes) {
   ord.reaction.setOptionalBool(
       $('#notes_heterogeneous'),
       notes.hasIsHeterogeneous() ? notes.getIsHeterogeneous() : null);
@@ -44,7 +46,7 @@ ord.notes.load = function(notes) {
   $('#notes_details').text(notes.getProcedureDetails());
 };
 
-ord.notes.unload = function() {
+function unload () {
   const notes = new proto.ord.ReactionNotes();
   notes.setIsHeterogeneous(
       ord.reaction.getOptionalBool($('#notes_heterogeneous')));
@@ -62,8 +64,8 @@ ord.notes.unload = function() {
   return notes;
 };
 
-ord.notes.validateNotes = function(node, validateNode) {
-  const notes = ord.notes.unload();
+function validateNotes (node, validateNode) {
+  const notes = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/notes.js
+++ b/editor/js/notes.js
@@ -16,11 +16,15 @@
 
 goog.module('ord.notes');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, validateNotes};
+exports = {
+  load,
+  unload,
+  validateNotes
+};
 
 goog.require('proto.ord.ReactionNotes');
 
-function load (notes) {
+function load(notes) {
   ord.reaction.setOptionalBool(
       $('#notes_heterogeneous'),
       notes.hasIsHeterogeneous() ? notes.getIsHeterogeneous() : null);
@@ -44,9 +48,9 @@ function load (notes) {
       notes.hasIsSensitiveToLight() ? notes.getIsSensitiveToLight() : null);
   $('#notes_safety').text(notes.getSafetyNotes());
   $('#notes_details').text(notes.getProcedureDetails());
-};
+}
 
-function unload () {
+function unload() {
   const notes = new proto.ord.ReactionNotes();
   notes.setIsHeterogeneous(
       ord.reaction.getOptionalBool($('#notes_heterogeneous')));
@@ -62,12 +66,12 @@ function unload () {
   notes.setSafetyNotes($('#notes_safety').text());
   notes.setProcedureDetails($('#notes_details').text());
   return notes;
-};
+}
 
-function validateNotes (node, validateNode) {
+function validateNotes(node, validateNode) {
   const notes = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(notes, 'ReactionNotes', validateNode);
-};
+}

--- a/editor/js/notes.js
+++ b/editor/js/notes.js
@@ -19,25 +19,25 @@ goog.provide('ord.notes');
 goog.require('proto.ord.ReactionNotes');
 
 ord.notes.load = function(notes) {
-  setOptionalBool(
+  ord.reaction.setOptionalBool(
       $('#notes_heterogeneous'),
       notes.hasIsHeterogeneous() ? notes.getIsHeterogeneous() : null);
-  setOptionalBool(
+  ord.reaction.setOptionalBool(
       $('#notes_precipitate'),
       notes.hasFormsPrecipitate() ? notes.getFormsPrecipitate() : null);
-  setOptionalBool(
+  ord.reaction.setOptionalBool(
       $('#notes_exothermic'),
       notes.hasIsExothermic() ? notes.getIsExothermic() : null);
-  setOptionalBool(
+  ord.reaction.setOptionalBool(
       $('#notes_offgas'), notes.hasOffgasses() ? notes.getOffgasses() : null);
-  setOptionalBool(
+  ord.reaction.setOptionalBool(
       $('#notes_moisture'),
       notes.hasIsSensitiveToMoisture() ? notes.getIsSensitiveToMoisture() :
                                          null);
-  setOptionalBool(
+  ord.reaction.setOptionalBool(
       $('#notes_oxygen'),
       notes.hasIsSensitiveToOxygen() ? notes.getIsSensitiveToOxygen() : null);
-  setOptionalBool(
+  ord.reaction.setOptionalBool(
       $('#notes_light'),
       notes.hasIsSensitiveToLight() ? notes.getIsSensitiveToLight() : null);
   $('#notes_safety').text(notes.getSafetyNotes());
@@ -46,13 +46,17 @@ ord.notes.load = function(notes) {
 
 ord.notes.unload = function() {
   const notes = new proto.ord.ReactionNotes();
-  notes.setIsHeterogeneous(getOptionalBool($('#notes_heterogeneous')));
-  notes.setFormsPrecipitate(getOptionalBool($('#notes_precipitate')));
-  notes.setIsExothermic(getOptionalBool($('#notes_exothermic')));
-  notes.setOffgasses(getOptionalBool($('#notes_offgas')));
-  notes.setIsSensitiveToMoisture(getOptionalBool($('#notes_moisture')));
-  notes.setIsSensitiveToOxygen(getOptionalBool($('#notes_oxygen')));
-  notes.setIsSensitiveToLight(getOptionalBool($('#notes_light')));
+  notes.setIsHeterogeneous(
+      ord.reaction.getOptionalBool($('#notes_heterogeneous')));
+  notes.setFormsPrecipitate(
+      ord.reaction.getOptionalBool($('#notes_precipitate')));
+  notes.setIsExothermic(ord.reaction.getOptionalBool($('#notes_exothermic')));
+  notes.setOffgasses(ord.reaction.getOptionalBool($('#notes_offgas')));
+  notes.setIsSensitiveToMoisture(
+      ord.reaction.getOptionalBool($('#notes_moisture')));
+  notes.setIsSensitiveToOxygen(
+      ord.reaction.getOptionalBool($('#notes_oxygen')));
+  notes.setIsSensitiveToLight(ord.reaction.getOptionalBool($('#notes_light')));
   notes.setSafetyNotes($('#notes_safety').text());
   notes.setProcedureDetails($('#notes_details').text());
   return notes;
@@ -63,5 +67,5 @@ ord.notes.validateNotes = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(notes, 'ReactionNotes', validateNode);
+  ord.reaction.validate(notes, 'ReactionNotes', validateNode);
 };

--- a/editor/js/observations.js
+++ b/editor/js/observations.js
@@ -28,7 +28,7 @@ ord.observations.load = function(observations) {
 
 ord.observations.loadObservation = function(observation) {
   const node = ord.observations.add();
-  writeMetric('.observation_time', observation.getTime(), node);
+  ord.reaction.writeMetric('.observation_time', observation.getTime(), node);
 
   $('.observation_comment', node).text(observation.getComment());
 
@@ -73,7 +73,7 @@ ord.observations.unload = function() {
     if (!node.attr('id')) {
       // Not a template
       const observation = ord.observations.unloadObservation(node);
-      if (!isEmptyMessage(observation)) {
+      if (!ord.reaction.isEmptyMessage(observation)) {
         observations.push(observation);
       }
     }
@@ -83,8 +83,9 @@ ord.observations.unload = function() {
 
 ord.observations.unloadObservation = function(node) {
   const observation = new proto.ord.ReactionObservation();
-  const time = readMetric('.observation_time', new proto.ord.Time(), node);
-  if (!isEmptyMessage(time)) {
+  const time =
+      ord.reaction.readMetric('.observation_time', new proto.ord.Time(), node);
+  if (!ord.reaction.isEmptyMessage(time)) {
     observation.setTime(time);
   }
 
@@ -96,7 +97,7 @@ ord.observations.unloadObservation = function(node) {
 
   if ($('input[value=\'text\']', node).is(':checked')) {
     const stringValue = $('.observation_image_text', node).text();
-    if (!isEmptyMessage(stringValue)) {
+    if (!ord.reaction.isEmptyMessage(stringValue)) {
       image.setStringValue(stringValue);
     }
   }
@@ -108,24 +109,24 @@ ord.observations.unloadObservation = function(node) {
   }
   if ($('input[value=\'upload\']', node).is(':checked')) {
     const bytesValue = ord.uploads.unload(node);
-    if (!isEmptyMessage(bytesValue)) {
+    if (!ord.reaction.isEmptyMessage(bytesValue)) {
       image.setBytesValue(bytesValue);
     }
   }
   if ($('input[value=\'url\']', node).is(':checked')) {
     const url = $('.observation_image_text', node).text();
-    if (!isEmptyMessage(url)) {
+    if (!ord.reaction.isEmptyMessage(url)) {
       image.setUrl(url);
     }
   }
-  if (!isEmptyMessage(image)) {
+  if (!ord.reaction.isEmptyMessage(image)) {
     observation.setImage(image);
   }
   return observation;
 };
 
 ord.observations.add = function() {
-  const node = addSlowly('#observation_template', '#observations');
+  const node = ord.reaction.addSlowly('#observation_template', '#observations');
 
   const typeButtons = $('input[type=\'radio\']', node);
   typeButtons.attr(
@@ -143,7 +144,7 @@ ord.observations.add = function() {
   ord.uploads.initialize(node);
 
   // Add live validation handling.
-  addChangeHandler(node, () => {
+  ord.reaction.addChangeHandler(node, () => {
     ord.observations.validateObservation(node);
   });
 
@@ -155,5 +156,5 @@ ord.observations.validateObservation = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(observation, 'ReactionObservation', validateNode);
+  ord.reaction.validate(observation, 'ReactionObservation', validateNode);
 };

--- a/editor/js/observations.js
+++ b/editor/js/observations.js
@@ -16,19 +16,23 @@
 
 goog.module('ord.observations');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, add, validateObservation};
+exports = {
+  load,
+  unload,
+  add,
+  validateObservation
+};
 
 goog.require('proto.ord.ReactionObservation');
 
 // Freely create radio button groups by generating new input names.
 let radioGroupCounter = 0;
 
-function load (observations) {
-  observations.forEach(
-      observation => loadObservation(observation));
-};
+function load(observations) {
+  observations.forEach(observation => loadObservation(observation));
+}
 
-function loadObservation (observation) {
+function loadObservation(observation) {
   const node = add();
   ord.reaction.writeMetric('.observation_time', observation.getTime(), node);
 
@@ -66,9 +70,9 @@ function loadObservation (observation) {
     $('.observation_image_text', node).text(url);
     $('input[value=\'url\']', node).prop('checked', true);
   }
-};
+}
 
-function unload () {
+function unload() {
   const observations = [];
   $('.observation').each(function(index, node) {
     node = $(node);
@@ -81,9 +85,9 @@ function unload () {
     }
   });
   return observations;
-};
+}
 
-function unloadObservation (node) {
+function unloadObservation(node) {
   const observation = new proto.ord.ReactionObservation();
   const time =
       ord.reaction.readMetric('.observation_time', new proto.ord.Time(), node);
@@ -125,14 +129,13 @@ function unloadObservation (node) {
     observation.setImage(image);
   }
   return observation;
-};
+}
 
-function add () {
+function add() {
   const node = ord.reaction.addSlowly('#observation_template', '#observations');
 
   const typeButtons = $('input[type=\'radio\']', node);
-  typeButtons.attr(
-      'name', 'observations_' + radioGroupCounter++);
+  typeButtons.attr('name', 'observations_' + radioGroupCounter++);
   typeButtons.change(function() {
     if ((this.value == 'text') || (this.value == 'number') ||
         (this.value == 'url')) {
@@ -151,12 +154,12 @@ function add () {
   });
 
   return node;
-};
+}
 
-function validateObservation (node, validateNode) {
+function validateObservation(node, validateNode) {
   const observation = unloadObservation(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(observation, 'ReactionObservation', validateNode);
-};
+}

--- a/editor/js/observations.js
+++ b/editor/js/observations.js
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 
-goog.provide('ord.observations');
+goog.module('ord.observations');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, add, validateObservation};
 
 goog.require('proto.ord.ReactionObservation');
 
 // Freely create radio button groups by generating new input names.
-ord.observations.radioGroupCounter = 0;
+let radioGroupCounter = 0;
 
-ord.observations.load = function(observations) {
+function load (observations) {
   observations.forEach(
-      observation => ord.observations.loadObservation(observation));
+      observation => loadObservation(observation));
 };
 
-ord.observations.loadObservation = function(observation) {
-  const node = ord.observations.add();
+function loadObservation (observation) {
+  const node = add();
   ord.reaction.writeMetric('.observation_time', observation.getTime(), node);
 
   $('.observation_comment', node).text(observation.getComment());
@@ -66,13 +68,13 @@ ord.observations.loadObservation = function(observation) {
   }
 };
 
-ord.observations.unload = function() {
+function unload () {
   const observations = [];
   $('.observation').each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
       // Not a template
-      const observation = ord.observations.unloadObservation(node);
+      const observation = unloadObservation(node);
       if (!ord.reaction.isEmptyMessage(observation)) {
         observations.push(observation);
       }
@@ -81,7 +83,7 @@ ord.observations.unload = function() {
   return observations;
 };
 
-ord.observations.unloadObservation = function(node) {
+function unloadObservation (node) {
   const observation = new proto.ord.ReactionObservation();
   const time =
       ord.reaction.readMetric('.observation_time', new proto.ord.Time(), node);
@@ -125,12 +127,12 @@ ord.observations.unloadObservation = function(node) {
   return observation;
 };
 
-ord.observations.add = function() {
+function add () {
   const node = ord.reaction.addSlowly('#observation_template', '#observations');
 
   const typeButtons = $('input[type=\'radio\']', node);
   typeButtons.attr(
-      'name', 'observations_' + ord.observations.radioGroupCounter++);
+      'name', 'observations_' + radioGroupCounter++);
   typeButtons.change(function() {
     if ((this.value == 'text') || (this.value == 'number') ||
         (this.value == 'url')) {
@@ -145,14 +147,14 @@ ord.observations.add = function() {
 
   // Add live validation handling.
   ord.reaction.addChangeHandler(node, () => {
-    ord.observations.validateObservation(node);
+    validateObservation(node);
   });
 
   return node;
 };
 
-ord.observations.validateObservation = function(node, validateNode) {
-  const observation = ord.observations.unloadObservation(node);
+function validateObservation (node, validateNode) {
+  const observation = unloadObservation(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/outcomes.js
+++ b/editor/js/outcomes.js
@@ -14,21 +14,22 @@
  * limitations under the License.
  */
 
-goog.provide('ord.outcomes');
+goog.module('ord.outcomes');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, add, addAnalysis, addProcess, addRaw, validateOutcome, validateAnalysis};
 
 goog.require('ord.products');
-
 goog.require('proto.ord.ReactionOutcome');
 
 // Freely create radio button groups by generating new input names.
-ord.outcomes.radioGroupCounter = 0;
+let radioGroupCounter = 0;
 
-ord.outcomes.load = function(outcomes) {
-  outcomes.forEach(outcome => ord.outcomes.loadOutcome(outcome));
+function load (outcomes) {
+  outcomes.forEach(outcome => loadOutcome(outcome));
 };
 
-ord.outcomes.loadOutcome = function(outcome) {
-  const node = ord.outcomes.add();
+function loadOutcome (outcome) {
+  const node = add();
 
   const time = outcome.getReactionTime();
   if (time != null) {
@@ -44,15 +45,15 @@ ord.outcomes.loadOutcome = function(outcome) {
   const names = analyses.stringKeys_();
   names.forEach(function(name) {
     const analysis = analyses.get(name);
-    ord.outcomes.loadAnalysis(node, name, analysis);
+    loadAnalysis(node, name, analysis);
   });
 
   const products = outcome.getProductsList();
   ord.products.load(node, products);
 };
 
-ord.outcomes.loadAnalysis = function(analysesNode, name, analysis) {
-  const node = ord.outcomes.addAnalysis(analysesNode);
+function loadAnalysis (analysesNode, name, analysis) {
+  const node = addAnalysis(analysesNode);
 
   $('.outcome_analysis_name', node).text(name).trigger('input');
 
@@ -68,16 +69,16 @@ ord.outcomes.loadAnalysis = function(analysesNode, name, analysis) {
   const processNames = processes.stringKeys_();
   processNames.forEach(function(name) {
     const process = processes.get(name);
-    const processNode = ord.outcomes.addProcess(node);
-    ord.outcomes.loadProcess(processNode, name, process);
+    const processNode = addProcess(node);
+    loadProcess(processNode, name, process);
   });
 
   const raws = analysis.getRawDataMap();
   const rawNames = raws.stringKeys_();
   rawNames.forEach(function(name) {
     const raw = raws.get(name);
-    const rawNode = ord.outcomes.addRaw(node);
-    ord.outcomes.loadRaw(rawNode, name, raw);
+    const rawNode = addRaw(node);
+    loadRaw(rawNode, name, raw);
   });
   $('.outcome_analysis_manufacturer', node)
       .text(analysis.getInstrumentManufacturer());
@@ -96,7 +97,7 @@ ord.outcomes.loadAnalysis = function(analysesNode, name, analysis) {
           null);
 };
 
-ord.outcomes.loadProcess = function(node, name, process) {
+function loadProcess (node, name, process) {
   $('.outcome_process_name', node).text(name);
   $('.outcome_process_description', node).text(process.getDescription());
   $('.outcome_process_format', node).text(process.getFormat());
@@ -131,7 +132,7 @@ ord.outcomes.loadProcess = function(node, name, process) {
   }
 };
 
-ord.outcomes.loadRaw = function(node, name, raw) {
+function loadRaw (node, name, raw) {
   $('.outcome_raw_name', node).text(name);
   $('.outcome_raw_description', node).text(raw.getDescription());
   $('.outcome_raw_format', node).text(raw.getFormat());
@@ -166,13 +167,13 @@ ord.outcomes.loadRaw = function(node, name, raw) {
   }
 };
 
-ord.outcomes.unload = function() {
+function unload () {
   const outcomes = [];
   $('.outcome').each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
       // Not a template.
-      const outcome = ord.outcomes.unloadOutcome(node);
+      const outcome = unloadOutcome(node);
       if (!ord.reaction.isEmptyMessage(outcome)) {
         outcomes.push(outcome);
       }
@@ -181,7 +182,7 @@ ord.outcomes.unload = function() {
   return outcomes;
 };
 
-ord.outcomes.unloadOutcome = function(node) {
+function unloadOutcome (node) {
   const outcome = new proto.ord.ReactionOutcome();
 
   const time =
@@ -204,13 +205,13 @@ ord.outcomes.unloadOutcome = function(node) {
     node = $(node);
     if (!node.attr('id')) {
       // Not a template.
-      ord.outcomes.unloadAnalysis(node, analyses);
+      unloadAnalysis(node, analyses);
     }
   });
   return outcome;
 };
 
-ord.outcomes.unloadAnalysisSingle = function(analysisNode) {
+function unloadAnalysisSingle (analysisNode) {
   const analysis = new proto.ord.ReactionAnalysis();
   analysis.setType(
       ord.reaction.getSelector($('.outcome_analysis_type', analysisNode)));
@@ -224,14 +225,14 @@ ord.outcomes.unloadAnalysisSingle = function(analysisNode) {
   $('.outcome_process', analysisNode).each(function(index, processNode) {
     processNode = $(processNode);
     if (!processNode.attr('id')) {
-      ord.outcomes.unloadProcess(processNode, processes);
+      unloadProcess(processNode, processes);
     }
   });
   const raws = analysis.getRawDataMap();
   $('.outcome_raw', analysisNode).each(function(index, rawNode) {
     rawNode = $(rawNode);
     if (!rawNode.attr('id')) {
-      ord.outcomes.unloadRaw(rawNode, raws);
+      unloadRaw(rawNode, raws);
     }
   });
   analysis.setInstrumentManufacturer(
@@ -249,8 +250,8 @@ ord.outcomes.unloadAnalysisSingle = function(analysisNode) {
   return analysis;
 };
 
-ord.outcomes.unloadAnalysis = function(analysisNode, analyses) {
-  const analysis = ord.outcomes.unloadAnalysisSingle(analysisNode);
+function unloadAnalysis (analysisNode, analyses) {
+  const analysis = unloadAnalysisSingle(analysisNode);
   const name = $('.outcome_analysis_name', analysisNode).text();
   if (!ord.reaction.isEmptyMessage(name) ||
       !ord.reaction.isEmptyMessage(analysis)) {
@@ -258,7 +259,7 @@ ord.outcomes.unloadAnalysis = function(analysisNode, analyses) {
   }
 };
 
-ord.outcomes.unloadProcess = function(node, processes) {
+function unloadProcess (node, processes) {
   const name = $('.outcome_process_name', node).text();
 
   const process = new proto.ord.Data();
@@ -295,7 +296,7 @@ ord.outcomes.unloadProcess = function(node, processes) {
   }
 };
 
-ord.outcomes.unloadRaw = function(node, raws) {
+function unloadRaw (node, raws) {
   const name = $('.outcome_raw_name', node).text();
 
   const raw = new proto.ord.Data();
@@ -331,16 +332,16 @@ ord.outcomes.unloadRaw = function(node, raws) {
   }
 };
 
-ord.outcomes.add = function() {
+function add () {
   const node = ord.reaction.addSlowly('#outcome_template', '#outcomes');
   // Add live validation handling.
   ord.reaction.addChangeHandler(node, () => {
-    ord.outcomes.validateOutcome(node);
+    validateOutcome(node);
   });
   return node;
 };
 
-ord.outcomes.addAnalysis = function(node) {
+function addAnalysis (node) {
   const analysisNode = ord.reaction.addSlowly(
       '#outcome_analysis_template', $('.outcome_analyses', node));
 
@@ -374,17 +375,17 @@ ord.outcomes.addAnalysis = function(node) {
 
   // Add live validation handling.
   ord.reaction.addChangeHandler(analysisNode, () => {
-    ord.outcomes.validateAnalysis(analysisNode);
+    validateAnalysis(analysisNode);
   });
   return analysisNode;
 };
 
-ord.outcomes.addProcess = function(node) {
+function addProcess (node) {
   const processNode = ord.reaction.addSlowly(
       '#outcome_process_template', $('.outcome_processes', node));
 
   const typeButtons = $('input[type=\'radio\']', processNode);
-  typeButtons.attr('name', 'outcomes_' + ord.outcomes.radioGroupCounter++);
+  typeButtons.attr('name', 'outcomes_' + radioGroupCounter++);
   typeButtons.change(function() {
     if ((this.value == 'text') || (this.value == 'number') ||
         (this.value == 'url')) {
@@ -399,12 +400,12 @@ ord.outcomes.addProcess = function(node) {
   return processNode;
 };
 
-ord.outcomes.addRaw = function(node) {
+function addRaw (node) {
   const rawNode =
       ord.reaction.addSlowly('#outcome_raw_template', $('.outcome_raws', node));
 
   const typeButtons = $('input[type=\'radio\']', rawNode);
-  typeButtons.attr('name', 'outcomes_' + ord.outcomes.radioGroupCounter++);
+  typeButtons.attr('name', 'outcomes_' + radioGroupCounter++);
   typeButtons.change(function() {
     if ((this.value == 'text') || (this.value == 'number') ||
         (this.value == 'url')) {
@@ -419,16 +420,16 @@ ord.outcomes.addRaw = function(node) {
   return rawNode;
 };
 
-ord.outcomes.validateOutcome = function(node, validateNode) {
-  const outcome = ord.outcomes.unloadOutcome(node);
+function validateOutcome (node, validateNode) {
+  const outcome = unloadOutcome(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(outcome, 'ReactionOutcome', validateNode);
 };
 
-ord.outcomes.validateAnalysis = function(node, validateNode) {
-  const analysis = ord.outcomes.unloadAnalysisSingle(node);
+function validateAnalysis (node, validateNode) {
+  const analysis = unloadAnalysisSingle(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/outcomes.js
+++ b/editor/js/outcomes.js
@@ -32,11 +32,12 @@ ord.outcomes.loadOutcome = function(outcome) {
 
   const time = outcome.getReactionTime();
   if (time != null) {
-    writeMetric('.outcome_time', time, node);
+    ord.reaction.writeMetric('.outcome_time', time, node);
   }
   const conversion = outcome.getConversion();
   if (conversion) {
-    writeMetric('.outcome_conversion', outcome.getConversion(), node);
+    ord.reaction.writeMetric(
+        '.outcome_conversion', outcome.getConversion(), node);
   }
 
   const analyses = outcome.getAnalysesMap();
@@ -55,7 +56,8 @@ ord.outcomes.loadAnalysis = function(analysesNode, name, analysis) {
 
   $('.outcome_analysis_name', node).text(name).trigger('input');
 
-  setSelector($('.outcome_analysis_type', node), analysis.getType());
+  ord.reaction.setSelector(
+      $('.outcome_analysis_type', node), analysis.getType());
   const chmoId = analysis.getChmoId();
   if (chmoId != 0) {
     $('.outcome_analysis_chmo_id', node).text(analysis.getChmoId());
@@ -83,11 +85,11 @@ ord.outcomes.loadAnalysis = function(analysesNode, name, analysis) {
   if (calibrated) {
     $('.outcome_analysis_calibrated', node).text(calibrated.getValue());
   }
-  setOptionalBool(
+  ord.reaction.setOptionalBool(
       $('.outcome_analysis_internal_standard', node),
       analysis.hasUsesInternalStandard() ? analysis.getUsesInternalStandard() :
                                            null);
-  setOptionalBool(
+  ord.reaction.setOptionalBool(
       $('.outcome_analysis_authentic_standard', node),
       analysis.hasUsesAuthenticStandard() ?
           analysis.getUsesAuthenticStandard() :
@@ -171,7 +173,7 @@ ord.outcomes.unload = function() {
     if (!node.attr('id')) {
       // Not a template.
       const outcome = ord.outcomes.unloadOutcome(node);
-      if (!isEmptyMessage(outcome)) {
+      if (!ord.reaction.isEmptyMessage(outcome)) {
         outcomes.push(outcome);
       }
     }
@@ -182,14 +184,15 @@ ord.outcomes.unload = function() {
 ord.outcomes.unloadOutcome = function(node) {
   const outcome = new proto.ord.ReactionOutcome();
 
-  const time = readMetric('.outcome_time', new proto.ord.Time(), node);
-  if (!isEmptyMessage(time)) {
+  const time =
+      ord.reaction.readMetric('.outcome_time', new proto.ord.Time(), node);
+  if (!ord.reaction.isEmptyMessage(time)) {
     outcome.setReactionTime(time);
   }
 
-  const conversion =
-      readMetric('.outcome_conversion', new proto.ord.Percentage(), node);
-  if (!isEmptyMessage(conversion)) {
+  const conversion = ord.reaction.readMetric(
+      '.outcome_conversion', new proto.ord.Percentage(), node);
+  if (!ord.reaction.isEmptyMessage(conversion)) {
     outcome.setConversion(conversion);
   }
 
@@ -209,7 +212,8 @@ ord.outcomes.unloadOutcome = function(node) {
 
 ord.outcomes.unloadAnalysisSingle = function(analysisNode) {
   const analysis = new proto.ord.ReactionAnalysis();
-  analysis.setType(getSelector($('.outcome_analysis_type', analysisNode)));
+  analysis.setType(
+      ord.reaction.getSelector($('.outcome_analysis_type', analysisNode)));
   const chmoId = $('.outcome_analysis_chmo_id', analysisNode).text();
   if (!isNaN(chmoId)) {
     analysis.setChmoId(chmoId);
@@ -234,13 +238,13 @@ ord.outcomes.unloadAnalysisSingle = function(analysisNode) {
       $('.outcome_analysis_manufacturer', analysisNode).text());
   const calibrated = new proto.ord.DateTime();
   calibrated.setValue($('.outcome_analysis_calibrated', analysisNode).text());
-  if (!isEmptyMessage(calibrated)) {
+  if (!ord.reaction.isEmptyMessage(calibrated)) {
     analysis.setInstrumentLastCalibrated(calibrated);
   }
-  analysis.setUsesInternalStandard(
-      getOptionalBool($('.outcome_analysis_internal_standard', analysisNode)));
-  analysis.setUsesAuthenticStandard(
-      getOptionalBool($('.outcome_analysis_authentic_standard', analysisNode)));
+  analysis.setUsesInternalStandard(ord.reaction.getOptionalBool(
+      $('.outcome_analysis_internal_standard', analysisNode)));
+  analysis.setUsesAuthenticStandard(ord.reaction.getOptionalBool(
+      $('.outcome_analysis_authentic_standard', analysisNode)));
 
   return analysis;
 };
@@ -248,7 +252,8 @@ ord.outcomes.unloadAnalysisSingle = function(analysisNode) {
 ord.outcomes.unloadAnalysis = function(analysisNode, analyses) {
   const analysis = ord.outcomes.unloadAnalysisSingle(analysisNode);
   const name = $('.outcome_analysis_name', analysisNode).text();
-  if (!isEmptyMessage(name) || !isEmptyMessage(analysis)) {
+  if (!ord.reaction.isEmptyMessage(name) ||
+      !ord.reaction.isEmptyMessage(analysis)) {
     analyses.set(name, analysis);
   }
 };
@@ -262,7 +267,7 @@ ord.outcomes.unloadProcess = function(node, processes) {
 
   if ($('input[value=\'text\']', node).is(':checked')) {
     const stringValue = $('.outcome_process_text', node).text();
-    if (!isEmptyMessage(stringValue)) {
+    if (!ord.reaction.isEmptyMessage(stringValue)) {
       process.setStringValue(stringValue);
     }
   }
@@ -274,17 +279,18 @@ ord.outcomes.unloadProcess = function(node, processes) {
   }
   if ($('input[value=\'upload\']', node).is(':checked')) {
     const bytesValue = ord.uploads.unload(node);
-    if (!isEmptyMessage(bytesValue)) {
+    if (!ord.reaction.isEmptyMessage(bytesValue)) {
       process.setBytesValue(bytesValue);
     }
   }
   if ($('input[value=\'url\']', node).is(':checked')) {
     const url = $('.outcome_process_text', node).text();
-    if (!isEmptyMessage(url)) {
+    if (!ord.reaction.isEmptyMessage(url)) {
       process.setUrl(url);
     }
   }
-  if (!isEmptyMessage(name) || !isEmptyMessage(process)) {
+  if (!ord.reaction.isEmptyMessage(name) ||
+      !ord.reaction.isEmptyMessage(process)) {
     processes.set(name, process);
   }
 };
@@ -298,7 +304,7 @@ ord.outcomes.unloadRaw = function(node, raws) {
 
   if ($('input[value=\'text\']', node).is(':checked')) {
     const stringValue = $('.outcome_raw_text', node).text();
-    if (!isEmptyMessage(stringValue)) {
+    if (!ord.reaction.isEmptyMessage(stringValue)) {
       raw.setStringValue(stringValue);
     }
   }
@@ -310,33 +316,33 @@ ord.outcomes.unloadRaw = function(node, raws) {
   }
   if ($('input[value=\'upload\']', node).is(':checked')) {
     const bytesValue = ord.uploads.unload(node);
-    if (!isEmptyMessage(bytesValue)) {
+    if (!ord.reaction.isEmptyMessage(bytesValue)) {
       raw.setBytesValue(bytesValue);
     }
   }
   if ($('input[value=\'url\']', node).is(':checked')) {
     const url = $('.outcome_raw_text', node).text();
-    if (!isEmptyMessage(url)) {
+    if (!ord.reaction.isEmptyMessage(url)) {
       raw.setUrl(url);
     }
   }
-  if (!isEmptyMessage(name) || !isEmptyMessage(raw)) {
+  if (!ord.reaction.isEmptyMessage(name) || !ord.reaction.isEmptyMessage(raw)) {
     raws.set(name, raw);
   }
 };
 
 ord.outcomes.add = function() {
-  const node = addSlowly('#outcome_template', '#outcomes');
+  const node = ord.reaction.addSlowly('#outcome_template', '#outcomes');
   // Add live validation handling.
-  addChangeHandler(node, () => {
+  ord.reaction.addChangeHandler(node, () => {
     ord.outcomes.validateOutcome(node);
   });
   return node;
 };
 
 ord.outcomes.addAnalysis = function(node) {
-  const analysisNode =
-      addSlowly('#outcome_analysis_template', $('.outcome_analyses', node));
+  const analysisNode = ord.reaction.addSlowly(
+      '#outcome_analysis_template', $('.outcome_analyses', node));
 
   // Handle name changes.
   const nameNode = $('.outcome_analysis_name', analysisNode);
@@ -367,15 +373,15 @@ ord.outcomes.addAnalysis = function(node) {
   });
 
   // Add live validation handling.
-  addChangeHandler(analysisNode, () => {
+  ord.reaction.addChangeHandler(analysisNode, () => {
     ord.outcomes.validateAnalysis(analysisNode);
   });
   return analysisNode;
 };
 
 ord.outcomes.addProcess = function(node) {
-  const processNode =
-      addSlowly('#outcome_process_template', $('.outcome_processes', node));
+  const processNode = ord.reaction.addSlowly(
+      '#outcome_process_template', $('.outcome_processes', node));
 
   const typeButtons = $('input[type=\'radio\']', processNode);
   typeButtons.attr('name', 'outcomes_' + ord.outcomes.radioGroupCounter++);
@@ -394,7 +400,8 @@ ord.outcomes.addProcess = function(node) {
 };
 
 ord.outcomes.addRaw = function(node) {
-  const rawNode = addSlowly('#outcome_raw_template', $('.outcome_raws', node));
+  const rawNode =
+      ord.reaction.addSlowly('#outcome_raw_template', $('.outcome_raws', node));
 
   const typeButtons = $('input[type=\'radio\']', rawNode);
   typeButtons.attr('name', 'outcomes_' + ord.outcomes.radioGroupCounter++);
@@ -417,7 +424,7 @@ ord.outcomes.validateOutcome = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(outcome, 'ReactionOutcome', validateNode);
+  ord.reaction.validate(outcome, 'ReactionOutcome', validateNode);
 };
 
 ord.outcomes.validateAnalysis = function(node, validateNode) {
@@ -425,5 +432,5 @@ ord.outcomes.validateAnalysis = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(analysis, 'ReactionAnalysis', validateNode);
+  ord.reaction.validate(analysis, 'ReactionAnalysis', validateNode);
 };

--- a/editor/js/outcomes.js
+++ b/editor/js/outcomes.js
@@ -16,7 +16,16 @@
 
 goog.module('ord.outcomes');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, add, addAnalysis, addProcess, addRaw, validateOutcome, validateAnalysis};
+exports = {
+  load,
+  unload,
+  add,
+  addAnalysis,
+  addProcess,
+  addRaw,
+  validateOutcome,
+  validateAnalysis
+};
 
 goog.require('ord.products');
 goog.require('proto.ord.ReactionOutcome');
@@ -24,11 +33,11 @@ goog.require('proto.ord.ReactionOutcome');
 // Freely create radio button groups by generating new input names.
 let radioGroupCounter = 0;
 
-function load (outcomes) {
+function load(outcomes) {
   outcomes.forEach(outcome => loadOutcome(outcome));
-};
+}
 
-function loadOutcome (outcome) {
+function loadOutcome(outcome) {
   const node = add();
 
   const time = outcome.getReactionTime();
@@ -50,9 +59,9 @@ function loadOutcome (outcome) {
 
   const products = outcome.getProductsList();
   ord.products.load(node, products);
-};
+}
 
-function loadAnalysis (analysesNode, name, analysis) {
+function loadAnalysis(analysesNode, name, analysis) {
   const node = addAnalysis(analysesNode);
 
   $('.outcome_analysis_name', node).text(name).trigger('input');
@@ -95,9 +104,9 @@ function loadAnalysis (analysesNode, name, analysis) {
       analysis.hasUsesAuthenticStandard() ?
           analysis.getUsesAuthenticStandard() :
           null);
-};
+}
 
-function loadProcess (node, name, process) {
+function loadProcess(node, name, process) {
   $('.outcome_process_name', node).text(name);
   $('.outcome_process_description', node).text(process.getDescription());
   $('.outcome_process_format', node).text(process.getFormat());
@@ -130,9 +139,9 @@ function loadProcess (node, name, process) {
     $('.outcome_process_text', node).text(url);
     $('input[value=\'url\']', node).prop('checked', true);
   }
-};
+}
 
-function loadRaw (node, name, raw) {
+function loadRaw(node, name, raw) {
   $('.outcome_raw_name', node).text(name);
   $('.outcome_raw_description', node).text(raw.getDescription());
   $('.outcome_raw_format', node).text(raw.getFormat());
@@ -165,9 +174,9 @@ function loadRaw (node, name, raw) {
     $('.outcome_raw_text', node).text(url);
     $('input[value=\'url\']', node).prop('checked', true);
   }
-};
+}
 
-function unload () {
+function unload() {
   const outcomes = [];
   $('.outcome').each(function(index, node) {
     node = $(node);
@@ -180,9 +189,9 @@ function unload () {
     }
   });
   return outcomes;
-};
+}
 
-function unloadOutcome (node) {
+function unloadOutcome(node) {
   const outcome = new proto.ord.ReactionOutcome();
 
   const time =
@@ -209,9 +218,9 @@ function unloadOutcome (node) {
     }
   });
   return outcome;
-};
+}
 
-function unloadAnalysisSingle (analysisNode) {
+function unloadAnalysisSingle(analysisNode) {
   const analysis = new proto.ord.ReactionAnalysis();
   analysis.setType(
       ord.reaction.getSelector($('.outcome_analysis_type', analysisNode)));
@@ -248,18 +257,18 @@ function unloadAnalysisSingle (analysisNode) {
       $('.outcome_analysis_authentic_standard', analysisNode)));
 
   return analysis;
-};
+}
 
-function unloadAnalysis (analysisNode, analyses) {
+function unloadAnalysis(analysisNode, analyses) {
   const analysis = unloadAnalysisSingle(analysisNode);
   const name = $('.outcome_analysis_name', analysisNode).text();
   if (!ord.reaction.isEmptyMessage(name) ||
       !ord.reaction.isEmptyMessage(analysis)) {
     analyses.set(name, analysis);
   }
-};
+}
 
-function unloadProcess (node, processes) {
+function unloadProcess(node, processes) {
   const name = $('.outcome_process_name', node).text();
 
   const process = new proto.ord.Data();
@@ -294,9 +303,9 @@ function unloadProcess (node, processes) {
       !ord.reaction.isEmptyMessage(process)) {
     processes.set(name, process);
   }
-};
+}
 
-function unloadRaw (node, raws) {
+function unloadRaw(node, raws) {
   const name = $('.outcome_raw_name', node).text();
 
   const raw = new proto.ord.Data();
@@ -330,18 +339,18 @@ function unloadRaw (node, raws) {
   if (!ord.reaction.isEmptyMessage(name) || !ord.reaction.isEmptyMessage(raw)) {
     raws.set(name, raw);
   }
-};
+}
 
-function add () {
+function add() {
   const node = ord.reaction.addSlowly('#outcome_template', '#outcomes');
   // Add live validation handling.
   ord.reaction.addChangeHandler(node, () => {
     validateOutcome(node);
   });
   return node;
-};
+}
 
-function addAnalysis (node) {
+function addAnalysis(node) {
   const analysisNode = ord.reaction.addSlowly(
       '#outcome_analysis_template', $('.outcome_analyses', node));
 
@@ -378,9 +387,9 @@ function addAnalysis (node) {
     validateAnalysis(analysisNode);
   });
   return analysisNode;
-};
+}
 
-function addProcess (node) {
+function addProcess(node) {
   const processNode = ord.reaction.addSlowly(
       '#outcome_process_template', $('.outcome_processes', node));
 
@@ -398,9 +407,9 @@ function addProcess (node) {
   });
   ord.uploads.initialize(processNode);
   return processNode;
-};
+}
 
-function addRaw (node) {
+function addRaw(node) {
   const rawNode =
       ord.reaction.addSlowly('#outcome_raw_template', $('.outcome_raws', node));
 
@@ -418,20 +427,20 @@ function addRaw (node) {
   });
   ord.uploads.initialize(rawNode);
   return rawNode;
-};
+}
 
-function validateOutcome (node, validateNode) {
+function validateOutcome(node, validateNode) {
   const outcome = unloadOutcome(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(outcome, 'ReactionOutcome', validateNode);
-};
+}
 
-function validateAnalysis (node, validateNode) {
+function validateAnalysis(node, validateNode) {
   const analysis = unloadAnalysisSingle(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(analysis, 'ReactionAnalysis', validateNode);
-};
+}

--- a/editor/js/pressure.js
+++ b/editor/js/pressure.js
@@ -16,14 +16,19 @@
 
 goog.module('ord.pressure');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, addMeasurement, validatePressure};
+exports = {
+  load,
+  unload,
+  addMeasurement,
+  validatePressure
+};
 
 goog.require('proto.ord.Pressure');
 goog.require('proto.ord.PressureConditions');
 goog.require('proto.ord.PressureConditions.Measurement');
 goog.require('proto.ord.Time');
 
-function load (pressure) {
+function load(pressure) {
   const control = pressure.getControl();
   if (control) {
     ord.reaction.setSelector($('#pressure_control_type'), control.getType());
@@ -43,9 +48,9 @@ function load (pressure) {
         $('#pressure_atmosphere_type'), atmosphere.getType());
     $('#pressure_atmosphere_details').text(atmosphere.getDetails());
   }
-};
+}
 
-function loadMeasurement (measurement, node) {
+function loadMeasurement(measurement, node) {
   const type = measurement.getType();
   ord.reaction.setSelector($('.pressure_measurement_type', node), type);
   $('.pressure_measurement_details', node).text(measurement.getDetails());
@@ -55,9 +60,9 @@ function loadMeasurement (measurement, node) {
 
   const time = measurement.getTime();
   ord.reaction.writeMetric('.pressure_measurement_time', time, node);
-};
+}
 
-function unload () {
+function unload() {
   const pressure = new proto.ord.PressureConditions();
 
   const control = new proto.ord.PressureConditions.PressureControl();
@@ -93,9 +98,9 @@ function unload () {
   pressure.setMeasurementsList(measurements);
 
   return pressure;
-};
+}
 
-function unloadMeasurement (node) {
+function unloadMeasurement(node) {
   const measurement = new proto.ord.PressureConditions.Measurement();
   const type = ord.reaction.getSelector($('.pressure_measurement_type', node));
   measurement.setType(type);
@@ -113,17 +118,17 @@ function unloadMeasurement (node) {
   }
 
   return measurement;
-};
+}
 
-function addMeasurement () {
+function addMeasurement() {
   return ord.reaction.addSlowly(
       '#pressure_measurement_template', '#pressure_measurements');
-};
+}
 
-function validatePressure (node, validateNode) {
+function validatePressure(node, validateNode) {
   const pressure = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(pressure, 'PressureConditions', validateNode);
-};
+}

--- a/editor/js/pressure.js
+++ b/editor/js/pressure.js
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-goog.provide('ord.pressure');
+goog.module('ord.pressure');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, addMeasurement, validatePressure};
 
 goog.require('proto.ord.Pressure');
 goog.require('proto.ord.PressureConditions');
 goog.require('proto.ord.PressureConditions.Measurement');
 goog.require('proto.ord.Time');
 
-ord.pressure.load = function(pressure) {
+function load (pressure) {
   const control = pressure.getControl();
   if (control) {
     ord.reaction.setSelector($('#pressure_control_type'), control.getType());
@@ -29,8 +31,8 @@ ord.pressure.load = function(pressure) {
   }
   const measurements = pressure.getMeasurementsList();
   measurements.forEach(function(measurement) {
-    const node = ord.pressure.addMeasurement();
-    ord.pressure.loadMeasurement(measurement, node);
+    const node = addMeasurement();
+    loadMeasurement(measurement, node);
   });
   const setpoint = pressure.getSetpoint();
   ord.reaction.writeMetric('#pressure_setpoint', setpoint);
@@ -43,7 +45,7 @@ ord.pressure.load = function(pressure) {
   }
 };
 
-ord.pressure.loadMeasurement = function(measurement, node) {
+function loadMeasurement (measurement, node) {
   const type = measurement.getType();
   ord.reaction.setSelector($('.pressure_measurement_type', node), type);
   $('.pressure_measurement_details', node).text(measurement.getDetails());
@@ -55,7 +57,7 @@ ord.pressure.loadMeasurement = function(measurement, node) {
   ord.reaction.writeMetric('.pressure_measurement_time', time, node);
 };
 
-ord.pressure.unload = function() {
+function unload () {
   const pressure = new proto.ord.PressureConditions();
 
   const control = new proto.ord.PressureConditions.PressureControl();
@@ -82,7 +84,7 @@ ord.pressure.unload = function() {
   $('.pressure_measurement').each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
-      const measurement = ord.pressure.unloadMeasurement(node);
+      const measurement = unloadMeasurement(node);
       if (!ord.reaction.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
@@ -93,7 +95,7 @@ ord.pressure.unload = function() {
   return pressure;
 };
 
-ord.pressure.unloadMeasurement = function(node) {
+function unloadMeasurement (node) {
   const measurement = new proto.ord.PressureConditions.Measurement();
   const type = ord.reaction.getSelector($('.pressure_measurement_type', node));
   measurement.setType(type);
@@ -113,13 +115,13 @@ ord.pressure.unloadMeasurement = function(node) {
   return measurement;
 };
 
-ord.pressure.addMeasurement = function() {
+function addMeasurement () {
   return ord.reaction.addSlowly(
       '#pressure_measurement_template', '#pressure_measurements');
 };
 
-ord.pressure.validatePressure = function(node, validateNode) {
-  const pressure = ord.pressure.unload();
+function validatePressure (node, validateNode) {
+  const pressure = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/pressure.js
+++ b/editor/js/pressure.js
@@ -24,7 +24,7 @@ goog.require('proto.ord.Time');
 ord.pressure.load = function(pressure) {
   const control = pressure.getControl();
   if (control) {
-    setSelector($('#pressure_control_type'), control.getType());
+    ord.reaction.setSelector($('#pressure_control_type'), control.getType());
     $('#pressure_control_details').text(control.getDetails());
   }
   const measurements = pressure.getMeasurementsList();
@@ -33,46 +33,48 @@ ord.pressure.load = function(pressure) {
     ord.pressure.loadMeasurement(measurement, node);
   });
   const setpoint = pressure.getSetpoint();
-  writeMetric('#pressure_setpoint', setpoint);
+  ord.reaction.writeMetric('#pressure_setpoint', setpoint);
 
   const atmosphere = pressure.getAtmosphere();
   if (atmosphere) {
-    setSelector($('#pressure_atmosphere_type'), atmosphere.getType());
+    ord.reaction.setSelector(
+        $('#pressure_atmosphere_type'), atmosphere.getType());
     $('#pressure_atmosphere_details').text(atmosphere.getDetails());
   }
 };
 
 ord.pressure.loadMeasurement = function(measurement, node) {
   const type = measurement.getType();
-  setSelector($('.pressure_measurement_type', node), type);
+  ord.reaction.setSelector($('.pressure_measurement_type', node), type);
   $('.pressure_measurement_details', node).text(measurement.getDetails());
 
   const pressure = measurement.getPressure();
-  writeMetric('.pressure_measurement_pressure', pressure, node);
+  ord.reaction.writeMetric('.pressure_measurement_pressure', pressure, node);
 
   const time = measurement.getTime();
-  writeMetric('.pressure_measurement_time', time, node);
+  ord.reaction.writeMetric('.pressure_measurement_time', time, node);
 };
 
 ord.pressure.unload = function() {
   const pressure = new proto.ord.PressureConditions();
 
   const control = new proto.ord.PressureConditions.PressureControl();
-  control.setType(getSelector($('#pressure_control_type')));
+  control.setType(ord.reaction.getSelector($('#pressure_control_type')));
   control.setDetails($('#pressure_control_details').text());
-  if (!isEmptyMessage(control)) {
+  if (!ord.reaction.isEmptyMessage(control)) {
     pressure.setControl(control);
   }
 
-  const setpoint = readMetric('#pressure_setpoint', new proto.ord.Pressure());
-  if (!isEmptyMessage(setpoint)) {
+  const setpoint =
+      ord.reaction.readMetric('#pressure_setpoint', new proto.ord.Pressure());
+  if (!ord.reaction.isEmptyMessage(setpoint)) {
     pressure.setSetpoint(setpoint);
   }
 
   const atmosphere = new proto.ord.PressureConditions.Atmosphere();
-  atmosphere.setType(getSelector('#pressure_atmosphere_type'));
+  atmosphere.setType(ord.reaction.getSelector('#pressure_atmosphere_type'));
   atmosphere.setDetails($('#pressure_atmosphere_details').text());
-  if (!isEmptyMessage(atmosphere)) {
+  if (!ord.reaction.isEmptyMessage(atmosphere)) {
     pressure.setAtmosphere(atmosphere);
   }
 
@@ -81,7 +83,7 @@ ord.pressure.unload = function() {
     node = $(node);
     if (!node.attr('id')) {
       const measurement = ord.pressure.unloadMeasurement(node);
-      if (!isEmptyMessage(measurement)) {
+      if (!ord.reaction.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
     }
@@ -93,18 +95,18 @@ ord.pressure.unload = function() {
 
 ord.pressure.unloadMeasurement = function(node) {
   const measurement = new proto.ord.PressureConditions.Measurement();
-  const type = getSelector($('.pressure_measurement_type', node));
+  const type = ord.reaction.getSelector($('.pressure_measurement_type', node));
   measurement.setType(type);
   const details = $('.pressure_measurement_details', node).text();
   measurement.setDetails(details);
-  const pressure = readMetric(
+  const pressure = ord.reaction.readMetric(
       '.pressure_measurement_pressure', new proto.ord.Pressure(), node);
-  if (!isEmptyMessage(pressure)) {
+  if (!ord.reaction.isEmptyMessage(pressure)) {
     measurement.setPressure(pressure);
   }
-  const time =
-      readMetric('.pressure_measurement_time', new proto.ord.Time(), node);
-  if (!isEmptyMessage(time)) {
+  const time = ord.reaction.readMetric(
+      '.pressure_measurement_time', new proto.ord.Time(), node);
+  if (!ord.reaction.isEmptyMessage(time)) {
     measurement.setTime(time);
   }
 
@@ -112,7 +114,8 @@ ord.pressure.unloadMeasurement = function(node) {
 };
 
 ord.pressure.addMeasurement = function() {
-  return addSlowly('#pressure_measurement_template', '#pressure_measurements');
+  return ord.reaction.addSlowly(
+      '#pressure_measurement_template', '#pressure_measurements');
 };
 
 ord.pressure.validatePressure = function(node, validateNode) {
@@ -120,5 +123,5 @@ ord.pressure.validatePressure = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(pressure, 'PressureConditions', validateNode);
+  ord.reaction.validate(pressure, 'PressureConditions', validateNode);
 };

--- a/editor/js/products.js
+++ b/editor/js/products.js
@@ -31,23 +31,23 @@ ord.products.loadProduct = function(outcomeNode, product) {
     ord.compounds.loadIntoCompound(node, compound);
   }
 
-  setOptionalBool(
+  ord.reaction.setOptionalBool(
       $('.outcome_product_desired', node),
       product.hasIsDesiredProduct() ? product.getIsDesiredProduct() : null);
 
   const compoundYield = product.getCompoundYield();
   if (compoundYield) {
-    writeMetric('.outcome_product_yield', compoundYield, node);
+    ord.reaction.writeMetric('.outcome_product_yield', compoundYield, node);
   }
 
   const purity = product.getPurity();
   if (purity) {
-    writeMetric('.outcome_product_purity', purity, node);
+    ord.reaction.writeMetric('.outcome_product_purity', purity, node);
   }
 
   const selectivity = product.getSelectivity();
   if (selectivity) {
-    setSelector(
+    ord.reaction.setSelector(
         $('.outcome_product_selectivity_type', node), selectivity.getType());
     $('.outcome_product_selectivity_details', node)
         .text(selectivity.getDetails());
@@ -85,7 +85,8 @@ ord.products.loadProduct = function(outcomeNode, product) {
 
   const texture = product.getTexture();
   if (texture) {
-    setSelector($('.outcome_product_texture_type', node), texture.getType());
+    ord.reaction.setSelector(
+        $('.outcome_product_texture_type', node), texture.getType());
     $('.outcome_product_texture_details', node).text(texture.getDetails());
   }
 };
@@ -97,7 +98,7 @@ ord.products.unload = function(node) {
     if (!productNode.attr('id')) {
       // Not a template.
       const product = ord.products.unloadProduct(productNode);
-      if (!isEmptyMessage(product)) {
+      if (!ord.reaction.isEmptyMessage(product)) {
         products.push(product);
       }
     }
@@ -110,28 +111,28 @@ ord.products.unloadProduct = function(node) {
 
   const compoundNode = $('.outcome_product_compound');
   const compound = ord.compounds.unloadCompound(compoundNode);
-  if (!isEmptyMessage(compound)) {
+  if (!ord.reaction.isEmptyMessage(compound)) {
     product.setCompound(compound);
   }
 
   product.setIsDesiredProduct(
-      getOptionalBool($('.outcome_product_desired', node)));
+      ord.reaction.getOptionalBool($('.outcome_product_desired', node)));
 
-  const yeild =
-      readMetric('.outcome_product_yield', new proto.ord.Percentage(), node);
-  if (!isEmptyMessage(yeild)) {
+  const yeild = ord.reaction.readMetric(
+      '.outcome_product_yield', new proto.ord.Percentage(), node);
+  if (!ord.reaction.isEmptyMessage(yeild)) {
     product.setCompoundYield(yeild);
   }
 
-  const purity =
-      readMetric('.outcome_product_purity', new proto.ord.Percentage(), node);
-  if (!isEmptyMessage(purity)) {
+  const purity = ord.reaction.readMetric(
+      '.outcome_product_purity', new proto.ord.Percentage(), node);
+  if (!ord.reaction.isEmptyMessage(purity)) {
     product.setPurity(purity);
   }
 
   const selectivity = new proto.ord.Selectivity();
   selectivity.setType(
-      getSelector($('.outcome_product_selectivity_type', node)));
+      ord.reaction.getSelector($('.outcome_product_selectivity_type', node)));
   selectivity.setDetails(
       $('.outcome_product_selectivity_details', node).text());
   const selectivityValue =
@@ -144,7 +145,7 @@ ord.products.unloadProduct = function(node) {
   if (!isNaN(selectivityPrecision)) {
     selectivity.setPrecision(selectivityPrecision);
   }
-  if (!isEmptyMessage(selectivity)) {
+  if (!ord.reaction.isEmptyMessage(selectivity)) {
     product.setSelectivity(selectivity);
   }
 
@@ -164,9 +165,10 @@ ord.products.unloadProduct = function(node) {
   product.setIsolatedColor(color);
 
   const texture = new proto.ord.ReactionProduct.Texture();
-  texture.setType(getSelector($('.outcome_product_texture_type', node)));
+  texture.setType(
+      ord.reaction.getSelector($('.outcome_product_texture_type', node)));
   texture.setDetails($('.outcome_product_texture_details', node).text());
-  if (!isEmptyMessage(texture)) {
+  if (!ord.reaction.isEmptyMessage(texture)) {
     product.setTexture(texture);
   }
 
@@ -189,8 +191,8 @@ ord.products.unloadAnalysisKeys = function(node, tag) {
 };
 
 ord.products.add = function(node) {
-  const productNode =
-      addSlowly('#outcome_product_template', $('.outcome_products', node));
+  const productNode = ord.reaction.addSlowly(
+      '#outcome_product_template', $('.outcome_products', node));
 
   // Add an empty compound node.
   ord.compounds.add(productNode);
@@ -206,32 +208,32 @@ ord.products.add = function(node) {
   $('.component .vendor', productNode).hide();
 
   // Add live validation handling.
-  addChangeHandler(productNode, () => {
+  ord.reaction.addChangeHandler(productNode, () => {
     ord.products.validateProduct(productNode);
   });
   return productNode;
 };
 
 ord.products.addIdentity = function(node) {
-  return addSlowly(
+  return ord.reaction.addSlowly(
       '#outcome_product_analysis_identity_template',
       $('.outcome_product_analysis_identities', node));
 };
 
 ord.products.addYield = function(node) {
-  return addSlowly(
+  return ord.reaction.addSlowly(
       '#outcome_product_analysis_yield_template',
       $('.outcome_product_analysis_yields', node));
 };
 
 ord.products.addPurity = function(node) {
-  return addSlowly(
+  return ord.reaction.addSlowly(
       '#outcome_product_analysis_purity_template',
       $('.outcome_product_analysis_purities', node));
 };
 
 ord.products.addSelectivity = function(node) {
-  return addSlowly(
+  return ord.reaction.addSlowly(
       '#outcome_product_analysis_selectivity_template',
       $('.outcome_product_analysis_selectivities', node));
 };
@@ -241,5 +243,5 @@ ord.products.validateProduct = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(product, 'ReactionProduct', validateNode);
+  ord.reaction.validate(product, 'ReactionProduct', validateNode);
 };

--- a/editor/js/products.js
+++ b/editor/js/products.js
@@ -16,16 +16,25 @@
 
 goog.module('ord.products');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, add, addIdentity, addYield, addPurity, addSelectivity, validateProduct};
+exports = {
+  load,
+  unload,
+  add,
+  addIdentity,
+  addYield,
+  addPurity,
+  addSelectivity,
+  validateProduct
+};
 
 goog.require('ord.compounds');
 goog.require('proto.ord.ReactionProduct');
 
-function load (node, products) {
+function load(node, products) {
   products.forEach(product => loadProduct(node, product));
-};
+}
 
-function loadProduct (outcomeNode, product) {
+function loadProduct(outcomeNode, product) {
   const node = add(outcomeNode);
 
   const compound = product.getCompound();
@@ -91,9 +100,9 @@ function loadProduct (outcomeNode, product) {
         $('.outcome_product_texture_type', node), texture.getType());
     $('.outcome_product_texture_details', node).text(texture.getDetails());
   }
-};
+}
 
-function unload (node) {
+function unload(node) {
   const products = [];
   $('.outcome_product', node).each(function(index, productNode) {
     productNode = $(productNode);
@@ -106,9 +115,9 @@ function unload (node) {
     }
   });
   return products;
-};
+}
 
-function unloadProduct (node) {
+function unloadProduct(node) {
   const product = new proto.ord.ReactionProduct();
 
   const compoundNode = $('.outcome_product_compound');
@@ -175,9 +184,9 @@ function unloadProduct (node) {
   }
 
   return product;
-};
+}
 
-function unloadAnalysisKeys (node, tag) {
+function unloadAnalysisKeys(node, tag) {
   const values = [];
   $('.outcome_product_analysis_' + tag, node).each(function(index, tagNode) {
     tagNode = $(tagNode);
@@ -190,9 +199,9 @@ function unloadAnalysisKeys (node, tag) {
     }
   });
   return values;
-};
+}
 
-function add (node) {
+function add(node) {
   const productNode = ord.reaction.addSlowly(
       '#outcome_product_template', $('.outcome_products', node));
 
@@ -214,36 +223,36 @@ function add (node) {
     validateProduct(productNode);
   });
   return productNode;
-};
+}
 
-function addIdentity (node) {
+function addIdentity(node) {
   return ord.reaction.addSlowly(
       '#outcome_product_analysis_identity_template',
       $('.outcome_product_analysis_identities', node));
-};
+}
 
-function addYield (node) {
+function addYield(node) {
   return ord.reaction.addSlowly(
       '#outcome_product_analysis_yield_template',
       $('.outcome_product_analysis_yields', node));
-};
+}
 
-function addPurity (node) {
+function addPurity(node) {
   return ord.reaction.addSlowly(
       '#outcome_product_analysis_purity_template',
       $('.outcome_product_analysis_purities', node));
-};
+}
 
-function addSelectivity (node) {
+function addSelectivity(node) {
   return ord.reaction.addSlowly(
       '#outcome_product_analysis_selectivity_template',
       $('.outcome_product_analysis_selectivities', node));
-};
+}
 
-function validateProduct (node, validateNode) {
+function validateProduct(node, validateNode) {
   const product = unloadProduct(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(product, 'ReactionProduct', validateNode);
-};
+}

--- a/editor/js/products.js
+++ b/editor/js/products.js
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-goog.provide('ord.products');
+goog.module('ord.products');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, add, addIdentity, addYield, addPurity, addSelectivity, validateProduct};
 
 goog.require('ord.compounds');
 goog.require('proto.ord.ReactionProduct');
 
-ord.products.load = function(node, products) {
-  products.forEach(product => ord.products.loadProduct(node, product));
+function load (node, products) {
+  products.forEach(product => loadProduct(node, product));
 };
 
-ord.products.loadProduct = function(outcomeNode, product) {
-  const node = ord.products.add(outcomeNode);
+function loadProduct (outcomeNode, product) {
+  const node = add(outcomeNode);
 
   const compound = product.getCompound();
   if (compound) {
@@ -63,22 +65,22 @@ ord.products.loadProduct = function(outcomeNode, product) {
 
   const identities = product.getAnalysisIdentityList();
   identities.forEach(identity => {
-    const analysisNode = ord.products.addIdentity(node);
+    const analysisNode = addIdentity(node);
     $('.analysis_key_selector', analysisNode).val(identity);
   });
   const yields = product.getAnalysisYieldList();
   yields.forEach(yeild => {
-    const analysisNode = ord.products.addYield(node);
+    const analysisNode = addYield(node);
     $('.analysis_key_selector', analysisNode).val(yeild);
   });
   const purities = product.getAnalysisPurityList();
   purities.forEach(purity => {
-    const analysisNode = ord.products.addPurity(node);
+    const analysisNode = addPurity(node);
     $('.analysis_key_selector', analysisNode).val(purity);
   });
   const selectivities = product.getAnalysisSelectivityList();
   selectivities.forEach(selectivity => {
-    const analysisNode = ord.products.addSelectivity(node);
+    const analysisNode = addSelectivity(node);
     $('.analysis_key_selector', analysisNode).val(selectivity);
   });
   $('.outcome_product_color', node).text(product.getIsolatedColor());
@@ -91,13 +93,13 @@ ord.products.loadProduct = function(outcomeNode, product) {
   }
 };
 
-ord.products.unload = function(node) {
+function unload (node) {
   const products = [];
   $('.outcome_product', node).each(function(index, productNode) {
     productNode = $(productNode);
     if (!productNode.attr('id')) {
       // Not a template.
-      const product = ord.products.unloadProduct(productNode);
+      const product = unloadProduct(productNode);
       if (!ord.reaction.isEmptyMessage(product)) {
         products.push(product);
       }
@@ -106,7 +108,7 @@ ord.products.unload = function(node) {
   return products;
 };
 
-ord.products.unloadProduct = function(node) {
+function unloadProduct (node) {
   const product = new proto.ord.ReactionProduct();
 
   const compoundNode = $('.outcome_product_compound');
@@ -149,16 +151,16 @@ ord.products.unloadProduct = function(node) {
     product.setSelectivity(selectivity);
   }
 
-  const identities = ord.products.unloadAnalysisKeys(node, 'identity');
+  const identities = unloadAnalysisKeys(node, 'identity');
   product.setAnalysisIdentityList(identities);
 
-  const yields = ord.products.unloadAnalysisKeys(node, 'yield');
+  const yields = unloadAnalysisKeys(node, 'yield');
   product.setAnalysisYieldList(yields);
 
-  const purities = ord.products.unloadAnalysisKeys(node, 'purity');
+  const purities = unloadAnalysisKeys(node, 'purity');
   product.setAnalysisPurityList(purities);
 
-  const selectivities = ord.products.unloadAnalysisKeys(node, 'selectivity');
+  const selectivities = unloadAnalysisKeys(node, 'selectivity');
   product.setAnalysisSelectivityList(selectivities);
 
   const color = $('.outcome_product_color', node).text();
@@ -175,7 +177,7 @@ ord.products.unloadProduct = function(node) {
   return product;
 };
 
-ord.products.unloadAnalysisKeys = function(node, tag) {
+function unloadAnalysisKeys (node, tag) {
   const values = [];
   $('.outcome_product_analysis_' + tag, node).each(function(index, tagNode) {
     tagNode = $(tagNode);
@@ -190,7 +192,7 @@ ord.products.unloadAnalysisKeys = function(node, tag) {
   return values;
 };
 
-ord.products.add = function(node) {
+function add (node) {
   const productNode = ord.reaction.addSlowly(
       '#outcome_product_template', $('.outcome_products', node));
 
@@ -209,37 +211,37 @@ ord.products.add = function(node) {
 
   // Add live validation handling.
   ord.reaction.addChangeHandler(productNode, () => {
-    ord.products.validateProduct(productNode);
+    validateProduct(productNode);
   });
   return productNode;
 };
 
-ord.products.addIdentity = function(node) {
+function addIdentity (node) {
   return ord.reaction.addSlowly(
       '#outcome_product_analysis_identity_template',
       $('.outcome_product_analysis_identities', node));
 };
 
-ord.products.addYield = function(node) {
+function addYield (node) {
   return ord.reaction.addSlowly(
       '#outcome_product_analysis_yield_template',
       $('.outcome_product_analysis_yields', node));
 };
 
-ord.products.addPurity = function(node) {
+function addPurity (node) {
   return ord.reaction.addSlowly(
       '#outcome_product_analysis_purity_template',
       $('.outcome_product_analysis_purities', node));
 };
 
-ord.products.addSelectivity = function(node) {
+function addSelectivity (node) {
   return ord.reaction.addSlowly(
       '#outcome_product_analysis_selectivity_template',
       $('.outcome_product_analysis_selectivities', node));
 };
 
-ord.products.validateProduct = function(node, validateNode) {
-  const product = ord.products.unloadProduct(node);
+function validateProduct (node, validateNode) {
+  const product = unloadProduct(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/provenance.js
+++ b/editor/js/provenance.js
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-goog.provide('ord.provenance');
+goog.module('ord.provenance');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, addModification, validateProvenance};
 
 goog.require('proto.ord.DateTime');
 goog.require('proto.ord.Person');
 goog.require('proto.ord.ReactionProvenance');
 goog.require('proto.ord.RecordEvent');
 
-ord.provenance.load = function(provenance) {
+function load (provenance) {
   const experimenter = provenance.getExperimenter();
   if (experimenter) {
-    ord.provenance.loadPerson($('#provenance_experimenter'), experimenter);
+    loadPerson($('#provenance_experimenter'), experimenter);
   }
   $('#provenance_city').text(provenance.getCity());
 
@@ -39,27 +41,27 @@ ord.provenance.load = function(provenance) {
 
   const created = provenance.getRecordCreated();
   if (created) {
-    ord.provenance.loadRecordEvent($('#provenance_created'), created);
+    loadRecordEvent($('#provenance_created'), created);
   }
   provenance.getRecordModifiedList().forEach(modified => {
-    const node = ord.provenance.addModification();
-    ord.provenance.loadRecordEvent(node, modified);
+    const node = addModification();
+    loadRecordEvent(node, modified);
   });
 };
 
-ord.provenance.loadRecordEvent = function(node, record) {
+function loadRecordEvent (node, record) {
   const time = record.getTime();
   if (time) {
     $('.provenance_time', node).text(time.getValue());
   }
   const person = record.getPerson();
   if (person) {
-    ord.provenance.loadPerson(node, record.getPerson());
+    loadPerson(node, record.getPerson());
   }
   $('.provenance_details', node).text(record.getDetails());
 };
 
-ord.provenance.loadPerson = function(node, person) {
+function loadPerson (node, person) {
   $('.provenance_username', node).text(person.getUsername());
   $('.provenance_name', node).text(person.getName());
   $('.provenance_orcid', node).text(person.getOrcid());
@@ -67,11 +69,11 @@ ord.provenance.loadPerson = function(node, person) {
   $('.provenance_email', node).text(person.getEmail());
 };
 
-ord.provenance.unload = function() {
+function unload () {
   const provenance = new proto.ord.ReactionProvenance();
 
   const experimenter =
-      ord.provenance.unloadPerson($('#provenance_experimenter'));
+      unloadPerson($('#provenance_experimenter'));
   if (!ord.reaction.isEmptyMessage(experimenter)) {
     provenance.setExperimenter(experimenter);
   }
@@ -88,7 +90,7 @@ ord.provenance.unload = function() {
   provenance.setPatent($('#provenance_patent').text());
   provenance.setPublicationUrl($('#provenance_url').text());
 
-  const created = ord.provenance.unloadRecordEvent($('#provenance_created'));
+  const created = unloadRecordEvent($('#provenance_created'));
   if (!ord.reaction.isEmptyMessage(created)) {
     provenance.setRecordCreated(created);
   }
@@ -99,7 +101,7 @@ ord.provenance.unload = function() {
         node = $(node);
         if (!node.attr('id')) {
           // Not a template.
-          const modified = ord.provenance.unloadRecordEvent(node);
+          const modified = unloadRecordEvent(node);
           if (!ord.reaction.isEmptyMessage(modified)) {
             modifieds.push(modified);
           }
@@ -109,14 +111,14 @@ ord.provenance.unload = function() {
   return provenance;
 };
 
-ord.provenance.unloadRecordEvent = function(node) {
+function unloadRecordEvent (node) {
   const created = new proto.ord.RecordEvent();
   const createdTime = new proto.ord.DateTime();
   createdTime.setValue($('.provenance_time', node).text());
   if (!ord.reaction.isEmptyMessage(createdTime)) {
     created.setTime(createdTime);
   }
-  const createdPerson = ord.provenance.unloadPerson(node);
+  const createdPerson = unloadPerson(node);
   if (!ord.reaction.isEmptyMessage(createdPerson)) {
     created.setPerson(createdPerson);
   }
@@ -125,7 +127,7 @@ ord.provenance.unloadRecordEvent = function(node) {
   return created;
 };
 
-ord.provenance.unloadPerson = function(node) {
+function unloadPerson (node) {
   const person = new proto.ord.Person();
   person.setUsername($('.provenance_username', node).text());
   person.setName($('.provenance_name', node).text());
@@ -135,13 +137,13 @@ ord.provenance.unloadPerson = function(node) {
   return person;
 };
 
-ord.provenance.addModification = function() {
+function addModification () {
   return ord.reaction.addSlowly(
       '#provenance_modified_template', '#provenance_modifieds');
 };
 
-ord.provenance.validateProvenance = function(node, validateNode) {
-  const provenance = ord.provenance.unload();
+function validateProvenance (node, validateNode) {
+  const provenance = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/provenance.js
+++ b/editor/js/provenance.js
@@ -16,14 +16,19 @@
 
 goog.module('ord.provenance');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, addModification, validateProvenance};
+exports = {
+  load,
+  unload,
+  addModification,
+  validateProvenance
+};
 
 goog.require('proto.ord.DateTime');
 goog.require('proto.ord.Person');
 goog.require('proto.ord.ReactionProvenance');
 goog.require('proto.ord.RecordEvent');
 
-function load (provenance) {
+function load(provenance) {
   const experimenter = provenance.getExperimenter();
   if (experimenter) {
     loadPerson($('#provenance_experimenter'), experimenter);
@@ -47,9 +52,9 @@ function load (provenance) {
     const node = addModification();
     loadRecordEvent(node, modified);
   });
-};
+}
 
-function loadRecordEvent (node, record) {
+function loadRecordEvent(node, record) {
   const time = record.getTime();
   if (time) {
     $('.provenance_time', node).text(time.getValue());
@@ -59,21 +64,20 @@ function loadRecordEvent (node, record) {
     loadPerson(node, record.getPerson());
   }
   $('.provenance_details', node).text(record.getDetails());
-};
+}
 
-function loadPerson (node, person) {
+function loadPerson(node, person) {
   $('.provenance_username', node).text(person.getUsername());
   $('.provenance_name', node).text(person.getName());
   $('.provenance_orcid', node).text(person.getOrcid());
   $('.provenance_organization', node).text(person.getOrganization());
   $('.provenance_email', node).text(person.getEmail());
-};
+}
 
-function unload () {
+function unload() {
   const provenance = new proto.ord.ReactionProvenance();
 
-  const experimenter =
-      unloadPerson($('#provenance_experimenter'));
+  const experimenter = unloadPerson($('#provenance_experimenter'));
   if (!ord.reaction.isEmptyMessage(experimenter)) {
     provenance.setExperimenter(experimenter);
   }
@@ -109,9 +113,9 @@ function unload () {
       });
   provenance.setRecordModifiedList(modifieds);
   return provenance;
-};
+}
 
-function unloadRecordEvent (node) {
+function unloadRecordEvent(node) {
   const created = new proto.ord.RecordEvent();
   const createdTime = new proto.ord.DateTime();
   createdTime.setValue($('.provenance_time', node).text());
@@ -125,9 +129,9 @@ function unloadRecordEvent (node) {
   const createdDetails = $('.provenance_details', node).text();
   created.setDetails(createdDetails);
   return created;
-};
+}
 
-function unloadPerson (node) {
+function unloadPerson(node) {
   const person = new proto.ord.Person();
   person.setUsername($('.provenance_username', node).text());
   person.setName($('.provenance_name', node).text());
@@ -135,17 +139,17 @@ function unloadPerson (node) {
   person.setOrganization($('.provenance_organization', node).text());
   person.setEmail($('.provenance_email', node).text());
   return person;
-};
+}
 
-function addModification () {
+function addModification() {
   return ord.reaction.addSlowly(
       '#provenance_modified_template', '#provenance_modifieds');
-};
+}
 
-function validateProvenance (node, validateNode) {
+function validateProvenance(node, validateNode) {
   const provenance = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(provenance, 'ReactionProvenance', validateNode);
-};
+}

--- a/editor/js/provenance.js
+++ b/editor/js/provenance.js
@@ -72,7 +72,7 @@ ord.provenance.unload = function() {
 
   const experimenter =
       ord.provenance.unloadPerson($('#provenance_experimenter'));
-  if (!isEmptyMessage(experimenter)) {
+  if (!ord.reaction.isEmptyMessage(experimenter)) {
     provenance.setExperimenter(experimenter);
   }
 
@@ -80,7 +80,7 @@ ord.provenance.unload = function() {
 
   const start = new proto.ord.DateTime();
   start.setValue($('#provenance_start').text());
-  if (!isEmptyMessage(start)) {
+  if (!ord.reaction.isEmptyMessage(start)) {
     provenance.setExperimentStart(start);
   }
 
@@ -89,7 +89,7 @@ ord.provenance.unload = function() {
   provenance.setPublicationUrl($('#provenance_url').text());
 
   const created = ord.provenance.unloadRecordEvent($('#provenance_created'));
-  if (!isEmptyMessage(created)) {
+  if (!ord.reaction.isEmptyMessage(created)) {
     provenance.setRecordCreated(created);
   }
 
@@ -100,7 +100,7 @@ ord.provenance.unload = function() {
         if (!node.attr('id')) {
           // Not a template.
           const modified = ord.provenance.unloadRecordEvent(node);
-          if (!isEmptyMessage(modified)) {
+          if (!ord.reaction.isEmptyMessage(modified)) {
             modifieds.push(modified);
           }
         }
@@ -113,11 +113,11 @@ ord.provenance.unloadRecordEvent = function(node) {
   const created = new proto.ord.RecordEvent();
   const createdTime = new proto.ord.DateTime();
   createdTime.setValue($('.provenance_time', node).text());
-  if (!isEmptyMessage(createdTime)) {
+  if (!ord.reaction.isEmptyMessage(createdTime)) {
     created.setTime(createdTime);
   }
   const createdPerson = ord.provenance.unloadPerson(node);
-  if (!isEmptyMessage(createdPerson)) {
+  if (!ord.reaction.isEmptyMessage(createdPerson)) {
     created.setPerson(createdPerson);
   }
   const createdDetails = $('.provenance_details', node).text();
@@ -136,7 +136,8 @@ ord.provenance.unloadPerson = function(node) {
 };
 
 ord.provenance.addModification = function() {
-  return addSlowly('#provenance_modified_template', '#provenance_modifieds');
+  return ord.reaction.addSlowly(
+      '#provenance_modified_template', '#provenance_modifieds');
 };
 
 ord.provenance.validateProvenance = function(node, validateNode) {
@@ -144,5 +145,5 @@ ord.provenance.validateProvenance = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(provenance, 'ReactionProvenance', validateNode);
+  ord.reaction.validate(provenance, 'ReactionProvenance', validateNode);
 };

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -57,6 +57,8 @@ const session = {
   dataset: null,
   index: null  // Ordinal position of the Reaction in its Dataset.
 };
+// Export session, because it's used by test.js.
+exports.session = session;
 
 async function init(fileName, index) {
   session.fileName = fileName;

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -27,6 +27,7 @@ exports = {
   addSlowly,
   addChangeHandler,
   validate,
+  toggleValidateMessage,
   compareDataset,
   unloadReaction,
   isEmptyMessage,

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -14,7 +14,30 @@
  * limitations under the License.
  */
 
-goog.provide('ord.reaction');
+goog.module('ord.reaction');
+goog.module.declareLegacyNamespace();
+exports = {
+  init,
+  commit,
+  downloadReaction,
+  validateReaction,
+  setTextFromFile,
+  removeSlowly,
+  collapseToggle,
+  addSlowly,
+  addChangeHandler,
+  validate,
+  compareDataset,
+  unloadReaction,
+  isEmptyMessage,
+  readMetric,
+  writeMetric,
+  setSelector,
+  getSelector,
+  getSelectorText,
+  setOptionalBool,
+  getOptionalBool
+};
 
 goog.require('ord.conditions');
 goog.require('ord.enums');
@@ -122,8 +145,8 @@ function validate(message, messageTypeString, validateNode) {
   xhr.responseType = 'json';
   xhr.onload = function() {
     const errors = xhr.response;
-    statusNode = $('.validate_status', validateNode);
-    messageNode = $('.validate_message', validateNode);
+    const statusNode = $('.validate_status', validateNode);
+    const messageNode = $('.validate_message', validateNode);
     statusNode.removeClass('fa-check');
     statusNode.removeClass('fa-exclamation-triangle');
     statusNode.css('backgroundColor', null);
@@ -134,9 +157,9 @@ function validate(message, messageTypeString, validateNode) {
       statusNode.text(' ' + errors.length);
 
       messageNode.empty();
-      for (index = 0; index < errors.length; index++) {
-        error = errors[index];
-        errorNode = $('<div></div>');
+      for (let index = 0; index < errors.length; index++) {
+        const error = errors[index];
+        const errorNode = $('<div></div>');
         errorNode.text('\u2022 ' + error);
         messageNode.append(errorNode);
       }
@@ -179,7 +202,7 @@ function renderReaction(reaction) {
 }
 
 function validateReaction() {
-  var validateNode = $('#reaction_validate');
+  const validateNode = $('#reaction_validate');
   const reaction = unloadReaction();
   validate(reaction, 'Reaction', validateNode);
   // Trigger all submessages to validate.
@@ -358,7 +381,7 @@ function isEmptyMessage(obj) {
   if ([null, undefined, ''].includes(obj)) {
     return true;
   }
-  array = obj.array;
+  const array = obj.array;
   if (array !== undefined) {
     // message is a protobuf message, test underlying array
     return isEmptyMessage(array);
@@ -566,7 +589,7 @@ function getOptionalBool(node) {
 function initCollapse(node) {
   node.addClass('fa');
   node.addClass('fa-chevron-down');
-  node.attr('onclick', 'collapseToggle(this)');
+  node.attr('onclick', 'ord.reaction.collapseToggle(this)');
   if (node.hasClass('starts_collapsed')) {
     node.trigger('click');
   }

--- a/editor/js/setups.js
+++ b/editor/js/setups.js
@@ -27,13 +27,13 @@ ord.setups.load = function(setup) {
     ord.setups.loadVessel(vessel);
   }
   const isAutomated = setup.hasIsAutomated() ? setup.getIsAutomated() : null;
-  setOptionalBool($('#setup_automated'), isAutomated);
+  ord.reaction.setOptionalBool($('#setup_automated'), isAutomated);
   if (isAutomated) {
     $('#automation_platform').show();
   }
 
   $('#setup_automated').change(function() {
-    if (getSelectorText(this) == 'TRUE') {
+    if (ord.reaction.getSelectorText(this) == 'TRUE') {
       $('#automation_platform').show();
     } else {
       $('#automation_platform').hide();
@@ -48,7 +48,8 @@ ord.setups.load = function(setup) {
 
   const environment = setup.getEnvironment();
   if (environment != null) {
-    setSelector($('#setup_environment_type'), environment.getType());
+    ord.reaction.setSelector(
+        $('#setup_environment_type'), environment.getType());
     $('#setup_environment_details').text(environment.getDetails());
   }
 };
@@ -56,30 +57,31 @@ ord.setups.load = function(setup) {
 ord.setups.loadVessel = function(vessel) {
   const type = vessel.getType();
   if (type) {
-    setSelector($('#setup_vessel_type'), type.getType());
+    ord.reaction.setSelector($('#setup_vessel_type'), type.getType());
     $('#setup_vessel_details').text(type.getDetails());
   }
   const material = vessel.getMaterial();
   if (material) {
-    setSelector($('#setup_vessel_material'), material.getType());
+    ord.reaction.setSelector($('#setup_vessel_material'), material.getType());
     $('#setup_vessel_material_details').text(material.getDetails());
   }
   const preparations = vessel.getPreparationsList();
   preparations.forEach(preparation => {
     const node = ord.setups.addVesselPreparation();
-    setSelector(
+    ord.reaction.setSelector(
         $('.setup_vessel_preparation_type', node), preparation.getType());
     $('.setup_vessel_preparation_details', node).text(preparation.getDetails());
   });
   const attachments = vessel.getAttachmentsList();
   attachments.forEach(attachment => {
     const node = ord.setups.addVesselAttachment();
-    setSelector($('.setup_vessel_attachment_type', node), attachment.getType());
+    ord.reaction.setSelector(
+        $('.setup_vessel_attachment_type', node), attachment.getType());
     $('.setup_vessel_attachment_details', node).text(attachment.getDetails());
   });
   if (vessel.hasVolume()) {
     const volume = vessel.getVolume();
-    writeMetric('#setup_vessel_volume', volume);
+    ord.reaction.writeMetric('#setup_vessel_volume', volume);
   }
 };
 
@@ -87,11 +89,11 @@ ord.setups.unload = function() {
   const setup = new proto.ord.ReactionSetup();
 
   const vessel = ord.setups.unloadVessel();
-  if (!isEmptyMessage(vessel)) {
+  if (!ord.reaction.isEmptyMessage(vessel)) {
     setup.setVessel(vessel);
   }
 
-  const isAutomated = getOptionalBool($('#setup_automated'));
+  const isAutomated = ord.reaction.getOptionalBool($('#setup_automated'));
   setup.setIsAutomated(isAutomated);
 
   const platform = $('#setup_platform').text();
@@ -101,9 +103,9 @@ ord.setups.unload = function() {
   ord.codes.unload(codes);
 
   const environment = new proto.ord.ReactionSetup.ReactionEnvironment();
-  environment.setType(getSelector($('#setup_environment_type')));
+  environment.setType(ord.reaction.getSelector($('#setup_environment_type')));
   environment.setDetails($('#setup_environment_details').text());
-  if (!isEmptyMessage(environment)) {
+  if (!ord.reaction.isEmptyMessage(environment)) {
     setup.setEnvironment(environment);
   }
 
@@ -114,16 +116,16 @@ ord.setups.unloadVessel = function() {
   const vessel = new proto.ord.Vessel();
 
   type = new proto.ord.VesselType();
-  type.setType(getSelector($('#setup_vessel_type')));
+  type.setType(ord.reaction.getSelector($('#setup_vessel_type')));
   type.setDetails($('#setup_vessel_details').text());
-  if (!isEmptyMessage(type)) {
+  if (!ord.reaction.isEmptyMessage(type)) {
     vessel.setType(type);
   }
 
   const material = new proto.ord.VesselMaterial();
-  material.setType(getSelector('#setup_vessel_material'));
+  material.setType(ord.reaction.getSelector('#setup_vessel_material'));
   material.setDetails($('#setup_vessel_material_details').text());
-  if (!isEmptyMessage(material)) {
+  if (!ord.reaction.isEmptyMessage(material)) {
     vessel.setMaterial(material);
   }
 
@@ -135,9 +137,10 @@ ord.setups.unloadVessel = function() {
       return;
     }
     const preparation = new proto.ord.VesselPreparation();
-    preparation.setType(getSelector($('.setup_vessel_preparation_type', node)));
+    preparation.setType(
+        ord.reaction.getSelector($('.setup_vessel_preparation_type', node)));
     preparation.setDetails($('.setup_vessel_preparation_details', node).text());
-    if (!isEmptyMessage(preparation)) {
+    if (!ord.reaction.isEmptyMessage(preparation)) {
       preparations.push(preparation);
     }
   });
@@ -151,16 +154,18 @@ ord.setups.unloadVessel = function() {
       return;
     }
     const attachment = new proto.ord.VesselAttachment();
-    attachment.setType(getSelector($('.setup_vessel_attachment_type', node)));
+    attachment.setType(
+        ord.reaction.getSelector($('.setup_vessel_attachment_type', node)));
     attachment.setDetails($('.setup_vessel_attachment_details', node).text());
-    if (!isEmptyMessage(attachment)) {
+    if (!ord.reaction.isEmptyMessage(attachment)) {
       attachments.push(attachment);
     }
   });
   vessel.setAttachmentsList(attachments);
 
-  const volume = readMetric('#setup_vessel_volume', new proto.ord.Volume());
-  if (!isEmptyMessage(volume)) {
+  const volume =
+      ord.reaction.readMetric('#setup_vessel_volume', new proto.ord.Volume());
+  if (!ord.reaction.isEmptyMessage(volume)) {
     vessel.setVolume(volume);
   }
 
@@ -168,12 +173,12 @@ ord.setups.unloadVessel = function() {
 };
 
 ord.setups.addVesselPreparation = function() {
-  return addSlowly(
+  return ord.reaction.addSlowly(
       '#setup_vessel_preparation_template', '#setup_vessel_preparations');
 };
 
 ord.setups.addVesselAttachment = function() {
-  return addSlowly(
+  return ord.reaction.addSlowly(
       '#setup_vessel_attachment_template', '#setup_vessel_attachments');
 };
 
@@ -182,5 +187,5 @@ ord.setups.validateSetup = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(setup, 'ReactionSetup', validateNode);
+  ord.reaction.validate(setup, 'ReactionSetup', validateNode);
 };

--- a/editor/js/setups.js
+++ b/editor/js/setups.js
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-goog.provide('ord.setups');
+goog.module('ord.setups');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, addVesselPreparation, validateSetup};
 
 goog.require('ord.codes');
 goog.require('proto.ord.ReactionSetup');
 goog.require('proto.ord.Vessel');
 goog.require('proto.ord.Volume');
 
-ord.setups.load = function(setup) {
+function load (setup) {
   const vessel = setup.getVessel();
   if (vessel) {
-    ord.setups.loadVessel(vessel);
+    loadVessel(vessel);
   }
   const isAutomated = setup.hasIsAutomated() ? setup.getIsAutomated() : null;
   ord.reaction.setOptionalBool($('#setup_automated'), isAutomated);
@@ -54,7 +56,7 @@ ord.setups.load = function(setup) {
   }
 };
 
-ord.setups.loadVessel = function(vessel) {
+function loadVessel (vessel) {
   const type = vessel.getType();
   if (type) {
     ord.reaction.setSelector($('#setup_vessel_type'), type.getType());
@@ -67,14 +69,14 @@ ord.setups.loadVessel = function(vessel) {
   }
   const preparations = vessel.getPreparationsList();
   preparations.forEach(preparation => {
-    const node = ord.setups.addVesselPreparation();
+    const node = addVesselPreparation();
     ord.reaction.setSelector(
         $('.setup_vessel_preparation_type', node), preparation.getType());
     $('.setup_vessel_preparation_details', node).text(preparation.getDetails());
   });
   const attachments = vessel.getAttachmentsList();
   attachments.forEach(attachment => {
-    const node = ord.setups.addVesselAttachment();
+    const node = addVesselAttachment();
     ord.reaction.setSelector(
         $('.setup_vessel_attachment_type', node), attachment.getType());
     $('.setup_vessel_attachment_details', node).text(attachment.getDetails());
@@ -85,10 +87,10 @@ ord.setups.loadVessel = function(vessel) {
   }
 };
 
-ord.setups.unload = function() {
+function unload () {
   const setup = new proto.ord.ReactionSetup();
 
-  const vessel = ord.setups.unloadVessel();
+  const vessel = unloadVessel();
   if (!ord.reaction.isEmptyMessage(vessel)) {
     setup.setVessel(vessel);
   }
@@ -112,10 +114,10 @@ ord.setups.unload = function() {
   return setup;
 };
 
-ord.setups.unloadVessel = function() {
+function unloadVessel () {
   const vessel = new proto.ord.Vessel();
 
-  type = new proto.ord.VesselType();
+  const type = new proto.ord.VesselType();
   type.setType(ord.reaction.getSelector($('#setup_vessel_type')));
   type.setDetails($('#setup_vessel_details').text());
   if (!ord.reaction.isEmptyMessage(type)) {
@@ -172,18 +174,18 @@ ord.setups.unloadVessel = function() {
   return vessel;
 };
 
-ord.setups.addVesselPreparation = function() {
+function addVesselPreparation () {
   return ord.reaction.addSlowly(
       '#setup_vessel_preparation_template', '#setup_vessel_preparations');
 };
 
-ord.setups.addVesselAttachment = function() {
+function addVesselAttachment () {
   return ord.reaction.addSlowly(
       '#setup_vessel_attachment_template', '#setup_vessel_attachments');
 };
 
-ord.setups.validateSetup = function(node, validateNode) {
-  const setup = ord.setups.unload();
+function validateSetup (node, validateNode) {
+  const setup = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/setups.js
+++ b/editor/js/setups.js
@@ -16,14 +16,19 @@
 
 goog.module('ord.setups');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, addVesselPreparation, validateSetup};
+exports = {
+  load,
+  unload,
+  addVesselPreparation,
+  validateSetup
+};
 
 goog.require('ord.codes');
 goog.require('proto.ord.ReactionSetup');
 goog.require('proto.ord.Vessel');
 goog.require('proto.ord.Volume');
 
-function load (setup) {
+function load(setup) {
   const vessel = setup.getVessel();
   if (vessel) {
     loadVessel(vessel);
@@ -54,9 +59,9 @@ function load (setup) {
         $('#setup_environment_type'), environment.getType());
     $('#setup_environment_details').text(environment.getDetails());
   }
-};
+}
 
-function loadVessel (vessel) {
+function loadVessel(vessel) {
   const type = vessel.getType();
   if (type) {
     ord.reaction.setSelector($('#setup_vessel_type'), type.getType());
@@ -85,9 +90,9 @@ function loadVessel (vessel) {
     const volume = vessel.getVolume();
     ord.reaction.writeMetric('#setup_vessel_volume', volume);
   }
-};
+}
 
-function unload () {
+function unload() {
   const setup = new proto.ord.ReactionSetup();
 
   const vessel = unloadVessel();
@@ -112,9 +117,9 @@ function unload () {
   }
 
   return setup;
-};
+}
 
-function unloadVessel () {
+function unloadVessel() {
   const vessel = new proto.ord.Vessel();
 
   const type = new proto.ord.VesselType();
@@ -172,22 +177,22 @@ function unloadVessel () {
   }
 
   return vessel;
-};
+}
 
-function addVesselPreparation () {
+function addVesselPreparation() {
   return ord.reaction.addSlowly(
       '#setup_vessel_preparation_template', '#setup_vessel_preparations');
-};
+}
 
-function addVesselAttachment () {
+function addVesselAttachment() {
   return ord.reaction.addSlowly(
       '#setup_vessel_attachment_template', '#setup_vessel_attachments');
-};
+}
 
-function validateSetup (node, validateNode) {
+function validateSetup(node, validateNode) {
   const setup = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(setup, 'ReactionSetup', validateNode);
-};
+}

--- a/editor/js/stirring.js
+++ b/editor/js/stirring.js
@@ -21,12 +21,12 @@ goog.require('proto.ord.StirringConditions');
 ord.stirring.load = function(stirring) {
   const method = stirring.getMethod();
   if (method) {
-    setSelector($('#stirring_method_type'), method.getType());
+    ord.reaction.setSelector($('#stirring_method_type'), method.getType());
     $('#stirring_method_details').text(method.getDetails());
   }
   const rate = stirring.getRate();
   if (rate) {
-    setSelector($('#stirring_rate_type'), rate.getType());
+    ord.reaction.setSelector($('#stirring_rate_type'), rate.getType());
     $('#stirring_rate_details').text(rate.getDetails());
     const rpm = rate.getRpm();
     if (rpm != 0) {
@@ -39,20 +39,20 @@ ord.stirring.unload = function() {
   const stirring = new proto.ord.StirringConditions();
 
   const method = new proto.ord.StirringConditions.StirringMethod();
-  method.setType(getSelector($('#stirring_method_type')));
+  method.setType(ord.reaction.getSelector($('#stirring_method_type')));
   method.setDetails($('#stirring_method_details').text());
-  if (!isEmptyMessage(method)) {
+  if (!ord.reaction.isEmptyMessage(method)) {
     stirring.setMethod(method);
   }
 
   const rate = new proto.ord.StirringConditions.StirringRate();
-  rate.setType(getSelector($('#stirring_rate_type')));
+  rate.setType(ord.reaction.getSelector($('#stirring_rate_type')));
   rate.setDetails($('#stirring_rate_details').text());
   const rpm = parseFloat($('#stirring_rpm').text());
   if (!isNaN(rpm)) {
     rate.setRpm(rpm);
   }
-  if (!isEmptyMessage(rate)) {
+  if (!ord.reaction.isEmptyMessage(rate)) {
     stirring.setRate(rate);
   }
   return stirring;
@@ -63,5 +63,5 @@ ord.stirring.validateStirring = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(stirring, 'StirringConditions', validateNode);
+  ord.reaction.validate(stirring, 'StirringConditions', validateNode);
 };

--- a/editor/js/stirring.js
+++ b/editor/js/stirring.js
@@ -16,11 +16,15 @@
 
 goog.module('ord.stirring');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, validateStirring};
+exports = {
+  load,
+  unload,
+  validateStirring
+};
 
 goog.require('proto.ord.StirringConditions');
 
-function load (stirring) {
+function load(stirring) {
   const method = stirring.getMethod();
   if (method) {
     ord.reaction.setSelector($('#stirring_method_type'), method.getType());
@@ -35,9 +39,9 @@ function load (stirring) {
       $('#stirring_rpm').text(rpm);
     }
   }
-};
+}
 
-function unload () {
+function unload() {
   const stirring = new proto.ord.StirringConditions();
 
   const method = new proto.ord.StirringConditions.StirringMethod();
@@ -58,12 +62,12 @@ function unload () {
     stirring.setRate(rate);
   }
   return stirring;
-};
+}
 
-function validateStirring (node, validateNode) {
+function validateStirring(node, validateNode) {
   const stirring = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(stirring, 'StirringConditions', validateNode);
-};
+}

--- a/editor/js/stirring.js
+++ b/editor/js/stirring.js
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
-goog.provide('ord.stirring');
+goog.module('ord.stirring');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, validateStirring};
 
 goog.require('proto.ord.StirringConditions');
 
-ord.stirring.load = function(stirring) {
+function load (stirring) {
   const method = stirring.getMethod();
   if (method) {
     ord.reaction.setSelector($('#stirring_method_type'), method.getType());
@@ -35,7 +37,7 @@ ord.stirring.load = function(stirring) {
   }
 };
 
-ord.stirring.unload = function() {
+function unload () {
   const stirring = new proto.ord.StirringConditions();
 
   const method = new proto.ord.StirringConditions.StirringMethod();
@@ -58,8 +60,8 @@ ord.stirring.unload = function() {
   return stirring;
 };
 
-ord.stirring.validateStirring = function(node, validateNode) {
-  const stirring = ord.stirring.unload();
+function validateStirring (node, validateNode) {
+  const stirring = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/temperature.js
+++ b/editor/js/temperature.js
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-goog.provide('ord.temperature');
+goog.module('ord.temperature');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, addMeasurement, validateTemperature};
 
 goog.require('proto.ord.Temperature');
 goog.require('proto.ord.TemperatureConditions');
@@ -22,7 +24,7 @@ goog.require('proto.ord.TemperatureConditions.Measurement');
 goog.require('proto.ord.TemperatureConditions.TemperatureControl');
 goog.require('proto.ord.Time');
 
-ord.temperature.load = function(temperature) {
+function load (temperature) {
   const control = temperature.getControl();
   if (control) {
     ord.reaction.setSelector($('#temperature_control'), control.getType());
@@ -30,14 +32,14 @@ ord.temperature.load = function(temperature) {
   }
   const measurements = temperature.getMeasurementsList();
   measurements.forEach(function(measurement) {
-    const node = ord.temperature.addMeasurement();
-    ord.temperature.loadMeasurement(measurement, node);
+    const node = addMeasurement();
+    loadMeasurement(measurement, node);
   });
   const setpoint = temperature.getSetpoint();
   ord.reaction.writeMetric('#temperature_setpoint', setpoint);
 };
 
-ord.temperature.loadMeasurement = function(measurement, node) {
+function loadMeasurement (measurement, node) {
   const type = measurement.getType();
   ord.reaction.setSelector($('.temperature_measurement_type', node), type);
   $('.temperature_measurement_details', node).text(measurement.getDetails());
@@ -50,7 +52,7 @@ ord.temperature.loadMeasurement = function(measurement, node) {
   ord.reaction.writeMetric('.temperature_measurement_time', time, node);
 };
 
-ord.temperature.unload = function() {
+function unload () {
   const temperature = new proto.ord.TemperatureConditions();
 
   const control = new proto.ord.TemperatureConditions.TemperatureControl();
@@ -70,7 +72,7 @@ ord.temperature.unload = function() {
   $('.temperature_measurement').each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
-      const measurement = ord.temperature.unloadMeasurement(node);
+      const measurement = unloadMeasurement(node);
       if (!ord.reaction.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
@@ -80,7 +82,7 @@ ord.temperature.unload = function() {
   return temperature;
 };
 
-ord.temperature.unloadMeasurement = function(node) {
+function unloadMeasurement (node) {
   const measurement = new proto.ord.TemperatureConditions.Measurement();
   const type =
       ord.reaction.getSelector($('.temperature_measurement_type', node));
@@ -101,13 +103,13 @@ ord.temperature.unloadMeasurement = function(node) {
   return measurement;
 };
 
-ord.temperature.addMeasurement = function() {
+function addMeasurement () {
   return ord.reaction.addSlowly(
       '#temperature_measurement_template', '#temperature_measurements');
 };
 
-ord.temperature.validateTemperature = function(node, validateNode) {
-  const temperature = ord.temperature.unload();
+function validateTemperature (node, validateNode) {
+  const temperature = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }

--- a/editor/js/temperature.js
+++ b/editor/js/temperature.js
@@ -16,7 +16,12 @@
 
 goog.module('ord.temperature');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, addMeasurement, validateTemperature};
+exports = {
+  load,
+  unload,
+  addMeasurement,
+  validateTemperature
+};
 
 goog.require('proto.ord.Temperature');
 goog.require('proto.ord.TemperatureConditions');
@@ -24,7 +29,7 @@ goog.require('proto.ord.TemperatureConditions.Measurement');
 goog.require('proto.ord.TemperatureConditions.TemperatureControl');
 goog.require('proto.ord.Time');
 
-function load (temperature) {
+function load(temperature) {
   const control = temperature.getControl();
   if (control) {
     ord.reaction.setSelector($('#temperature_control'), control.getType());
@@ -37,9 +42,9 @@ function load (temperature) {
   });
   const setpoint = temperature.getSetpoint();
   ord.reaction.writeMetric('#temperature_setpoint', setpoint);
-};
+}
 
-function loadMeasurement (measurement, node) {
+function loadMeasurement(measurement, node) {
   const type = measurement.getType();
   ord.reaction.setSelector($('.temperature_measurement_type', node), type);
   $('.temperature_measurement_details', node).text(measurement.getDetails());
@@ -50,9 +55,9 @@ function loadMeasurement (measurement, node) {
 
   const time = measurement.getTime();
   ord.reaction.writeMetric('.temperature_measurement_time', time, node);
-};
+}
 
-function unload () {
+function unload() {
   const temperature = new proto.ord.TemperatureConditions();
 
   const control = new proto.ord.TemperatureConditions.TemperatureControl();
@@ -80,9 +85,9 @@ function unload () {
   });
   temperature.setMeasurementsList(measurements);
   return temperature;
-};
+}
 
-function unloadMeasurement (node) {
+function unloadMeasurement(node) {
   const measurement = new proto.ord.TemperatureConditions.Measurement();
   const type =
       ord.reaction.getSelector($('.temperature_measurement_type', node));
@@ -101,17 +106,17 @@ function unloadMeasurement (node) {
     measurement.setTime(time);
   }
   return measurement;
-};
+}
 
-function addMeasurement () {
+function addMeasurement() {
   return ord.reaction.addSlowly(
       '#temperature_measurement_template', '#temperature_measurements');
-};
+}
 
-function validateTemperature (node, validateNode) {
+function validateTemperature(node, validateNode) {
   const temperature = unload();
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(temperature, 'TemperatureConditions', validateNode);
-};
+}

--- a/editor/js/temperature.js
+++ b/editor/js/temperature.js
@@ -25,7 +25,7 @@ goog.require('proto.ord.Time');
 ord.temperature.load = function(temperature) {
   const control = temperature.getControl();
   if (control) {
-    setSelector($('#temperature_control'), control.getType());
+    ord.reaction.setSelector($('#temperature_control'), control.getType());
     $('#temperature_control_details').text(control.getDetails());
   }
   const measurements = temperature.getMeasurementsList();
@@ -34,34 +34,35 @@ ord.temperature.load = function(temperature) {
     ord.temperature.loadMeasurement(measurement, node);
   });
   const setpoint = temperature.getSetpoint();
-  writeMetric('#temperature_setpoint', setpoint);
+  ord.reaction.writeMetric('#temperature_setpoint', setpoint);
 };
 
 ord.temperature.loadMeasurement = function(measurement, node) {
   const type = measurement.getType();
-  setSelector($('.temperature_measurement_type', node), type);
+  ord.reaction.setSelector($('.temperature_measurement_type', node), type);
   $('.temperature_measurement_details', node).text(measurement.getDetails());
 
   const temperature = measurement.getTemperature();
-  writeMetric('.temperature_measurement_temperature', temperature, node);
+  ord.reaction.writeMetric(
+      '.temperature_measurement_temperature', temperature, node);
 
   const time = measurement.getTime();
-  writeMetric('.temperature_measurement_time', time, node);
+  ord.reaction.writeMetric('.temperature_measurement_time', time, node);
 };
 
 ord.temperature.unload = function() {
   const temperature = new proto.ord.TemperatureConditions();
 
   const control = new proto.ord.TemperatureConditions.TemperatureControl();
-  control.setType(getSelector($('#temperature_control')));
+  control.setType(ord.reaction.getSelector($('#temperature_control')));
   control.setDetails($('#temperature_control_details').text());
-  if (!isEmptyMessage(control)) {
+  if (!ord.reaction.isEmptyMessage(control)) {
     temperature.setControl(control);
   }
 
-  const setpoint =
-      readMetric('#temperature_setpoint', new proto.ord.Temperature());
-  if (!isEmptyMessage(setpoint)) {
+  const setpoint = ord.reaction.readMetric(
+      '#temperature_setpoint', new proto.ord.Temperature());
+  if (!ord.reaction.isEmptyMessage(setpoint)) {
     temperature.setSetpoint(setpoint);
   }
 
@@ -70,7 +71,7 @@ ord.temperature.unload = function() {
     node = $(node);
     if (!node.attr('id')) {
       const measurement = ord.temperature.unloadMeasurement(node);
-      if (!isEmptyMessage(measurement)) {
+      if (!ord.reaction.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
     }
@@ -81,26 +82,27 @@ ord.temperature.unload = function() {
 
 ord.temperature.unloadMeasurement = function(node) {
   const measurement = new proto.ord.TemperatureConditions.Measurement();
-  const type = getSelector($('.temperature_measurement_type', node));
+  const type =
+      ord.reaction.getSelector($('.temperature_measurement_type', node));
   measurement.setType(type);
   const details = $('.temperature_measurement_details', node).text();
   measurement.setDetails(details);
-  const temperature = readMetric(
+  const temperature = ord.reaction.readMetric(
       '.temperature_measurement_temperature', new proto.ord.Temperature(),
       node);
-  if (!isEmptyMessage(temperature)) {
+  if (!ord.reaction.isEmptyMessage(temperature)) {
     measurement.setTemperature(temperature);
   }
-  const time =
-      readMetric('.temperature_measurement_time', new proto.ord.Time(), node);
-  if (!isEmptyMessage(time)) {
+  const time = ord.reaction.readMetric(
+      '.temperature_measurement_time', new proto.ord.Time(), node);
+  if (!ord.reaction.isEmptyMessage(time)) {
     measurement.setTime(time);
   }
   return measurement;
 };
 
 ord.temperature.addMeasurement = function() {
-  return addSlowly(
+  return ord.reaction.addSlowly(
       '#temperature_measurement_template', '#temperature_measurements');
 };
 
@@ -109,5 +111,5 @@ ord.temperature.validateTemperature = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(temperature, 'TemperatureConditions', validateNode);
+  ord.reaction.validate(temperature, 'TemperatureConditions', validateNode);
 };

--- a/editor/js/test.js
+++ b/editor/js/test.js
@@ -41,6 +41,7 @@ const puppeteer = require('puppeteer');
     await page.waitFor('body[ready=true]');
     const test = page.evaluate(async function(url) {
       const reaction = ord.reaction.unloadReaction();
+      const session = ord.reaction.session;
       const reactions = session.dataset.getReactionsList();
       reactions[session.index] = reaction;
       return await ord.reaction

--- a/editor/js/test.js
+++ b/editor/js/test.js
@@ -40,10 +40,11 @@ const puppeteer = require('puppeteer');
     await page.goto(url);
     await page.waitFor('body[ready=true]');
     const test = page.evaluate(async function(url) {
-      const reaction = unloadReaction();
+      const reaction = ord.reaction.unloadReaction();
       const reactions = session.dataset.getReactionsList();
       reactions[session.index] = reaction;
-      return await compareDataset(session.fileName, session.dataset)
+      return await ord.reaction
+          .compareDataset(session.fileName, session.dataset)
           .then(() => {
             console.log('PASS', url);
             return 0;

--- a/editor/js/uploads.js
+++ b/editor/js/uploads.js
@@ -16,7 +16,13 @@
 
 goog.module('ord.uploads');
 goog.module.declareLegacyNamespace();
-exports = {putAll, retrieve, initialize, load, unload};
+exports = {
+  putAll,
+  retrieve,
+  initialize,
+  load,
+  unload
+};
 
 // Map token strings to byte arrays to round-trip uploaded byte_values.
 let tokenBytes = {};
@@ -25,36 +31,36 @@ let tokenBytes = {};
 let tokenFiles = {};
 
 // Return a short random string of ASCII characters.
-function newToken () {
+function newToken() {
   return 'upload_' + Math.random().toString(36).substring(2);
-};
+}
 
 // Tag this file for upload and return a random token to access it later.
-function newFile (file) {
+function newFile(file) {
   const token = newToken();
   tokenFiles[token] = file;
   return token;
-};
+}
 
 // Get back a file that was previously recorded at newFile().
-function getFile (token) {
+function getFile(token) {
   return tokenFiles[token];
-};
+}
 
 // Remember bytes at load() so they can be restored at unload().
-function stashUpload (bytesValue) {
+function stashUpload(bytesValue) {
   const token = newToken();
   tokenBytes[token] = bytesValue;
   return token;
-};
+}
 
 // At unload, recall bytes that were stashed at load().
-function unstashUpload (token) {
+function unstashUpload(token) {
   return tokenBytes[token];
-};
+}
 
 // Sends all files referenced in tokenFiles to the server.
-function putAll (fileName) {
+function putAll(fileName) {
   const tokens = Object.getOwnPropertyNames(tokenFiles);
   tokens.forEach(token => {
     const file = tokenFiles[token];
@@ -67,10 +73,10 @@ function putAll (fileName) {
       xhr.send(payload);
     };
   });
-};
+}
 
 // Look up the bytesValue of the given uploader and send back it as a download.
-function retrieve (uploader) {
+function retrieve(uploader) {
   const token = uploader.attr('data-token');
   const xhr = new XMLHttpRequest();
   xhr.open('POST', '/dataset/proto/download/' + token);
@@ -85,10 +91,10 @@ function retrieve (uploader) {
   };
   const bytesValue = tokenBytes[token];
   xhr.send(bytesValue);
-};
+}
 
 // Configure behaviors of a ".uploader" DOM element.
-function initialize (node) {
+function initialize(node) {
   $('.uploader_chooser_file', node).on('input', (event) => {
     const file = event.target.files[0];
     $('.uploader_file_name', node).show();
@@ -97,18 +103,18 @@ function initialize (node) {
     $('.uploader', node).attr('data-token', token);
     $('.uploader_file_retrieve', node).hide();
   });
-};
+}
 
-function load (node, bytesValue) {
+function load(node, bytesValue) {
   const token = stashUpload(bytesValue);
   $('.uploader', node).show();
   $('.uploader', node).attr('data-token', token);
   $('.uploader_chooser_button', node).text('Replace...');
   $('.uploader_file_name', node).hide();
   $('.uploader_file_retrieve', node).show();
-};
+}
 
-function unload (node) {
+function unload(node) {
   const token = $('.uploader', node).attr('data-token');
   const bytesValue = unstashUpload(token);
   if (bytesValue) {
@@ -119,4 +125,4 @@ function unload (node) {
     const bytes = (new TextEncoder()).encode(token);
     return bytes;
   }
-};
+}

--- a/editor/js/workups.js
+++ b/editor/js/workups.js
@@ -16,16 +16,22 @@
 
 goog.module('ord.workups');
 goog.module.declareLegacyNamespace();
-exports = {load, unload, add, addMeasurement, validateWorkup};
+exports = {
+  load,
+  unload,
+  add,
+  addMeasurement,
+  validateWorkup
+};
 
 goog.require('ord.inputs');
 goog.require('proto.ord.ReactionWorkup');
 
-function load (workups) {
+function load(workups) {
   workups.forEach(workup => loadWorkup(workup));
-};
+}
 
-function loadWorkup (workup) {
+function loadWorkup(workup) {
   const node = add();
   ord.reaction.setSelector($('.workup_type', node), workup.getType());
   $('.workup_details', node).text(workup.getDetails());
@@ -83,9 +89,9 @@ function loadWorkup (workup) {
   ord.reaction.setOptionalBool(
       $('.workup_automated', node),
       workup.hasIsAutomated() ? workup.getIsAutomated() : null);
-};
+}
 
-function loadMeasurement (workupNode, measurement) {
+function loadMeasurement(workupNode, measurement) {
   const node = addMeasurement(workupNode);
   ord.reaction.setSelector(
       $('.workup_temperature_measurement_type', node), measurement.getType());
@@ -101,9 +107,9 @@ function loadMeasurement (workupNode, measurement) {
     ord.reaction.writeMetric(
         '.workup_temperature_measurement_temperature', temperature, node);
   }
-};
+}
 
-function unload () {
+function unload() {
   const workups = [];
   $('.workup').each(function(index, node) {
     node = $(node);
@@ -115,9 +121,9 @@ function unload () {
     }
   });
   return workups;
-};
+}
 
-function unloadWorkup (node) {
+function unloadWorkup(node) {
   const workup = new proto.ord.ReactionWorkup();
 
   workup.setType(ord.reaction.getSelector($('.workup_type', node)));
@@ -202,9 +208,9 @@ function unloadWorkup (node) {
   workup.setIsAutomated(
       ord.reaction.getOptionalBool($('.workup_automated', node)));
   return workup;
-};
+}
 
-function unloadMeasurement (node) {
+function unloadMeasurement(node) {
   const measurement = new proto.ord.TemperatureConditions.Measurement();
   measurement.setType(ord.reaction.getSelector(
       $('.workup_temperature_measurement_type', node)));
@@ -222,9 +228,9 @@ function unloadMeasurement (node) {
     measurement.setTemperature(temperature);
   }
   return measurement;
-};
+}
 
-function add () {
+function add() {
   const workupNode = ord.reaction.addSlowly('#workup_template', '#workups');
   const inputNode = $('.workup_input', workupNode);
   // The template for ReactionWorkup.input is taken from Reaction.inputs.
@@ -247,18 +253,18 @@ function add () {
   });
 
   return workupNode;
-};
+}
 
-function addMeasurement (node) {
+function addMeasurement(node) {
   return ord.reaction.addSlowly(
       '#workup_temperature_measurement_template',
       $('.workup_temperature_measurements', node));
-};
+}
 
-function validateWorkup (node, validateNode) {
+function validateWorkup(node, validateNode) {
   const workup = unloadWorkup(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
   ord.reaction.validate(workup, 'ReactionWorkup', validateNode);
-};
+}

--- a/editor/js/workups.js
+++ b/editor/js/workups.js
@@ -25,11 +25,11 @@ ord.workups.load = function(workups) {
 
 ord.workups.loadWorkup = function(workup) {
   const node = ord.workups.add();
-  setSelector($('.workup_type', node), workup.getType());
+  ord.reaction.setSelector($('.workup_type', node), workup.getType());
   $('.workup_details', node).text(workup.getDetails());
   const duration = workup.getDuration();
   if (duration) {
-    writeMetric('.workup_duration', duration, node);
+    ord.reaction.writeMetric('.workup_duration', duration, node);
   }
 
   const input = workup.getInput();
@@ -41,13 +41,13 @@ ord.workups.loadWorkup = function(workup) {
   if (temperature) {
     const control = temperature.getControl();
     if (control) {
-      setSelector(
+      ord.reaction.setSelector(
           $('.workup_temperature_control_type', node), control.getType());
       $('.workup_temperature_details', node).text(control.getDetails());
     }
     const setpoint = temperature.getSetpoint();
     if (setpoint) {
-      writeMetric('.workup_temperature_setpoint', setpoint, node);
+      ord.reaction.writeMetric('.workup_temperature_setpoint', setpoint, node);
     }
 
     temperature.getMeasurementsList().forEach(
@@ -60,12 +60,14 @@ ord.workups.loadWorkup = function(workup) {
   if (stirring) {
     const method = stirring.getMethod();
     if (method) {
-      setSelector($('.workup_stirring_method_type', node), method.getType());
+      ord.reaction.setSelector(
+          $('.workup_stirring_method_type', node), method.getType());
       $('.workup_stirring_method_details', node).text(method.getDetails());
     }
     const rate = stirring.getRate();
     if (rate) {
-      setSelector($('.workup_stirring_rate_type', node), rate.getType());
+      ord.reaction.setSelector(
+          $('.workup_stirring_rate_type', node), rate.getType());
       $('.workup_stirring_rate_details', node).text(rate.getDetails());
       const rpm = rate.getRpm();
       if (rpm != 0) {
@@ -76,24 +78,25 @@ ord.workups.loadWorkup = function(workup) {
   if (workup.hasTargetPh()) {
     $('.workup_target_ph', node).text(workup.getTargetPh());
   }
-  setOptionalBool(
+  ord.reaction.setOptionalBool(
       $('.workup_automated', node),
       workup.hasIsAutomated() ? workup.getIsAutomated() : null);
 };
 
 ord.workups.loadMeasurement = function(workupNode, measurement) {
   const node = ord.workups.addMeasurement(workupNode);
-  setSelector(
+  ord.reaction.setSelector(
       $('.workup_temperature_measurement_type', node), measurement.getType());
   $('.workup_temperature_measurement_details', node)
       .text(measurement.getDetails());
   const time = measurement.getTime();
   if (time) {
-    writeMetric('.workup_temperature_measurement_time', time, node);
+    ord.reaction.writeMetric(
+        '.workup_temperature_measurement_time', time, node);
   }
   const temperature = measurement.getTemperature();
   if (temperature) {
-    writeMetric(
+    ord.reaction.writeMetric(
         '.workup_temperature_measurement_temperature', temperature, node);
   }
 };
@@ -104,7 +107,7 @@ ord.workups.unload = function() {
     node = $(node);
     if (!node.attr('id')) {
       const workup = ord.workups.unloadWorkup(node);
-      if (!isEmptyMessage(workup)) {
+      if (!ord.reaction.isEmptyMessage(workup)) {
         workups.push(workup);
       }
     }
@@ -115,32 +118,34 @@ ord.workups.unload = function() {
 ord.workups.unloadWorkup = function(node) {
   const workup = new proto.ord.ReactionWorkup();
 
-  workup.setType(getSelector($('.workup_type', node)));
+  workup.setType(ord.reaction.getSelector($('.workup_type', node)));
 
   workup.setDetails($('.workup_details', node).text());
 
-  const duration = readMetric('.workup_duration', new proto.ord.Time(), node);
-  if (!isEmptyMessage(duration)) {
+  const duration =
+      ord.reaction.readMetric('.workup_duration', new proto.ord.Time(), node);
+  if (!ord.reaction.isEmptyMessage(duration)) {
     workup.setDuration(duration);
   }
 
   const input = ord.inputs.unloadInputUnnamed(node);
-  if (!isEmptyMessage(input)) {
+  if (!ord.reaction.isEmptyMessage(input)) {
     workup.setInput(input);
   }
 
   const control = new proto.ord.TemperatureConditions.TemperatureControl();
-  control.setType(getSelector($('.workup_temperature_control_type', node)));
+  control.setType(
+      ord.reaction.getSelector($('.workup_temperature_control_type', node)));
   control.setDetails($('.workup_temperature_details', node).text());
 
   const temperature = new proto.ord.TemperatureConditions();
-  if (!isEmptyMessage(control)) {
+  if (!ord.reaction.isEmptyMessage(control)) {
     temperature.setControl(control);
   }
 
-  const setpoint = readMetric(
+  const setpoint = ord.reaction.readMetric(
       '.workup_temperature_setpoint', new proto.ord.Temperature(), node);
-  if (!isEmptyMessage(setpoint)) {
+  if (!ord.reaction.isEmptyMessage(setpoint)) {
     temperature.setSetpoint(setpoint);
   }
 
@@ -151,13 +156,13 @@ ord.workups.unloadWorkup = function(node) {
     if (!measurementNode.attr('id')) {
       // Not a template.
       const measurement = ord.workups.unloadMeasurement(measurementNode);
-      if (!isEmptyMessage(measurement)) {
+      if (!ord.reaction.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
     }
   });
   temperature.setMeasurementsList(measurements);
-  if (!isEmptyMessage(temperature)) {
+  if (!ord.reaction.isEmptyMessage(temperature)) {
     workup.setTemperature(temperature);
   }
 
@@ -166,24 +171,25 @@ ord.workups.unloadWorkup = function(node) {
   const stirring = new proto.ord.StirringConditions();
 
   const method = new proto.ord.StirringConditions.StirringMethod();
-  method.setType(getSelector($('.workup_stirring_method_type', node)));
+  method.setType(
+      ord.reaction.getSelector($('.workup_stirring_method_type', node)));
   method.setDetails($('.workup_stirring_method_details').text());
-  if (!isEmptyMessage(method)) {
+  if (!ord.reaction.isEmptyMessage(method)) {
     stirring.setMethod(method);
   }
 
   const rate = new proto.ord.StirringConditions.StirringRate();
-  rate.setType(getSelector($('.workup_stirring_rate_type', node)));
+  rate.setType(ord.reaction.getSelector($('.workup_stirring_rate_type', node)));
   rate.setDetails($('.workup_stirring_rate_details').text());
   const rpm = parseFloat($('.workup_stirring_rate_rpm', node).text());
   if (!isNaN(rpm)) {
     rate.setRpm(rpm);
   }
-  if (!isEmptyMessage(rate)) {
+  if (!ord.reaction.isEmptyMessage(rate)) {
     stirring.setRate(rate);
   }
 
-  if (!isEmptyMessage(stirring)) {
+  if (!ord.reaction.isEmptyMessage(stirring)) {
     workup.setStirring(stirring);
   }
 
@@ -191,32 +197,33 @@ ord.workups.unloadWorkup = function(node) {
   if (!isNaN(targetPh)) {
     workup.setTargetPh(targetPh);
   }
-  workup.setIsAutomated(getOptionalBool($('.workup_automated', node)));
+  workup.setIsAutomated(
+      ord.reaction.getOptionalBool($('.workup_automated', node)));
   return workup;
 };
 
 ord.workups.unloadMeasurement = function(node) {
   const measurement = new proto.ord.TemperatureConditions.Measurement();
-  measurement.setType(
-      getSelector($('.workup_temperature_measurement_type', node)));
+  measurement.setType(ord.reaction.getSelector(
+      $('.workup_temperature_measurement_type', node)));
   measurement.setDetails(
       $('.workup_temperature_measurement_details', node).text());
-  const time = readMetric(
+  const time = ord.reaction.readMetric(
       '.workup_temperature_measurement_time', new proto.ord.Time(), node);
-  if (!isEmptyMessage(time)) {
+  if (!ord.reaction.isEmptyMessage(time)) {
     measurement.setTime(time);
   }
-  const temperature = readMetric(
+  const temperature = ord.reaction.readMetric(
       '.workup_temperature_measurement_temperature',
       new proto.ord.Temperature(), node);
-  if (!isEmptyMessage(temperature)) {
+  if (!ord.reaction.isEmptyMessage(temperature)) {
     measurement.setTemperature(temperature);
   }
   return measurement;
 };
 
 ord.workups.add = function() {
-  const workupNode = addSlowly('#workup_template', '#workups');
+  const workupNode = ord.reaction.addSlowly('#workup_template', '#workups');
   const inputNode = $('.workup_input', workupNode);
   // The template for ReactionWorkup.input is taken from Reaction.inputs.
   const workupInputNode = ord.inputs.add(inputNode);
@@ -233,7 +240,7 @@ ord.workups.add = function() {
   $('.remove', inputNode).hide();
 
   // Add live validation handling.
-  addChangeHandler(workupNode, () => {
+  ord.reaction.addChangeHandler(workupNode, () => {
     ord.workups.validateWorkup(workupNode);
   });
 
@@ -241,7 +248,7 @@ ord.workups.add = function() {
 };
 
 ord.workups.addMeasurement = function(node) {
-  return addSlowly(
+  return ord.reaction.addSlowly(
       '#workup_temperature_measurement_template',
       $('.workup_temperature_measurements', node));
 };
@@ -251,5 +258,5 @@ ord.workups.validateWorkup = function(node, validateNode) {
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }
-  validate(workup, 'ReactionWorkup', validateNode);
+  ord.reaction.validate(workup, 'ReactionWorkup', validateNode);
 };

--- a/editor/js/workups.js
+++ b/editor/js/workups.js
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-goog.provide('ord.workups');
+goog.module('ord.workups');
+goog.module.declareLegacyNamespace();
+exports = {load, unload, add, addMeasurement, validateWorkup};
 
 goog.require('ord.inputs');
 goog.require('proto.ord.ReactionWorkup');
 
-ord.workups.load = function(workups) {
-  workups.forEach(workup => ord.workups.loadWorkup(workup));
+function load (workups) {
+  workups.forEach(workup => loadWorkup(workup));
 };
 
-ord.workups.loadWorkup = function(workup) {
-  const node = ord.workups.add();
+function loadWorkup (workup) {
+  const node = add();
   ord.reaction.setSelector($('.workup_type', node), workup.getType());
   $('.workup_details', node).text(workup.getDetails());
   const duration = workup.getDuration();
@@ -51,7 +53,7 @@ ord.workups.loadWorkup = function(workup) {
     }
 
     temperature.getMeasurementsList().forEach(
-        measurement => ord.workups.loadMeasurement(node, measurement));
+        measurement => loadMeasurement(node, measurement));
   }
 
   $('.workup_keep_phase', node).text(workup.getKeepPhase());
@@ -83,8 +85,8 @@ ord.workups.loadWorkup = function(workup) {
       workup.hasIsAutomated() ? workup.getIsAutomated() : null);
 };
 
-ord.workups.loadMeasurement = function(workupNode, measurement) {
-  const node = ord.workups.addMeasurement(workupNode);
+function loadMeasurement (workupNode, measurement) {
+  const node = addMeasurement(workupNode);
   ord.reaction.setSelector(
       $('.workup_temperature_measurement_type', node), measurement.getType());
   $('.workup_temperature_measurement_details', node)
@@ -101,12 +103,12 @@ ord.workups.loadMeasurement = function(workupNode, measurement) {
   }
 };
 
-ord.workups.unload = function() {
+function unload () {
   const workups = [];
   $('.workup').each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
-      const workup = ord.workups.unloadWorkup(node);
+      const workup = unloadWorkup(node);
       if (!ord.reaction.isEmptyMessage(workup)) {
         workups.push(workup);
       }
@@ -115,7 +117,7 @@ ord.workups.unload = function() {
   return workups;
 };
 
-ord.workups.unloadWorkup = function(node) {
+function unloadWorkup (node) {
   const workup = new proto.ord.ReactionWorkup();
 
   workup.setType(ord.reaction.getSelector($('.workup_type', node)));
@@ -155,7 +157,7 @@ ord.workups.unloadWorkup = function(node) {
     measurementNode = $(measurementNode);
     if (!measurementNode.attr('id')) {
       // Not a template.
-      const measurement = ord.workups.unloadMeasurement(measurementNode);
+      const measurement = unloadMeasurement(measurementNode);
       if (!ord.reaction.isEmptyMessage(measurement)) {
         measurements.push(measurement);
       }
@@ -202,7 +204,7 @@ ord.workups.unloadWorkup = function(node) {
   return workup;
 };
 
-ord.workups.unloadMeasurement = function(node) {
+function unloadMeasurement (node) {
   const measurement = new proto.ord.TemperatureConditions.Measurement();
   measurement.setType(ord.reaction.getSelector(
       $('.workup_temperature_measurement_type', node)));
@@ -222,7 +224,7 @@ ord.workups.unloadMeasurement = function(node) {
   return measurement;
 };
 
-ord.workups.add = function() {
+function add () {
   const workupNode = ord.reaction.addSlowly('#workup_template', '#workups');
   const inputNode = $('.workup_input', workupNode);
   // The template for ReactionWorkup.input is taken from Reaction.inputs.
@@ -241,20 +243,20 @@ ord.workups.add = function() {
 
   // Add live validation handling.
   ord.reaction.addChangeHandler(workupNode, () => {
-    ord.workups.validateWorkup(workupNode);
+    validateWorkup(workupNode);
   });
 
   return workupNode;
 };
 
-ord.workups.addMeasurement = function(node) {
+function addMeasurement (node) {
   return ord.reaction.addSlowly(
       '#workup_temperature_measurement_template',
       $('.workup_temperature_measurements', node));
 };
 
-ord.workups.validateWorkup = function(node, validateNode) {
-  const workup = ord.workups.unloadWorkup(node);
+function validateWorkup (node, validateNode) {
+  const workup = unloadWorkup(node);
   if (!validateNode) {
     validateNode = $('.validate', node).first();
   }


### PR DESCRIPTION
`goog.provide` is deprecated , and the linter prefers us to use `goog.module`. This requires a lot of changes to how we import/export methods... (see [here](https://github.com/google/closure-library/wiki/goog.module:-an-ES6-module-like-alternative-to-goog.provide) for more details)