### PR TITLE
Factor out duplicated Data message handling code

### DIFF
--- a/editor/css/reaction.css
+++ b/editor/css/reaction.css
@@ -114,39 +114,39 @@ fieldset {
 .navSection:hover {
   background-color: lightblue;
 }
-.uploader .adder {
+.data_uploader .adder {
   width: 208px;
   display: inline-block;
   padding-left: 2px;
   position: relative;
 }
-.uploadertext {
+.data_uploader_text {
   display: inline-block;
   border: solid;
   border-width: 1px;
   border-color: #c0c0c0;
   height: 21px;
 }
-.uploader_chooser_file {
+.data_uploader_chooser_file {
   opacity: 0;
   position: absolute;
   width: 100px;
 }
-.uploader_chooser_button {
+.data_uploader_chooser_button {
   width: 99px;
 }
-.uploader_chooser_file, .uploader_chooser_button {
+.data_uploader_chooser_file, .data_uploader_chooser_button {
   cursor: pointer;
 }
-.uploader_chooser_button, .uploader_file_retrieve {
+.data_uploader_chooser_button, .data_uploader_file_retrieve {
   text-align: center;
 }
-.uploader_file_name {
+.data_uploader_file_name {
   min-width: 99px;
   overflow-x: visible;
   vertical-align: bottom
 }
-.uploader_file_retrieve {
+.data_uploader_file_retrieve {
   width: 100px;
   border: none;
   cursor: pointer;

--- a/editor/db/test/full.pbtxt
+++ b/editor/db/test/full.pbtxt
@@ -443,7 +443,7 @@ reactions {
         raw_data {
           key: "139"
           value {
-            float_value: 140.5
+            float_value: 140.0
             description: "141"
             format: "142"
           }

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -373,29 +373,6 @@ limitations under the License.
               <div onclick="ord.reaction.removeSlowly(this, '.setup_code');" class="remove">remove</div>
               <table>
                 <tr><td align="right">name</td><td><div class="setup_code_name edittext"></div></td></tr>
-                <tr>
-                  <td align="right">value</td>
-                  <td>
-                    <div class="setup_code_text edittext"></div>
-                    <div class="uploader" data-token="" style="display: none;">
-                      <input class="uploader_chooser_file uploadertext" type="file">
-                      <div class="uploader_chooser_button uploadertext">Choose...</div>
-                      <div class="uploader_file_name uploadertext"></div>
-                      <div class="uploader_file_retrieve uploadertext" onclick="ord.uploads.retrieve($(this).closest('.uploader'));" style="display: none;">retrieve</div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td align="right">type</td>
-                  <td>
-                    <input type="radio" value="text" checked> text
-                    <input type="radio" value="number"> number
-                    <input type="radio" value="url"> url
-                    <input type="radio" value="upload"> upload
-                  </td>
-                </tr>
-                <tr><td align="right">description</td><td><div class="setup_code_description edittext"></div></td></tr>
-                <tr><td align="right">file format</td><td><div class="setup_code_format edittext"></div></td></tr>
               </table>
             </fieldset>
           </div>
@@ -639,29 +616,6 @@ limitations under the License.
                 <tr><td align="right">time</td><td><div class="observation_time_value edittext shorttext"></div>
                                                    <div class="observation_time_units selector" data-proto="Time_TimeUnit"></div>
                                                    +/- <div class="observation_time_precision edittext shorttext"></div></td></tr>
-                <tr>
-                  <td align="right">value</td>
-                  <td>
-                    <div class="observation_image_text edittext"></div>
-                    <div class="uploader" data-token="" style="display: none;">
-                      <input class="uploader_chooser_file uploadertext" type="file">
-                      <div class="uploader_chooser_button uploadertext">Choose...</div>
-                      <div class="uploader_file_name uploadertext"></div>
-                      <div class="uploader_file_retrieve uploadertext" onclick="ord.uploads.retrieve($(this).closest('.uploader'));" style="display: none;">retrieve</div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td align="right">type</td>
-                  <td>
-                    <input type="radio" value="text" checked> text
-                    <input type="radio" value="number"> number
-                    <input type="radio" value="url"> url
-                    <input type="radio" value="upload"> upload
-                  </td>
-                </tr>
-                <tr><td align="right">description</td><td><div class="observation_image_description edittext"></div></td></tr>
-                <tr><td align="right">file format</td><td><div class="observation_image_format edittext"></div></td></tr>
                 <tr><td align="right">comment</td><td><div class="observation_comment edittext"></div></td></tr>
               </table>
             </fieldset>
@@ -975,29 +929,6 @@ limitations under the License.
               <div onclick="ord.reaction.removeSlowly(this, '.outcome_processed_data');" class="remove">remove</div>
               <table>
                 <tr><td align="right">name</td><td><div class="outcome_processed_data_name edittext"></div></td></tr>
-                <tr>
-                  <td align="right">content</td>
-                  <td>
-                    <div class="outcome_processed_data_text edittext"></div>
-                    <div class="uploader" data-token="" style="display: none;">
-                      <input class="uploader_chooser_file uploadertext" type="file">
-                      <div class="uploader_chooser_button uploadertext">Choose...</div>
-                      <div class="uploader_file_name uploadertext"></div>
-                      <div class="uploader_file_retrieve uploadertext" onclick="ord.uploads.retrieve($(this).closest('.uploader'));" style="display: none;">retrieve</div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td align="right">type</td>
-                  <td>
-                    <input type="radio" value="text" checked> text
-                    <input type="radio" value="number"> number
-                    <input type="radio" value="url"> url
-                    <input type="radio" value="upload"> upload
-                  </td>
-                </tr>
-                <tr><td align="right">description</td><td><div class="outcome_processed_data_description edittext"></div></td></tr>
-                <tr><td align="right">file format</td><td><div class="outcome_processed_data_format edittext"></div></td></tr>
               </table>
             </fieldset>
           </div>
@@ -1011,29 +942,6 @@ limitations under the License.
               <div onclick="ord.reaction.removeSlowly(this, '.outcome_raw_data');" class="remove">remove</div>
               <table>
                 <tr><td align="right">name</td><td><div class="outcome_raw_data_name edittext"></div></td></tr>
-                <tr>
-                  <td align="right">content</td>
-                  <td>
-                    <div class="outcome_raw_data_text edittext"></div>
-                    <div class="uploader" data-token="" style="display: none;">
-                      <input class="uploader_chooser_file uploadertext" type="file">
-                      <div class="uploader_chooser_button uploadertext">Choose...</div>
-                      <div class="uploader_file_name uploadertext"></div>
-                      <div class="uploader_file_retrieve uploadertext" onclick="ord.uploads.retrieve($(this).closest('.uploader'));" style="display: none;">retrieve</div>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td align="right">type</td>
-                  <td>
-                    <input type="radio" value="text" checked> text
-                    <input type="radio" value="number"> number
-                    <input type="radio" value="url"> url
-                    <input type="radio" value="upload"> upload
-                  </td>
-                </tr>
-                <tr><td align="right">description</td><td><div class="outcome_raw_data_description edittext"></div></td></tr>
-                <tr><td align="right">file format</td><td><div class="outcome_raw_data_format edittext"></div></td></tr>
               </table>
             </fieldset>
           </div>
@@ -1133,6 +1041,34 @@ limitations under the License.
               </div>
           </div>
       </div>
+    </div>
+
+    <div id="data_template" class="data" style="display: none;">
+      <table>
+      <tr>
+        <td align="right">data</td>
+        <td>
+          <div class="data_text edittext"></div>
+          <div class="data_uploader" data-token="" style="display: none;">
+            <input class="data_uploader_chooser_file data_uploader_text" type="file">
+            <div class="data_uploader_chooser_button data_uploader_text">Choose...</div>
+            <div class="data_uploader_file_name data_uploader_text"></div>
+            <div class="data_uploader_file_retrieve data_uploader_text" onclick="ord.uploads.retrieve($(this).closest('.data_uploader'));" style="display: none;">retrieve</div>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <td align="right">type</td>
+        <td>
+          <input type="radio" value="text" checked> text
+          <input type="radio" value="number"> number
+          <input type="radio" value="url"> url
+          <input type="radio" value="upload"> upload
+        </td>
+      </tr>
+      <tr><td align="right">description</td><td><div class="data_description edittext"></div></td></tr>
+      <tr><td align="right">file format</td><td><div class="data_format edittext"></div></td></tr>
+      </table>
     </div>
 
     <script>

--- a/editor/js/codes.js
+++ b/editor/js/codes.js
@@ -22,6 +22,7 @@ exports = {
   addCode
 };
 
+goog.require('ord.data');
 goog.require('proto.ord.Data');
 
 // Freely create radio button groups by generating new input names.
@@ -47,48 +48,7 @@ function load(codes) {
 function loadCode(name, code) {
   const node = addCode();
   $('.setup_code_name', node).text(name);
-  $('.setup_code_description', node).text(code.getDescription());
-  $('.setup_code_format', node).text(code.getFormat());
-  let value;
-  switch (code.getKindCase()) {
-    case proto.ord.Data.KindCase.FLOAT_VALUE:
-      value = code.getFloatValue();
-      $('.setup_code_text', node).show();
-      $('.uploader', node).hide();
-      $('.setup_code_text', node).text(value);
-      $('input[value=\'number\']', node).prop('checked', true);
-      break;
-    case proto.ord.Data.KindCase.INTEGER_VALUE:
-      value = code.getIntegerValue();
-      $('.setup_code_text', node).show();
-      $('.uploader', node).hide();
-      $('.setup_code_text', node).text(value);
-      $('input[value=\'number\']', node).prop('checked', true);
-      break;
-    case proto.ord.Data.KindCase.BYTES_VALUE:
-      value = code.getBytesValue();
-      $('.setup_code_text', node).hide();
-      $('.uploader', node).show();
-      ord.uploads.load(node, value);
-      $('input[value=\'upload\']', node).prop('checked', true);
-      break;
-    case proto.ord.Data.KindCase.STRING_VALUE:
-      value = code.getStringValue();
-      $('.setup_code_text', node).show();
-      $('.uploader', node).hide();
-      $('.setup_code_text', node).text(stringValue);
-      $('input[value=\'text\']', node).prop('checked', true);
-      break;
-    case proto.ord.Data.KindCase.URL:
-      value = code.getUrl();
-      $('.setup_code_text', node).show();
-      $('.uploader', node).hide();
-      $('.setup_code_text', node).text(value);
-      $('input[value=\'url\']', node).prop('checked', true);
-      break;
-    default:
-      break;
-  }
+  ord.data.loadData(node, code);
 }
 
 /**
@@ -112,40 +72,7 @@ function unload(codes) {
  */
 function unloadCode(codes, node) {
   const name = $('.setup_code_name', node).text();
-
-  const code = new proto.ord.Data();
-
-  const description = $('.setup_code_description', node).text();
-  code.setDescription(description);
-  const format = $('.setup_code_format', node).text();
-  code.setFormat(format);
-
-  if ($('input[value=\'text\']', node).is(':checked')) {
-    const stringValue = $('.setup_code_text', node).text();
-    if (!ord.reaction.isEmptyMessage(stringValue)) {
-      code.setStringValue(stringValue);
-    }
-  }
-  if ($('input[value=\'number\']', node).is(':checked')) {
-    const value = parseFloat($('.setup_code_text', node).text());
-    if (Number.isInteger(value)) {
-      code.setIntegerValue(value);
-    } else if (!Number.isNaN(value)) {
-      code.setFloatValue(value);
-    }
-  }
-  if ($('input[value=\'upload\']', node).is(':checked')) {
-    const bytesValue = ord.uploads.unload(node);
-    if (!ord.reaction.isEmptyMessage(bytesValue)) {
-      code.setBytesValue(bytesValue);
-    }
-  }
-  if ($('input[value=\'url\']', node).is(':checked')) {
-    const url = $('.setup_code_text', node).text();
-    if (!ord.reaction.isEmptyMessage(url)) {
-      code.setUrl(url);
-    }
-  }
+  const code = ord.data.unloadData(node);
   if (!ord.reaction.isEmptyMessage(name) ||
       !ord.reaction.isEmptyMessage(code)) {
     codes.set(name, code);
@@ -158,19 +85,6 @@ function unloadCode(codes, node) {
  */
 function addCode() {
   const node = ord.reaction.addSlowly('#setup_code_template', '#setup_codes');
-
-  const typeButtons = $('input[type=\'radio\']', node);
-  typeButtons.attr('name', 'codes_' + radioGroupCounter++);
-  typeButtons.change(function() {
-    if ((this.value == 'text') || (this.value == 'number') ||
-        (this.value == 'url')) {
-      $('.setup_code_text', node).show();
-      $('.uploader', node).hide();
-    } else {
-      $('.setup_code_text', node).hide();
-      $('.uploader', node).show();
-    }
-  });
-  ord.uploads.initialize(node);
+  ord.data.addData(node);
   return node;
 }

--- a/editor/js/data.js
+++ b/editor/js/data.js
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2020 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.module('ord.data');
+goog.module.declareLegacyNamespace();
+exports = {
+  addData,
+  loadData,
+  unloadData,
+};
+
+goog.require('proto.ord.Data');
+
+// Freely create radio button groups by generating new input names.
+let radioGroupCounter = 0;
+
+/**
+ * Adds a new Data section to the form.
+ * @param {!Node} parentNode Parent node.
+ * @return {!Node} The newly added node for the Data record.
+ */
+function addData(parentNode) {
+  const target = parentNode.children('fieldset').first();
+  const node = ord.reaction.addSlowly('#data_template', target);
+  const typeButtons = $('input[type=\'radio\']', node);
+  typeButtons.attr('name', 'data_' + radioGroupCounter++);
+  typeButtons.change(function() {
+    if ((this.value === 'text') || (this.value === 'number') ||
+        (this.value === 'url')) {
+      $('.data_text', node).show();
+      $('.data_uploader', node).hide();
+    } else {
+      $('.data_text', node).hide();
+      $('.data_uploader', node).show();
+    }
+  });
+  ord.uploads.initialize(node);
+  return node;
+}
+
+/**
+ * Populates an existing Data section in the form.
+ * @param {!Node} node Root node.
+ * @param {!proto.ord.Data} data
+ */
+function loadData(node, data) {
+  $('.data_description', node).text(data.getDescription());
+  $('.data_format', node).text(data.getFormat());
+  let value;
+  switch (data.getKindCase()) {
+    case proto.ord.Data.KindCase.FLOAT_VALUE:
+      value = data.getFloatValue().toString();
+      if (value.indexOf('.') === -1) {
+        value = value.concat('.');
+      }
+      $('.data_text', node).show();
+      $('.data_uploader', node).hide();
+      $('.data_text', node).text(value);
+      $('input[value=\'number\']', node).prop('checked', true);
+      break;
+    case proto.ord.Data.KindCase.INTEGER_VALUE:
+      value = data.getIntegerValue();
+      $('.data_text', node).show();
+      $('.data_uploader', node).hide();
+      $('.data_text', node).text(value);
+      $('input[value=\'number\']', node).prop('checked', true);
+      break;
+    case proto.ord.Data.KindCase.BYTES_VALUE:
+      value = data.getBytesValue();
+      $('.data_text', node).hide();
+      $('.data_uploader', node).show();
+      ord.uploads.load(node, value);
+      $('input[value=\'upload\']', node).prop('checked', true);
+      break;
+    case proto.ord.Data.KindCase.STRING_VALUE:
+      value = data.getStringValue();
+      $('.data_text', node).show();
+      $('.data_uploader', node).hide();
+      $('.data_text', node).text(value);
+      $('input[value=\'text\']', node).prop('checked', true);
+      break;
+    case proto.ord.Data.KindCase.URL:
+      value = data.getUrl();
+      $('.data_text', node).show();
+      $('.data_uploader', node).hide();
+      $('.data_text', node).text(value);
+      $('input[value=\'url\']', node).prop('checked', true);
+      break;
+    default:
+      break;
+  }
+}
+
+/**
+ * Fetches a Data section from the form.
+ * @param {!Node} node Root node of the Data section to fetch.
+ * @return {!proto.ord.Data}
+ */
+function unloadData(node) {
+  const data = new proto.ord.Data();
+  const description = $('.data_description', node).text();
+  data.setDescription(description);
+  const format = $('.data_format', node).text();
+  data.setFormat(format);
+  if ($('input[value=\'text\']', node).is(':checked')) {
+    const stringValue = $('.data_text', node).text();
+    if (!ord.reaction.isEmptyMessage(stringValue)) {
+      data.setStringValue(stringValue);
+    }
+  }
+  if ($('input[value=\'number\']', node).is(':checked')) {
+    const stringValue = $('.setup_code_text', node).text();
+    const value = parseFloat(stringValue);
+    if (Number.isInteger(value) && stringValue.indexOf('.') === -1) {
+      data.setIntegerValue(value);
+    } else if (!Number.isNaN(value)) {
+      data.setFloatValue(value);
+    }
+  }
+  if ($('input[value=\'upload\']', node).is(':checked')) {
+    const bytesValue = ord.uploads.unload(node);
+    if (!ord.reaction.isEmptyMessage(bytesValue)) {
+      data.setBytesValue(bytesValue);
+    }
+  }
+  if ($('input[value=\'url\']', node).is(':checked')) {
+    const url = $('.setup_code_text', node).text();
+    if (!ord.reaction.isEmptyMessage(url)) {
+      data.setUrl(url);
+    }
+  }
+  return data;
+}

--- a/editor/js/data.js
+++ b/editor/js/data.js
@@ -120,24 +120,21 @@ function unloadData(node) {
     if (!ord.reaction.isEmptyMessage(stringValue)) {
       data.setStringValue(stringValue);
     }
-  }
-  if ($('input[value=\'number\']', node).is(':checked')) {
-    const stringValue = $('.setup_code_text', node).text();
+  } else if ($('input[value=\'number\']', node).is(':checked')) {
+    const stringValue = $('.data_text', node).text();
     const value = parseFloat(stringValue);
     if (Number.isInteger(value) && stringValue.indexOf('.') === -1) {
       data.setIntegerValue(value);
     } else if (!Number.isNaN(value)) {
       data.setFloatValue(value);
     }
-  }
-  if ($('input[value=\'upload\']', node).is(':checked')) {
+  } else if ($('input[value=\'upload\']', node).is(':checked')) {
     const bytesValue = ord.uploads.unload(node);
     if (!ord.reaction.isEmptyMessage(bytesValue)) {
       data.setBytesValue(bytesValue);
     }
-  }
-  if ($('input[value=\'url\']', node).is(':checked')) {
-    const url = $('.setup_code_text', node).text();
+  } else if ($('input[value=\'url\']', node).is(':checked')) {
+    const url = $('.data_text', node).text();
     if (!ord.reaction.isEmptyMessage(url)) {
       data.setUrl(url);
     }

--- a/editor/js/data.js
+++ b/editor/js/data.js
@@ -64,7 +64,7 @@ function loadData(node, data) {
     case proto.ord.Data.KindCase.FLOAT_VALUE:
       value = data.getFloatValue().toString();
       if (value.indexOf('.') === -1) {
-        value = value.concat('.');
+        value = value.concat('.0');
       }
       $('.data_text', node).show();
       $('.data_uploader', node).hide();

--- a/editor/js/observations.js
+++ b/editor/js/observations.js
@@ -23,6 +23,7 @@ exports = {
   validateObservation
 };
 
+goog.require('ord.data');
 goog.require('proto.ord.ReactionObservation');
 
 // Freely create radio button groups by generating new input names.
@@ -43,41 +44,8 @@ function load(observations) {
 function loadObservation(observation) {
   const node = add();
   ord.reaction.writeMetric('.observation_time', observation.getTime(), node);
-
   $('.observation_comment', node).text(observation.getComment());
-
-  const image = observation.getImage();
-  $('.observation_image_description', node).text(image.getDescription());
-  $('.observation_image_format', node).text(image.getFormat());
-
-  const stringValue = image.getStringValue();
-  const floatValue = image.getFloatValue();
-  const bytesValue = image.getBytesValue();
-  const url = image.getUrl();
-  if (stringValue) {
-    $('.observation_image_text', node).show();
-    $('.uploader', node).hide();
-    $('.observation_image_text', node).text(stringValue);
-    $('input[value=\'text\']', node).prop('checked', true);
-  }
-  if (floatValue) {
-    $('.observation_image_text', node).show();
-    $('.uploader', node).hide();
-    $('.observation_image_text', node).text(floatValue);
-    $('input[value=\'number\']', node).prop('checked', true);
-  }
-  if (bytesValue) {
-    $('.observation_image_text', node).hide();
-    $('.uploader', node).show();
-    ord.uploads.load(node, bytesValue);
-    $('input[value=\'upload\']', node).prop('checked', true);
-  }
-  if (url) {
-    $('.observation_image_text', node).show();
-    $('.uploader', node).hide();
-    $('.observation_image_text', node).text(url);
-    $('input[value=\'url\']', node).prop('checked', true);
-  }
+  ord.data.loadData(node, observation.getImage());
 }
 
 /**
@@ -111,37 +79,8 @@ function unloadObservation(node) {
   if (!ord.reaction.isEmptyMessage(time)) {
     observation.setTime(time);
   }
-
   observation.setComment($('.observation_comment', node).text());
-
-  const image = new proto.ord.Data();
-  image.setDescription($('.observation_image_description', node).text());
-  image.setFormat($('.observation_image_format', node).text());
-
-  if ($('input[value=\'text\']', node).is(':checked')) {
-    const stringValue = $('.observation_image_text', node).text();
-    if (!ord.reaction.isEmptyMessage(stringValue)) {
-      image.setStringValue(stringValue);
-    }
-  }
-  if ($('input[value=\'number\']', node).is(':checked')) {
-    const floatValue = parseFloat($('.setup_code_text', node).text());
-    if (!isNaN(floatValue)) {
-      image.setFloatValue(floatValue);
-    }
-  }
-  if ($('input[value=\'upload\']', node).is(':checked')) {
-    const bytesValue = ord.uploads.unload(node);
-    if (!ord.reaction.isEmptyMessage(bytesValue)) {
-      image.setBytesValue(bytesValue);
-    }
-  }
-  if ($('input[value=\'url\']', node).is(':checked')) {
-    const url = $('.observation_image_text', node).text();
-    if (!ord.reaction.isEmptyMessage(url)) {
-      image.setUrl(url);
-    }
-  }
+  const image = ord.data.unloadData(node);
   if (!ord.reaction.isEmptyMessage(image)) {
     observation.setImage(image);
   }
@@ -154,26 +93,11 @@ function unloadObservation(node) {
  */
 function add() {
   const node = ord.reaction.addSlowly('#observation_template', '#observations');
-
-  const typeButtons = $('input[type=\'radio\']', node);
-  typeButtons.attr('name', 'observations_' + radioGroupCounter++);
-  typeButtons.change(function() {
-    if ((this.value == 'text') || (this.value == 'number') ||
-        (this.value == 'url')) {
-      $('.observation_image_text', node).show();
-      $('.uploader', node).hide();
-    } else {
-      $('.observation_image_text', node).hide();
-      $('.uploader', node).show();
-    }
-  });
-  ord.uploads.initialize(node);
-
+  ord.data.addData(node);
   // Add live validation handling.
   ord.reaction.addChangeHandler(node, () => {
     validateObservation(node);
   });
-
   return node;
 }
 

--- a/editor/js/outcomes.js
+++ b/editor/js/outcomes.js
@@ -27,6 +27,7 @@ exports = {
   validateAnalysis
 };
 
+goog.require('ord.data');
 goog.require('ord.products');
 goog.require('proto.ord.ReactionOutcome');
 
@@ -128,49 +129,7 @@ function loadAnalysis(outcomeNode, name, analysis) {
  */
 function loadProcessedData(node, name, processedData) {
   $('.outcome_processed_data_name', node).text(name);
-  $('.outcome_processed_data_description', node)
-      .text(processedData.getDescription());
-  $('.outcome_processed_data_format', node).text(processedData.getFormat());
-  let value;
-  switch (processedData.getKindCase()) {
-    case proto.ord.Data.KindCase.FLOAT_VALUE:
-      value = processedData.getFloatValue();
-      $('.outcome_processed_data_text', node).show();
-      $('.uploader', node).hide();
-      $('.outcome_processed_data_text', node).text(value);
-      $('input[value=\'number\']', node).prop('checked', true);
-      break;
-    case proto.ord.Data.KindCase.INTEGER_VALUE:
-      value = processedData.getIntegerValue();
-      $('.outcome_processed_data_text', node).show();
-      $('.uploader', node).hide();
-      $('.outcome_processed_data_text', node).text(value);
-      $('input[value=\'number\']', node).prop('checked', true);
-      break;
-    case proto.ord.Data.KindCase.BYTES_VALUE:
-      value = processedData.getBytesValue();
-      $('.outcome_processed_data_text', node).hide();
-      $('.uploader', node).show();
-      ord.uploads.load(node, value);
-      $('input[value=\'upload\']', node).prop('checked', true);
-      break;
-    case proto.ord.Data.KindCase.STRING_VALUE:
-      value = processedData.getStringValue();
-      $('.outcome_processed_data_text', node).show();
-      $('.uploader', node).hide();
-      $('.outcome_processed_data_text', node).text(stringValue);
-      $('input[value=\'text\']', node).prop('checked', true);
-      break;
-    case proto.ord.Data.KindCase.URL:
-      value = processedData.getUrl();
-      $('.outcome_processed_data_text', node).show();
-      $('.uploader', node).hide();
-      $('.outcome_processed_data_text', node).text(value);
-      $('input[value=\'url\']', node).prop('checked', true);
-      break;
-    default:
-      break;
-  }
+  ord.data.loadData(node, processedData);
 }
 
 /**
@@ -181,48 +140,7 @@ function loadProcessedData(node, name, processedData) {
  */
 function loadRawData(node, name, rawData) {
   $('.outcome_raw_data_name', node).text(name);
-  $('.outcome_raw_data_description', node).text(rawData.getDescription());
-  $('.outcome_raw_data_format', node).text(rawData.getFormat());
-  let value;
-  switch (rawData.getKindCase()) {
-    case proto.ord.Data.KindCase.FLOAT_VALUE:
-      value = rawData.getFloatValue();
-      $('.outcome_raw_data_text', node).show();
-      $('.uploader', node).hide();
-      $('.outcome_raw_data_text', node).text(value);
-      $('input[value=\'number\']', node).prop('checked', true);
-      break;
-    case proto.ord.Data.KindCase.INTEGER_VALUE:
-      value = rawData.getIntegerValue();
-      $('.outcome_raw_data_text', node).show();
-      $('.uploader', node).hide();
-      $('.outcome_raw_data_text', node).text(value);
-      $('input[value=\'number\']', node).prop('checked', true);
-      break;
-    case proto.ord.Data.KindCase.BYTES_VALUE:
-      value = rawData.getBytesValue();
-      $('.outcome_raw_data_text', node).hide();
-      $('.uploader', node).show();
-      ord.uploads.load(node, value);
-      $('input[value=\'upload\']', node).prop('checked', true);
-      break;
-    case proto.ord.Data.KindCase.STRING_VALUE:
-      value = rawData.getStringValue();
-      $('.outcome_raw_data_text', node).show();
-      $('.uploader', node).hide();
-      $('.outcome_raw_data_text', node).text(stringValue);
-      $('input[value=\'text\']', node).prop('checked', true);
-      break;
-    case proto.ord.Data.KindCase.URL:
-      value = rawData.getUrl();
-      $('.outcome_raw_data_text', node).show();
-      $('.uploader', node).hide();
-      $('.outcome_raw_data_text', node).text(value);
-      $('input[value=\'url\']', node).prop('checked', true);
-      break;
-    default:
-      break;
-  }
+  ord.data.loadData(rawData);
 }
 
 /**
@@ -345,37 +263,7 @@ function unloadAnalysis(analysisNode, analyses) {
  */
 function unloadProcessedData(node, processedDataMap) {
   const name = $('.outcome_processed_data_name', node).text();
-
-  const processedData = new proto.ord.Data();
-  processedData.setDescription($('.outcome_processed_data_description').text());
-  processedData.setFormat($('.outcome_processed_data_format').text());
-
-  if ($('input[value=\'text\']', node).is(':checked')) {
-    const stringValue = $('.outcome_processed_data_text', node).text();
-    if (!ord.reaction.isEmptyMessage(stringValue)) {
-      processedData.setStringValue(stringValue);
-    }
-  }
-  if ($('input[value=\'number\']', node).is(':checked')) {
-    const value = parseFloat($('.outcome_processed_data_text', node).text());
-    if (Number.isInteger(value)) {
-      processedData.setIntegerValue(value);
-    } else if (!Number.isNaN(value)) {
-      processedData.setFloatValue(value);
-    }
-  }
-  if ($('input[value=\'upload\']', node).is(':checked')) {
-    const bytesValue = ord.uploads.unload(node);
-    if (!ord.reaction.isEmptyMessage(bytesValue)) {
-      processedData.setBytesValue(bytesValue);
-    }
-  }
-  if ($('input[value=\'url\']', node).is(':checked')) {
-    const url = $('.outcome_processed_data_text', node).text();
-    if (!ord.reaction.isEmptyMessage(url)) {
-      processedData.setUrl(url);
-    }
-  }
+  const processedData = ord.data.unloadData(node);
   if (!ord.reaction.isEmptyMessage(name) ||
       !ord.reaction.isEmptyMessage(processedData)) {
     processedDataMap.set(name, processedData);
@@ -390,37 +278,7 @@ function unloadProcessedData(node, processedDataMap) {
  */
 function unloadRawData(node, rawDataMap) {
   const name = $('.outcome_raw_data_name', node).text();
-
-  const rawData = new proto.ord.Data();
-  rawData.setDescription($('.outcome_raw_data_description', node).text());
-  rawData.setFormat($('.outcome_raw_data_format', node).text());
-
-  if ($('input[value=\'text\']', node).is(':checked')) {
-    const stringValue = $('.outcome_raw_data_text', node).text();
-    if (!ord.reaction.isEmptyMessage(stringValue)) {
-      rawData.setStringValue(stringValue);
-    }
-  }
-  if ($('input[value=\'number\']', node).is(':checked')) {
-    const value = parseFloat($('.outcome_raw_data_text', node).text());
-    if (Number.isInteger(value)) {
-      rawData.setIntegerValue(value);
-    } else if (!Number.isNaN(value)) {
-      rawData.setFloatValue(value);
-    }
-  }
-  if ($('input[value=\'upload\']', node).is(':checked')) {
-    const bytesValue = ord.uploads.unload(node);
-    if (!ord.reaction.isEmptyMessage(bytesValue)) {
-      rawData.setBytesValue(bytesValue);
-    }
-  }
-  if ($('input[value=\'url\']', node).is(':checked')) {
-    const url = $('.outcome_raw_data_text', node).text();
-    if (!ord.reaction.isEmptyMessage(url)) {
-      rawData.setUrl(url);
-    }
-  }
+  const rawData = ord.data.unloadData(node);
   if (!ord.reaction.isEmptyMessage(name) || !ord.reaction.isEmptyMessage(raw)) {
     rawDataMap.set(name, rawData);
   }
@@ -493,20 +351,7 @@ function addProcessedData(node) {
   const processNode = ord.reaction.addSlowly(
       '#outcome_processed_data_template',
       $('.outcome_processed_data_repeated', node));
-
-  const typeButtons = $('input[type=\'radio\']', processNode);
-  typeButtons.attr('name', 'outcomes_' + radioGroupCounter++);
-  typeButtons.change(function() {
-    if ((this.value == 'text') || (this.value == 'number') ||
-        (this.value == 'url')) {
-      $('.outcome_processed_data_text', processNode).show();
-      $('.uploader', processNode).hide();
-    } else {
-      $('.outcome_processed_data_text', processNode).hide();
-      $('.uploader', processNode).show();
-    }
-  });
-  ord.uploads.initialize(processNode);
+  ord.data.addData(processNode);
   return processNode;
 }
 
@@ -518,20 +363,7 @@ function addProcessedData(node) {
 function addRawData(node) {
   const rawNode = ord.reaction.addSlowly(
       '#outcome_raw_data_template', $('.outcome_raw_data_repeated', node));
-
-  const typeButtons = $('input[type=\'radio\']', rawNode);
-  typeButtons.attr('name', 'outcomes_' + radioGroupCounter++);
-  typeButtons.change(function() {
-    if ((this.value == 'text') || (this.value == 'number') ||
-        (this.value == 'url')) {
-      $('.outcome_raw_data_text', rawNode).show();
-      $('.uploader', rawNode).hide();
-    } else {
-      $('.outcome_raw_data_text', rawNode).hide();
-      $('.uploader', rawNode).show();
-    }
-  });
-  ord.uploads.initialize(rawNode);
+  ord.data.addData(rawNode);
   return rawNode;
 }
 

--- a/editor/js/outcomes.js
+++ b/editor/js/outcomes.js
@@ -140,7 +140,7 @@ function loadProcessedData(node, name, processedData) {
  */
 function loadRawData(node, name, rawData) {
   $('.outcome_raw_data_name', node).text(name);
-  ord.data.loadData(rawData);
+  ord.data.loadData(node, rawData);
 }
 
 /**

--- a/editor/js/uploads.js
+++ b/editor/js/uploads.js
@@ -100,7 +100,7 @@ function putAll(dirName) {
 /**
  * Looks up the bytesValue of the given uploader and sends back it as a
  * download.
- * @param {!Node} uploader An `.uploader` div.
+ * @param {!Node} uploader A `.data_uploader` div.
  */
 function retrieve(uploader) {
   const token = uploader.attr('data-token');
@@ -121,40 +121,40 @@ function retrieve(uploader) {
 
 /**
  * Configures the behavior of an uploader.
- * @param {!Node} node An `.uploader` div.
+ * @param {!Node} node A `.data_uploader` div.
  */
 function initialize(node) {
-  $('.uploader_chooser_file', node).on('input', (event) => {
+  $('.data_uploader_chooser_file', node).on('input', (event) => {
     const file = event.target.files[0];
-    $('.uploader_file_name', node).show();
-    $('.uploader_file_name', node).text(file.name);
+    $('.data_uploader_file_name', node).show();
+    $('.data_uploader_file_name', node).text(file.name);
     const token = newFile(file);
-    $('.uploader', node).attr('data-token', token);
-    $('.uploader_file_retrieve', node).hide();
+    $('.data_uploader', node).attr('data-token', token);
+    $('.data_uploader_file_retrieve', node).hide();
   });
 }
 
 /**
  * Loads a token and filename into an uploader.
- * @param {!Node} node An `.uploader` div.
+ * @param {!Node} node A `.data_uploader` div.
  * @param {!Uint8Array} bytesValue File content as bytes.
  */
 function load(node, bytesValue) {
   const token = stashUpload(bytesValue);
-  $('.uploader', node).show();
-  $('.uploader', node).attr('data-token', token);
-  $('.uploader_chooser_button', node).text('Replace...');
-  $('.uploader_file_name', node).hide();
-  $('.uploader_file_retrieve', node).show();
+  $('.data_uploader', node).show();
+  $('.data_uploader', node).attr('data-token', token);
+  $('.data_uploader_chooser_button', node).text('Replace...');
+  $('.data_uploader_file_name', node).hide();
+  $('.data_uploader_file_retrieve', node).show();
 }
 
 /**
  * Retrieves the stored bytes from an uploader.
- * @param {!Node} node An `.uploader` div.
+ * @param {!Node} node A `.data_uploader` div.
  * @returns {!Uint8Array}
  */
 function unload(node) {
-  const token = $('.uploader', node).attr('data-token');
+  const token = $('.data_uploader', node).attr('data-token');
   const bytesValue = unstashUpload(token);
   if (bytesValue) {
     // This is just a round-trip for bytesValue.

--- a/run_editor_tests.sh
+++ b/run_editor_tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2020 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs editor javascript tests.
+set -x
+
+docker build --file=editor/Dockerfile -t openreactiondatabase/ord-editor .
+CONTAINER=$(docker run --rm -d -p 5000:5000 openreactiondatabase/ord-editor)
+node editor/js/test.js
+test $? -eq 0 || docker logs "${CONTAINER}"
+docker stop "${CONTAINER}"


### PR DESCRIPTION
I realized that I completely missed the _fourth_ copy of the `Data` handling code in `observations.js` when writing #358.

The alignment in the form is a bit less pretty since there are two tables that don't quite line up, but it's not bad and the boost to backend code readability is __huge__. We can even write tests for `data.js` now!

Huzzah for code reuse!

Fixes #357 
Supercedes #358 