### PR TITLE
Quick input definition by string

### DIFF
--- a/editor/html/reaction.html
+++ b/editor/html/reaction.html
@@ -300,6 +300,7 @@ limitations under the License.
           </div>
 
           <div onclick="ord.inputs.add('#inputs');" class="add">+ add input</div>
+          <div onclick="ord.inputs.addInputByString('#inputs');" class="add"><span class="fa fa-search" aria-hidden="true"></span> resolve text</div>
       </fieldset>
 
       <fieldset id="section_setup" class="section">

--- a/editor/js/inputs.js
+++ b/editor/js/inputs.js
@@ -65,7 +65,7 @@ function loadInput(root, name, input) {
  * @param {!Node} root Root node for the reaction input.
  */
 function addInputByString(root) {
-  var string = prompt(`Please describe the input in one of the following forms:
+  const string = prompt(`Please describe the input in one of the following forms:
 (1) [AMOUNT] of [NAME]
 (2) [AMOUNT] of [CONCENTRATION] [SOLUTE] in [SOLVENT]`);
   if (!(string)) {
@@ -76,7 +76,7 @@ function addInputByString(root) {
   xhr.responseType = 'arraybuffer';
   xhr.onload = () => {
     if (xhr.status == 409) {
-      var decoder = new TextDecoder('utf-8');
+      const decoder = new TextDecoder('utf-8');
       alert('Could not parse: ' + decoder.decode(xhr.response));
     } else {
       const bytes = new Uint8Array(xhr.response);
@@ -84,8 +84,8 @@ function addInputByString(root) {
       if (input) {
         const input_node = loadInput(root, string, input);
         $('.edittext', input_node).trigger('blur');
-      };
-    };
+      }
+    }
   };
   xhr.send(string);
 }

--- a/editor/js/inputs.js
+++ b/editor/js/inputs.js
@@ -23,7 +23,7 @@ exports = {
   unloadInputUnnamed,
   add,
   validateInput,
-  addInputByString
+  addInputByString,
   remove,
 };
 

--- a/editor/js/inputs.js
+++ b/editor/js/inputs.js
@@ -22,7 +22,8 @@ exports = {
   unload,
   unloadInputUnnamed,
   add,
-  validateInput
+  validateInput,
+  addInputByString
 };
 
 goog.require('ord.compounds');
@@ -48,11 +49,44 @@ function load(inputs) {
  * @param {!Node} root Root node for the reaction input.
  * @param {string} name The name of this input.
  * @param {!proto.ord.ReactionInput} input
+ * @return {!Node} The new input node.
  */
 function loadInput(root, name, input) {
   const node = add(root);
   loadInputUnnamed(node, input);
   $('.input_name', node).text(name);
+  return node;
+}
+
+/**
+ * Adds and populates a single reaction input section in the form according to
+ * a short-hand string describing a stock solution.
+ * @param {!Node} root Root node for the reaction input.
+ */
+function addInputByString(root) {
+  var string = prompt(`Please describe the input in one of the following forms:
+(1) [AMOUNT] of [NAME]
+(2) [AMOUNT] of [CONCENTRATION] [SOLUTE] in [SOLVENT]`);
+  if (!(string)) {
+    return;
+  }
+  const xhr = new XMLHttpRequest();
+  xhr.open('POST', '/resolve/input');
+  xhr.responseType = 'arraybuffer';
+  xhr.onload = () => {
+    if (xhr.status == 409) {
+      var decoder = new TextDecoder('utf-8');
+      alert('Could not parse: ' + decoder.decode(xhr.response));
+    } else {
+      const bytes = new Uint8Array(xhr.response);
+      const input = proto.ord.ReactionInput.deserializeBinary(bytes);
+      if (input) {
+        const input_node = loadInput(root, string, input);
+        $('.edittext', input_node).trigger('blur');
+      };
+    };
+  };
+  xhr.send(string);
 }
 
 /**

--- a/editor/js/inputs.js
+++ b/editor/js/inputs.js
@@ -65,7 +65,8 @@ function loadInput(root, name, input) {
  * @param {!Node} root Root node for the reaction input.
  */
 function addInputByString(root) {
-  const string = prompt(`Please describe the input in one of the following forms:
+  const string =
+      prompt(`Please describe the input in one of the following forms:
 (1) [AMOUNT] of [NAME]
 (2) [AMOUNT] of [CONCENTRATION] [SOLUTE] in [SOLVENT]`);
   if (!(string)) {

--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -32,7 +32,6 @@ from google.protobuf import text_format
 
 from ord_schema import dataset_templating
 from ord_schema import message_helpers
-from ord_schema import updates
 from ord_schema import resolvers
 from ord_schema import validations
 from ord_schema.proto import dataset_pb2

--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -370,7 +370,7 @@ def canonicalize_smiles():
 def _canonicalize_smiles(smiles):
     """Canonicalizes a SMILES string."""
     try:
-        return updates.canonicalize_smiles(smiles)
+        return resolvers.canonicalize_smiles(smiles)
     except ValueError:
         return smiles  # Return the original SMILES on failure.
 

--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -333,7 +333,6 @@ def validate_reaction(message_name):
     return json.dumps({'errors': output.errors, 'warnings': output.warnings})
 
 
-
 @app.route('/resolve/input', methods=['POST'])
 def resolve_input():
     """Resolve an input string to a ReactionInput message."""
@@ -355,7 +354,8 @@ def resolve_compound(identifier_type):
     if not compound_name:
         return ''
     try:
-        smiles, resolver = resolvers.name_resolve(identifier_type, compound_name)
+        smiles, resolver = resolvers.name_resolve(identifier_type,
+                                                  compound_name)
         return flask.jsonify((_canonicalize_smiles(smiles), resolver))
     except ValueError:
         return ''

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -1,0 +1,172 @@
+# Copyright 2020 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Automated updates for Reaction messages."""
+
+import datetime
+import uuid
+import re
+import urllib.parse
+import urllib.request
+import urllib.error
+from absl import logging
+
+from ord_schema import message_helpers
+from ord_schema import units
+from ord_schema.proto import reaction_pb2
+
+_COMPOUND_STRUCTURAL_IDENTIFIERS = [
+    reaction_pb2.CompoundIdentifier.SMILES,
+    reaction_pb2.CompoundIdentifier.INCHI,
+    reaction_pb2.CompoundIdentifier.MOLBLOCK,
+    reaction_pb2.CompoundIdentifier.CXSMILES,
+    reaction_pb2.CompoundIdentifier.XYZ,
+]
+
+_USERNAME = 'github-actions'
+_EMAIL = 'github-actions@github.com'
+
+
+def name_resolve(value_type, value):
+    """Resolves compound identifiers to SMILES via multiple APIs."""
+    smiles = None
+    for resolver, resolver_func in _NAME_RESOLVERS.items():
+        try:
+            smiles = resolver_func(value_type, value)
+            if smiles is not None:
+                return smiles, resolver
+        except urllib.error.HTTPError as error:
+            logging.info('%s could not resolve %s %s: %s', resolver, value_type,
+                         value, error)
+    raise ValueError(f'Could not resolve {value_type} {value} to SMILES')
+
+
+def resolve_names(message):
+    """Attempts to resolve compound NAME identifiers to SMILES.
+
+    When a NAME identifier is resolved, a SMILES identifier is added to the list
+    of identifiers for that compound. Note that this function moves on to the
+    next Compound after the first successful name resolution.
+
+    Args:
+        message: Reaction proto.
+
+    Returns:
+        Boolean whether `message` was modified.
+    """
+    modified = False
+    compounds = message_helpers.find_submessages(message, reaction_pb2.Compound)
+    for compound in compounds:
+        if any(identifier.type in _COMPOUND_STRUCTURAL_IDENTIFIERS
+               for identifier in compound.identifiers):
+            continue  # Compound already has a structural identifier.
+        for identifier in compound.identifiers:
+            if identifier.type == identifier.NAME:
+                try:
+                    smiles, resolver = name_resolve(
+                        'name', identifier.value)
+                    new_identifier = compound.identifiers.add()
+                    new_identifier.type = new_identifier.SMILES
+                    new_identifier.value = smiles
+                    new_identifier.details = f'NAME resolved by the {resolver}'
+                    modified = True
+                    break
+                except ValueError:
+                    pass
+    return modified
+
+
+def _pubchem_resolve(value_type, value):
+    """Resolves compound identifiers to SMILES via the PubChem REST API."""
+    response = urllib.request.urlopen(
+        f'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/{value_type}/'
+        f'{urllib.parse.quote(value)}/property/IsomericSMILES/txt')
+    return response.read().decode().strip()
+
+
+def _cactus_resolve(value_type, value):
+    """Resolves compound identifiers to SMILES via the CACTUS API."""
+    del value_type
+    response = urllib.request.urlopen(
+        'https://cactus.nci.nih.gov/chemical/structure/'
+        f'{urllib.parse.quote(value)}/smiles')
+    return response.read().decode().strip()
+
+
+def _emolecules_resolve(value_type, value):
+    """Resolves compound identifiers to SMILES via the eMolecules API."""
+    del value_type
+    response = urllib.request.urlopen(
+        'https://www.emolecules.com/lookup?q={}'.format(
+            urllib.parse.quote(value)))
+    response_text = response.read().decode().strip()
+    if response_text == '__END__':
+        raise urllib.error.HTTPError(None, None,
+                                     'eMolecules lookup unsuccessful', None,
+                                     None)
+    return response_text.split('\t')[0]
+
+
+def resolve_input(input_string):
+    """Resolve a text-based description of an input in one of the following
+    formats:
+        (1) [AMOUNT] of [NAME]
+        (2) [AMOUNT] of [CONCENTRATION] [SOLUTE] in [SOLVENT]
+
+    Args:
+        input_string: String describing the input.
+
+    Returns:
+        ReactionInput message.
+
+    Raises:
+        ValueError: if the string cannot be parsed properly.
+    """
+    reaction_input = reaction_pb2.ReactionInput()
+    unit_resolver = units.UnitResolver()
+    amount_string, description = input_string.split(' of ')
+    if ' in ' not in description:
+        component_name = description
+        component = reaction_input.components.add()
+        component.CopyFrom(message_helpers.build_compound(
+            name=component_name.strip(), amount=amount_string))
+        resolve_names(reaction_input)
+        return reaction_input
+    else:
+        pattern = re.compile(r'(\d+.?\d*)\s*(\w+) (.*) in (.*)')
+        match = pattern.fullmatch(description.strip())
+        if not match:
+            raise ValueError('String did not match template!')
+        conc_value, conc_units, solute_name, solvent_name = match.groups()
+        solute = reaction_input.components.add()
+        solvent = reaction_input.components.add()
+        solute.CopyFrom(message_helpers.build_compound(\
+            name=solute_name.strip()))
+        solvent.CopyFrom(message_helpers.build_compound(
+            name=solvent_name.strip(), amount=amount_string))
+        if solvent.WhichOneof('amount') != 'volume':
+            raise ValueError('Total amount of solution must be a volume!')
+        solvent.volume_includes_solutes = True
+        message_helpers.set_solute_moles(solute,
+                                         [solvent],
+                                         f'{conc_value} {conc_units}')
+        resolve_names(reaction_input)
+        return reaction_input
+
+
+# Standard name resolvers.
+_NAME_RESOLVERS = {
+    'PubChem API': _pubchem_resolve,
+    'NCI/CADD Chemical Identifier Resolver': _cactus_resolve,
+    'eMolecules Lookup Service': _emolecules_resolve,
+}

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -159,14 +159,14 @@ def resolve_input(input_string):
                                            amount=amount_string))
         resolve_names(reaction_input)
         return reaction_input
-    pattern = re.compile(r'(\d+.?\d*)\s*(\w+) (.*) in (.*)')
+    pattern = re.compile(r'(\d+.?\d*)\s?(\w+)\s(.+)\sin\s(.+)')
     match = pattern.fullmatch(description.strip())
     if not match:
         raise ValueError('String did not match template!')
     conc_value, conc_units, solute_name, solvent_name = match.groups()
     solute = reaction_input.components.add()
     solvent = reaction_input.components.add()
-    solute.CopyFrom(message_helpers.build_compound(\
+    solute.CopyFrom(message_helpers.build_compound(
         name=solute_name.strip()))
     solvent.CopyFrom(
         message_helpers.build_compound(name=solvent_name.strip(),

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -166,8 +166,7 @@ def resolve_input(input_string):
     conc_value, conc_units, solute_name, solvent_name = match.groups()
     solute = reaction_input.components.add()
     solvent = reaction_input.components.add()
-    solute.CopyFrom(message_helpers.build_compound(
-        name=solute_name.strip()))
+    solute.CopyFrom(message_helpers.build_compound(name=solute_name.strip()))
     solvent.CopyFrom(
         message_helpers.build_compound(name=solvent_name.strip(),
                                        amount=amount_string))

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -134,6 +134,8 @@ def resolve_input(input_string):
     """
     reaction_input = reaction_pb2.ReactionInput()
     unit_resolver = units.UnitResolver()
+    if ' of ' not in input_string:
+        raise ValueError('String does not match template!')
     amount_string, description = input_string.split(' of ')
     if ' in ' not in description:
         component_name = description

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -89,8 +89,7 @@ def resolve_names(message):
         for identifier in compound.identifiers:
             if identifier.type == identifier.NAME:
                 try:
-                    smiles, resolver = name_resolve(
-                        'name', identifier.value)
+                    smiles, resolver = name_resolve('name', identifier.value)
                     new_identifier = compound.identifiers.add()
                     new_identifier.type = new_identifier.SMILES
                     new_identifier.value = smiles
@@ -155,8 +154,9 @@ def resolve_input(input_string):
     if ' in ' not in description:
         component_name = description
         component = reaction_input.components.add()
-        component.CopyFrom(message_helpers.build_compound(
-            name=component_name.strip(), amount=amount_string))
+        component.CopyFrom(
+            message_helpers.build_compound(name=component_name.strip(),
+                                           amount=amount_string))
         resolve_names(reaction_input)
         return reaction_input
     pattern = re.compile(r'(\d+.?\d*)\s*(\w+) (.*) in (.*)')
@@ -168,13 +168,13 @@ def resolve_input(input_string):
     solvent = reaction_input.components.add()
     solute.CopyFrom(message_helpers.build_compound(\
         name=solute_name.strip()))
-    solvent.CopyFrom(message_helpers.build_compound(
-        name=solvent_name.strip(), amount=amount_string))
+    solvent.CopyFrom(
+        message_helpers.build_compound(name=solvent_name.strip(),
+                                       amount=amount_string))
     if solvent.WhichOneof('amount') != 'volume':
         raise ValueError('Total amount of solution must be a volume!')
     solvent.volume_includes_solutes = True
-    message_helpers.set_solute_moles(solute,
-                                     [solvent],
+    message_helpers.set_solute_moles(solute, [solvent],
                                      f'{conc_value} {conc_units}')
     resolve_names(reaction_input)
     return reaction_input

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -27,9 +27,9 @@ class ResolversTest(parameterized.TestCase, absltest.TestCase):
         reaction_input = resolvers.resolve_input(string)
         self.assertEqual(reaction_input.components[0].mass,
                          reaction_pb2.Mass(value=10, units='GRAM'))
-        self.assertEqual(reaction_input.components[0].identifiers[0],
-                         reaction_pb2.CompoundIdentifier(type='NAME',
-                                                         value='THF'))
+        self.assertEqual(
+            reaction_input.components[0].identifiers[0],
+            reaction_pb2.CompoundIdentifier(type='NAME', value='THF'))
         self.assertEqual(len(reaction_input.components), 1)
 
         string = '100 mL of 5.0uM sodium hydroxide  in water'
@@ -37,20 +37,21 @@ class ResolversTest(parameterized.TestCase, absltest.TestCase):
         self.assertEqual(len(reaction_input.components), 2)
         self.assertEqual(reaction_input.components[0].moles,
                          reaction_pb2.Moles(value=500, units='NANOMOLE'))
-        self.assertEqual(reaction_input.components[0].identifiers[0],
-                         reaction_pb2.CompoundIdentifier(type='NAME',
-                            value='sodium hydroxide'))
+        self.assertEqual(
+            reaction_input.components[0].identifiers[0],
+            reaction_pb2.CompoundIdentifier(type='NAME',
+                                            value='sodium hydroxide'))
         self.assertEqual(reaction_input.components[1].volume,
                          reaction_pb2.Volume(value=100, units='MILLILITER'))
         self.assertEqual(reaction_input.components[1].volume_includes_solutes,
                          True)
-        self.assertEqual(reaction_input.components[1].identifiers[0],
-                         reaction_pb2.CompoundIdentifier(type='NAME',
-                                                         value='water'))
+        self.assertEqual(
+            reaction_input.components[1].identifiers[0],
+            reaction_pb2.CompoundIdentifier(type='NAME', value='water'))
 
     @parameterized.named_parameters(
         ('bad amount', '100 g of 5.0uM sodium hydroxide  in water',
-            'amount of solution must be a volume'),
+         'amount of solution must be a volume'),
         ('missing concentration', '100 L of 5 grapes in water',
          'String did not match template'),
     )

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -1,0 +1,63 @@
+# Copyright 2020 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ord_schema.units."""
+
+from absl.testing import absltest
+from absl.testing import parameterized
+
+from ord_schema import resolvers
+from ord_schema.proto import reaction_pb2
+
+
+class ResolversTest(parameterized.TestCase, absltest.TestCase):
+
+    def test_input_resolve(self):
+        string = '10 g of THF'
+        reaction_input = resolvers.resolve_input(string)
+        self.assertEqual(reaction_input.components[0].mass,
+                         reaction_pb2.Mass(value=10, units='GRAM'))
+        self.assertEqual(reaction_input.components[0].identifiers[0],
+                         reaction_pb2.CompoundIdentifier(type='NAME',
+                                                         value='THF'))
+        self.assertEqual(len(reaction_input.components), 1)
+
+        string = '100 mL of 5.0uM sodium hydroxide  in water'
+        reaction_input = resolvers.resolve_input(string)
+        self.assertEqual(len(reaction_input.components), 2)
+        self.assertEqual(reaction_input.components[0].moles,
+                         reaction_pb2.Moles(value=500, units='NANOMOLE'))
+        self.assertEqual(reaction_input.components[0].identifiers[0],
+                         reaction_pb2.CompoundIdentifier(type='NAME',
+                            value='sodium hydroxide'))
+        self.assertEqual(reaction_input.components[1].volume,
+                         reaction_pb2.Volume(value=100, units='MILLILITER'))
+        self.assertEqual(reaction_input.components[1].volume_includes_solutes,
+                         True)
+        self.assertEqual(reaction_input.components[1].identifiers[0],
+                         reaction_pb2.CompoundIdentifier(type='NAME',
+                                                         value='water'))
+
+    @parameterized.named_parameters(
+        ('bad amount', '100 g of 5.0uM sodium hydroxide  in water',
+            'amount of solution must be a volume'),
+        ('missing concentration', '100 L of 5 grapes in water',
+         'String did not match template'),
+    )
+    def test_input_resolve_should_fail(self, string, expected_error):
+        with self.assertRaisesRegex((KeyError, ValueError), expected_error):
+            resolvers.resolve_input(string)
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -15,12 +15,32 @@
 
 from absl.testing import absltest
 from absl.testing import parameterized
+from rdkit import Chem
 
 from ord_schema import resolvers
 from ord_schema.proto import reaction_pb2
 
 
-class ResolversTest(parameterized.TestCase, absltest.TestCase):
+class NameResolversTest(absltest.TestCase):
+
+    def test_resolve_names(self):
+        roundtrip_smi = lambda smi: Chem.MolToSmiles(Chem.MolFromSmiles(smi))
+        message = reaction_pb2.Reaction()
+        message.inputs['test'].components.add().identifiers.add(type='NAME',
+                                                                value='aspirin')
+        self.assertTrue(resolvers.resolve_names(message))
+        resolved_smi = roundtrip_smi(
+            message.inputs['test'].components[0].identifiers[1].value)
+        self.assertEqual(resolved_smi, roundtrip_smi('CC(=O)Oc1ccccc1C(O)=O'))
+        self.assertEqual(
+            message.inputs['test'].components[0].identifiers[1].type,
+            reaction_pb2.CompoundIdentifier.IdentifierType.SMILES)
+        self.assertRegex(
+            message.inputs['test'].components[0].identifiers[1].details,
+            'NAME resolved')
+
+
+class InputResolversTest(parameterized.TestCase, absltest.TestCase):
 
     def test_input_resolve(self):
         string = '10 g of THF'

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -41,8 +41,9 @@ _UNIT_SYNONYMS = {
     },
     reaction_pb2.Volume: {
         reaction_pb2.Volume.MILLILITER: ['mL', 'milliliter', 'milliliters'],
-        reaction_pb2.Volume.MICROLITER: ['μL', 'uL', 'micl', 'microliter',
-                                         'microliters'],
+        reaction_pb2.Volume.MICROLITER: [
+            'μL', 'uL', 'micl', 'microliter', 'microliters'
+        ],
         reaction_pb2.Volume.LITER: ['L', 'liter', 'liters', 'litres'],
         reaction_pb2.Volume.NANOLITER: ['nL', 'nanoliter', 'nanoliters'],
     },

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -40,10 +40,11 @@ _UNIT_SYNONYMS = {
         reaction_pb2.Moles.NANOMOLE: ['nmol', 'nanomoles'],
     },
     reaction_pb2.Volume: {
-        reaction_pb2.Volume.MILLILITER: ['mL', 'milliliters'],
-        reaction_pb2.Volume.MICROLITER: ['μL', 'uL', 'micl', 'microliters'],
-        reaction_pb2.Volume.LITER: ['L', 'liters', 'litres'],
-        reaction_pb2.Volume.NANOLITER: ['nL', 'nanoliters'],
+        reaction_pb2.Volume.MILLILITER: ['mL', 'milliliter', 'milliliters'],
+        reaction_pb2.Volume.MICROLITER: ['μL', 'uL', 'micl', 'microliter',
+                                         'microliters'],
+        reaction_pb2.Volume.LITER: ['L', 'liter', 'liters', 'litres'],
+        reaction_pb2.Volume.NANOLITER: ['nL', 'nanoliter', 'nanoliters'],
     },
     reaction_pb2.Length: {
         reaction_pb2.Length.CENTIMETER: ['cm', 'centimeter'],

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -22,6 +22,7 @@ import urllib.error
 from absl import logging
 
 from ord_schema import message_helpers
+from ord_schema import resolvers
 from ord_schema.proto import reaction_pb2
 
 _COMPOUND_STRUCTURAL_IDENTIFIERS = [
@@ -34,51 +35,6 @@ _COMPOUND_STRUCTURAL_IDENTIFIERS = [
 
 _USERNAME = 'github-actions'
 _EMAIL = 'github-actions@github.com'
-
-
-def name_resolve(value_type, value):
-    """Resolves compound identifiers to SMILES via multiple APIs."""
-    smiles = None
-    for resolver, resolver_func in _NAME_RESOLVERS.items():
-        try:
-            smiles = resolver_func(value_type, value)
-            if smiles is not None:
-                return smiles, resolver
-        except urllib.error.HTTPError as error:
-            logging.info('%s could not resolve %s %s: %s', resolver, value_type,
-                         value, error)
-    raise ValueError(f'Could not resolve {value_type} {value} to SMILES')
-
-
-def _pubchem_resolve(value_type, value):
-    """Resolves compound identifiers to SMILES via the PubChem REST API."""
-    response = urllib.request.urlopen(
-        f'https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/{value_type}/'
-        f'{urllib.parse.quote(value)}/property/IsomericSMILES/txt')
-    return response.read().decode().strip()
-
-
-def _cactus_resolve(value_type, value):
-    """Resolves compound identifiers to SMILES via the CACTUS API."""
-    del value_type
-    response = urllib.request.urlopen(
-        'https://cactus.nci.nih.gov/chemical/structure/'
-        f'{urllib.parse.quote(value)}/smiles')
-    return response.read().decode().strip()
-
-
-def _emolecules_resolve(value_type, value):
-    """Resolves compound identifiers to SMILES via the eMolecules API."""
-    del value_type
-    response = urllib.request.urlopen(
-        'https://www.emolecules.com/lookup?q={}'.format(
-            urllib.parse.quote(value)))
-    response_text = response.read().decode().strip()
-    if response_text == '__END__':
-        raise urllib.error.HTTPError(None, None,
-                                     'eMolecules lookup unsuccessful', None,
-                                     None)
-    return response_text.split('\t')[0]
 
 
 def resolve_names(message):
@@ -103,7 +59,8 @@ def resolve_names(message):
         for identifier in compound.identifiers:
             if identifier.type == identifier.NAME:
                 try:
-                    smiles, resolver = name_resolve('name', identifier.value)
+                    smiles, resolver = resolvers.name_resolve(
+                        'name', identifier.value)
                     new_identifier = compound.identifiers.add()
                     new_identifier.type = new_identifier.SMILES
                     new_identifier.value = smiles
@@ -191,12 +148,5 @@ def update_dataset(dataset):
 
 # Standard updates.
 _UPDATES = [
-    resolve_names,
+    resolvers.resolve_names,
 ]
-
-# Standard name resolvers.
-_NAME_RESOLVERS = {
-    'PubChem API': _pubchem_resolve,
-    'NCI/CADD Chemical Identifier Resolver': _cactus_resolve,
-    'eMolecules Lookup Service': _emolecules_resolve,
-}

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -15,14 +15,8 @@
 
 import datetime
 import re
-import urllib.parse
-import urllib.request
-import urllib.error
 import uuid
 
-from absl import logging
-
-from ord_schema import message_helpers
 from ord_schema import resolvers
 from ord_schema.proto import reaction_pb2
 

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -14,7 +14,6 @@
 """Tests for ord_schema.updates."""
 
 from absl.testing import absltest
-from rdkit import Chem
 
 from ord_schema import updates
 from ord_schema.proto import reaction_pb2

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -21,25 +21,6 @@ from ord_schema.proto import reaction_pb2
 from ord_schema.proto import dataset_pb2
 
 
-class UpdatesTest(absltest.TestCase):
-
-    def test_resolve_names(self):
-        roundtrip_smi = lambda smi: Chem.MolToSmiles(Chem.MolFromSmiles(smi))
-        message = reaction_pb2.Reaction()
-        message.inputs['test'].components.add().identifiers.add(type='NAME',
-                                                                value='aspirin')
-        self.assertTrue(updates.resolve_names(message))
-        resolved_smi = roundtrip_smi(
-            message.inputs['test'].components[0].identifiers[1].value)
-        self.assertEqual(resolved_smi, roundtrip_smi('CC(=O)Oc1ccccc1C(O)=O'))
-        self.assertEqual(
-            message.inputs['test'].components[0].identifiers[1].type,
-            reaction_pb2.CompoundIdentifier.IdentifierType.SMILES)
-        self.assertRegex(
-            message.inputs['test'].components[0].identifiers[1].details,
-            'NAME resolved')
-
-
 class UpdateReactionTest(absltest.TestCase):
 
     def test_with_updates_simple(self):


### PR DESCRIPTION
Fixes #444 and fixes #372 

This adds a very simple parsing tool to "quick add" an input. Only two patterns are supported and they are quite rigid:

(1) [AMOUNT] of [NAME]
(2) [AMOUNT] of [CONCENTRATION] [SOLUTE] in [SOLVENT]

Any thoughts on making it more flexible? I'll leave it to Steve if he wants to get fancy with regex. This is at least functional and does seem to add a bit of convenience.