### PR TITLE
Refactor query.py

### DIFF
--- a/ord_schema/interface/query.py
+++ b/ord_schema/interface/query.py
@@ -40,6 +40,7 @@ For example, a reaction query might have the following predicates:
 Note that a predicate is matched if it applies to _any_ input/output.
 """
 
+import abc
 import binascii
 import enum
 import json
@@ -68,13 +69,14 @@ def fetch_results(cursor):
     return reactions
 
 
-class ReactionQueryBase:
+class ReactionQueryBase(abc.ABC):
     """Base class for reaction-based queries."""
 
+    @abc.abstractmethod
     def json(self):
         """Returns a JSON representation of the query."""
-        raise NotImplementedError()
 
+    @abc.abstractmethod
     def run(self, cursor, limit=None):
         """Runs the query.
 
@@ -86,7 +88,6 @@ class ReactionQueryBase:
         Returns:
             Dict mapping reaction IDs to serialized Reaction protos.
         """
-        raise NotImplementedError()
 
 
 class ReactionIdQuery(ReactionQueryBase):

--- a/ord_schema/interface/query.py
+++ b/ord_schema/interface/query.py
@@ -132,11 +132,13 @@ class ReactionSmartsQuery(ReactionQueryBase):
         Returns:
             Dict mapping reaction IDs to serialized Reaction protos.
         """
-        components = [sql.SQL("""
+        components = [
+            sql.SQL("""
             SELECT reactions.reaction_id, reactions.serialized
             FROM reactions
             INNER JOIN rdkit.reactions USING (reaction_id)
-            WHERE rdkit.reactions.r@>%s::qmol""")]
+            WHERE rdkit.reactions.r@>%s::qmol""")
+        ]
         args = [self._reaction_smarts]
         if limit:
             components.append(sql.SQL(' LIMIT %s'))
@@ -186,14 +188,16 @@ class ReactionComponentQuery(ReactionQueryBase):
             Dict mapping reaction IDs to serialized Reaction protos.
         """
         self._setup(cursor)
-        components = [sql.SQL("""
+        components = [
+            sql.SQL("""
             SELECT reactions.reaction_id, reactions.serialized
             FROM reactions
             INNER JOIN inputs USING (reaction_id)
             INNER JOIN rdk.inputs USING (reaction_id)
             INNER JOIN outputs USING (reaction_id)
             INNER JOIN rdk.outputs USING (reaction_id)
-            WHERE """)]
+            WHERE """)
+        ]
         args = []
         predicates = []
         for predicate in self._predicates:

--- a/ord_schema/interface/query.py
+++ b/ord_schema/interface/query.py
@@ -208,6 +208,8 @@ class ReactionComponentQuery(ReactionQueryBase):
         Returns:
             Dict mapping reaction IDs to serialized Reaction protos.
         """
