### PR TITLE
Fixing bug in #479 made in haste

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -287,7 +287,7 @@ def molblock_from_compound(compound):
     Raises:
         ValueError: if no structural identifiers are defined.
     """
-    return (get_compound_smiles(compound) or
+    return (get_compound_molblock(compound) or
             Chem.MolToMolBlock(mol_from_compound(compound)))
 
 

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -360,6 +360,10 @@ class CompoundIdentifiersTest(absltest.TestCase):
         self.assertEqual(
             compound.identifiers[0],
             reaction_pb2.CompoundIdentifier(type='NAME', value='ice'))
+        compound = reaction_pb2.Compound()
+        identifier = message_helpers.set_compound_molblock(compound,
+                                                           _BENZENE_MOLBLOCK)
+        self.assertEqual(_BENZENE_MOLBLOCK, compound.identifiers[0].value)
 
     def test_identifier_getters(self):
         compound = reaction_pb2.Compound()
@@ -368,6 +372,13 @@ class CompoundIdentifiersTest(absltest.TestCase):
         self.assertIsNone(message_helpers.get_compound_smiles(compound))
         compound.identifiers.add(type='SMILES', value='O')
         self.assertEqual(message_helpers.get_compound_smiles(compound), 'O')
+        self.assertEqual(message_helpers.smiles_from_compound(compound), 'O')
+        compound = reaction_pb2.Compound()
+        compound.identifiers.add(type='MOLBLOCK', value=_BENZENE_MOLBLOCK)
+        self.assertEqual(message_helpers.get_compound_molblock(compound),
+                         _BENZENE_MOLBLOCK)
+        self.assertEqual(message_helpers.molblock_from_compound(compound),
+                         _BENZENE_MOLBLOCK)
 
 
 class LoadAndWriteMessageTest(parameterized.TestCase, absltest.TestCase):

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -361,8 +361,8 @@ class CompoundIdentifiersTest(absltest.TestCase):
             compound.identifiers[0],
             reaction_pb2.CompoundIdentifier(type='NAME', value='ice'))
         compound = reaction_pb2.Compound()
-        identifier = message_helpers.set_compound_molblock(compound,
-                                                           _BENZENE_MOLBLOCK)
+        identifier = message_helpers.set_compound_molblock(
+            compound, _BENZENE_MOLBLOCK)
         self.assertEqual(_BENZENE_MOLBLOCK, compound.identifiers[0].value)
 
     def test_identifier_getters(self):


### PR DESCRIPTION
In updating some message helpers to avoid redundant code, I hastily left in the wrong identifier. This patches a new bug from PR #479 