### PR TITLE
Write binary Datasets when updating submissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 docs/_build/
 # Misc python.
 __pycache__
+.coverage.*
 *.egg-info
 .ipynb_checkpoints
 # vim swap files

--- a/ord_schema/process_dataset.py
+++ b/ord_schema/process_dataset.py
@@ -65,6 +65,8 @@ flags.DEFINE_string('input_file', None,
 flags.DEFINE_boolean('write_errors', False,
                      'If True, errors will be written to <filename>.error.')
 flags.DEFINE_string('output', None, 'Filename for output Dataset.')
+flags.DEFINE_boolean('write_binary', True,
+                     'If True, write a binary version of the output Dataset.')
 flags.DEFINE_boolean('validate', True, 'If True, validate Reaction protos.')
 flags.DEFINE_boolean('update', False, 'If True, update Reaction protos.')
 flags.DEFINE_boolean('cleanup', False, 'If True, use git to clean up.')
@@ -261,6 +263,12 @@ def _run_updates(inputs, datasets):
         cleanup(inputs, output_filename)
     logging.info('writing combined Dataset to %s', output_filename)
     message_helpers.write_message(combined, output_filename)
+    # Write a binary version for fast read/write.
+    root, ext = os.path.splitext(output_filename)
+    if FLAGS.write_binary and ext != '.pb':
+        binary_filename = root + '.pb'
+        logging.info('writing combined Dataset (binary) to %s', binary_filename)
+        message_helpers.write_message(combined, binary_filename)
 
 
 def run():

--- a/ord_schema/process_dataset.py
+++ b/ord_schema/process_dataset.py
@@ -269,6 +269,9 @@ def _run_updates(inputs, datasets):
         binary_filename = root + '.pb'
         logging.info('writing combined Dataset (binary) to %s', binary_filename)
         message_helpers.write_message(combined, binary_filename)
+        args = ['git', 'add', binary_filename]
+        logging.info('Running command: %s', ' '.join(args))
+        subprocess.run(args, check=True)
 
 
 def run():

--- a/ord_schema/process_dataset_test.py
+++ b/ord_schema/process_dataset_test.py
@@ -225,6 +225,7 @@ class SubmissionWorkflowTest(absltest.TestCase):
         self.assertNotEmpty(dataset.reactions[0].reaction_id)
         # Check for binary output.
         root, ext = os.path.splitext(filenames[0])
+        self.assertEqual(ext, '.pbtxt')
         self.assertTrue(os.path.exists(root + '.pb'))
 
     def test_add_sharded_dataset(self):

--- a/ord_schema/process_dataset_test.py
+++ b/ord_schema/process_dataset_test.py
@@ -97,6 +97,8 @@ class ProcessDatasetTest(absltest.TestCase):
                                  base='main'):
             process_dataset.main(())
         self.assertTrue(os.path.exists(output))
+        self.assertTrue(
+            os.path.exists(os.path.join(self.test_subdirectory, 'output.pb')))
         dataset = message_helpers.load_message(output, dataset_pb2.Dataset)
         self.assertLen(dataset.reactions, 1)
         self.assertStartsWith(dataset.reactions[0].reaction_id, 'ord-')

--- a/ord_schema/process_dataset_test.py
+++ b/ord_schema/process_dataset_test.py
@@ -94,10 +94,11 @@ class ProcessDatasetTest(absltest.TestCase):
         with flagsaver.flagsaver(input_pattern=self.dataset1_filename,
                                  update=True,
                                  output=output,
+                                 write_binary=False,
                                  base='main'):
             process_dataset.main(())
         self.assertTrue(os.path.exists(output))
-        self.assertTrue(
+        self.assertFalse(
             os.path.exists(os.path.join(self.test_subdirectory, 'output.pb')))
         dataset = message_helpers.load_message(output, dataset_pb2.Dataset)
         self.assertLen(dataset.reactions, 1)
@@ -222,6 +223,9 @@ class SubmissionWorkflowTest(absltest.TestCase):
         self.assertNotEmpty(dataset.dataset_id)
         self.assertLen(dataset.reactions, 1)
         self.assertNotEmpty(dataset.reactions[0].reaction_id)
+        # Check for binary output.
+        root, ext = os.path.splitext(filenames[0])
+        self.assertTrue(os.path.exists(root + '.pb'))
 
     def test_add_sharded_dataset(self):
         reaction = reaction_pb2.Reaction()


### PR DESCRIPTION
Related to #457; this enables _much_ faster reading of submitted Datasets.

This adds a `--write_binary` flag (defaults to True) to process_datasets.py that writes a combined binary Dataset _alongside_ the pbtxt version.