+        if not self._predicates:
+            return {}
         self._setup(cursor)
         components = [
             sql.SQL("""

--- a/ord_schema/interface/query.py
+++ b/ord_schema/interface/query.py
@@ -191,9 +191,13 @@ class ReactionComponentQuery(ReactionQueryBase):
     def json(self):
         """Returns a JSON representation of the query."""
         return json.dumps({
-            'useStereochemistry': self._do_chiral_sss,
-            'similarity': self._tanimoto_threshold,
-            'components': [predicate.json() for predicate in self._predicates],
+            'useStereochemistry':
+                self._do_chiral_sss,
+            'similarity':
+                self._tanimoto_threshold,
+            'components': [
+                predicate.to_dict() for predicate in self._predicates
+            ],
         })
 
     def _setup(self, cursor):
@@ -332,13 +336,13 @@ class ReactionComponentPredicate:
     def mode(self):
         return self._mode
 
-    def json(self):
-        """Returns a JSON representation of the predicate."""
-        return json.dumps({
+    def to_dict(self):
+        """Returns a dict representation of the predicate."""
+        return {
             'pattern': self._pattern,
             'source': self._TABLE_TO_SOURCE[self._table],
             'mode': self._mode.name.lower(),
-        })
+        }
 
     def get(self):
         """Builds the SQL predicate.

--- a/ord_schema/interface/query.py
+++ b/ord_schema/interface/query.py
@@ -293,11 +293,11 @@ class OrdPostgres:
     def cursor(self):
         return self._connection.cursor()
 
-    def query(self, query, return_ids=False):
+    def run_query(self, query, return_ids=False):
         """Runs a query against the database.
 
         Args:
-            query: sql.SQL query object.
+            query: ReactionQueryBase query.
             return_ids: If True, only return reaction IDs. If False, return
                 full Reaction records.
 

--- a/ord_schema/interface/query.py
+++ b/ord_schema/interface/query.py
@@ -83,15 +83,15 @@ class ReactionQueryBase:
 
 
 class ReactionIdQuery(ReactionQueryBase):
-    """Looks up a specific reaction by ID."""
+    """Looks up reactions by ID."""
 
-    def __init__(self, reaction_id):
+    def __init__(self, reaction_ids):
         """Initializes the query.
 
         Args:
-            reaction_id: Reaction ID.
+            reaction_ids: List of reaction IDs.
         """
-        self._reaction_id = reaction_id
+        self._reaction_ids = reaction_ids
 
     def run(self, cursor, limit=None):
         """Runs the query.
@@ -105,10 +105,9 @@ class ReactionIdQuery(ReactionQueryBase):
         """
         del limit  # Unused.
         query = sql.SQL(
-            'SELECT serialized FROM reactions WHERE reaction_id = %s LIMIT 1')
-        cursor.execute(query, [self._reaction_id])
-        for result in cursor:
-            return {self._reaction_id: result[0]}
+            'SELECT serialized FROM reactions WHERE reaction_id = ANY (%s)')
+        cursor.execute(query, [self._reaction_ids])
+        return fetch_results(cursor)
 
 
 class ReactionSmartsQuery(ReactionQueryBase):

--- a/ord_schema/interface/query.py
+++ b/ord_schema/interface/query.py
@@ -238,19 +238,19 @@ class ReactionComponentQuery(ReactionQueryBase):
         if requires_inputs:
             tables.append(
                 sql.SQL("""
-                    INNER JOIN inputs USING (reaction_id) """))
+            INNER JOIN inputs USING (reaction_id) """))
         if requires_rdk_inputs:
             tables.append(
                 sql.SQL("""
-                    INNER JOIN rdk.inputs USING (reaction_id) """))
+            INNER JOIN rdk.inputs USING (reaction_id) """))
         if requires_outputs:
             tables.append(
                 sql.SQL("""
