### PR TITLE
Sort out docker-compose for the web interface

### DIFF
--- a/ord_schema/interface/Dockerfile
+++ b/ord_schema/interface/Dockerfile
@@ -1,0 +1,42 @@
+# Copyright 2020 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To build the interface using the current state of ord-schema:
+# $ cd path/to/ord-schema
+# $ docker build \
+#     --file=ord_schema/interface/Dockerfile \
+#     -t openreactiondatabase/ord-interface \
+#     .
+#
+# To push the built image to Docker Hub:
+# docker push openreactiondatabase/ord-interface
+
+FROM continuumio/miniconda3
+
+RUN apt-get update && apt-get install --yes build-essential procps unzip
+RUN conda install -c rdkit rdkit
+RUN conda install flask
+
+# COPY and install the local state of ord-schema.
+WORKDIR /usr/src/app/ord-schema
+COPY setup.py requirements.txt ./
+COPY ord_schema/ ord_schema/
+RUN pip install -r requirements.txt
+RUN python setup.py install
+
+# Build and launch the interface.
+WORKDIR /usr/src/app/ord-schema/ord_schema/interface
+EXPOSE 5000
+RUN pip install gunicorn
+CMD gunicorn search:app -b 0.0.0.0:5000 --access-logfile '-'

--- a/ord_schema/interface/docker-compose.yml
+++ b/ord_schema/interface/docker-compose.yml
@@ -1,3 +1,17 @@
+# Copyright 2020 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 version: "3"
 services:
   ord-postgres:

--- a/ord_schema/interface/docker-compose.yml
+++ b/ord_schema/interface/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+services:
+  ord-postgres:
+    image: "openreactiondatabase/ord-postgres:latest"
+  web:
+    depends_on:
+      - ord-postgres
+    environment:
+      - ORD_POSTGRES_HOST=ord-postgres
+    image: "openreactiondatabase/ord-interface:latest"
+    ports:
+      - "5000:5000"

--- a/ord_schema/interface/docker/Dockerfile
+++ b/ord_schema/interface/docker/Dockerfile
@@ -12,16 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# To build an updated ord-postgres image containing the latest data:
-# $ cd .../ord-schema/ord_schema/interface/docker
-# $ docker build -t openreactiondatabase/ord-postgres .
-#
-# To push the built image to Docker Hub:
-# docker push openreactiondatabase/ord-postgres
-
 FROM mcs07/postgres-rdkit
 
-RUN apt-get update && apt-get install --yes build-essential git libpq-dev wget
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
+    build-essential git libpq-dev wget
 
 ENV ORD_ROOT=/home/ord
 RUN wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
@@ -31,15 +25,13 @@ RUN conda update conda --yes
 RUN conda install -c rdkit rdkit
 
 WORKDIR "${ORD_ROOT}"
-# Bust the cache to get the latest ord-data commits; see
+# Bust the cache to get the latest commits; see
 # https://stackoverflow.com/a/39278224.
+ADD https://api.github.com/repos/Open-Reaction-Database/ord-schema/git/refs/heads/main ord-schema-version.json
+RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
 ADD https://api.github.com/repos/Open-Reaction-Database/ord-data/git/refs/heads/main ord-data-version.json
 RUN git clone https://github.com/Open-Reaction-Database/ord-data.git
-
-# COPY and install the local state of ord-schema.
 WORKDIR "${ORD_ROOT}/ord-schema"
-COPY setup.py requirements.txt ./
-COPY ord_schema/ ord_schema/
 RUN pip install -r requirements.txt
 RUN python setup.py install
 
@@ -52,3 +44,4 @@ ENV POSTGRES_USER=ord-postgres
 ENV POSTGRES_PASSWORD=ord-postgres
 COPY postgres.conf /etc/postgresql/postgresql.conf
 ENV ORD_INPUT="${ORD_ROOT}/ord-data/data/*/*.pbtxt"
+COPY build_database.sh .

--- a/ord_schema/interface/docker/Dockerfile
+++ b/ord_schema/interface/docker/Dockerfile
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# To build an updated ord-postgres image containing the latest data:
+# $ cd .../ord-schema/ord_schema/interface/docker
+# $ docker build -t openreactiondatabase/ord-postgres .
+#
+# To push the built image to Docker Hub:
+# docker push openreactiondatabase/ord-postgres
+
 FROM mcs07/postgres-rdkit
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
-    build-essential git libpq-dev wget
+RUN apt-get update && apt-get install --yes build-essential git libpq-dev wget
 
 ENV ORD_ROOT=/home/ord
 RUN wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
@@ -25,13 +31,15 @@ RUN conda update conda --yes
 RUN conda install -c rdkit rdkit
 
 WORKDIR "${ORD_ROOT}"
-# Bust the cache to get the latest commits; see
+# Bust the cache to get the latest ord-data commits; see
 # https://stackoverflow.com/a/39278224.
-ADD https://api.github.com/repos/Open-Reaction-Database/ord-schema/git/refs/heads/main ord-schema-version.json
-RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
 ADD https://api.github.com/repos/Open-Reaction-Database/ord-data/git/refs/heads/main ord-data-version.json
 RUN git clone https://github.com/Open-Reaction-Database/ord-data.git
