### PR TITLE
Use local state for editor Dockerfile

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -76,20 +76,15 @@ jobs:
     - uses: actions/setup-node@v1.4.2
     - name: Build and launch editor
       run: |
-        cd "${GITHUB_WORKSPACE}/editor"
-        docker build \
-          -t ord-editor \
-          --build-arg "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}" \
-          --build-arg "GITHUB_SHA=${GITHUB_SHA}" \
-          --build-arg "GITHUB_REF=${GITHUB_REF}" \
-          .
+        cd "${GITHUB_WORKSPACE}"
+        docker build --file=editor/Dockerfile -t ord-editor .
         docker run --rm -d -p 5000:5000 --name editor ord-editor
         # NOTE(kearnes): This also leaves time for the server to get ready.
         npm install puppeteer
     - name: Run editor tests
       timeout-minutes: 5
       run: |
-        cd "${GITHUB_WORKSPACE}/editor"
-        node js/test.js
+        cd "${GITHUB_WORKSPACE}"
+        node editor/js/test.js
     - name: Cleanup
       run: docker stop editor

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -12,14 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# To build the editor using the current state of ord-schema:
+# $ cd path/to/ord-schema
+# $ docker build --file=editor/Dockerfile -t openreactiondatabase/ord-editor .
+#
+# To test the editor:
+# $ docker run --rm -d -p 5000:5000 --name editor openreactiondatabase/ord-editor
+# $ node editor/js/test.js
+# $ docker stop editor
+#
+# To push the built image to Docker Hub:
+# docker push openreactiondatabase/ord-editor
+
 FROM continuumio/miniconda3
-WORKDIR /usr/src/app
 
 RUN apt-get update && apt-get install --yes build-essential procps unzip
 RUN conda install -c rdkit rdkit
 RUN conda install flask nodejs
 
 # Fetch/build editor dependencies.
+# NOTE(kearnes): Do this before COPYing the local state so it can be cached.
+WORKDIR /usr/src/app/ord-schema/editor
 RUN git clone https://github.com/Open-Reaction-Database/ketcher.git
 WORKDIR ketcher
 RUN npm install && npm run build
@@ -29,35 +42,17 @@ RUN tar -xzf v20200517.tar.gz
 RUN wget https://storage.googleapis.com/ord-editor-test/editor_test_protobuf_1dae8fdd.tar
 RUN tar -xzf editor_test_protobuf_1dae8fdd.tar
 
-RUN git init ord-schema
-RUN mkdir ord-schema/editor
-RUN mv closure-library-20200517 ord-schema/editor/
-RUN mv ketcher ord-schema/editor/
-RUN mv protobuf ord-schema/editor/
-
-ARG GITHUB_REPOSITORY=Open-Reaction-Database/ord-schema
-ARG GITHUB_SHA=refs/heads/main
-ARG GITHUB_REF=refs/heads/main
-# Bust the cache to get the latest commits; see
-# https://stackoverflow.com/a/39278224.
-ADD "https://api.github.com/repos/${GITHUB_REPOSITORY}/git/${GITHUB_REF}" ord-schema-version.json
-
-WORKDIR ord-schema
-RUN git remote add origin https://github.com/${GITHUB_REPOSITORY}.git
-RUN git fetch --depth=1 origin "+${GITHUB_SHA}:${GITHUB_REF}"
-RUN git checkout "${GITHUB_REF}"
+# COPY and install the local state of ord-schema.
+WORKDIR /usr/src/app/ord-schema
+COPY setup.py requirements.txt ./
+COPY editor/ editor/
+COPY ord_schema/ ord_schema/
 RUN pip install -r requirements.txt
 RUN python setup.py install
 
-# Build the editor.
-WORKDIR editor
-# Uncomment these lines to copy over any local changes in ord-schema/editor.
-#COPY css/*.css css/
-#COPY html/*.html html/
-#COPY js/*.js js/
-#COPY py/*.py py/
+# Build and launch the editor.
+WORKDIR /usr/src/app/ord-schema/editor
 RUN make
-
 EXPOSE 5000
 RUN pip install gunicorn
 CMD gunicorn py.serve:app -b 0.0.0.0:5000 --access-logfile '-'


### PR DESCRIPTION
Fixes #354 

This should also make it possible for us to automate docker builds on pushes to `main`.