### PR TITLE
Disable debug logging

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -53,4 +53,4 @@ RUN make
 
 EXPOSE 5000
 RUN pip install gunicorn
-CMD gunicorn py.serve:app -b 0.0.0.0:5000 --log-level debug --access-logfile '-'
+CMD gunicorn py.serve:app -b 0.0.0.0:5000 --access-logfile '-'


### PR DESCRIPTION
I think all we're gaining from this is the python validation warnings; there might be another way to get them if we want them.

Turning this off should get rid of the annoying 'Closing connection' logging from the health checks.