+
+# COPY and install the local state of ord-schema.
 WORKDIR "${ORD_ROOT}/ord-schema"
+COPY setup.py requirements.txt ./
+COPY ord_schema/ ord_schema/
 RUN pip install -r requirements.txt
 RUN python setup.py install
 
@@ -44,4 +52,3 @@ ENV POSTGRES_USER=ord-postgres
 ENV POSTGRES_PASSWORD=ord-postgres
 COPY postgres.conf /etc/postgresql/postgresql.conf
 ENV ORD_INPUT="${ORD_ROOT}/ord-data/data/*/*.pbtxt"
-COPY build_database.sh .

--- a/ord_schema/interface/docker/Dockerfile
+++ b/ord_schema/interface/docker/Dockerfile
@@ -12,26 +12,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# To build an updated ord-postgres image containing the latest data:
+# $ cd path/to/ord-schema
+# $ ./ord_schema/interface/docker/update_image.sh
+#
+# To push the built image to Docker Hub:
+# docker push openreactiondatabase/ord-postgres
+
 FROM mcs07/postgres-rdkit
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y \
-    build-essential git libpq-dev wget
+RUN apt-get update && apt-get install --yes build-essential git libpq-dev wget
 
 ENV ORD_ROOT=/home/ord
 RUN wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
 RUN /bin/bash ./Miniconda3-latest-Linux-x86_64.sh -b -p "${ORD_ROOT}/miniconda3"
 ENV PATH="${ORD_ROOT}/miniconda3/bin:${PATH}"
 RUN conda update conda --yes
+RUN conda install python=3.7
 RUN conda install -c rdkit rdkit
 
 WORKDIR "${ORD_ROOT}"
-# Bust the cache to get the latest commits; see
+# Bust the cache to get the latest ord-data commits; see
 # https://stackoverflow.com/a/39278224.
-ADD https://api.github.com/repos/Open-Reaction-Database/ord-schema/git/refs/heads/main ord-schema-version.json
-RUN git clone https://github.com/Open-Reaction-Database/ord-schema.git
-ADD https://api.github.com/repos/Open-Reaction-Database/ord-data/git/refs/heads/main ord-data-version.json
-RUN git clone https://github.com/Open-Reaction-Database/ord-data.git
+ENV ORD_REPO=ord-submissions-test
+ADD "https://api.github.com/repos/Open-Reaction-Database/${ORD_REPO}/git/refs/heads/main" ord-data-version.json
+RUN git clone "https://github.com/Open-Reaction-Database/${ORD_REPO}.git"
+
+# COPY and install the local state of ord-schema.
 WORKDIR "${ORD_ROOT}/ord-schema"
+COPY setup.py requirements.txt ./
+COPY ord_schema/ ord_schema/
 RUN pip install -r requirements.txt
 RUN python setup.py install
 
@@ -42,6 +52,6 @@ ENV PGDATA=/data
 ENV POSTGRES_DB=ord
 ENV POSTGRES_USER=ord-postgres
 ENV POSTGRES_PASSWORD=ord-postgres
-COPY postgres.conf /etc/postgresql/postgresql.conf
-ENV ORD_INPUT="${ORD_ROOT}/ord-data/data/*/*.pbtxt"
-COPY build_database.sh .
+COPY ord_schema/interface/docker/postgres.conf /etc/postgresql/postgresql.conf
+ENV ORD_INPUT="${ORD_ROOT}/${ORD_REPO}/data/*/*.pbtxt"
+COPY ord_schema/interface/docker/build_database.sh .

--- a/ord_schema/interface/search.py
+++ b/ord_schema/interface/search.py
@@ -44,6 +44,7 @@ from ord_schema.interface import query
 app = flask.Flask(__name__, template_folder='.')
 app.config['ORD_POSTGRES_HOST'] = os.getenv('ORD_POSTGRES_HOST', 'localhost')
 
+
 @app.route('/')
 def show_root():
     """Shows the web form.

--- a/ord_schema/interface/search.py
+++ b/ord_schema/interface/search.py
@@ -35,12 +35,14 @@ These query types are mutually exclusive. All query parameters are assumed to
 be URL-encoded.
 """
 
+import os
+
 import flask
 
 from ord_schema.interface import query
 
 app = flask.Flask(__name__, template_folder='.')
-
+app.config['ORD_POSTGRES_HOST'] = os.getenv('ORD_POSTGRES_HOST', 'localhost')
 
 @app.route('/')
 def show_root():
@@ -93,5 +95,5 @@ def connect():
     return query.OrdPostgres(dbname='ord',
                              user='ord-postgres',
                              password='ord-postgres',
-                             host='localhost',
+                             host=app.config['ORD_POSTGRES_HOST'],
                              port=5432)


### PR DESCRIPTION
The following commands assume that the `ord-postgres` image is either built locally or pulled from Docker Hub:

```
$ cd .../ord-schema
$ docker build --file=ord_schema/interface/Dockerfile -t openreactiondatabase/ord-interface .
$ cd ord_schema/interface
$ docker-compose up
```

Now the interface is available at `localhost:5000`