### PR TITLE
Require provenance in datasets

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -251,8 +251,9 @@ including required fields and checks for consistency across messages.
   message.
 * If `reaction_id` is set for a `Reaction` in `reactions`, it must be unique.
 * Each entry in `reaction_ids` must match `^ord-[0-9a-f]{32}$`.
-* When run with `validate_ids=True` (default is False), `dataset_id` must
-  match `^ord_dataset-[0-9a-f]{32}$`.
+* When run with `strict=True` (default is False):
+  * `dataset_id` must match `^ord_dataset-[0-9a-f]{32}$`.
+  * Each entry in `reactions` must have a defined `reaction_id`.
 
 ### DatasetExample
 
@@ -339,8 +340,9 @@ including required fields and checks for consistency across messages.
   `INTERNAL_STANDARD` role.
 * If `Reaction.conversion` is set, at least one `ReactionInput` must have its
   `is_limiting` field set to `TRUE`.
-* When run with `validate_ids=True` (default is False), `reaction_id` must
-  match `^ord-[0-9a-f]{32}$`.
+* When run with `strict=True` (default is False):
+  * `reaction_id` must either be empty or match `^ord-[0-9a-f]{32}$`.
+  * `Reaction.provenance` must be defined.
 
 ### ReactionAnalysis
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -251,9 +251,8 @@ including required fields and checks for consistency across messages.
   message.
 * If `reaction_id` is set for a `Reaction` in `reactions`, it must be unique.
 * Each entry in `reaction_ids` must match `^ord-[0-9a-f]{32}$`.
-* When run with `strict=True` (default is False):
-  * `dataset_id` must match `^ord_dataset-[0-9a-f]{32}$`.
-  * Each entry in `reactions` must have a defined `reaction_id`.
+* If `options.validate_ids=True`, `dataset_id` must match 
+  `^ord_dataset-[0-9a-f]{32}$`.
 
 ### DatasetExample
 
@@ -340,9 +339,8 @@ including required fields and checks for consistency across messages.
   `INTERNAL_STANDARD` role.
 * If `Reaction.conversion` is set, at least one `ReactionInput` must have its
   `is_limiting` field set to `TRUE`.
-* When run with `strict=True` (default is False):
-  * `reaction_id` must either be empty or match `^ord-[0-9a-f]{32}$`.
-  * `Reaction.provenance` must be defined.
+* If `options.validate_ids=True`, `reaction_id` must match `^ord-[0-9a-f]{32}$`.
+* If `options.require_provenance=True`, `Reaction.provenance` must be defined.
 
 ### ReactionAnalysis
 

--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -304,7 +304,9 @@ def validate_reaction(message_name):
     """Receives a serialized Reaction protobuf and runs validations."""
     message = message_helpers.create_message(message_name)
     message.ParseFromString(flask.request.get_data())
-    errors = validations.validate_message(message, raise_on_error=False)
+    errors = validations.validate_message(message,
+                                          raise_on_error=False,
+                                          strict=True)
     return json.dumps(errors)
 
 

--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -304,9 +304,10 @@ def validate_reaction(message_name):
     """Receives a serialized Reaction protobuf and runs validations."""
     message = message_helpers.create_message(message_name)
     message.ParseFromString(flask.request.get_data())
+    options = validations.ValidationOptions(require_provenance=True)
     errors = validations.validate_message(message,
                                           raise_on_error=False,
-                                          strict=True)
+                                          options=options)
     return json.dumps(errors)
 
 

--- a/ord_schema/process_dataset.py
+++ b/ord_schema/process_dataset.py
@@ -242,10 +242,12 @@ def _run_updates(inputs, datasets):
             logging.info('Running command: %s', ' '.join(args))
             subprocess.run(args, check=True)
     combined = _combine_datasets(datasets)
-    # Final validation (incl. IDs) to make sure we didn't break anything.
+    # Final validation to make sure we didn't break anything.
+    options = validations.ValidationOptions(validate_ids=True,
+                                            require_provenance=True)
     validations.validate_datasets({'_COMBINED': combined},
                                   FLAGS.write_errors,
-                                  strict=True)
+                                  options=options)
     if FLAGS.output:
         output_filename = FLAGS.output
     else:

--- a/ord_schema/process_dataset.py
+++ b/ord_schema/process_dataset.py
@@ -245,7 +245,7 @@ def _run_updates(inputs, datasets):
     # Final validation (incl. IDs) to make sure we didn't break anything.
     validations.validate_datasets({'_COMBINED': combined},
                                   FLAGS.write_errors,
-                                  validate_ids=True)
+                                  strict=True)
     if FLAGS.output:
         output_filename = FLAGS.output
     else:

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -31,6 +31,7 @@ from ord_schema.proto import reaction_pb2
 
 @dataclasses.dataclass
 class ValidationOptions:
+    """Options for message validation."""
     # Check that Dataset and Reaction IDs are well-formed.
     validate_ids: bool = False
     # Require ReactionProvenance for Reactions.