-                    INNER JOIN outputs USING (reaction_id) """))
+            INNER JOIN outputs USING (reaction_id) """))
         if requires_rdk_outputs:
             tables.append(
                 sql.SQL("""
-                    INNER JOIN rdk.outputs USING (reaction_id) """))
+            INNER JOIN rdk.outputs USING (reaction_id) """))
         return tables
 
     def run(self, cursor, limit=None):

--- a/ord_schema/interface/search.html
+++ b/ord_schema/interface/search.html
@@ -66,7 +66,7 @@
       select {
         grid-column: match;
       }
-      #add_input {
+      #add_component {
         grid-column: add;
       }
       #similarity {
@@ -121,18 +121,16 @@
       </div>
 
       <div id="reagents">
-        <a href="#" id="add_input">+ input</a>
-
-        <span class="label">output</span>
-        <div class="output edittext"></div>
-        <select class="output">
-          <option value="exact">exact</option>
-          <option value="similar">similar</option>
-          <option value="substructure">substructure</option>
-          <option value="smarts">smarts</option>
-        </select>
+        <a href="#" id="add_component">+ component</a>
 
         <div></div> <!-- Blank grid cell to the right of the output. -->
+
+        <span class="label">use stereochemistry</span>
+        <div class="stereo edittext"></div>
+        <select class="stereo">
+          <option value="true">true</option>
+          <option value="false">false</option>
+        </select>
 
         <span class="label">similarity</span>
         <div id="similarity"></div>
@@ -143,8 +141,8 @@
         <span class="label">reaction IDs</span>
         <div id="reaction_ids" class="edittext"></div>
 
-        <span class="label">reaction SMILES</span>
-        <div id="reaction_smiles" class="edittext"></div>
+        <span class="label">reaction SMARTS</span>
+        <div id="reaction_smarts" class="edittext"></div>
       </div>
 
       <div id="go">
@@ -171,10 +169,14 @@
       </pre>
     </div>
 
-    <div id="input_template" style="display: none;">
-      <span class="label">input</span>
-      <div class="input edittext"></div>
-      <select class="input">
+    <div id="component_template" style="display: none;">
+      <span class="label">Component</span>
+      <div class="component edittext"></div>
+      <select class="source">
+        <option value="input">input</option>
+        <option value="output">output</option>
+      </select>
+      <select class="component">
         <option value="exact">exact</option>
         <option value="similar">similar</option>
         <option value="substructure">substructure</option>
@@ -194,7 +196,7 @@
         xhr.send();
       }
       
-      // Inputs, output, similarity.
+      // Components.
       function showReagentsTab() {
         $('#reagents').show();
         $('#reactions').hide();
@@ -210,14 +212,14 @@
         $('#reactionsTab').css('background-color', 'lightblue');
       }
 
-      // Add an input field, for "+ input" button (and initialization).
-      function addInput() {
-        const input = $('#input_template').clone();
-        const anchor = $('#add_input');
-        input.children().each((index, node) => {
+      // Add a component field, for "+ component" button (and initialization).
+      function addComponent() {
+        const component = $('#component_template').clone();
+        const anchor = $('#add_component');
+        component.children().each((index, node) => {
           anchor.before(node);
         });
-        // Return value is the text field <div/> of the new input.
+        // Return value is the text field <div/> of the new component.
         return anchor.prev().prev();
       }
 
@@ -226,8 +228,18 @@
         return node.text().trim();
       }
 
+      // Get the component source (input/output).
+      function getComponentSource(node) {
+        return $('option:selected', node.next()).text()
+      }
+
       // Get the matching option for a text field.
       function getMatchMode(node) {
+        return $('option:selected', node.next().next()).text()
+      }
+
+      // Get the stereochemistry option.
+      function getUseStereochemistry(node) {
         return $('option:selected', node.next()).text()
       }
 
@@ -246,31 +258,26 @@
         let path = '/?'
         let hasReagent = false;
 
-        // Inputs.
-        const inputs = $('.input.edittext');
-        inputs.each((index, node) => {
-          const input = $(node);
-          if (input.is(':hidden')) {
+        // Components.
+        const components = $('.component.edittext');
+        components.each((index, node) => {
+          const component = $(node);
+          if (component.is(':hidden')) {
             // The template.
             return;
           }
-          const inputText = getText(input);
-          if (inputText) {
-            const matchMode = getMatchMode(input);
-            path += 'input=' + encodeURIComponent(inputText) + ';' + matchMode + '&';
+          const componentText = getText(component);
+          if (componentText) {
+            const sourceTable = getComponentSource(component);
+            const matchMode = getMatchMode(component);
+            path += 'component=' + encodeURIComponent(componentText) + ';' + sourceTable + ';' + matchMode + '&';
           }
           hasReagent = true;
         });
-        // Output.
-        const output = $('.output.edittext');
-        const outputText = getText(output);
-        if (outputText) {
-          const matchMode = getMatchMode(output);
-          path += 'output=' + encodeURIComponent(outputText) + ';' + matchMode + '&';
-          hasReagent = true;
-        }
-        // Similarity threshold.
+        // Fingerprint similarity options.
         if (hasReagent) {
+          const useStereochemistry = getUseStereochemistry();
+          path += 'use_stereochemistry=' + encodeURIComponent(useStereochemistry) + '&';
           const similarity = getSimilarity();
           path += 'similarity=' + encodeURIComponent(similarity / 100) + '&';
         }
@@ -285,11 +292,11 @@
         if (reactionIds.length > 0) {
           path += 'reaction_ids=' + encodeURIComponent(reactionIds.join(',')) + '&';
         }
-        // Reaction SMILES.
-        const reactionSmiles = $('#reaction_smiles');
-        const reactionSmilesText = getText(reactionSmiles);
-        if (reactionSmilesText) {
-          path += 'reaction_smiles=' + encodeURIComponent(reactionSmilesText) + '&';
+        // Reaction SMARTS.
+        const reactionSmarts = $('#reaction_smarts');
+        const reactionSmartsText = getText(reactionSmarts);
+        if (reactionSmartsText) {
+          path += 'reaction_smarts=' + encodeURIComponent(reactionSmartsText) + '&';
         }
         if (path.slice(-1) == '&') {
           path = path.slice(0, -1);
@@ -298,42 +305,42 @@
       }
 
       // Initialize the user inputs from the current predicate.
-      function importPredicate() {
-        predicate = JSON.parse('{{ predicate|safe }}')
+      function importQuery() {
+        query = JSON.parse('{{ query|safe }}')
 
-        // Inputs.
-        if (predicate.inputs && (predicate.inputs.length > 0)) {
-          predicate.inputs.forEach(input => {
-            const edittext = addInput();
-            edittext.text(input.smiles);
-            edittext.next().val(input.matchMode);
+        // Components.
+        if (query.hasAttribute('components') && (query.components.length > 0)) {
+          query.components.forEach(component => {
+            const edittext = addComponent();
+            edittext.text(component.pattern);
+            edittext.next().val(component.source);
+            edittext.next().next().val(component.matchMode);
           });
         } else {
-          // Make sure there is at least one input for convenience.
-          addInput();
+          // Make sure there is at least one component for convenience.
+          addComponent();
         }
 
-        // Output.
-        if (predicate.output) {
-          const output = predicate.output;
-          const edittext = $('.output.edittext')
-          edittext.text(output.smiles);
-          edittext.next().val(output.matchMode);
+        // Fingerprint similarity options.
+        if (query.hasAttribute('useStereochemistry')) {
+          $('#stereo').val(query.useStereochemistry);
         }
-
-        // Similarity.
-        const similarity = predicate.similarity;
-        setSimilarity(similarity);
+        if (query.hasAttribute('similarity')) {
+          const similarity = query.similarity;
+          setSimilarity(similarity);
+        }
 
         // Reaction ID.
-        if (predicate.reactionIds) {
+        if (query.hasAttribute('reactionIds')) {
           const reactionIds = $('#reaction_ids')
           reactionIds.text(predicate.reactionIds.join(','));
         }
 
         // Reaction SMILES.
-        const reactionSmiles = $('#reaction_smiles');
-        reactionSmiles.text(predicate.reactionSmiles);
+        if (query.hasAttribute('reactionSmarts')) {
+          const reactionSmarts = $('#reaction_smarts');
+          reactionSmarts.text(predicate.reactionSmarts);
+        }
       }
 
       // Update the pbtxt when the user mouses over a result.
@@ -348,9 +355,9 @@
       // Make the .editext divs actually editable.
       $('.edittext').attr('contentEditable', 'true');
 
-      // Hook up the "+ input" button.
-      $('#add_input').click(() => {
-        addInput();
+      // Hook up the "+ component" button.
+      $('#add_component').click(() => {
+        addComponent();
       });
 
       // Hook up the query button.
@@ -374,10 +381,10 @@
         showReactionsTab();
       });
 
-      importPredicate();
+      importQuery();
 
       // Show the tab appropriate to the current predicate.
-      if (predicate.reactionIds || predicate.reactionSmiles) {
+      if (query.hasAttribute('reactionIds') || query.hasAttribute('reactionSmarts') {
         showReactionsTab();
       } else {
         showReagentsTab();

--- a/ord_schema/interface/search.html
+++ b/ord_schema/interface/search.html
@@ -126,11 +126,7 @@
         <div></div> <!-- Blank grid cell to the right of the output. -->
 
         <span class="label">use stereochemistry</span>
-        <div class="stereo edittext"></div>
-        <select class="stereo">
-          <option value="false">false</option>
-          <option value="true">true</option>
-        </select>
+        <input type="checkbox" id="stereo">
 
         <span class="label">similarity</span>
         <div id="similarity"></div>
@@ -220,7 +216,7 @@
           anchor.before(node);
         });
         // Return value is the text field <div/> of the new component.
-        return anchor.prev().prev();
+        return anchor.prev().prev().prev();
       }
 
       // Get the text from an .edittext div.
@@ -239,8 +235,8 @@
       }
 
       // Get the stereochemistry option.
-      function getUseStereochemistry(node) {
-        return $('option:selected', node.next()).text()
+      function getUseStereochemistry() {
+        return $('#stereo').is(":checked")
       }
 
       // Get the current value of the similarity slider.
@@ -254,7 +250,7 @@
       }
 
       // Read back the user inputs and build a query URL.
-      function exportPredicate() {
+      function exportQuery() {
         let path = '/?'
         let hasReagent = false;
 
@@ -306,7 +302,8 @@
 
       // Initialize the user inputs from the current predicate.
       function importQuery() {
-        query = JSON.parse('{{ query|safe }}')
+        const query = JSON.parse('{{ query|safe }}')
+        console.log(query);
 
         // Components.
         if ('components' in query && (query.components.length > 0)) {
@@ -314,7 +311,7 @@
             const edittext = addComponent();
             edittext.text(component.pattern);
             edittext.next().val(component.source);
-            edittext.next().next().val(component.matchMode);
+            edittext.next().next().val(component.mode);
           });
         } else {
           // Make sure there is at least one component for convenience.
@@ -323,7 +320,7 @@
 
         // Fingerprint similarity options.
         if ('useStereochemistry' in query) {
-          $('#stereo').val(query.useStereochemistry);
+          $('#stereo').prop( "checked", query.useStereochemistry === "true");
         }
         if ('similarity' in query) {
           const similarity = query.similarity;
@@ -333,14 +330,16 @@
         // Reaction ID.
         if ('reactionIds' in query) {
           const reactionIds = $('#reaction_ids')
-          reactionIds.text(predicate.reactionIds.join(','));
+          reactionIds.text(query.reactionIds.join(','));
         }
 
         // Reaction SMILES.
         if ('reactionSmarts' in query) {
           const reactionSmarts = $('#reaction_smarts');
-          reactionSmarts.text(predicate.reactionSmarts);
+          reactionSmarts.text(query.reactionSmarts);
         }
+
+        return query;
       }
 
       // Update the pbtxt when the user mouses over a result.
@@ -362,7 +361,7 @@
 
       // Hook up the query button.
       $('#go').click(() => {
-        const path = exportPredicate();
+        const path = exportQuery();
         window.location.href = path;
       });
 
@@ -381,7 +380,7 @@
         showReactionsTab();
       });
 
-      importQuery();
+      const query = importQuery();
 
       // Show the tab appropriate to the current predicate.
       if ('reactionIds' in query || 'reactionSmarts' in query) {

--- a/ord_schema/interface/search.html
+++ b/ord_schema/interface/search.html
@@ -128,8 +128,8 @@
         <span class="label">use stereochemistry</span>
         <div class="stereo edittext"></div>
         <select class="stereo">
-          <option value="true">true</option>
           <option value="false">false</option>
+          <option value="true">true</option>
         </select>
 
         <span class="label">similarity</span>

--- a/ord_schema/interface/search.html
+++ b/ord_schema/interface/search.html
@@ -309,7 +309,7 @@
         query = JSON.parse('{{ query|safe }}')
 
         // Components.
-        if (query.hasAttribute('components') && (query.components.length > 0)) {
+        if ('components' in query && (query.components.length > 0)) {
           query.components.forEach(component => {
             const edittext = addComponent();
             edittext.text(component.pattern);
@@ -322,22 +322,22 @@
         }
 
         // Fingerprint similarity options.
-        if (query.hasAttribute('useStereochemistry')) {
+        if ('useStereochemistry' in query) {
           $('#stereo').val(query.useStereochemistry);
         }
-        if (query.hasAttribute('similarity')) {
+        if ('similarity' in query) {
           const similarity = query.similarity;
           setSimilarity(similarity);
         }
 
         // Reaction ID.
-        if (query.hasAttribute('reactionIds')) {
+        if ('reactionIds' in query) {
           const reactionIds = $('#reaction_ids')
           reactionIds.text(predicate.reactionIds.join(','));
         }
 
         // Reaction SMILES.
-        if (query.hasAttribute('reactionSmarts')) {
+        if ('reactionSmarts' in query) {
           const reactionSmarts = $('#reaction_smarts');
           reactionSmarts.text(predicate.reactionSmarts);
         }
@@ -384,7 +384,7 @@
       importQuery();
 
       // Show the tab appropriate to the current predicate.
-      if (query.hasAttribute('reactionIds') || query.hasAttribute('reactionSmarts') {
+      if ('reactionIds' in query || 'reactionSmarts' in query) {
         showReactionsTab();
       } else {
         showReagentsTab();

--- a/ord_schema/interface/search.py
+++ b/ord_schema/interface/search.py
@@ -14,44 +14,25 @@
 """Query web interface to the Open Reaction Database in Postgres.
 
 The client is stateless. Full information is in the URL so results can be
