### PR TITLE
Updates to reaction rendering

### DIFF
--- a/ord_schema/visualization/filters.py
+++ b/ord_schema/visualization/filters.py
@@ -647,7 +647,10 @@ def _get_compact_components(
         component: Compound message.
         is_last: Whether this is the last compound that will be displayed.
     """
-    roles_to_keep = [reaction_pb2.ReactionRole.REACTANT]
+    roles_to_keep = [
+        reaction_pb2.ReactionRole.REACTANT,
+        reaction_pb2.ReactionRole.UNSPECIFIED,
+    ]
     compounds = []
     for _, value in _sort_addition_order(inputs):
         for component in value.components:
@@ -664,7 +667,10 @@ def _get_compact_products(
     products: Iterable[reaction_pb2.ProductCompound]
 ) -> List[reaction_pb2.ProductCompound]:
     """Returns a list of product compounds for 'compact' visualization."""
-    roles_to_keep = [reaction_pb2.ReactionRole.PRODUCT]
+    roles_to_keep = [
+        reaction_pb2.ReactionRole.PRODUCT,
+        reaction_pb2.ReactionRole.UNSPECIFIED,
+    ]
     return [
         compound for compound in products
         if compound.reaction_role in roles_to_keep

--- a/ord_schema/visualization/filters.py
+++ b/ord_schema/visualization/filters.py
@@ -660,12 +660,24 @@ def _get_compact_components(
             yield compound, False
 
 
+def _get_compact_products(
+    products: Iterable[reaction_pb2.ProductCompound]
+) -> List[reaction_pb2.ProductCompound]:
+    """Returns a list of product compounds for 'compact' visualization."""
+    roles_to_keep = [reaction_pb2.ReactionRole.PRODUCT]
+    return [
+        compound for compound in products
+        if compound.reaction_role in roles_to_keep
+    ]
+
+
 TEMPLATE_FILTERS = {
     'round': _round,
     'is_true': _is_true,
     'datetimeformat': _datetimeformat,
     'uses_addition_order': _uses_addition_order,
     'get_compact_components': _get_compact_components,
+    'get_compact_products': _get_compact_products,
     'input_addition': _input_addition,
     'compound_svg': _compound_svg,
     'compound_png': _compound_png,

--- a/ord_schema/visualization/generate_text_test.py
+++ b/ord_schema/visualization/generate_text_test.py
@@ -58,7 +58,6 @@ class GenerateTextTest(absltest.TestCase):
                 name='hexanone',
                 smiles='CCCCC(=O)C',
             ).identifiers)
-        reaction.reaction_id = 'dummy_reaction_id'
         self._reaction = reaction
 
     def test_text(self):
@@ -80,7 +79,6 @@ class GenerateTextTest(absltest.TestCase):
         self.assertRegex(html, '40 min')
         self.assertRegex(html, 'solvent')
         self.assertRegex(html, '100 °C')
-        self.assertRegex(html, 'dummy_reaction_id')
 
     def test_compact_html(self):
         html = generate_text.generate_html(self._reaction, compact=True)
@@ -91,7 +89,6 @@ class GenerateTextTest(absltest.TestCase):
         self.assertNotRegex(html, '40 min')
         self.assertNotRegex(html, 'solvent')
         self.assertNotRegex(html, '100 °C')
-        self.assertRegex(html, 'dummy_reaction_id')
 
 
 if __name__ == '__main__':

--- a/ord_schema/visualization/template.html
+++ b/ord_schema/visualization/template.html
@@ -52,11 +52,6 @@
 </head>
 
 <body>
-{% if not compact %}
-<h2>{{ reaction.reaction_id }}</h2>
-{% else %}
-<p style="font-family: monospace;">{{ reaction.reaction_id }}</p>
-{% endif %}
 
 <table class="autogen_reaction_table">
 
@@ -119,7 +114,7 @@
         <span style="font-size:36px; padding: 0 10px 0 10px;">&#10230;</span>
       </td>
       {% for outcome in reaction.outcomes %}
-          {% for product in outcome.products %}
+          {% for product in outcome.products|get_compact_products %}
               <td class="clean">{{ product|compound_svg(bond_length) }}</td>
           {% endfor %}
       {% endfor %}


### PR DESCRIPTION
* Only shows `PRODUCT` and `UNSPECIFIED` roles on the right side of the arrow in "compact" mode.
* Only shows `REACTANT` and `UNSPECIFIED` roles on the left side of the arrow in "compact" mode.
* Removes the reaction ID from the rendering (this should be handled separately).

Normal:
![image](https://user-images.githubusercontent.com/952729/108405965-ff030b00-71de-11eb-865f-cb27a58c08e2.png)

Compact:
![image](https://user-images.githubusercontent.com/952729/108405909-eabf0e00-71de-11eb-8b09-d4aec348a803.png)
