### PR TITLE
Create a base image for faster docker building/testing

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,4 +25,9 @@ RUN apt-get update && apt-get install -y \
     unzip \
  && rm -rf /var/lib/apt/lists/*
 
-RUN conda install -c rdkit flask gunicorn rdkit && conda clean -afy
+RUN conda install -c rdkit \
+    flask \
+    gunicorn \
+    nodejs \
+    rdkit \
+ && conda clean -afy

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2020 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a base image used to speed up builds for ord-editor, etc.
+#
+# $ docker build -t openreactiondatabase/ord-base .
+# $ docker push openreactiondatabase/ord-base
+
+FROM continuumio/miniconda3
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    procps \
+    unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN conda install -c rdkit flask gunicorn rdkit && conda clean -afy

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -24,11 +24,7 @@
 # To push the built image to Docker Hub:
 # docker push openreactiondatabase/ord-editor
 
-FROM continuumio/miniconda3
-
-RUN apt-get update && apt-get install --yes build-essential procps unzip
-RUN conda install -c rdkit rdkit
-RUN conda install flask nodejs
+FROM openreactiondatabase/ord-base
 
 # Fetch/build editor dependencies.
 # NOTE(kearnes): Do this before COPYing the local state so it can be cached.
@@ -54,5 +50,4 @@ RUN python setup.py install
 WORKDIR /usr/src/app/ord-schema/editor
 RUN make
 EXPOSE 5000
-RUN pip install gunicorn
 CMD gunicorn py.serve:app -b 0.0.0.0:5000 --access-logfile '-'

--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -24,22 +24,11 @@
 # To push the built image to Docker Hub:
 # docker push openreactiondatabase/ord-editor
 
-FROM openreactiondatabase/ord-base
-
-# Fetch/build editor dependencies.
-# NOTE(kearnes): Do this before COPYing the local state so it can be cached.
-WORKDIR /usr/src/app/ord-schema/editor
-RUN git clone https://github.com/Open-Reaction-Database/ketcher.git
-WORKDIR ketcher
-RUN npm install && npm run build
-WORKDIR ..
-RUN wget https://github.com/google/closure-library/archive/v20200517.tar.gz
-RUN tar -xzf v20200517.tar.gz
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protobuf-js-3.13.0.tar.gz
-RUN tar -xzf protobuf-js-3.13.0.tar.gz
+FROM openreactiondatabase/ord-editor-base
 
 # COPY and install the local state of ord-schema.
-WORKDIR /usr/src/app/ord-schema
+# NOTE(kearnes): WORKDIR is set in the base image.
+# WORKDIR /usr/src/app/ord-schema
 COPY setup.py requirements.txt ./
 COPY editor/ editor/
 COPY ord_schema/ ord_schema/
@@ -47,7 +36,7 @@ RUN pip install -r requirements.txt
 RUN python setup.py install
 
 # Build and launch the editor.
-WORKDIR /usr/src/app/ord-schema/editor
+WORKDIR editor
 RUN make
 EXPOSE 5000
 CMD gunicorn py.serve:app -b 0.0.0.0:5000 --access-logfile '-'

--- a/editor/base/Dockerfile
+++ b/editor/base/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This is a base image used to speed up builds for ord-editor, etc.
+# This is a base image used to speed up GitHub test builds for ord-editor.
 #
-# $ docker build -t openreactiondatabase/ord-base .
-# $ docker push openreactiondatabase/ord-base
+# $ docker build -t openreactiondatabase/ord-editor-base .
+# $ docker push openreactiondatabase/ord-editor-base
 
 FROM continuumio/miniconda3
 
@@ -31,3 +31,19 @@ RUN conda install -c rdkit \
     nodejs \
     rdkit \
  && conda clean -afy
+
+# Fetch and build editor dependencies.
+WORKDIR /usr/src/app/ord-schema/editor
+RUN git clone https://github.com/Open-Reaction-Database/ketcher.git \
+ && cd ketcher \
+ && npm install \
+ && npm run build \
+ && rm -rf node_modules
+RUN wget https://github.com/google/closure-library/archive/v20200517.tar.gz \
+ && tar -xzf v20200517.tar.gz \
+ && rm v20200517.tar.gz
+RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v3.13.0/protobuf-js-3.13.0.tar.gz \
+ && tar -xzf protobuf-js-3.13.0.tar.gz \
+ && rm protobuf-js-3.13.0.tar.gz
+
+WORKDIR ..

--- a/ord_schema/interface/Dockerfile
+++ b/ord_schema/interface/Dockerfile
@@ -46,5 +46,4 @@ RUN python setup.py install
 # Build and launch the interface.
 WORKDIR /usr/src/app/ord-schema/ord_schema/interface
 EXPOSE 5000
-RUN pip install gunicorn
 CMD gunicorn search:app -b 0.0.0.0:5000 --access-logfile '-'

--- a/ord_schema/interface/Dockerfile
+++ b/ord_schema/interface/Dockerfile
@@ -22,7 +22,19 @@
 # To push the built image to Docker Hub:
 # docker push openreactiondatabase/ord-interface
 
-FROM openreactiondatabase/ord-base
+FROM continuumio/miniconda3
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    procps \
+    unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN conda install -c rdkit \
+    flask \
+    gunicorn \
+    rdkit \
+ && conda clean -afy
 
 # COPY and install the local state of ord-schema.
 WORKDIR /usr/src/app/ord-schema
@@ -34,4 +46,5 @@ RUN python setup.py install
 # Build and launch the interface.
 WORKDIR /usr/src/app/ord-schema/ord_schema/interface
 EXPOSE 5000
+RUN pip install gunicorn
 CMD gunicorn search:app -b 0.0.0.0:5000 --access-logfile '-'

--- a/ord_schema/interface/Dockerfile
+++ b/ord_schema/interface/Dockerfile
@@ -22,11 +22,7 @@
 # To push the built image to Docker Hub:
 # docker push openreactiondatabase/ord-interface
 
-FROM continuumio/miniconda3
-
-RUN apt-get update && apt-get install --yes build-essential procps unzip
-RUN conda install -c rdkit rdkit
-RUN conda install flask
+FROM openreactiondatabase/ord-base
 
 # COPY and install the local state of ord-schema.
 WORKDIR /usr/src/app/ord-schema
@@ -38,5 +34,4 @@ RUN python setup.py install
 # Build and launch the interface.
 WORKDIR /usr/src/app/ord-schema/ord_schema/interface
 EXPOSE 5000
-RUN pip install gunicorn
 CMD gunicorn search:app -b 0.0.0.0:5000 --access-logfile '-'


### PR DESCRIPTION
Drastically improves GitHub build times for the editor tests and standardizes on recommended Dockerfile practices for managing image size, etc.