### PR TITLE
Draw compounds only after fully loaded

### DIFF
--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -195,9 +195,7 @@ limitations under the License.
                     </span>
                   </legend>
                   <!-- Compound rendering -->
-                  <div style="text-align: center">
-                    <img class="component_rendering" src="" style="margin-left: auto; margin-right: auto;"/>
-                  </div>
+                  <div class="image_container" style="text-align: center"></div>
                   <div class="identifiers"></div>
                   <!-- Shortcuts for name resolving & drawing -->
                   <div onclick="ord.compounds.drawIdentifier($(this).closest('.component'));" class="add"><span class="far fa-edit" aria-hidden="true"></span> draw compound</div>

--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -534,10 +534,9 @@ function renderCompound(node, compound) {
   xhr.onload = function() {
     const png_data = xhr.response;
     if (png_data) {
-      $('.component_rendering', node)[0].src = 'data:image/png;base64,' + png_data;
-    } else {
-      $('.component_rendering', node)[0].src = '';
-    }
+      var src = 'data:image/png;base64,' + png_data;
+      $('.image_container', node).append('<img class="component_rendering" src="' + src + '" style="margin-left: auto; margin-right: auto;"/>')
+    } 
   };
   xhr.send(binary);
 }

--- a/editor/js/compounds.js
+++ b/editor/js/compounds.js
@@ -535,6 +535,7 @@ function renderCompound(node, compound) {
     const png_data = xhr.response;
     if (png_data) {
       var src = 'data:image/png;base64,' + png_data;
+      $('.image_container', node).empty();
       $('.image_container', node).append('<img class="component_rendering" src="' + src + '" style="margin-left: auto; margin-right: auto;"/>')
     } 
   };


### PR DESCRIPTION
Seems to fix #344; would like testing! This fixes by _creating_ the image node entirely after the compound itself is loaded and we get the data of the image's png.

If this seems good, I'll clean it up.

Having an empty `src` in the nodes was problematic -- I think that sometimes, we would set `src` midway during the image loading. It wouldn't load with the new `src`, nor would it refresh.

