### PR TITLE
Use css display and jquery show/hide for toggling warning nodes

### DIFF
--- a/editor/css/reaction.css
+++ b/editor/css/reaction.css
@@ -100,7 +100,7 @@ body {
 }
 .validate_warning_status {
   color: yellow;
-  visibility: hidden;
+  display: none;
 }
 .validate_warning_message {
   background-color: #FAFAD2;

--- a/editor/js/reaction.js
+++ b/editor/js/reaction.js
@@ -277,8 +277,9 @@ function validate(message, messageTypeString, node, validateNode) {
     const warningStatusNode = $('.validate_warning_status', validateNode);
     const warningMessageNode = $('.validate_warning_message', validateNode);
     if (warnings.length) {
-      warningStatusNode.css('visibility', 'visible');
+      warningStatusNode.show();
       warningStatusNode.text(' ' + warnings.length);
+      warningMessageNode.show();
       warningMessageNode.empty();
       for (let index = 0; index < warnings.length; index++) {
         const warning = warnings[index];
@@ -287,9 +288,9 @@ function validate(message, messageTypeString, node, validateNode) {
         warningMessageNode.append(warningNode);
       }
     } else {
-      warningStatusNode.css('visibility', 'hidden');
+      warningStatusNode.hide();
       warningMessageNode.html('');
-      warningMessageNode.css('visibility', 'hidden');
+      warningMessageNode.hide();
     }
   };
   xhr.send(binary);


### PR DESCRIPTION
Fixes #442. 
`display: none` prevents the warning node from taking up space too. jquery's `show` and `hide` toggle this attribute.