### PR TITLE
Use SVG instead of PNG in HTML reaction table

### DIFF
--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -195,7 +195,7 @@ limitations under the License.
                     </span>
                   </legend>
                   <!-- Compound rendering -->
-                  <div class="component_rendering" style="margin-left: auto; margin-right: auto;"></div>
+                  <div class="component_rendering" style="text-align: center;"></div>
                   <div class="identifiers"></div>
                   <!-- Shortcuts for name resolving & drawing -->
                   <div onclick="ord.compounds.drawIdentifier($(this).closest('.component'));" class="add"><span class="far fa-edit" aria-hidden="true"></span> draw compound</div>

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -195,9 +195,7 @@ limitations under the License.
                     </span>
                   </legend>
                   <!-- Compound rendering -->
-                  <div style="text-align: center">
-                    <img class="component_rendering" src="" style="margin-left: auto; margin-right: auto;"/>
-                  </div>
+                  <div class="component_rendering" src="" style="margin-left: auto; margin-right: auto;"></div>
                   <div class="identifiers"></div>
                   <!-- Shortcuts for name resolving & drawing -->
                   <div onclick="ord.compounds.drawIdentifier($(this).closest('.component'));" class="add"><span class="far fa-edit" aria-hidden="true"></span> draw compound</div>

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -195,7 +195,7 @@ limitations under the License.
                     </span>
                   </legend>
                   <!-- Compound rendering -->
-                  <div class="component_rendering" src="" style="margin-left: auto; margin-right: auto;"></div>
+                  <div class="component_rendering" style="margin-left: auto; margin-right: auto;"></div>
                   <div class="identifiers"></div>
                   <!-- Shortcuts for name resolving & drawing -->
                   <div onclick="ord.compounds.drawIdentifier($(this).closest('.component'));" class="add"><span class="far fa-edit" aria-hidden="true"></span> draw compound</div>

