### PR TITLE
Round floating point values for display

### DIFF
--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -192,14 +192,15 @@ function checkInteger(node) {
  * @return {number}
  */
 function prepareFloat(value) {
-  // Round to 15 decimal places; this avoid floating point precision issues
+  // Round to 15 significant digits; this avoid floating point precision issues
   // that can be quite jarring to users.
   //
   // See:
   //   * https://stackoverflow.com/a/3644302
   //   * https://medium.com/swlh/ed74c471c1b8
-  const factor = Math.pow(10, 15);
-  return Math.round(value.toPrecision(15) * factor) / factor;
+  const precision = 15;
+  const factor = Math.pow(10, precision);
+  return Math.round(value.toPrecision(precision) * factor) / factor;
 }
 
 /**

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -450,7 +450,7 @@ function loadReaction(reaction) {
   $('.floattext').each(function(index) {
     const node = $(this);
     if (node.text() !== '') {
-      node.text(prepareFloat(node.text()));
+      node.text(prepareFloat(parseFloat(node.text())));
     }
   });
 }

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -187,6 +187,22 @@ function checkInteger(node) {
 }
 
 /**
+ * Prepares a floating point value for display in the form.
+ * @param {number} value
+ * @return {number}
+ */
+function prepareFloat(value) {
+  // Round to 7 decimal places; this avoid floating point precision issues
+  // that can be quite jarring to users.
+  //
+  // See:
+  //   * https://stackoverflow.com/a/3644302
+  //   * https://medium.com/swlh/ed74c471c1b8
+  const factor = Math.pow(10, 7);
+  return Math.round(value * factor) / factor;
+}
+
+/**
  * Adds a jQuery handler to a node such that the handler is run once whenever
  * data entry within that node is changed, *except through remove* -- this must
  * be handled manually. (This prevents inconsistent timing in the ordering of
@@ -428,6 +444,14 @@ function loadReaction(reaction) {
     ord.provenance.load(provenance);
   }
   $('#reaction_id').text(reaction.getReactionId());
+
+  // Clean up floating point entries.
+  $('.floattext').each(function(index) {
+    const node = $(this);
+    if (node.text() !== '') {
+      node.text(prepareFloat(node.text()));
+    }
+  });
 }
 
 /**

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -192,15 +192,15 @@ function checkInteger(node) {
  * @return {number}
  */
 function prepareFloat(value) {
-  // Round to 15 significant digits; this avoid floating point precision issues
+  // Round to N significant digits; this avoid floating point precision issues
   // that can be quite jarring to users.
   //
   // See:
   //   * https://stackoverflow.com/a/3644302
   //   * https://medium.com/swlh/ed74c471c1b8
-  const precision = 15;
-  const factor = Math.pow(10, precision);
-  return Math.round(value.toPrecision(precision) * factor) / factor;
+  //   * https://stackoverflow.com/a/19623253
+  const precision = 7;
+  return parseFloat(value.toPrecision(precision));
 }
 
 /**

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -192,14 +192,14 @@ function checkInteger(node) {
  * @return {number}
  */
 function prepareFloat(value) {
-  // Round to 7 decimal places; this avoid floating point precision issues
+  // Round to 15 decimal places; this avoid floating point precision issues
   // that can be quite jarring to users.
   //
   // See:
   //   * https://stackoverflow.com/a/3644302
   //   * https://medium.com/swlh/ed74c471c1b8
-  const factor = Math.pow(10, 7);
-  return Math.round(value * factor) / factor;
+  const factor = Math.pow(10, 15);
+  return Math.round(value.toPrecision(15) * factor) / factor;
 }
 
 /**

--- a/editor/js/setups.js
+++ b/editor/js/setups.js
@@ -20,6 +20,7 @@ exports = {
   load,
   unload,
   addVesselPreparation,
+  addVesselAttachment,
   validateSetup
 };
 

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -186,7 +186,7 @@ def format_message(message):
     txt = f'{message.value:15g}'.strip()
     txt += ' '
     if message.precision:
-        txt += '(p/m '
+        txt += '(± '
         txt += f'{message.precision:15g}'.strip()
         txt += ') '
     txt += _UNIT_SYNONYMS[type(message)][message.units][0]

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -183,11 +183,8 @@ def format_message(message):
     """
     if message.units == getattr(type(message)(), 'UNSPECIFIED'):
         return None
-    txt = f'{message.value:15g}'.strip()
-    txt += ' '
+    txt = f'{message.value:.7g} '
     if message.precision:
-        txt += '(± '
-        txt += f'{message.precision:15g}'.strip()
-        txt += ') '
+        txt += f'(± {message.precision:.7g}) '
     txt += _UNIT_SYNONYMS[type(message)][message.units][0]
     return txt

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -183,8 +183,8 @@ def format_message(message):
     """
     if message.units == getattr(type(message)(), 'UNSPECIFIED'):
         return None
-    txt = f'{message.value:.4g} '
+    txt = f'{message.value:.7g} '
     if message.precision:
-        txt += f'(p/m {message.precision}) '
+        txt += f'(p/m {message.precision:.7g}) '
     txt += _UNIT_SYNONYMS[type(message)][message.units][0]
     return txt

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -183,8 +183,8 @@ def format_message(message):
     """
     if message.units == getattr(type(message)(), 'UNSPECIFIED'):
         return None
-    txt = f'{message.value:.7g} '
+    txt = f'{message.value:.15g} '
     if message.precision:
-        txt += f'(p/m {message.precision:.7g}) '
+        txt += f'(p/m {message.precision:.15g}) '
     txt += _UNIT_SYNONYMS[type(message)][message.units][0]
     return txt

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -184,9 +184,10 @@ def format_message(message):
     if message.units == getattr(type(message)(), 'UNSPECIFIED'):
         return None
     txt = f'{message.value:15g}'.strip()
+    txt += ' '
     if message.precision:
         txt += '(p/m '
         txt += f'{message.precision:15g}'.strip()
-        txt += ')'
+        txt += ') '
     txt += _UNIT_SYNONYMS[type(message)][message.units][0]
     return txt

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -183,8 +183,10 @@ def format_message(message):
     """
     if message.units == getattr(type(message)(), 'UNSPECIFIED'):
         return None
-    txt = f'{message.value:.15g} '
+    txt = f'{message.value:15g}'.strip()
     if message.precision:
-        txt += f'(p/m {message.precision:.15g}) '
+        txt += '(p/m '
+        txt += f'{message.precision:15g}'.strip()
+        txt += ')'
     txt += _UNIT_SYNONYMS[type(message)][message.units][0]
     return txt


### PR DESCRIPTION
Fixes #229 

* Rounds floating point values loaded into the form from protocol buffers to 7 decimal digits (matching 32-bit float precision).
* Rounds float values similarity in python when formatting "units" messages (affects the HTML reaction table).