### PR TITLE
Add docker-compose configuration for the editor

### DIFF
--- a/editor/README.md
+++ b/editor/README.md
@@ -108,7 +108,7 @@ so remember to download your Dataset when you are done.
 
 ## How it Works
 
-Datasets to be edited are stored in the ORD_EDITOR_DB directory as `.pbtxt`
+Datasets to be edited are stored in the ORD_EDITOR_LOCAL directory as `.pbtxt`
 files (protobuf text format).
 
 When you load a Reaction in the editor, the editor reads the entire Dataset

--- a/editor/docker-compose.yml
+++ b/editor/docker-compose.yml
@@ -1,0 +1,47 @@
+# Copyright 2020 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# docker-compose configuration for the ORD editor + postgres backend database.
+#
+# Two environment variables are required:
+#   * ORD_EDITOR_POSTGRES_PASSWORD: The postgres password.
+#   * ORD_EDITOR_MOUNT: Mount location for the volume on which the database
+#     is stored. This is designed for use with GCP, where the mount location
+#     refers to a persistent disk that will not disappear when the image is
+#     restarted. See https://github.com/docker-library/docs/blob/master/postgres/README.md#pgdata
+#     for more details. When running locally, this should be set to something
+#     like "${HOME}/ord-editor-data".
+#
+# In the editor image, the ORD_EDITOR_DB variable is set to the hostname of
+# the postgres image so the editor can connect to the backend. Note that the
+# postgres server is not exposed externally; it is only visible to the editor
+# image.
+
+version: "3"
+services:
+  db:
+    image: "postgres"
+    environment:
+      - POSTGRES_PASSWORD="${ORD_EDITOR_POSTGRES_PASSWORD}"
+      - PGDATA=/var/lib/postgresql/data/pgdata
+    volumes:
+      - "${ORD_EDITOR_MOUNT}:/var/lib/postgresql/data"
+  web:
+    depends_on:
+      - db
+    environment:
+      - ORD_EDITOR_DB=db
+    image: "openreactiondatabase/ord-editor"
+    ports:
+      - "5000:5000"

--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -1098,7 +1098,11 @@ limitations under the License.
           }
         });
       }
