### PR TITLE
Fix build errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,12 @@
 absl-py>=0.9.0
 flask>=1.1.2
 numpy>=1.18.1
+openpyxl>=3.0.5
 pandas>=1.0.4
 protobuf>=3.13.0
 protoc-wheel-0>=3.14.0
 pygithub>=1.51
 python-dateutil>=1.10.0
 jinja2>=2.0.0
+xlrd<2.0.0
+xlwt>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,9 @@
 absl-py>=0.9.0
 flask>=1.1.2
 numpy>=1.18.1
-openpyxl>=3.0.5
 pandas>=1.0.4
 protobuf>=3.13.0
 protoc-wheel-0>=3.14.0
 pygithub>=1.51
 python-dateutil>=1.10.0
 jinja2>=2.0.0
-xlrd>=1.0.0
-xlwt>=1.3.0


### PR DESCRIPTION
* xlrd 2.0.0 seems to break xlsx loading via pd.read_excel

Note that some of the packages in requirements.txt are [optional dependencies](https://pandas.pydata.org/docs/getting_started/install.html#optional-dependencies) required for some pandas functionality and are not used directly in ord_schema.