### PR TITLE
Aliquot workup step

### DIFF
--- a/editor/db/test/full.pbtxt
+++ b/editor/db/test/full.pbtxt
@@ -371,6 +371,11 @@ reactions {
     }
     target_ph: 89.0
     is_automated: true
+    volume {
+      value: 123.0
+      precision: 0.5
+      units: MILLILITER
+    }
   }
   outcomes {
     reaction_time {

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -284,12 +284,14 @@ limitations under the License.
                     <span class="collapse"></span>
                     Amount
                   </legend>
-                  <input type="radio" class="crude_amount_mass" value="mass" checked> mass
-                  <input type="radio" class="crude_amount_volume" value="volume"> volume
-                  <span style="padding-left:25px">value</span> <div class="crude_amount_value edittext shorttext floattext"></div>
-                  +/- <div class="crude_amount_precision edittext shorttext floattext"></div>
-                  <div class="crude_amount_units_mass selector" data-proto="Mass_MassUnit"></div>
-                  <div class="crude_amount_units_volume selector" data-proto="Volume_VolumeUnit" style="display: none;"></div>
+                  <div>
+                    <input type="radio" class="crude_amount_mass" value="mass" checked> mass
+                    <input type="radio" class="crude_amount_volume" value="volume"> volume
+                    <span style="padding-left:25px">value</span> <div class="crude_amount_value edittext shorttext floattext"></div>
+                    +/- <div class="crude_amount_precision edittext shorttext floattext"></div>
+                    <div class="crude_amount_units_mass selector" data-proto="Mass_MassUnit"></div>
+                    <div class="crude_amount_units_volume selector" data-proto="Volume_VolumeUnit" style="display: none;"></div>
+                  </div>
                 </fieldset>
                 <div onclick="ord.reaction.removeSlowly(this, '.crude');" class="remove">remove</div>
               </fieldset>
@@ -642,6 +644,20 @@ limitations under the License.
             <div class="workup_input">
               <!-- Shares ".input_template" with "#inputs" above. -->
             </div>
+            <fieldset class="amount">
+              <legend>
+                <span class="workup_amount collapse"></span>
+                Aliquot amount
+              </legend>
+              <div>
+                <input type="radio" class="workup_amount_mass" value="mass"> mass
+                <input type="radio" class="workup_amount_volume" value="volume" checked> volume
+                <span style="padding-left:25px">value</span> <div class="workup_amount_value edittext shorttext floattext"></div>
+                +/- <div class="workup_amount_precision edittext shorttext floattext"></div>
+                <div class="workup_amount_units_mass selector" data-proto="Mass_MassUnit" style="display: none;"></div>
+                <div class="workup_amount_units_volume selector" data-proto="Volume_VolumeUnit"></div>
+              </div>
+            </fieldset>
             <fieldset>
               <legend>
                 <span class="workup_temperature collapse"></span>

--- a/editor/js/amountsWorkups.js
+++ b/editor/js/amountsWorkups.js
@@ -122,7 +122,8 @@ function unloadVolume(node) {
   if (!isNaN(value)) {
     volume.setValue(value);
   }
-  const units = ord.reaction.getSelector($('.workup_amount_units_volume', node));
+  const units =
+      ord.reaction.getSelector($('.workup_amount_units_volume', node));
   volume.setUnits(units);
   const precision = parseFloat($('.workup_amount_precision', node).text());
   if (!isNaN(precision)) {

--- a/editor/js/amountsWorkups.js
+++ b/editor/js/amountsWorkups.js
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2020 Open Reaction Database Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+goog.module('ord.amountsWorkups');
+goog.module.declareLegacyNamespace();
+exports = {
+  load,
+  unload
+};
+
+goog.require('proto.ord.Mass');
+goog.require('proto.ord.Volume');
+
+/**
+ * Adds and populates the form's fields describing the amount of an aliquot.
+ * @param {!Node} node The div corresponding to the workup step whose amount
+ *     fields on the form should be updated.
+ * @param {?proto.ord.Mass} mass
+ * @param {?proto.ord.Volume} volume
+ */
+function load(node, mass, volume) {
+  const amount = $('.amount', node);
+  if (mass) {
+    $('input[value=\'mass\']', amount).prop('checked', true);
+    if (mass.hasValue()) {
+      $('.workup_amount_value', node).text(mass.getValue());
+    }
+    if (mass.hasPrecision()) {
+      $('.workup_amount_precision', node).text(mass.getPrecision());
+    }
+    $('.workup_amount_units_mass', node).show();
+    $('.workup_amount_units_volume', node).hide();
+    ord.reaction.setSelector(
+        $('.workup_amount_units_mass', amount), mass.getUnits());
+  }
+  if (volume) {
+    $('input[value=\'volume\']', amount).prop('checked', true);
+    if (volume.hasValue()) {
+      $('.workup_amount_value', node).text(volume.getValue());
+    }
+    if (volume.hasPrecision()) {
+      $('.workup_amount_precision', node).text(volume.getPrecision());
+    }
+    $('.workup_amount_units_volume', node).show();
+    $('.workup_amount_units_mass', node).hide();
+    ord.reaction.setSelector(
+        $('.workup_amount_units_volume', amount), volume.getUnits());
+  }
+}
+
+/**
+ * Sets the amount fields of a workup message according to the form.
+ * @param {!Node} node The div corresponding to the workup step whose amount
+ *     fields should be read from the form.
+ * @param {!proto.ord.ReactionWorkup} workup
+ */
+function unload(node, workup) {
+  const mass = unloadMass(node);
+  const volume = unloadVolume(node);
+  if (mass) {
+    if (!ord.reaction.isEmptyMessage(mass)) {
+      workup.setMass(mass);
+    }
+  }
+  if (volume) {
+    if (!ord.reaction.isEmptyMessage(volume)) {
+      workup.setVolume(volume);
+    }
+  }
+}
+
+/**
+ * Reads and returns a mass amount as defined in the form for a workup step.
+ * @param {!Node} node The div corresponding to the workup step whose mass
+ *     fields should be read from the form.
+ * @return {?proto.ord.Mass}
+ */
+function unloadMass(node) {
+  if (!$('.workup_amount_mass', node).is(':checked')) {
+    return null;
+  }
+  const mass = new proto.ord.Mass();
+  const value = parseFloat($('.workup_amount_value', node).text());
+  if (!isNaN(value)) {
+    mass.setValue(value);
+  }
+  const units = ord.reaction.getSelector($('.workup_amount_units_mass', node));
+  mass.setUnits(units);
+  const precision = parseFloat($('.workup_amount_precision', node).text());
+  if (!isNaN(precision)) {
+    mass.setPrecision(precision);
+  }
+  return mass;
+}
+
+/**
+ * Reads and returns a volumetric amount as defined in the form for a workup
+ * step.
+ * @param {!Node} node The div corresponding to the workups tep whose
+ *     volume fields should be read from the form.
+ * @return {?proto.ord.Volume}
+ */
+function unloadVolume(node) {
+  if (!$('.workup_amount_volume', node).is(':checked')) {
+    return null;
+  }
+  const volume = new proto.ord.Volume();
+  const value = parseFloat($('.workup_amount_value', node).text());
+  if (!isNaN(value)) {
+    volume.setValue(value);
+  }
+  const units = ord.reaction.getSelector($('.workup_amount_units_volume', node));
+  volume.setUnits(units);
+  const precision = parseFloat($('.workup_amount_precision', node).text());
+  if (!isNaN(precision)) {
+    volume.setPrecision(precision);
+  }
+  return volume;
+}

--- a/editor/js/workups.js
+++ b/editor/js/workups.js
@@ -26,6 +26,10 @@ exports = {
 
 goog.require('ord.inputs');
 goog.require('proto.ord.ReactionWorkup');
+goog.require('ord.amountsWorkups');
+
+// Freely create radio button groups by generating new input names.
+let radioGroupCounter = 0;
 
 /**
  * Adds and populates the reaction workup sections in the form.
@@ -52,6 +56,10 @@ function loadWorkup(workup) {
   if (input) {
     ord.inputs.loadInputUnnamed($('.workup_input', node), input);
   }
+
+  const mass = workup.getMass();
+  const volume = workup.getVolume();
+  ord.amountsWorkups.load(node, mass, volume);
 
   const temperature = workup.getTemperature();
   if (temperature) {
@@ -163,6 +171,8 @@ function unloadWorkup(node) {
   if (!ord.reaction.isEmptyMessage(input)) {
     workup.setInput(input);
   }
+
+  ord.amountsWorkups.unload(node, workup);
 
   const control = new proto.ord.TemperatureConditions.TemperatureControl();
   control.setType(
@@ -278,6 +288,20 @@ function add() {
   $('.input_name', inputNode).hide();
   // Unlike Reaction.inputs, this ReactionInput is not repeated.
   $('.remove', inputNode).hide();
+
+  // Create "amount" radio button group and connect it to the unit selectors.
+  const amountButtons = $('.amount input', workupNode);
+  amountButtons.attr('name', 'aliquots_' + radioGroupCounter++);
+  amountButtons.change(function() {
+    $('.amount .selector', workupNode).hide();
+    if (this.value == 'mass') {
+      $('.workup_amount_units_mass', workupNode).show();
+    }
+    if (this.value == 'volume') {
+      $('.workup_amount_units_volume', workupNode).show();
+    }
+  });
+  workupNode.find('.workup_amount').trigger('click');
 
   // Add live validation handling.
   ord.reaction.addChangeHandler(workupNode, () => {

--- a/ord_schema/proto/reaction.proto
+++ b/ord_schema/proto/reaction.proto
@@ -728,6 +728,10 @@ message ReactionWorkup {
     // Specify composition/amount in "input".
     // Often preceded by TEMPERATURE.
     ADDITION = 2;
+    // Sampling (by mass of volume) a portion of the mixture, often for
+    // dilution in a subsequent ADDITION step prior to analysis. The vessel to
+    // which the aliquot is transferred can be specified in "details".
+    ALIQUOT = 18;
     // Change of temperature.
     // Specify conditions in "temperature".
     TEMPERATURE = 3;
@@ -783,6 +787,13 @@ message ReactionWorkup {
   string details = 2;
   Time duration = 3;
   ReactionInput input = 4;
+  // When aliquotting a portion of the reaction mixture, the amount is
+  // specified by mass or volume. Note that the amounts for additions should
+  // be described in the "input" field instead; these are only for aliquots.
+  oneof amount {
+    Mass mass = 11;
+    Volume volume = 12;
+  }
   TemperatureConditions temperature = 5;
   string keep_phase = 6;
   StirringConditions stirring = 7;

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -664,6 +664,10 @@ def validate_reaction_workup(message):
     if (message.type == reaction_pb2.ReactionWorkup.PH_ADJUST and
             not message.HasField('target_ph')):
         warnings.warn('pH adjustment workup missing target pH', ValidationError)
+    if (message.type == reaction_pb2.ReactionWorkup.ALIQUOT and
+            not message.WhichOneof('amount')):
+        warnings.warn('Aliquot workup step missing volume/mass amount',
+                      ValidationError)
 
 
 def validate_reaction_outcome(message):


### PR DESCRIPTION
Resolves #424 by adding a mass/volume amount field to the workup message to be used for ALIQUOT-type steps. Adds corresponding fields to the editor, which requires lots of additional js to get the selectors correct. Addressed by basing implementation on the crude component amount fields, but long-term might want to consolidate all of the amount selector logic to avoid repeated code.