### PR TITLE
Improve validation buttons storing methods as attributes

### DIFF
--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -806,7 +806,7 @@ limitations under the License.
               <legend>
                 <span class="collapse"></span>
                 Product
-                <span class="validate" button-onclick="ord.products.validateProduct($(this).closest('.outcome_product')"></span>
+                <span class="validate" button-onclick="ord.products.validateProduct($(this).closest('.outcome_product'))"></span>
               </legend>
             <div onclick="ord.reaction.removeSlowly(this, '.outcome_product');" class="remove">remove</div>
 

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -42,7 +42,7 @@ limitations under the License.
         <div id="save" onclick="ord.reaction.commit();" style="visibility: hidden;">save</div>
         <div id="delete" class="remove" style="float: none;" onclick="location.href='/dataset/{{ file_name }}/delete/reaction/{{ index }}';">delete</div>
       </div>
-      <span id="reaction_validate" class="validate" button-onclick="ord.reaction.validateReaction()"></span>
+      <span id="reaction_validate" class="validate" onclick="ord.reaction.validateReaction()"></span>
     </div>
 
     <div id="reaction_render_wrapper" style="text-align: center">
@@ -110,7 +110,7 @@ limitations under the License.
                   <span class="collapse"></span>
                   Input
                   <span class="input_name_label">name: </span><div class="input_name edittext"></div>
-                  <span class="validate" button-onclick="ord.inputs.validateInput($(this).closest('.input'))"></span>
+                  <span class="validate" onclick="ord.inputs.validateInput($(this).closest('.input'))"></span>
                </legend>
                 
                 <div onclick="ord.reaction.removeSlowly(this, '.input');" class="remove">remove</div>
@@ -173,7 +173,7 @@ limitations under the License.
                 <legend>
                   <span class="collapse"></span>
                   Component
-                  <span class="validate" button-onclick="ord.compounds.validateCompound($(this).closest('.component'))"></span>
+                  <span class="validate" onclick="ord.compounds.validateCompound($(this).closest('.component'))"></span>
                 </legend>
                 <div onclick="ord.reaction.removeSlowly(this, '.component');" class="remove">remove</div>
                 <table class="component_role_limiting">
@@ -311,7 +311,7 @@ limitations under the License.
         <legend>
           <span class="collapse"></span>
           Setup
-          <span class="validate" button-onclick="ord.setups.validateSetup($(this).closest('#section_setup'))"></span>
+          <span class="validate" onclick="ord.setups.validateSetup($(this).closest('#section_setup'))"></span>
         </legend>
         <table>
           <tr><td align="right">vessel</td><td><div id="setup_vessel_type" class="selector" data-proto="VesselType_VesselTypeEnum"></div>
@@ -401,13 +401,13 @@ limitations under the License.
         <legend>
           <span class="collapse"></span>
           Conditions
-          <span class="validate" button-onclick="ord.conditions.validateConditions($('#section_conditions'))"></span>
+          <span class="validate" onclick="ord.conditions.validateConditions($('#section_conditions'))"></span>
         </legend>
         <fieldset id="section_conditions_temperature">
           <legend>
             <span class="collapse"></span>
             Temperature
-            <span class="validate" button-onclick="ord.temperature.validateTemperature($(this).closest('#section_conditions_temperature'))"></span>
+            <span class="validate" onclick="ord.temperature.validateTemperature($(this).closest('#section_conditions_temperature'))"></span>
           </legend>
           <table>
             <tr><td align="right">control</td><td><div id="temperature_control" class="selector" data-proto="TemperatureConditions_TemperatureControl_TemperatureControlType"></div>
@@ -443,7 +443,7 @@ limitations under the License.
           <legend>
             <span class="collapse"></span>
             Pressure
-            <span class="validate" button-onclick="ord.pressure.validatePressure($(this).closest('#section_conditions_pressure'))"></span>
+            <span class="validate" onclick="ord.pressure.validatePressure($(this).closest('#section_conditions_pressure'))"></span>
           </legend>
             <table>
               <tr><td align="right">control</td><td><div id="pressure_control_type" class="selector" data-proto="PressureConditions_PressureControl_PressureControlType"></div>
