### PR TITLE
Add the ability to delete Datasets

### DIFF
--- a/editor/html/dataset.html
+++ b/editor/html/dataset.html
@@ -74,6 +74,7 @@ limitations under the License.
     <div id="top_buttons">
       <div id="download" onclick="ord.dataset.download();">download</div>
       <div id="save" onclick="ord.dataset.commit();" style="visibility: hidden;">save</div>
+      <div id="delete" class="remove" style="float: none;" onclick="if(confirm('Are you sure you want to delete this Dataset? This cannot be undone.')) { location.href='/dataset/{{ file_name }}/delete'; }">delete</div>
     </div>
 
     <div class="spacer"></div>

--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -109,6 +109,14 @@ def new_dataset(file_name):
     return 'ok'
 
 
+@app.route('/dataset/<file_name>/delete')
+def delete_dataset(file_name):
+    """Removes a Dataset."""
+    with lock(file_name):
+        os.remove(get_path(file_name))
+    return flask.redirect('/datasets')
+
+
 @app.route('/dataset/enumerate', methods=['POST'])
 def enumerate_dataset():
     """Creates a new dataset based on a template reaction and a spreadsheet.
@@ -195,7 +203,7 @@ def clone_reaction(file_name, index):
 
 @app.route('/dataset/<file_name>/delete/reaction/<index>')
 def delete_reaction(file_name, index):
-    """Removes a specific Reaction from the Dataset and view the Datset."""
+    """Removes a specific Reaction from the Dataset and view the Dataset."""
     dataset = get_dataset(file_name)
     try:
         index = int(index)
@@ -582,9 +590,6 @@ def init_user():
     path = get_user_path()
     if not os.path.isdir(path):
         os.mkdir(path)
-    if not os.listdir(path):
-        dataset = dataset_pb2.Dataset()
-        put_dataset('dataset', dataset)
 
 
 def ensure_user():

--- a/editor/py/serve_test.py
+++ b/editor/py/serve_test.py
@@ -43,6 +43,10 @@ class ServeTest(parameterized.TestCase, absltest.TestCase):
         self.testdata = os.path.join(
             os.path.dirname(__file__),
             '../../examples/2_Nielsen_Deoxyfluorination_Screen')
+        # Start with an initial empty dataset called 'dataset'.
+        response = self.client.post('/dataset/dataset/new',
+                                    follow_redirects=True)
+        self.assertEqual(response.status_code, 200)
 
     def _get_dataset(self):
         """Returns a Dataset for testing."""


### PR DESCRIPTION
* Adds a button for deleting a Dataset; confirmation is required prior to deletion.
* Removes the default `dataset` Dataset. Users can choose "create new dataset" and give it their own name.

Fixes #388 