### PR TITLE
Use current head in editor test

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Build and launch editor
       run: |
         cd "${GITHUB_WORKSPACE}/editor"
-        docker build -t ord-editor .
+        docker build -t ord-editor --build-arg "GITHUB_REF=${GITHUB_REF}" .
         docker run --rm -d -p 5000:5000 --name editor ord-editor
         # NOTE(kearnes): This also leaves time for the server to get ready.
         npm install puppeteer

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -80,6 +80,7 @@ jobs:
         docker build \
           -t ord-editor \
           --build-arg "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}" \
+          --build-arg "GITHUB_SHA=${GITHUB_SHA}" \
           --build-arg "GITHUB_REF=${GITHUB_REF}" \
           .
         docker run --rm -d -p 5000:5000 --name editor ord-editor

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -77,7 +77,11 @@ jobs:
     - name: Build and launch editor
       run: |
         cd "${GITHUB_WORKSPACE}/editor"
-        docker build -t ord-editor --build-arg "GITHUB_REF=${GITHUB_REF}" .
+        docker build \
+          -t ord-editor \
+          --build-arg "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}" \
+          --build-arg "GITHUB_REF=${GITHUB_REF}" \
+          .
         docker run --rm -d -p 5000:5000 --name editor ord-editor
         # NOTE(kearnes): This also leaves time for the server to get ready.
         npm install puppeteer

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -45,7 +45,6 @@ ADD "https://api.github.com/repos/${GITHUB_REPOSITORY}/git/${GITHUB_REF}" ord-sc
 WORKDIR ord-schema
 RUN git remote add origin https://github.com/${GITHUB_REPOSITORY}.git
 RUN git fetch --depth=1 origin "+${GITHUB_SHA}:${GITHUB_REF}"
-RUN cat editor/README.md
 RUN git checkout "${GITHUB_REF}"
 RUN pip install -r requirements.txt
 RUN python setup.py install

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -35,10 +35,11 @@ RUN mv ketcher ord-schema/editor/
 RUN mv protobuf ord-schema/editor/
 
 WORKDIR ord-schema
+ARG GITHUB_REPOSITORY=Open-Reaction-Database/ord-schema
 ARG GITHUB_REF=refs/heads/main
 # Bust the cache to get the latest commits; see
 # https://stackoverflow.com/a/39278224.
-ADD "https://api.github.com/repos/Open-Reaction-Database/ord-schema/git/${GITHUB_REF}" ord-schema-version.json
+ADD "https://api.github.com/repos/${GITHUB_REPOSITORY}/git/${GITHUB_REF}" ord-schema-version.json
 RUN git checkout "${GITHUB_REF##*/}"
 RUN git pull origin "${GITHUB_REF##*/}"
 RUN pip install -r requirements.txt

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -29,21 +29,24 @@ RUN tar -xzf v20200517.tar.gz
 RUN wget https://storage.googleapis.com/ord-editor-test/editor_test_protobuf_1dae8fdd.tar
 RUN tar -xzf editor_test_protobuf_1dae8fdd.tar
 
-ARG GITHUB_REPOSITORY=Open-Reaction-Database/ord-schema
-ARG GITHUB_REF=refs/heads/main
-RUN git clone https://github.com/${GITHUB_REPOSITORY}.git
-# NOTE(kearnes): These moves are only here so they are cached even when the
-# ord-schema repo changes.
+RUN git init ord-schema
+RUN mkdir ord-schema/editor
 RUN mv closure-library-20200517 ord-schema/editor/
 RUN mv ketcher ord-schema/editor/
 RUN mv protobuf ord-schema/editor/
 
-WORKDIR ord-schema
+ARG GITHUB_REPOSITORY=Open-Reaction-Database/ord-schema
+ARG GITHUB_SHA=refs/heads/main
+ARG GITHUB_REF=refs/heads/main
 # Bust the cache to get the latest commits; see
 # https://stackoverflow.com/a/39278224.
 ADD "https://api.github.com/repos/${GITHUB_REPOSITORY}/git/${GITHUB_REF}" ord-schema-version.json
-RUN git checkout "${GITHUB_REF##*/}"
-RUN git pull origin "${GITHUB_REF##*/}"
+
+WORKDIR ord-schema
+RUN git remote add origin https://github.com/${GITHUB_REPOSITORY}.git
+RUN git fetch --depth=1 origin "+${GITHUB_SHA}:${GITHUB_REF}"
+RUN cat editor/README.md
+RUN git checkout "${GITHUB_REF}"
 RUN pip install -r requirements.txt
 RUN python setup.py install
 

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -29,14 +29,16 @@ RUN tar -xzf v20200517.tar.gz
 RUN wget https://storage.googleapis.com/ord-editor-test/editor_test_protobuf_1dae8fdd.tar
 RUN tar -xzf editor_test_protobuf_1dae8fdd.tar
 
-RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
+ARG GITHUB_REPOSITORY=Open-Reaction-Database/ord-schema
+ARG GITHUB_REF=refs/heads/main
+RUN git clone https://github.com/${GITHUB_REPOSITORY}.git
+# NOTE(kearnes): These moves are only here so they are cached even when the
+# ord-schema repo changes.
 RUN mv closure-library-20200517 ord-schema/editor/
 RUN mv ketcher ord-schema/editor/
 RUN mv protobuf ord-schema/editor/
 
 WORKDIR ord-schema
-ARG GITHUB_REPOSITORY=Open-Reaction-Database/ord-schema
-ARG GITHUB_REF=refs/heads/main
 # Bust the cache to get the latest commits; see
 # https://stackoverflow.com/a/39278224.
 ADD "https://api.github.com/repos/${GITHUB_REPOSITORY}/git/${GITHUB_REF}" ord-schema-version.json

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -35,10 +35,12 @@ RUN mv ketcher ord-schema/editor/
 RUN mv protobuf ord-schema/editor/
 
 WORKDIR ord-schema
+ARG GITHUB_REF=refs/heads/main
 # Bust the cache to get the latest commits; see
 # https://stackoverflow.com/a/39278224.
-ADD https://api.github.com/repos/Open-Reaction-Database/ord-schema/git/refs/heads/main ord-schema-version.json
-RUN git pull
+ADD "https://api.github.com/repos/Open-Reaction-Database/ord-schema/git/${GITHUB_REF}" ord-schema-version.json
+RUN git checkout "${GITHUB_REF##*/}"
+RUN git pull origin "${GITHUB_REF##*/}"
 RUN pip install -r requirements.txt
 RUN python setup.py install
 


### PR DESCRIPTION
#351 was too simple; it always uses `main` in `Open-Reaction-Database/ord-schema`.