### PR TITLE
Solve a race crash in temp-dir creation.

### DIFF
--- a/editor/py/serve.py
+++ b/editor/py/serve.py
@@ -44,8 +44,10 @@ app = flask.Flask(__name__, template_folder='../html')
 
 # For dataset merges operations like byte-value uploads and enumeration.
 TEMP = '/tmp/ord-editor'
-if not os.path.isdir(TEMP):
+try:
     os.mkdir(TEMP)
+except FileExistsError:
+    pass
 
 # Defaults for development, overridden in docker-compose.yml.
 POSTGRES_HOST = os.getenv('POSTGRES_HOST', 'localhost')


### PR DESCRIPTION
I observed a crash in a gunicorn thread where both threads tried to create the TEMP directory and the second one raised FileExistsError.