### PR TITLE
Fix review sync, which was dropping datasets.

### DIFF
--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -550,7 +550,7 @@ def sync_reviews():
                                               remote.filename[:-6])
                 query = psycopg2.sql.SQL(
                     'INSERT INTO datasets VALUES (%s, %s, %s)')
-        cursor.execute(query, [user_id, name, pbtxt])
+                cursor.execute(query, [user_id, name, pbtxt])
     flask.g.db.commit()
     return flask.redirect('/review')
 


### PR DESCRIPTION
Because the "execute()" call was incorrectly indented, only the final INSERT query was actually evaluated.