### PR TITLE
Use gunicorn as the web server

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -48,7 +48,7 @@ WORKDIR editor
 #COPY css/*.css css/
 #COPY html/*.html html/
 #COPY js/*.js js/
-COPY py/*.py py/
+#COPY py/*.py py/
 RUN make
 
 EXPOSE 5000

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -15,7 +15,7 @@
 FROM continuumio/miniconda3
 WORKDIR /usr/src/app
 
-RUN apt-get update && apt-get install --yes build-essential unzip
+RUN apt-get update && apt-get install --yes build-essential procps unzip
 RUN conda install -c rdkit rdkit
 RUN conda install flask nodejs
 
@@ -29,18 +29,20 @@ RUN tar -xzf v20200517.tar.gz
 RUN wget https://storage.googleapis.com/ord-editor-test/editor_test_protobuf_1dae8fdd.tar
 RUN tar -xzf editor_test_protobuf_1dae8fdd.tar
 
-# Bust the cache to get the latest commits; see
-# https://stackoverflow.com/a/39278224.
-ADD https://api.github.com/repos/Open-Reaction-Database/ord-schema/git/refs/heads/main ord-schema-version.json
 RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
 RUN mv closure-library-20200517 ord-schema/editor/
 RUN mv ketcher ord-schema/editor/
 RUN mv protobuf ord-schema/editor/
 
-# Build the editor.
 WORKDIR ord-schema
+# Bust the cache to get the latest commits; see
+# https://stackoverflow.com/a/39278224.
+ADD https://api.github.com/repos/Open-Reaction-Database/ord-schema/git/refs/heads/main ord-schema-version.json
+RUN git pull
 RUN pip install -r requirements.txt
 RUN python setup.py install
+
+# Build the editor.
 WORKDIR editor
 # Uncomment these lines to copy over any local changes in ord-schema/editor.
 #COPY css/*.css css/
@@ -50,6 +52,5 @@ WORKDIR editor
 #COPY serve.sh .
 RUN make
 
-ENV ORD_EDITOR_PORT=5000
-EXPOSE "${ORD_EDITOR_PORT}"
-CMD ./serve.sh --host=0.0.0.0 --port="${ORD_EDITOR_PORT}"
+EXPOSE 5000
+CMD ./serve.sh --host=0.0.0.0

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -48,9 +48,9 @@ WORKDIR editor
 #COPY css/*.css css/
 #COPY html/*.html html/
 #COPY js/*.js js/
-#COPY py/*.py py/
+COPY py/*.py py/
 RUN make
 
 EXPOSE 5000
 RUN pip install gunicorn
-CMD gunicorn py.serve:app -b 0.0.0.0:5000 --log-level debug
+CMD gunicorn py.serve:app -b 0.0.0.0:5000 --log-level debug --access-logfile '-'

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -49,8 +49,8 @@ WORKDIR editor
 #COPY html/*.html html/
 #COPY js/*.js js/
 #COPY py/*.py py/
-#COPY serve.sh .
 RUN make
 
 EXPOSE 5000
-CMD ./serve.sh --host=0.0.0.0
+RUN pip install gunicorn
+CMD gunicorn py.serve:app -b 0.0.0.0:5000 --log-level debug

--- a/editor/serve.sh
+++ b/editor/serve.sh
@@ -16,6 +16,5 @@
 
 export PYTHONPATH=py:../build/lib
 export FLASK_APP=serve.py
-export FLASK_ENV=development
 
-python -m flask run $@
+python -m flask run "$@"


### PR DESCRIPTION
Flask recommends that you do not use their built-in server in production: https://flask.palletsprojects.com/en/master/deploying/#deployment-options. I went with the first standalone option listed on their page: `gunicorn`.

The logs look a bit different than Flask's built-in server; for example:

```
[2020-08-13 16:07:03 +0000] [10] [DEBUG] GET /dataset/dataset/reaction/0
[2020-08-13 16:07:03 +0000] [10] [DEBUG] GET /dataset/dataset/reaction/0
[2020-08-13 16:07:03 +0000] [10] [DEBUG] GET /css/ketcher-bootstrap.css
[2020-08-13 16:07:03 +0000] [10] [DEBUG] GET /js/reaction.js
[2020-08-13 16:07:03 +0000] [10] [DEBUG] GET /css/reaction.css
[2020-08-13 16:07:03 +0000] [10] [DEBUG] GET /dataset/dataset/reaction/deps.js
[2020-08-13 16:07:03 +0000] [10] [DEBUG] GET /ketcher/iframe
[2020-08-13 16:07:03 +0000] [10] [DEBUG] GET /ketcher/ketcher.js
[2020-08-13 16:07:03 +0000] [10] [DEBUG] GET /ketcher/ketcher.css
[2020-08-13 16:07:04 +0000] [10] [DEBUG] GET /ketcher/info
[2020-08-13 16:07:04 +0000] [10] [DEBUG] GET /ketcher/library.sdf
[2020-08-13 16:07:04 +0000] [10] [DEBUG] GET /ketcher/ketcher.svg
[2020-08-13 16:07:04 +0000] [10] [DEBUG] GET /dataset/proto/read/dataset
[2020-08-13 16:07:04 +0000] [10] [DEBUG] GET /ketcher/library.svg
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/ReactionInput
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/Reaction
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/ReactionSetup
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/ReactionConditions
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/TemperatureConditions
/opt/conda/lib/python3.7/site-packages/ord_schema-0.0.0-py3.7.egg/ord_schema/validations.py:175: UserWarning: TemperatureConditions: Temperature setpoints should be specified; even if using ambient conditions, estimate room temperature and the precision of your estimate.
  warnings.warn(message)
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/PressureConditions
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/StirringConditions
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/IlluminationConditions
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/ReactionNotes
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/ReactionOutcome
/opt/conda/lib/python3.7/site-packages/ord_schema-0.0.0-py3.7.egg/ord_schema/validations.py:175: UserWarning: ReactionOutcome: No products or conversion are specified for reaction; this is permissible only for multistep reactions
  warnings.warn(message)
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/ElectrochemistryConditions
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/FlowConditions
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /dataset/proto/validate/ReactionProvenance
[2020-08-13 16:07:05 +0000] [10] [DEBUG] POST /render/reaction
```