-      const observer = new IntersectionObserver(observerCallback);
+      const headerSize = $('#header').outerHeight();
+      let observerOptions = {
+          rootMargin: '-' + headerSize + 'px 0px 0px 0px'
+      }
+      const observer = new IntersectionObserver(observerCallback, observerOptions);
 
       $('.section').each(function(index) {
         observer.observe(this);

--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -42,7 +42,7 @@ from ord_schema.visualization import drawing
 # pylint: disable=invalid-name,no-member,inconsistent-return-statements
 app = flask.Flask(__name__, template_folder='../html')
 app.config['ORD_EDITOR_LOCAL'] = os.path.abspath(
-    os.getenv('ORD_EDITOR_LOCAL', 'ord-editor-local'))
+    os.getenv('ORD_EDITOR_LOCAL', 'db'))
 app.config['REVIEW_ROOT'] = flask.safe_join(app.config['ORD_EDITOR_LOCAL'],
                                             '.review')
 app.config['REVIEW_DATA_ROOT'] = flask.safe_join(app.config['REVIEW_ROOT'],

--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -41,7 +41,8 @@ from ord_schema.visualization import drawing
 
 # pylint: disable=invalid-name,no-member,inconsistent-return-statements
 app = flask.Flask(__name__, template_folder='../html')
-app.config['ORD_EDITOR_LOCAL'] = os.path.abspath(os.getenv('ORD_EDITOR_LOCAL', 'ord-editor-local'))
+app.config['ORD_EDITOR_LOCAL'] = os.path.abspath(
+    os.getenv('ORD_EDITOR_LOCAL', 'ord-editor-local'))
 app.config['REVIEW_ROOT'] = flask.safe_join(app.config['ORD_EDITOR_LOCAL'],
                                             '.review')
 app.config['REVIEW_DATA_ROOT'] = flask.safe_join(app.config['REVIEW_ROOT'],

--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -41,8 +41,8 @@ from ord_schema.visualization import drawing
 
 # pylint: disable=invalid-name,no-member,inconsistent-return-statements
 app = flask.Flask(__name__, template_folder='../html')
-app.config['ORD_EDITOR_DB'] = os.path.abspath(os.getenv('ORD_EDITOR_DB', 'db'))
-app.config['REVIEW_ROOT'] = flask.safe_join(app.config['ORD_EDITOR_DB'],
+app.config['ORD_EDITOR_LOCAL'] = os.path.abspath(os.getenv('ORD_EDITOR_LOCAL', 'ord-editor-local'))
+app.config['REVIEW_ROOT'] = flask.safe_join(app.config['ORD_EDITOR_LOCAL'],
                                             '.review')
 app.config['REVIEW_DATA_ROOT'] = flask.safe_join(app.config['REVIEW_ROOT'],
                                                  'ord-data')
@@ -648,7 +648,7 @@ def get_path(file_name, user=None, suffix='.pbtxt'):
     """
     if not user:
         user = flask.g.user
-    return flask.safe_join(app.config['ORD_EDITOR_DB'], user,
+    return flask.safe_join(app.config['ORD_EDITOR_LOCAL'], user,
                            f'{file_name}{suffix}')
 
 
@@ -660,7 +660,7 @@ def get_user_path():
     Returns:
         Path to the user directory.
     """
-    return flask.safe_join(app.config['ORD_EDITOR_DB'], flask.g.user)
+    return flask.safe_join(app.config['ORD_EDITOR_LOCAL'], flask.g.user)
 
 
 @app.before_request
@@ -691,7 +691,7 @@ def ensure_user():
 
 def redirect_to_user(user):
     """Sets the user cookie and return a redirect to the updated URL."""
-    flask.safe_join(app.config['ORD_EDITOR_DB'],
+    flask.safe_join(app.config['ORD_EDITOR_LOCAL'],
                     user)  # Check that the user is safe.
     url = url_for_user(user)
     # NOTE(kearnes): Use 307 so the request method is preserved. See
@@ -712,6 +712,6 @@ def url_for_user(user):
 def next_user():
     """Returns a user identifier not present in the root directory."""
     user = uuid.uuid4().hex
-    while os.path.isdir(flask.safe_join(app.config['ORD_EDITOR_DB'], user)):
+    while os.path.isdir(flask.safe_join(app.config['ORD_EDITOR_LOCAL'], user)):
         user = uuid.uuid4().hex
     return user

--- a/editor/py/serve_test.py
+++ b/editor/py/serve_test.py
@@ -36,7 +36,7 @@ class ServeTest(parameterized.TestCase, absltest.TestCase):
     def setUp(self):
         super().setUp()
         self.test_subdirectory = tempfile.mkdtemp(dir=flags.FLAGS.test_tmpdir)
-        serve.app.config['ORD_EDITOR_DB'] = self.test_subdirectory
+        serve.app.config['ORD_EDITOR_LOCAL'] = self.test_subdirectory
         serve.app.config['TESTING'] = True
         self.client = serve.app.test_client()
         # TODO(kearnes): Use a testdata directory next to this module.


### PR DESCRIPTION
Running `docker-compose up` starts two images: one containing a postgres database and the other containing the ORD web editor. The postgres database is exposed to the editor and can be accessed by connecting to `ORD_EDITOR_DB` with `ORD_EDITOR_POSTGRES_PASSWORD`. The postgres container writes to a mounted volume; this ensures that the database persists when restarting the image. On GCP, the mounted volume should be a persistent disk.

Also changes the current `ORD_EDITOR_DB` variable, which refers to the location of the local or mounted filesystem, to `ORD_EDITOR_LOCAL`.

