### PR TITLE
editor gunicorn worker config from 1 to 2

### DIFF
--- a/editor/Dockerfile
+++ b/editor/Dockerfile
@@ -68,6 +68,7 @@ RUN make
 EXPOSE 5000
 # TODO(kearnes): Remove timeout after we fix editor review latency.
 CMD gunicorn py.serve:app \
-    -b 0.0.0.0:5000 \
+    --bind 0.0.0.0:5000 \
+    --workers 2 \
     --access-logfile '-' \
     --timeout 60


### PR DESCRIPTION
After starting the editor locally, I observe the first page load hangs in about 50% of trials when I load with an empty Chrome cache (command-shift-R).

These hangs went away when I increased the gunicorn thread configuration from 1 to 2 workers. Maybe something in Chrome assumes that concurrent requests are possible, even when they are not.