--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -533,7 +533,6 @@ function renderCompound(node, compound) {
   xhr.responseType = 'json';
   xhr.onload = function() {
     const svg_data = xhr.response;
-    console.log(svg_data);
     if (svg_data) {
       $('.component_rendering', node).html(svg_data);
     } else {

--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -533,10 +533,11 @@ function renderCompound(node, compound) {
   xhr.responseType = 'json';
   xhr.onload = function() {
     const svg_data = xhr.response;
+    console.log(svg_data);
     if (svg_data) {
-      $('.component_rendering', node)[0].src = svg_data;
+      $('.component_rendering', node).html(svg_data);
     } else {
-      $('.component_rendering', node)[0].src = '';
+      $('.component_rendering', node).html('');
     }
   };
   xhr.send(binary);

--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -532,9 +532,9 @@ function renderCompound(node, compound) {
   const binary = compound.serializeBinary();
   xhr.responseType = 'json';
   xhr.onload = function() {
-    const png_data = xhr.response;
-    if (png_data) {
-      $('.component_rendering', node)[0].src = 'data:image/png;base64,' + png_data;
+    const svg_data = xhr.response;
+    if (svg_data) {
+      $('.component_rendering', node)[0].src = svg_data;
     } else {
       $('.component_rendering', node)[0].src = '';
     }

--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -348,7 +348,7 @@ def render_compound():
     compound.ParseFromString(flask.request.get_data())
     try:
         mol = message_helpers.mol_from_compound(compound)
-        return drawing.mol_to_svg(mol)
+        return flask.jsonify(drawing.mol_to_svg(mol))
     except ValueError:
         return ''
 

--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -343,14 +343,12 @@ def render_reaction():
 
 @app.route('/render/compound', methods=['POST'])
 def render_compound():
-    """Receives a serialized Compound message and returns base64-encoded png
-    data corresponding to a line drawing of the molecule."""
+    """Returns an HTML-tagged SVG for the given Compound."""
     compound = reaction_pb2.Compound()
     compound.ParseFromString(flask.request.get_data())
     try:
         mol = message_helpers.mol_from_compound(compound)
-        png_data = drawing.mol_to_png(mol)
-        return flask.jsonify(png_data)
+        return drawing.mol_to_svg(mol)
     except ValueError:
         return ''
 

--- a/ord_schema/visualization/drawing.py
+++ b/ord_schema/visualization/drawing.py
@@ -87,9 +87,8 @@ def mol_to_svg(mol, min_size=50, max_size=300, bond_length=25, padding=10):
     Chem.Kekulize(mol)
     rdDepictor.Compute2DCoords(mol)
     drawer = Draw.MolDraw2DSVG(max_size, max_size)
-    options = drawer.drawOptions()
-    options.fixedBondLength = bond_length
-    options.padding = 0.0
+    drawer.drawOptions().fixedBondLength = bond_length
+    drawer.drawOptions().padding = 0.0
     drawer.DrawMolecule(mol)
     min_x, max_x, min_y, max_y = np.inf, -np.inf, np.inf, -np.inf
     for atom in mol.GetAtoms():
@@ -101,9 +100,8 @@ def mol_to_svg(mol, min_size=50, max_size=300, bond_length=25, padding=10):
     size_x = max(min_size, int(max_x - min_x + 2 * padding))
     size_y = max(min_size, int(max_y - min_y + 2 * padding))
     drawer = Draw.MolDraw2DSVG(size_x, size_y)
-    options = drawer.drawOptions()
-    options.fixedBondLength = bond_length
-    options.padding = 0.0
+    drawer.drawOptions().fixedBondLength = bond_length
+    drawer.drawOptions().padding = 0.0
     drawer.DrawMolecule(mol)
     drawer.FinishDrawing()
     match = re.search(r'(<svg\s+.*</svg>)',

--- a/ord_schema/visualization/drawing.py
+++ b/ord_schema/visualization/drawing.py
@@ -71,7 +71,7 @@ def trim_image_whitespace(image, padding=0):
     return ImageOps.expand(image, border=padding, fill=(255, 255, 255))
 
 
-def mol_to_svg(mol, min_size=100, max_size=300, bond_length=25, padding=10):
+def mol_to_svg(mol, min_size=50, max_size=300, bond_length=25, padding=10):
     """Creates a (cropped) SVG molecule drawing as a string.
 
     Args:

--- a/ord_schema/visualization/drawing.py
+++ b/ord_schema/visualization/drawing.py
@@ -19,6 +19,9 @@ given an RDKit molecule object: mol_to_svg and mol_to_png.
 
 import io
 import base64
+import json
+import re
+
 import numpy as np
 from PIL import Image, ImageOps
 from rdkit import Chem
@@ -26,6 +29,7 @@ from rdkit.Chem import Draw
 from rdkit.Chem import rdDepictor
 
 rdDepictor.SetPreferCoordGen(True)
+
 
 # pylint: disable=unsubscriptable-object
 
@@ -63,7 +67,7 @@ def trim_image_whitespace(image, padding=0):
     y_range = (max([min(ys_nonzero) - margin,
                     0]), min([max(ys_nonzero) + margin, as_array.shape[1]]))
     as_array_cropped = as_array[x_range[0]:x_range[1], y_range[0]:y_range[1],
-                                0:3]
+                       0:3]
 
     image = Image.fromarray(as_array_cropped, mode='RGB')
     return ImageOps.expand(image, border=padding, fill=(255, 255, 255))
@@ -86,7 +90,9 @@ def mol_to_svg(mol, max_size=300, bond_length=25):
     drawer.drawOptions().fixedBondLength = bond_length
     drawer.DrawMolecule(mol)
     drawer.FinishDrawing()
-    return drawer.GetDrawingText()
+    match = re.search(r'(<svg\s+.*</svg>)', drawer.GetDrawingText(),
+                      flags=re.DOTALL)
+    return match.group(1)
 
 
 def mol_to_png(mol, max_size=1000, bond_length=25, png_quality=70):

--- a/ord_schema/visualization/drawing.py
+++ b/ord_schema/visualization/drawing.py
@@ -30,7 +30,6 @@ from rdkit.Chem import rdDepictor
 
 rdDepictor.SetPreferCoordGen(True)
 
-
 # pylint: disable=unsubscriptable-object
 
 
@@ -67,7 +66,7 @@ def trim_image_whitespace(image, padding=0):
     y_range = (max([min(ys_nonzero) - margin,
                     0]), min([max(ys_nonzero) + margin, as_array.shape[1]]))
     as_array_cropped = as_array[x_range[0]:x_range[1], y_range[0]:y_range[1],
-                       0:3]
+                                0:3]
 
     image = Image.fromarray(as_array_cropped, mode='RGB')
     return ImageOps.expand(image, border=padding, fill=(255, 255, 255))
@@ -90,7 +89,8 @@ def mol_to_svg(mol, max_size=300, bond_length=25):
     drawer.drawOptions().fixedBondLength = bond_length
     drawer.DrawMolecule(mol)
     drawer.FinishDrawing()
-    match = re.search(r'(<svg\s+.*</svg>)', drawer.GetDrawingText(),
+    match = re.search(r'(<svg\s+.*</svg>)',
+                      drawer.GetDrawingText(),
                       flags=re.DOTALL)
     return match.group(1)
 

--- a/ord_schema/visualization/drawing.py
+++ b/ord_schema/visualization/drawing.py
@@ -29,7 +29,6 @@ from rdkit.Chem import rdDepictor
 
 rdDepictor.SetPreferCoordGen(True)
 
-
 # pylint: disable=unsubscriptable-object
 
 
@@ -66,7 +65,7 @@ def trim_image_whitespace(image, padding=0):
     y_range = (max([min(ys_nonzero) - margin,
                     0]), min([max(ys_nonzero) + margin, as_array.shape[1]]))
     as_array_cropped = as_array[x_range[0]:x_range[1], y_range[0]:y_range[1],
-                       0:3]
+                                0:3]
 
     image = Image.fromarray(as_array_cropped, mode='RGB')
     return ImageOps.expand(image, border=padding, fill=(255, 255, 255))

--- a/ord_schema/visualization/generate_text.py
+++ b/ord_schema/visualization/generate_text.py
@@ -58,4 +58,4 @@ def generate_html(reaction):
     with open(os.path.join(os.path.dirname(__file__), 'template.html'),
               'r') as f:
         template = f.read()
-    return _generate(reaction, template, True)
+    return _generate(reaction, template_string=template, line_breaks=True)

--- a/ord_schema/visualization/template.html
+++ b/ord_schema/visualization/template.html
@@ -73,9 +73,7 @@
     <tr>
         {% for key, input in reaction.inputs|sort_addition_order %}
             {% for compound, border in input.components|get_input_borders %}
-                <td class="{{ border }}">
-                    <img src="data:image/png;base64,{{ compound|compound_png }}"/>
-                </td>
+                <td class="{{ border }}">{{ compound|compound_svg }}</td>
             {% endfor %}
         {% endfor %}
         <td class="clean">
@@ -96,7 +94,7 @@
         </td>
         {% for outcome in reaction.outcomes %}
             {% for product in outcome.products %}
-                <td class="clean"><img src="data:image/png;base64,{{ product.compound|compound_png }}"/></td>
+                <td class="clean">{{ product.compound|compound_svg }}</td>
             {% endfor %}
         {% endfor %}
     </tr>


### PR DESCRIPTION
It's _way_ faster and looks just as good.

Notable changes:
* Adds support for SVG cropping. This requires two passes; the first pass is used to identify the extent of the drawn image, and the second pass repeats the drawing on an appropriately-sized canvas.
* The primary use case is the drawings in the query interface, but I updated the uses in the editor as well. I'm not quite sure how to get the component images to center-align (in the Inputs section), but that's minor.