### PR TITLE
Updates to submission workflow

### DIFF
--- a/docs/submissions.rst
+++ b/docs/submissions.rst
@@ -2,7 +2,7 @@
 Submission Workflow
 ###################
 
-The submission workflow follows five major steps:
+The submission workflow follows four major steps:
 
 ******
 Create
@@ -122,20 +122,15 @@ from your fork to the official repository.
 Review
 ******
 
-Basic preprocessing and validation of your submission will be performed by
-automated scripts, and you will be asked to verify any changes performed by the
-automated workflow. During this phase of the review process, each ``Reaction``
-and ``Dataset`` message will receive a unique database identifier.
+Your submission will be automatically validated and manually reviewed by one of
+the ORD reviewers. The reviewers may suggest additional changes and continue to
+iterate with you until they are satisfied with the submission. After your pull
+request is approved, it will be merged into a new branch in the official
+repository; this new branch is staging point for automated preprocessing that is
+required before merging into the official database.
 
-After all validation checks have passed, your submission will undergo a manual
-review by one or more of the database administrators. The reviewers may suggest
-additional changes and continue to iterate with you until they are satisfied
-with the submission.
-
-*******
-Deposit
-*******
-
-Once the pull request receives approval from the reviewers and passes all
-automated checks, a reviewer will merge it into the official database
-repository.
+After your submission has been accepted, a reviewer will trigger various
+automated preprocessing steps, such as renaming the dataset and assigning
+reaction and dataset IDs. Once these changes are verified by the reviewer, the
+dataset will be merged into the "main" branch and become part of the official
+database.

--- a/docs/submissions.rst
+++ b/docs/submissions.rst
@@ -55,14 +55,6 @@ If you haven't done so already, you will need to `create a fork
 the `ord-data <https://github.com/Open-Reaction-Database/ord-data>`_ repository
 on GitHub.
 
-.. IMPORTANT::
-
-   After creating a fork, you need to manually enable GitHub Actions. Navigate
-   to the "Actions" tab on your fork (`screenshot
-   <https://github.com/Open-Reaction-Database/ord-schema/blob/main/docs/images/actions-tab.png>`__)
-   and click the button to enable workflows (`screenshot
-   <https://github.com/Open-Reaction-Database/ord-schema/blob/main/docs/images/enable-workflows.png>`__).
-
 .. tabs::
 
    .. group-tab:: Web

--- a/ord_schema/process_dataset.py
+++ b/ord_schema/process_dataset.py
@@ -73,7 +73,6 @@ flags.DEFINE_float('min_size', 0.1,
 flags.DEFINE_float('max_size', 100.0,
                    'Maximum size (in MB) for offloading Data values.')
 flags.DEFINE_string('base', None, 'Git branch to diff against.')
-flags.DEFINE_string('base', 'main', 'Git branch to diff against.')
 flags.DEFINE_integer(
     'issue', None,
     'GitHub pull request number. If provided, a comment will be added.')

--- a/ord_schema/process_dataset.py
+++ b/ord_schema/process_dataset.py
@@ -47,6 +47,7 @@ import uuid
 from absl import app
 from absl import flags
 from absl import logging
+import github
 from google.protobuf import text_format
 
 from ord_schema import data_storage
@@ -72,6 +73,11 @@ flags.DEFINE_float('min_size', 0.1,
 flags.DEFINE_float('max_size', 100.0,
                    'Maximum size (in MB) for offloading Data values.')
 flags.DEFINE_string('base', None, 'Git branch to diff against.')
+flags.DEFINE_string('base', 'main', 'Git branch to diff against.')
+flags.DEFINE_integer(
+    'issue', None,
+    'GitHub pull request number. If provided, a comment will be added.')
+flags.DEFINE_string('token', None, 'GitHub authentication token.')
 
 
 @dataclasses.dataclass(eq=True, frozen=True, order=True)
@@ -281,6 +287,12 @@ def run():
     if FLAGS.base:
         added, removed = get_change_stats(datasets, inputs, base=FLAGS.base)
         logging.info('Summary: +%d -%d reaction IDs', len(added), len(removed))
+        if FLAGS.issue and FLAGS.token:
+            client = github.Github(FLAGS.token)
+            repo = client.get_repo(os.environ['GITHUB_REPOSITORY'])
+            issue = repo.get_issue(FLAGS.issue)
+            issue.create_comment(
+                f'Summary: +{len(added)} -{len(removed)} reaction IDs')
     else:
         added, removed = None, None
     if FLAGS.update:

--- a/ord_schema/process_dataset.py
+++ b/ord_schema/process_dataset.py
@@ -174,10 +174,11 @@ def cleanup(inputs, output_filename):
 
 
 def _get_reaction_ids(dataset):
-    """Returns a list of reaction IDs in a Dataset."""
-    reaction_ids = []
+    """Returns a set containing the reaction IDs in a Dataset."""
+    reaction_ids = set()
     for reaction in dataset.reactions:
-        reaction_ids.append(reaction.reaction_id)
+        if reaction.reaction_id:
+            reaction_ids.add(reaction.reaction_id)
     return reaction_ids
 
 

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -32,8 +32,8 @@ _COMPOUND_STRUCTURAL_IDENTIFIERS = [
     reaction_pb2.CompoundIdentifier.XYZ,
 ]
 
-_USERNAME = 'github-actions[bot]'
-_EMAIL = '41898282+github-actions[bot]@users.noreply.github.com'
+_USERNAME = 'github-actions'
+_EMAIL = 'github-actions@github.com'
 
 
 def name_resolve(value_type, value):


### PR DESCRIPTION
* Reverts changes `process_dataset.py` so we can post comments on PRs again (from the same repo)
* Doesn't count empty IDs in the statistics
* Removes the documentation about enabling GitHub Actions in forks since this is no longer necessary