### PR TITLE
Use unicode ± instead of p/m

### DIFF
--- a/ord_schema/visualization/template.html
+++ b/ord_schema/visualization/template.html
@@ -130,7 +130,7 @@
                     {% if product.compound_yield.value %}
                         {{ product.compound_yield.value|round(3) }}%
                         {% if product.compound_yield.precision %}
-                            (p/m {{ product.compound_yield.precision|round(3) }}%)
+                            (± {{ product.compound_yield.precision|round(3) }}%)
                         {% endif %}
                         yield
                         {% if product.analysis_yield %}


### PR DESCRIPTION
(This is already being done in `ord_schema.units.format_message`