@@ -481,7 +481,7 @@ limitations under the License.
           <legend>
             <span class="collapse"></span>
             Stirring
-            <span class="validate" button-onclick="ord.stirring.validateStirring($(this).closest('#section_conditions_stirring'))"></span>
+            <span class="validate" onclick="ord.stirring.validateStirring($(this).closest('#section_conditions_stirring'))"></span>
           </legend>
           <table>
             <tr><td align="right">method</td><td><div id="stirring_method_type" class="selector" data-proto="StirringConditions_StirringMethod_StirringMethodType"></div>
@@ -495,7 +495,7 @@ limitations under the License.
           <legend>
             <span class="collapse starts_collapsed"></span>
             Illumination
-            <span class="validate" button-onclick="ord.illumination.validateIllumination($(this).closest('#section_conditions_illumination'))"></span>           
+            <span class="validate" onclick="ord.illumination.validateIllumination($(this).closest('#section_conditions_illumination'))"></span>           
           </legend>
           <table>
             <tr><td align="right">type</td><td><div id="illumination_type" class="selector" data-proto="IlluminationConditions_IlluminationType_IlluminationTypeEnum"></div>
@@ -513,7 +513,7 @@ limitations under the License.
           <legend>
             <span class="collapse starts_collapsed"></span>
             Electrochemistry
-            <span class="validate" button-onclick="ord.electro.validateElectro($(this).closest('#section_conditions_electro'))"></span>    
+            <span class="validate" onclick="ord.electro.validateElectro($(this).closest('#section_conditions_electro'))"></span>    
           </legend>
           <table>
             <tr><td align="right">type</td><td><div id="electro_type" class="selector" data-proto="ElectrochemistryConditions_ElectrochemistryType_ElectrochemistryTypeEnum"></div>
@@ -564,7 +564,7 @@ limitations under the License.
           <legend>
             <span class="collapse starts_collapsed"></span>
             Flow
-            <span class="validate" button-onclick="ord.flows.validateFlow($(this).closest('#section_conditions_flow'))"></span>  
+            <span class="validate" onclick="ord.flows.validateFlow($(this).closest('#section_conditions_flow'))"></span>  
           </legend>
           <table>
             <tr><td align="right">type</td><td><div id="flow_type" class="selector" data-proto="FlowConditions_FlowType_FlowTypeEnum"></div>
@@ -597,7 +597,7 @@ limitations under the License.
         <legend>
           <span class="collapse"></span>
           Notes
-          <span class="validate" button-onclick="ord.notes.validateNotes($('#section_notes'))"></span>
+          <span class="validate" onclick="ord.notes.validateNotes($('#section_notes'))"></span>
         </legend>
         <table>
           <tr><td align="right">is heterogeneous</td><td><div id="notes_heterogeneous" class="optional_bool"></div></td></tr>
@@ -626,7 +626,7 @@ limitations under the License.
               <legend>
                 <span class="collapse"></span>
                 Observation
-                <span class="validate" button-onclick="ord.observations.validateObservation($(this).closest('.observation'))"></span>
+                <span class="validate" onclick="ord.observations.validateObservation($(this).closest('.observation'))"></span>
               </legend>
               <div onclick="ord.reaction.removeSlowly(this, '.observation');" class="remove">remove</div>
               <table>
@@ -678,7 +678,7 @@ limitations under the License.
             <legend>
               <span class="collapse"></span>
               Workup
-              <span class="validate" button-onclick="ord.workups.validateWorkup($(this).closest('.workup'))"></span>
+              <span class="validate" onclick="ord.workups.validateWorkup($(this).closest('.workup'))"></span>
             </legend>
             <div onclick="ord.reaction.removeSlowly(this, '.workup');" class="remove">remove</div>
             <table>
