### PR TITLE
Updates to the editor navigation bar

### DIFF
--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -1083,21 +1083,15 @@ limitations under the License.
         navSelectors[section] = selector;
       });
 
-      // Show only the given section of the reaction schema.
+      // Navigate to the given section of the reaction schema.
       function setSelected(section) {
         $('.navSection').css('background-color', '');
-        $('.section').hide('slow');
-        if (section != null) {
-          $('#section_' + section).show('slow');
-          const selector = navSelectors[section];
-          selector.css('background-color', 'lightblue');
-        } else {
-          $('.section').show('slow')
-        }
+        $('#section_' + section)[0].scrollIntoView({behavior: 'smooth'});
+        const selector = navSelectors[section];
+        selector.css('background-color', 'lightblue');
         selected = section;
       }
 
-      // Show and hide the schema sections.
       $('.navSection').click(event => {
         const section = $(event.target).attr('data-section');
         if (section != selected) {

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -1083,7 +1083,6 @@ limitations under the License.
           } else {
             sectionToUnselect = section;
           }
-          return false;  // Break.
         });
         if (sectionToSelect) {
           setSelected(sectionToSelect);
@@ -1093,7 +1092,6 @@ limitations under the License.
           $('.section').each(function(index) {
             const section = $(this).attr('id').split('_')[1];
             const rect = this.getBoundingClientRect();
-            console.log(section, rect);
             if ((rect.y >= 0 && rect.y <= window.innerHeight) ||
                 (rect.y < 0 && rect.bottom > 0)) {
               setSelected(section);

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -1072,15 +1072,35 @@ limitations under the License.
     <script>
       // Intersection observer for updating the current location in the sidebar
       // as the user scrolls on the page.
+      let selectedSection = null;
       function observerCallback(entries) {
+        let sectionToSelect = null;
+        let sectionToUnselect = null;
         entries.forEach(entry => {
           const section = $(entry.target).attr('id').split('_')[1];
           if (entry.isIntersecting) {
-            setSelected(section);
+            sectionToSelect = section;
           } else {
-            clearSelected(section);
+            sectionToUnselect = section;
           }
+          return false;  // Break.
         });
+        if (sectionToSelect) {
+          setSelected(sectionToSelect);
+        } else if (sectionToUnselect && selectedSection === sectionToUnselect) {
+          clearSelected(sectionToUnselect);
+          // Fallback to the first visible section.
+          $('.section').each(function(index) {
+            const section = $(this).attr('id').split('_')[1];
+            const rect = this.getBoundingClientRect();
+            console.log(section, rect);
+            if ((rect.y >= 0 && rect.y <= window.innerHeight) ||
+                (rect.y < 0 && rect.bottom > 0)) {
+              setSelected(section);
+              return false;  // Break.
+            }
+          });
+        }
       }
       const observer = new IntersectionObserver(observerCallback);
 
@@ -1098,10 +1118,13 @@ limitations under the License.
 
       // Navigate to the given section of the form.
       function setSelected(section) {
+        $('.navSection').css('background-color', '');
         navSelectors[section].css('background-color', 'lightblue');
+        selectedSection = section;
       }
       function clearSelected(section) {
         navSelectors[section].css('background-color', '');
+        selectedSection = null;
       }
 
       $('.navSection').click(event => {

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -1070,49 +1070,49 @@ limitations under the License.
     </div>
 
     <script>
-      // The selected section name.
-      let selected = null;
+      // Intersection observer for updating the current location in the sidebar
+      // as the user scrolls on the page.
+      function observerCallback(entries) {
+        entries.forEach(entry => {
+          const section = $(entry.target).attr('id').split('_')[1];
+          if (entry.isIntersecting) {
+            setSelected(section);
+          } else {
+            clearSelected(section);
+          }
+        });
+      }
+      const observer = new IntersectionObserver(observerCallback);
 
-      // An index of the section selector controls.
-      const navSelectors = {};
+      $('.section').each(function(index) {
+        observer.observe(this);
+      });
 
       // Index the selector controls.
+      const navSelectors = {};
       $('.navSection').each((index, selector) => {
         selector = $(selector);
         const section = selector.attr('data-section');
         navSelectors[section] = selector;
       });
 
-      // Navigate to the given section of the reaction schema.
+      // Navigate to the given section of the form.
       function setSelected(section) {
-        $('.navSection').css('background-color', '');
-        $('#section_' + section)[0].scrollIntoView({behavior: 'smooth'});
-        const selector = navSelectors[section];
-        selector.css('background-color', 'lightblue');
-        selected = section;
+        navSelectors[section].css('background-color', 'lightblue');
+      }
+      function clearSelected(section) {
+        navSelectors[section].css('background-color', '');
       }
 
       $('.navSection').click(event => {
         const section = $(event.target).attr('data-section');
-        if (section != selected) {
-          setSelected(section);
-          history.pushState({section: section}, "", "#" + section);
-        } else {
-          setSelected(null);
-          history.pushState({section: null}, "", location.pathname);
-        }
+        $('#section_' + section)[0].scrollIntoView({behavior: 'smooth'});
       });
-
-      // Handle the back button.
-      onpopstate = function(event) {
-        const section = event.state.section;
-        setSelected(section);
-      }
 
       // Handle initialization.
       if (location.hash) {
         const section = location.hash.replace('#', '');
-        setSelected(section);
+        $('#section_' + section)[0].scrollIntoView({behavior: 'smooth'});
       }
     </script>
 

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -1072,33 +1072,15 @@ limitations under the License.
     <script>
       // Intersection observer for updating the current location in the sidebar
       // as the user scrolls on the page.
-      let selectedSection = null;
       function observerCallback(entries) {
-        let sectionToSelect = null;
-        let sectionToUnselect = null;
         entries.forEach(entry => {
           const section = $(entry.target).attr('id').split('_')[1];
           if (entry.isIntersecting) {
-            sectionToSelect = section;
+            setSelected(section);
           } else {
-            sectionToUnselect = section;
+            clearSelected(section);
           }
         });
-        if (sectionToSelect) {
-          setSelected(sectionToSelect);
-        } else if (sectionToUnselect && selectedSection === sectionToUnselect) {
-          clearSelected(sectionToUnselect);
-          // Fallback to the first visible section.
-          $('.section').each(function(index) {
-            const section = $(this).attr('id').split('_')[1];
-            const rect = this.getBoundingClientRect();
-            if ((rect.y >= 0 && rect.y <= window.innerHeight) ||
-                (rect.y < 0 && rect.bottom > 0)) {
-              setSelected(section);
-              return false;  // Break.
-            }
-          });
-        }
       }
       const observer = new IntersectionObserver(observerCallback);
 
@@ -1116,13 +1098,10 @@ limitations under the License.
 
       // Navigate to the given section of the form.
       function setSelected(section) {
-        $('.navSection').css('background-color', '');
         navSelectors[section].css('background-color', 'lightblue');
-        selectedSection = section;
       }
       function clearSelected(section) {
         navSelectors[section].css('background-color', '');
-        selectedSection = null;
       }
 
       $('.navSection').click(event => {


### PR DESCRIPTION
Related to #404 

* Changes sidebar behavior to scroll to the selected section rather than show/hide.
* Adds support for updating the sidebar selection as the user scrolls.

NOTE: The dynamic sidebar selection is quite complicated---how do you decide which section you're "in"? As a way of sidestepping this issue I chose to highlight the names of any sections that are currently visible:

![image](https://user-images.githubusercontent.com/952729/94218835-910e1e00-fea2-11ea-944d-af35f7ea2a5b.png)
