### PR TITLE
Don't add empty space in freeze

### DIFF
--- a/editor/js/dataset.js
+++ b/editor/js/dataset.js
@@ -282,9 +282,5 @@ function freeze() {
     const node = $(x);
     node.attr('contenteditable', 'false');
     node.css('background-color', '#ebebe4');
-    // Ensure non-editable divs have a text node to preserve vertical alignment.
-    if (!node.text()) {
-      node.text(' ');
-    }
   });
 }

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -974,9 +974,5 @@ function freeze() {
     const node = $(x);
     node.attr('contenteditable', 'false');
     node.css('background-color', '#ebebe4');
-    // Ensure non-editable divs have a text node to preserve vertical alignment.
-    if (!node.text()) {
-      node.text(' ');
-    }
   });
 }


### PR DESCRIPTION
Fixes #431 

Removing the extra space doesn't seem to break vertical alignment:

![image](https://user-images.githubusercontent.com/952729/95102351-86e4ee80-06f0-11eb-95ce-2ba6ece7d251.png)
