### PR TITLE
Editor bugs

### DIFF
--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -149,6 +149,12 @@ limitations under the License.
                     </span>
                     </td><td><div class="input_addition_duration_value edittext shorttext"></div><div class="input_addition_duration_units selector" data-proto="Time_TimeUnit"></div></td><td>
                     +/- <div class="input_addition_duration_precision edittext shorttext"></div></td></tr>
+                    <tr><td align="right">addition temperature
+                    <span data-toggle="tooltip" data-placement="right" title="Addition temperature specifies if the reaction input was heated or cooled prior to addition.">
+                      <span class="fa fa-question-circle" aria-hidden="true"></span>
+                    </span>
+                    </td><td><div class="input_addition_temperature_value edittext shorttext"></div><div class="input_addition_temperature_units selector" data-proto="Temperature_TemperatureUnit"></div></td><td>
+                    +/- <div class="input_addition_temperature_precision edittext shorttext"></div></td></tr>
                   </table>
                 </fieldset>
                 <fieldset>

--- a/editor/js/inputs.js
+++ b/editor/js/inputs.js
@@ -77,6 +77,10 @@ function loadInputUnnamed(node, input) {
   if (duration) {
     ord.reaction.writeMetric('.input_addition_duration', duration, node);
   }
+  const temperature = input.getAdditionTemperature();
+  if (temperature) {
+    ord.reaction.writeMetric('.input_addition_temperature', temperature, node);
+  }
   const flowRate = input.getFlowRate();
   if (flowRate) {
     ord.reaction.writeMetric('.input_flow_rate', flowRate, node);
@@ -146,6 +150,12 @@ function unloadInputUnnamed(node) {
       '.input_addition_duration', new proto.ord.Time(), node);
   if (!ord.reaction.isEmptyMessage(additionDuration)) {
     input.setAdditionDuration(additionDuration);
+  }
+
+  const additionTemperature = ord.reaction.readMetric(
+      '.input_addition_temperature', new proto.ord.Temperature(), node);
+  if (!ord.reaction.isEmptyMessage(additionTemperature)) {
+    input.setAdditionTemperature(additionTemperature);
   }
 
   const flowRate = ord.reaction.readMetric(

--- a/editor/js/outcomes.js
+++ b/editor/js/outcomes.js
@@ -371,7 +371,8 @@ function addAnalysis(node) {
           $(this).val('');
         }
       });
-      $('.analysis_key_selector option[value="' + old_name + '"]', node).remove();
+      $('.analysis_key_selector option[value="' + old_name + '"]', node)
+          .remove();
     }
     // Add new key.
     if (name) {

--- a/editor/js/outcomes.js
+++ b/editor/js/outcomes.js
@@ -35,6 +35,7 @@ let radioGroupCounter = 0;
 
 function load(outcomes) {
   outcomes.forEach(outcome => loadOutcome(outcome));
+  $('.outcome_analysis_name').trigger('input');
 }
 
 function loadOutcome(outcome) {
@@ -64,7 +65,7 @@ function loadOutcome(outcome) {
 function loadAnalysis(analysesNode, name, analysis) {
   const node = addAnalysis(analysesNode);
 
-  $('.outcome_analysis_name', node).text(name).trigger('input');
+  $('.outcome_analysis_name', node).text(name);
 
   ord.reaction.setSelector(
       $('.outcome_analysis_type', node), analysis.getType());
@@ -210,7 +211,7 @@ function unloadOutcome(node) {
   outcome.setProductsList(products);
 
   const analyses = outcome.getAnalysesMap();
-  $('.outcome_analysis').each(function(index, node) {
+  $('.outcome_analysis', node).each(function(index, node) {
     node = $(node);
     if (!node.attr('id')) {
       // Not a template.
@@ -365,17 +366,17 @@ function addAnalysis(node) {
     var old_name = nameNode.data('val');
     if (old_name) {
       // If any selector had this value selected, reset it.
-      $('.analysis_key_selector').each(function() {
+      $('.analysis_key_selector', node).each(function() {
         if ($(this).val() == old_name) {
           $(this).val('');
         }
       });
-      $('.analysis_key_selector option[value="' + old_name + '"]').remove();
+      $('.analysis_key_selector option[value="' + old_name + '"]', node).remove();
     }
     // Add new key.
     var name = nameNode.text();
     if (name) {
-      $('.analysis_key_selector')
+      $('.analysis_key_selector', node)
           .append('<option value="' + name + '">' + name + '</option>');
       // Ensure old value stored (necessary if focus does not change).
       nameNode.data('val', name);

--- a/editor/js/outcomes.js
+++ b/editor/js/outcomes.js
@@ -61,8 +61,8 @@ function loadOutcome(outcome) {
   ord.products.load(node, products);
 }
 
-function loadAnalysis(analysesNode, name, analysis) {
-  const node = addAnalysis(analysesNode);
+function loadAnalysis(outcomeNode, name, analysis) {
+  const node = addAnalysis(outcomeNode);
 
   $('.outcome_analysis_name', node).text(name).trigger('input');
 

--- a/editor/js/outcomes.js
+++ b/editor/js/outcomes.js
@@ -35,7 +35,6 @@ let radioGroupCounter = 0;
 
 function load(outcomes) {
   outcomes.forEach(outcome => loadOutcome(outcome));
-  $('.outcome_analysis_name').trigger('input');
 }
 
 function loadOutcome(outcome) {
@@ -65,7 +64,7 @@ function loadOutcome(outcome) {
 function loadAnalysis(analysesNode, name, analysis) {
   const node = addAnalysis(analysesNode);
 
-  $('.outcome_analysis_name', node).text(name);
+  $('.outcome_analysis_name', node).text(name).trigger('input');
 
   ord.reaction.setSelector(
       $('.outcome_analysis_type', node), analysis.getType());
@@ -362,8 +361,9 @@ function addAnalysis(node) {
     nameNode.data('val', nameNode.text());
   });
   nameNode.on('input', function() {
-    // Remove old key.
     var old_name = nameNode.data('val');
+    var name = nameNode.text();
+    // Remove old key.
     if (old_name) {
       // If any selector had this value selected, reset it.
       $('.analysis_key_selector', node).each(function() {
@@ -374,7 +374,6 @@ function addAnalysis(node) {
       $('.analysis_key_selector option[value="' + old_name + '"]', node).remove();
     }
     // Add new key.
-    var name = nameNode.text();
     if (name) {
       $('.analysis_key_selector', node)
           .append('<option value="' + name + '">' + name + '</option>');

--- a/editor/js/products.js
+++ b/editor/js/products.js
@@ -226,27 +226,35 @@ function add(node) {
 }
 
 function addIdentity(node) {
-  return ord.reaction.addSlowly(
+  const analysisSelectorNode = ord.reaction.addSlowly(
       '#outcome_product_analysis_identity_template',
       $('.outcome_product_analysis_identities', node));
+  $('.outcome_analysis_name').trigger('input');
+  return analysisSelectorNode;
 }
 
 function addYield(node) {
-  return ord.reaction.addSlowly(
+  const analysisSelectorNode = ord.reaction.addSlowly(
       '#outcome_product_analysis_yield_template',
       $('.outcome_product_analysis_yields', node));
+  $('.outcome_analysis_name').trigger('input');
+  return analysisSelectorNode;
 }
 
 function addPurity(node) {
-  return ord.reaction.addSlowly(
+  const analysisSelectorNode = ord.reaction.addSlowly(
       '#outcome_product_analysis_purity_template',
       $('.outcome_product_analysis_purities', node));
+  $('.outcome_analysis_name').trigger('input');
+  return analysisSelectorNode;
 }
 
 function addSelectivity(node) {
-  return ord.reaction.addSlowly(
+  const analysisSelectorNode = ord.reaction.addSlowly(
       '#outcome_product_analysis_selectivity_template',
       $('.outcome_product_analysis_selectivities', node));
+  $('.outcome_analysis_name').trigger('input');
+  return analysisSelectorNode;
 }
 
 function validateProduct(node, validateNode) {

--- a/editor/js/products.js
+++ b/editor/js/products.js
@@ -229,7 +229,6 @@ function addIdentity(node) {
   const analysisSelectorNode = ord.reaction.addSlowly(
       '#outcome_product_analysis_identity_template',
       $('.outcome_product_analysis_identities', node));
-  $('.outcome_analysis_name').trigger('input');
   return analysisSelectorNode;
 }
 
@@ -237,7 +236,6 @@ function addYield(node) {
   const analysisSelectorNode = ord.reaction.addSlowly(
       '#outcome_product_analysis_yield_template',
       $('.outcome_product_analysis_yields', node));
-  $('.outcome_analysis_name').trigger('input');
   return analysisSelectorNode;
 }
 
@@ -245,7 +243,6 @@ function addPurity(node) {
   const analysisSelectorNode = ord.reaction.addSlowly(
       '#outcome_product_analysis_purity_template',
       $('.outcome_product_analysis_purities', node));
-  $('.outcome_analysis_name').trigger('input');
   return analysisSelectorNode;
 }
 
@@ -253,7 +250,6 @@ function addSelectivity(node) {
   const analysisSelectorNode = ord.reaction.addSlowly(
       '#outcome_product_analysis_selectivity_template',
       $('.outcome_product_analysis_selectivities', node));
-  $('.outcome_analysis_name').trigger('input');
   return analysisSelectorNode;
 }
 

--- a/editor/js/products.js
+++ b/editor/js/products.js
@@ -120,7 +120,7 @@ function unload(node) {
 function unloadProduct(node) {
   const product = new proto.ord.ReactionProduct();
 
-  const compoundNode = $('.outcome_product_compound');
+  const compoundNode = $('.outcome_product_compound', node);
   const compound = ord.compounds.unloadCompound(compoundNode);
   if (!ord.reaction.isEmptyMessage(compound)) {
     product.setCompound(compound);

--- a/editor/js/products.js
+++ b/editor/js/products.js
@@ -227,7 +227,7 @@ function add(node) {
 
 function populateAnalysisSelector(node, analysisSelectorNode) {
   const outcomeNode = node.closest('.outcome');
-  $('.outcome_analysis_name', outcomeNode).each(function () {
+  $('.outcome_analysis_name', outcomeNode).each(function() {
     var name = $(this).text();
     if (name) {
       $('.analysis_key_selector', analysisSelectorNode)

--- a/editor/js/products.js
+++ b/editor/js/products.js
@@ -225,10 +225,22 @@ function add(node) {
   return productNode;
 }
 
+function populateAnalysisSelector(node, analysisSelectorNode) {
+  const outcomeNode = node.closest('.outcome');
+  $('.outcome_analysis_name', outcomeNode).each(function () {
+    var name = $(this).text();
+    if (name) {
+      $('.analysis_key_selector', analysisSelectorNode)
+          .append('<option value="' + name + '">' + name + '</option>');
+    }
+  });
+}
+
 function addIdentity(node) {
   const analysisSelectorNode = ord.reaction.addSlowly(
       '#outcome_product_analysis_identity_template',
       $('.outcome_product_analysis_identities', node));
+  populateAnalysisSelector(node, analysisSelectorNode);
   return analysisSelectorNode;
 }
 
@@ -236,6 +248,7 @@ function addYield(node) {
   const analysisSelectorNode = ord.reaction.addSlowly(
       '#outcome_product_analysis_yield_template',
       $('.outcome_product_analysis_yields', node));
+  populateAnalysisSelector(node, analysisSelectorNode);
   return analysisSelectorNode;
 }
 
@@ -243,6 +256,7 @@ function addPurity(node) {
   const analysisSelectorNode = ord.reaction.addSlowly(
       '#outcome_product_analysis_purity_template',
       $('.outcome_product_analysis_purities', node));
+  populateAnalysisSelector(node, analysisSelectorNode);
   return analysisSelectorNode;
 }
 
@@ -250,6 +264,7 @@ function addSelectivity(node) {
   const analysisSelectorNode = ord.reaction.addSlowly(
       '#outcome_product_analysis_selectivity_template',
       $('.outcome_product_analysis_selectivities', node));
+  populateAnalysisSelector(node, analysisSelectorNode);
   return analysisSelectorNode;
 }
 


### PR DESCRIPTION
This PR fixes the following bugs (#341 and #342):
- When multiple outcomes are present, analysis selectors for identity_analysis, yield_analysis, etc. included analyses from other outcomes (i.e., other time points)
- The form did not include `addition_temperature`
- The form saved each outcome with all of the analyses from all outcomes, rather than restricting unloading to analyses defined within that outcome
- When adding new analysis selectors within an outcome, the selector was empty and not pre-populated with the options allowed within that outcome 