### PR TITLE
Allow reactions to pass validations if they only have reaction SMILES

### DIFF
--- a/badges/reactions.py
+++ b/badges/reactions.py
@@ -21,6 +21,7 @@ from absl import app
 from absl import flags
 from absl import logging
 
+from ord_schema import message_helpers
 from ord_schema.proto import dataset_pb2
 
 FLAGS = flags.FLAGS
@@ -31,9 +32,8 @@ flags.DEFINE_string('output', None, 'Output SVG filename.')
 def main(argv):
     del argv  # Only used by app.run().
     num_reactions = 0
-    for filename in glob.glob(os.path.join(FLAGS.root, '*', '*.pb')):
-        with open(filename, 'rb') as f:
-            dataset = dataset_pb2.Dataset.FromString(f.read())
+    for filename in glob.glob(os.path.join(FLAGS.root, '*', '*.pb*')):
+        dataset = message_helpers.load_message(filename, dataset_pb2.Dataset)
         logging.info('%s:\t%d', filename, len(dataset.reactions))
         num_reactions += len(dataset.reactions)
     args = {

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -41,6 +41,7 @@ MessageType = TypeVar('MessageType')  # Generic for setting return types.
 
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-branches
+# pylint: disable=too-many-locals
 
 
 def build_compound(smiles: str = None,

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -128,8 +128,10 @@ class MessageHelpersTest(parameterized.TestCase, absltest.TestCase):
             value='c1ccccc1', type='SMILES')
         reactant1.components.add(reaction_role='SOLVENT').identifiers.add(
             value='N', type='SMILES')
-        self.assertEqual(message_helpers.get_reaction_smiles(reaction),
-                         'c1ccccc1>N>')
+        self.assertEqual(
+            message_helpers.get_reaction_smiles(reaction,
+                                                generate_if_missing=True),
+            'c1ccccc1>N>')
         reactant2 = reaction.inputs['reactant2']
         reactant2.components.add(reaction_role='REACTANT').identifiers.add(
             value='Cc1ccccc1', type='SMILES')
@@ -138,8 +140,10 @@ class MessageHelpersTest(parameterized.TestCase, absltest.TestCase):
         reaction.outcomes.add().products.add(
             reaction_role='PRODUCT').identifiers.add(value='O=C=O',
                                                      type='SMILES')
-        self.assertEqual(message_helpers.get_reaction_smiles(reaction),
-                         'Cc1ccccc1.c1ccccc1>N>O=C=O')
+        self.assertEqual(
+            message_helpers.get_reaction_smiles(reaction,
+                                                generate_if_missing=True),
+            'Cc1ccccc1.c1ccccc1>N>O=C=O')
 
     def test_get_reaction_smiles_failure(self):
         reaction = reaction_pb2.Reaction()
@@ -148,16 +152,19 @@ class MessageHelpersTest(parameterized.TestCase, absltest.TestCase):
         component.identifiers.add(value='benzene', type='NAME')
         with self.assertRaisesRegex(ValueError,
                                     'no valid reactants or products'):
-            message_helpers.get_reaction_smiles(reaction)
+            message_helpers.get_reaction_smiles(reaction,
+                                                generate_if_missing=True)
         component.identifiers.add(value='c1ccccc1', type='SMILES')
         with self.assertRaisesRegex(ValueError, 'must contain at least one'):
             message_helpers.get_reaction_smiles(reaction,
+                                                generate_if_missing=True,
                                                 allow_incomplete=False)
         reaction.outcomes.add().products.add(
             reaction_role='PRODUCT').identifiers.add(value='invalid',
                                                      type='SMILES')
         with self.assertRaisesRegex(ValueError, 'reaction contains errors'):
             message_helpers.get_reaction_smiles(reaction,
+                                                generate_if_missing=True,
                                                 allow_incomplete=False)
 
     @parameterized.named_parameters(

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -447,9 +447,7 @@ def validate_reaction(message: reaction_pb2.Reaction,
 
 def validate_reaction_identifier(message: reaction_pb2.ReactionIdentifier):
     check_type_and_details(message)
-    if message.type in [
-            message.REACTION_SMILES, message.REACTION_CXSMILES
-    ]:
+    if message.type in [message.REACTION_SMILES, message.REACTION_CXSMILES]:
         if message.type == message.REACTION_CXSMILES:
             smiles = message.value.split()[0]
         else:

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -447,7 +447,7 @@ def validate_reaction(message: reaction_pb2.Reaction,
 
 def validate_reaction_identifier(message: reaction_pb2.ReactionIdentifier):
     check_type_and_details(message)
-    if Chem and message.type in [
+    if message.type in [
             message.REACTION_SMILES, message.REACTION_CXSMILES
     ]:
         if message.type == message.REACTION_CXSMILES:
@@ -549,7 +549,7 @@ def validate_compound_identifier(message: reaction_pb2.CompoundIdentifier):
     check_type_and_details(message)
     if not message.value:
         warnings.warn('value must be set', ValidationError)
-    if Chem and message.type == message.SMILES:
+    if message.type == message.SMILES:
         mol = Chem.MolFromSmiles(message.value)
         if mol is None:
             warnings.warn(

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -175,6 +175,19 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
                                     'reaction input'):
             self._run_validation(message)
 
+    def test_reaction_smiles(self):
+        message = reaction_pb2.Reaction()
+        message.identifiers.add(value='test', type='REACTION_SMILES')
+        output = self._run_validation(message)
+        self.assertEmpty(output.errors)
+        self.assertEmpty(output.warnings)
+        # Now disable the exception for reaction SMILES only.
+        options = validations.ValidationOptions()
+        options.allow_reaction_smiles_only = False
+        with self.assertRaisesRegex(validations.ValidationError,
+                                    'reaction input'):
+            self._run_validation(message, options=options)
+
     # pylint: disable=too-many-statements
     def test_reaction_recursive(self):
         message = reaction_pb2.Reaction()

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -177,7 +177,7 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
 
     def test_reaction_smiles(self):
         message = reaction_pb2.Reaction()
-        message.identifiers.add(value='test', type='REACTION_SMILES')
+        message.identifiers.add(value='C>>C', type='REACTION_SMILES')
         output = self._run_validation(message)
         self.assertEmpty(output.errors)
         self.assertEmpty(output.warnings)
@@ -187,6 +187,13 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         with self.assertRaisesRegex(validations.ValidationError,
                                     'reaction input'):
             self._run_validation(message, options=options)
+
+    def test_bad_reaction_smiles(self):
+        message = reaction_pb2.Reaction()
+        message.identifiers.add(value='test', type='REACTION_SMILES')
+        with self.assertRaisesRegex(validations.ValidationError,
+                                    'requires at least two > characters'):
+            self._run_validation(message)
 
     # pylint: disable=too-many-statements
     def test_reaction_recursive(self):


### PR DESCRIPTION
* Adds a new option to ValidationOptions: `allow_reaction_smiles_only`
* When this is true (the default), reactions that have a `REACTION_{CX}SMILES` identifier, zero inputs, and zero outcomes will not be required to have inputs or outcomes. The other checks for e.g. provenance still apply.