@@ -319,9 +320,9 @@ def get_referenced_reaction_ids(message):
 
 
 def validate_dataset(message, options=None):
+    # pylint: disable=too-many-branches,too-many-nested-blocks
     if options is None:
         options = ValidationOptions()
-    # pylint: disable=too-many-branches,too-many-nested-blocks
     if not message.reactions and not message.reaction_ids:
         warnings.warn('Dataset requires reactions or reaction_ids',
                       ValidationError)

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -261,16 +261,18 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         message = reaction_pb2.Reaction(reaction_id=reaction_id)
         _ = message.inputs['test']
         message.outcomes.add()
+        options = validations.ValidationOptions(validate_ids=True)
         with self.assertRaisesRegex(validations.ValidationError, 'malformed'):
-            self._run_validation(message, recurse=False, strict=True)
+            self._run_validation(message, recurse=False, options=options)
 
     def test_missing_provenance(self):
         message = reaction_pb2.Reaction()
         _ = message.inputs['test']
         message.outcomes.add()
+        options = validations.ValidationOptions(require_provenance=True)
         with self.assertRaisesRegex(validations.ValidationError,
                                     'requires provenance'):
-            self._run_validation(message, recurse=False, strict=True)
+            self._run_validation(message, recurse=False, options=options)
 
     def test_data(self):
         message = reaction_pb2.Data()
@@ -286,29 +288,24 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
 
     def test_dataset_bad_reaction_id(self):
         message = dataset_pb2.Dataset(reaction_ids=['foo'])
+        options = validations.ValidationOptions(validate_ids=True)
         with self.assertRaisesRegex(validations.ValidationError, 'malformed'):
-            self._run_validation(message, strict=True)
-
-    def test_dataset_missing_reaction_id(self):
-        message = dataset_pb2.Dataset(
-            reactions=[reaction_pb2.Reaction()],
-            dataset_id='ord_dataset-c0bbd41f095a44a78b6221135961d809')
-        with self.assertRaisesRegex(validations.ValidationError,
-                                    'must have defined IDs'):
-            self._run_validation(message, recurse=False, strict=True)
+            self._run_validation(message, options=options)
 
     def test_dataset_records_and_ids(self):
         message = dataset_pb2.Dataset(
             reactions=[reaction_pb2.Reaction()],
             reaction_ids=['ord-c0bbd41f095a44a78b6221135961d809'])
+        options = validations.ValidationOptions(validate_ids=True)
         with self.assertRaisesRegex(validations.ValidationError, 'not both'):
-            self._run_validation(message, recurse=False, strict=True)
+            self._run_validation(message, recurse=False, options=options)
 
     def test_dataset_bad_id(self):
         message = dataset_pb2.Dataset(reactions=[reaction_pb2.Reaction()],
                                       dataset_id='foo')
+        options = validations.ValidationOptions(validate_ids=True)
         with self.assertRaisesRegex(validations.ValidationError, 'malformed'):
-            self._run_validation(message, recurse=False, strict=True)
+            self._run_validation(message, recurse=False, options=options)
 
     def test_dataset_example(self):
         message = dataset_pb2.DatasetExample()

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -241,13 +241,14 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         message.record_created.time.value = '2020-01-03'
         self.assertEmpty(self._run_validation(message))
 
-    @parameterized.parameters(['ord-c0bbd41f095a44a78b6221135961d809', ''])
-    def test_reaction_id(self, reaction_id):
+    def test_reaction_id(self):
         message = reaction_pb2.Reaction()
         _ = message.inputs['test']
         message.outcomes.add()
-        message.reaction_id = reaction_id
-        self.assertEmpty(self._run_validation(message, recurse=False))
+        message.reaction_id = 'ord-c0bbd41f095a44a78b6221135961d809'
+        options = validations.ValidationOptions(validate_ids=True)
+        self.assertEmpty(
+            self._run_validation(message, recurse=False, options=options))
 
     @parameterized.named_parameters(
         ('too short', 'ord-c0bbd41f095a4'),
@@ -256,6 +257,7 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         ('bad capitalization', 'ord-C0BBD41F095A44A78B6221135961D809'),
         ('bad characters', 'ord-h0bbd41f095a44a78b6221135961d809'),
         ('bad characters 2', 'ord-notARealId'),
+        ('empty', ''),
     )
     def test_bad_reaction_id(self, reaction_id):
         message = reaction_pb2.Reaction(reaction_id=reaction_id)


### PR DESCRIPTION
Fixes #273 

Changes:
* Replaces `validate_ids` with `strict`
* Strict checks include ID validation as well as provenance checks

I struggled with the different levels of strictness that are required by the editor and the submission workflow. The former doesn't care about reaction IDs but both care about provenance. My compromise is to allow empty reaction IDs when strictly validating Reactions but not Datasets. This allows the editor to use `strict=True` without emitting warnings about bad IDs.