### PR TITLE
ord.reaction.freeze() makes the editor read-only.

### DIFF
--- a/editor/css/reaction.css
+++ b/editor/css/reaction.css
@@ -27,6 +27,7 @@ body {
   padding: 2px;
   margin: 2px;
   display: inline-block;
+  height: 20px;
 }
 .edittext {
   width: 200px;

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -37,7 +37,8 @@ exports = {
   getSelector,
   getSelectorText,
   setOptionalBool,
-  getOptionalBool
+  getOptionalBool,
+  freeze
 };
 
 goog.require('ord.conditions');
@@ -905,4 +906,22 @@ function enumToStrings(protoEnum) {
  */
 function stringToEnum(name, protoEnum) {
   return protoEnum[name];
+}
+
+// Switch the UI into a read-only mode.
+function freeze() {
+  $('.edittext').attr('contenteditable', 'false')
+  $('select').attr('disabled', 'true')
+  $('.validate').hide()
+  $('.add').hide()
+  $('.remove').hide()
+  $('.text_upload').hide()
+  $('#provenance_created button').hide()
+  $('#save').hide()
+  $('.edittext').each((i, x) => {
+    // Ensure non-editable divs have a text node to preserve vertical alignment.
+    if (!$(x).text()) {
+      $(x).text(" ");
+    }
+  });
 }

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -921,7 +921,7 @@ function freeze() {
   $('.edittext').each((i, x) => {
     // Ensure non-editable divs have a text node to preserve vertical alignment.
     if (!$(x).text()) {
-      $(x).text(" ");
+      $(x).text(' ');
     }
   });
 }

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -910,14 +910,14 @@ function stringToEnum(name, protoEnum) {
 
 // Switch the UI into a read-only mode.
 function freeze() {
-  $('.edittext').attr('contenteditable', 'false')
-  $('select').attr('disabled', 'true')
-  $('.validate').hide()
-  $('.add').hide()
-  $('.remove').hide()
-  $('.text_upload').hide()
-  $('#provenance_created button').hide()
-  $('#save').hide()
+  $('.edittext').attr('contenteditable', 'false');
+  $('select').attr('disabled', 'true');
+  $('.validate').hide();
+  $('.add').hide();
+  $('.remove').hide();
+  $('.text_upload').hide();
+  $('#provenance_created button').hide();
+  $('#save').hide();
   $('.edittext').each((i, x) => {
     // Ensure non-editable divs have a text node to preserve vertical alignment.
     if (!$(x).text()) {

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -908,7 +908,9 @@ function stringToEnum(name, protoEnum) {
   return protoEnum[name];
 }
 
-// Switch the UI into a read-only mode.
+/**
+ * Switch the UI into a read-only mode. This is irreversible.
+ */
 function freeze() {
   $('.edittext').attr('contenteditable', 'false');
   $('select').attr('disabled', 'true');


### PR DESCRIPTION
Addressing #335, this introduces a global freeze() function in the editor that irreversibly mutates the UI into a read-only state.

This may be useful for example in rendering individual results from queries to the ORD.