-linked.
+linked. Query parameters are communicated in URL GET params:
 
-There are three kinds of query.
+  component=<pattern;source;(exact|substructure|similarity|smarts)>
 
-  inputs and output SMILES or SMARTS
+    The second token specifies whether the predicate should match an input or
+    an output.
 
-    These match against individual reagents and results. Each SMILES expression
-    can be freely specified for "exact", "substructure", or "similarity"
-    matching. SMARTS expressions do not allow such a specification.
+    The last token specifies the matching criterion. The default is "exact".
+    The pattern is a SMILES string, unless the token is "smarts" in which case
+    the pattern is a SMARTS string.
 
-  reaction ID
+    Component may be repeated any number of times.
 
-    Matches either zero or one reactions. The ID has the form,
-      "ord-<32-bit hex>".
+  reaction_ids=<ids>
 
-  reaction SMILES
+  reaction_smarts=<smarts>
 
-    Matches against RDKit fingerprints.
-
-Query parameters are communicated in URL GET params.
-
-  input=<pattern;(exact|substructure|similarity|smarts)>
-
-  output=<pattern;(exact|substructure|similarity|smarts)>
-
-    The token after the semicolon specifies the matching criterion. The default
-    is "exact". The pattern is a SMILES string, unless the token is "smarts" in
-    which case the pattern is a SMARTS string.
-
-    The "input" param may be repeated. The "output" param may not.
-
-  reaction_id=<id>
-
-  reaction_smiles=<smiles>
-
-If multiple conditions are given, then the query is interpreted as conjunction.
-
-All query parameters are assumed to be URL-encoded.
+These query types are mutually exclusive. All query parameters are assumed to
+be URL-encoded.
 """
 
 import flask

--- a/ord_schema/interface/search.py
+++ b/ord_schema/interface/search.py
@@ -89,7 +89,8 @@ def show_root():
             predicates.append(
                 query.ReactionComponentPredicate(smiles, table, mode))
         command = query.ReactionComponentQuery(
-            predicates, do_chiral_sss=do_chiral_sss,
+            predicates,
+            do_chiral_sss=do_chiral_sss,
             tanimoto_threshold=float(tanimoto_threshold))
     dataset = connect().run_query(command, return_ids=True)
     return flask.render_template('search.html',

--- a/ord_schema/interface/search.py
+++ b/ord_schema/interface/search.py
@@ -77,7 +77,7 @@ def show_root():
 
     if reaction_ids is not None:
         command = query.ReactionIdQuery(reaction_ids.split(','))
-    elif reaction_smarts is not None
+    elif reaction_smarts is not None:
         command = query.ReactionSmartsQuery(reaction_smarts)
     else:
         predicates = []

--- a/ord_schema/interface/search.py
+++ b/ord_schema/interface/search.py
@@ -68,7 +68,9 @@ def show_root():
                 mode_name)
             predicates.append(
                 query.ReactionComponentPredicate(pattern, table, mode))
-        kwargs = {'do_chiral_sss': use_stereochemistry}
+        kwargs = {}
+        if use_stereochemistry is not None:
+            kwargs['do_chiral_sss'] = use_stereochemistry
         if similarity is not None:
             kwargs['tanimoto_threshold'] = float(similarity)
         command = query.ReactionComponentQuery(predicates, **kwargs)

--- a/ord_schema/interface/search.py
+++ b/ord_schema/interface/search.py
@@ -81,7 +81,7 @@ def show_root():
         command = query.ReactionSmartsQuery(reaction_smarts)
     else:
         predicates = []
-        for table, queries in [('inputs', inputs), ('outputs', outputs)]
+        for table, queries in [('inputs', inputs), ('outputs', outputs)]:
             splits = [i.split(';', 1) for i in queries] if queries else []
         for smiles, mode_name in splits:
             mode = query.ReactionComponentPredicate.MatchMode.from_name(

--- a/ord_schema/interface/search.py
+++ b/ord_schema/interface/search.py
@@ -51,7 +51,7 @@ def show_root():
     """
     reaction_ids = flask.request.args.get('reaction_ids')
     reaction_smarts = flask.request.args.get('reaction_smarts')
-    components = flask.request.args.getlist('components')
+    components = flask.request.args.getlist('component')
     use_stereochemistry = flask.request.args.get('use_stereochemistry')
     similarity = flask.request.args.get('similarity')
 


### PR DESCRIPTION
* Refactors the query backend to provide three mutually exclusive query types (see the docstring for `query.py`).
* Plumbs the changes through `serve.py` and the associated HTML template.
* Updates `query_longtests.py`; we'll need additional tests here and for `serve.py` later (but this PR is getting big).