### PR TITLE
Allow arbitrary compound data

### DIFF
--- a/ord_schema/proto/reaction.proto
+++ b/ord_schema/proto/reaction.proto
@@ -260,6 +260,13 @@ message Compound {
     string how_computed = 4;
   }
   repeated Feature features = 13;
+  // Compounds may have arbitrary data associated with them. For example,
+  // product compounds could contain product-specific data that does not make
+  // sense to store at the analysis level, e.g., LC peak areas when multiple
+  // peaks are quantified. Reactants or other input species could contain
+  // data from quality control assays, e.g., an NMR spectrum from a purity
+  // check or the residual water ppm from a Karl Fischer titration.
+  map<string, Data> data = 15;
 }
 
 /**


### PR DESCRIPTION
Resolves #466

In addition to allowing arbitrary data to be defined for products (as suggested in issue #466), I thought it would be useful to also allow arbitrary data for compounds. I could imagine attaching the results of some QC to a starting material. For me, the most natural place to add a `map<string, Data>` field is to the Compound message so it can do double duty for starting materials and product compounds. 