@@ -772,7 +772,7 @@ limitations under the License.
             <legend>
               <span class="collapse"></span>
               Outcome
-              <span class="validate" button-onclick="ord.outcomes.validateOutcome($(this).closest('.outcome'))"></span>
+              <span class="validate" onclick="ord.outcomes.validateOutcome($(this).closest('.outcome'))"></span>
             </legend>
             <div onclick="ord.reaction.removeSlowly(this, '.outcome');" class="remove">remove</div>
             <table>
@@ -806,7 +806,7 @@ limitations under the License.
               <legend>
                 <span class="collapse"></span>
                 Product
-                <span class="validate" button-onclick="ord.products.validateProduct($(this).closest('.outcome_product'))"></span>
+                <span class="validate" onclick="ord.products.validateProduct($(this).closest('.outcome_product'))"></span>
               </legend>
             <div onclick="ord.reaction.removeSlowly(this, '.outcome_product');" class="remove">remove</div>
 
@@ -924,7 +924,7 @@ limitations under the License.
                 <span class="collapse"></span>
                 Analysis
                 <span class="analysis_name_label">label: </span><div class="outcome_analysis_name edittext"></div>
-                <span class="validate" button-onclick="ord.outcomes.validateAnalysis($(this).closest('.outcome_analysis'))" ></span>
+                <span class="validate" onclick="ord.outcomes.validateAnalysis($(this).closest('.outcome_analysis'))" ></span>
               </legend>
               <div onclick="ord.reaction.removeSlowly(this, '.outcome_analysis');" class="remove">remove</div>
               <table>
@@ -1043,7 +1043,7 @@ limitations under the License.
           <span data-toggle="tooltip" data-placement="right" title="Additional metadata about how this reaction was performed and originally reported.">
             <span class="fa fa-question-circle" aria-hidden="true"></span>
           </span>
-          <span class="validate" button-onclick="ord.provenance.validateProvenance($('#section_provenance'))"></span>
+          <span class="validate" onclick="ord.provenance.validateProvenance($('#section_provenance'))"></span>
         </legend>
         <div id="provenance_experimenter">
           <table>

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -91,7 +91,7 @@ async function init(fileName, index) {
   loadReaction(reaction);
   clean();
   // Trigger reaction-level validation.
-  setTimeout(validateReaction, 1000);
+  validateReaction();
   // Signal to tests that the DOM is initialized.
   ready();
 }

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -602,9 +602,12 @@ function initCollapse(node) {
 // inserting contents into a div in reaction.html
 function initValidateNode(oldNode) {
   let newNode = $('#validate_template').clone();
-  // Add attributes necessary for validation functions.
+  // Add attributes necessary for validation functions:
+  // Convert the placeholder onclick method into the button's onclick method.
   $('.validate_button', newNode)
-      .attr('onclick', oldNode.attr('button-onclick'));
+      .attr('onclick', oldNode.attr('onclick'));
+  oldNode.removeAttr('onclick');
+  // Add an id to the button.
   if (oldNode.attr('id')) {
     $('.validate_button', newNode).attr('id', oldNode.attr('id') + '_button');
   }

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -604,8 +604,7 @@ function initValidateNode(oldNode) {
   let newNode = $('#validate_template').clone();
   // Add attributes necessary for validation functions:
   // Convert the placeholder onclick method into the button's onclick method.
-  $('.validate_button', newNode)
-      .attr('onclick', oldNode.attr('onclick'));
+  $('.validate_button', newNode).attr('onclick', oldNode.attr('onclick'));
   oldNode.removeAttr('onclick');
   // Add an id to the button.
   if (oldNode.attr('id')) {


### PR DESCRIPTION
validateReaction didn't work, because one of the button's onclick methods was missing a parenthesis. Dang...

Also, onclick methods had been stored as custom `button-onclick` attributes in the HTML, and dynamically turned into `onclick` attributes when the editor loaded. This led to my IDE interpreting the attribute method as a generic block of text, not JS, and so it never noticed the error. Will change the code to represent JS as real JS.