### PR TITLE
Render reactions based on reaction SMILES

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -464,7 +464,8 @@ def validate_reaction_smiles(reaction_smiles: str) -> str:
         if num_errors:
             raise ValueError('reaction SMILES contains errors')
     except ValueError as error:
-        raise ValueError(f'bad reaction SMILES: {reaction_smiles}') from error
+        raise ValueError(
+            f'bad reaction SMILES ({str(error)}): {reaction_smiles}') from error
     return rdChemReactions.ReactionToSmiles(reaction)
 
 

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -458,7 +458,7 @@ def validate_reaction_smiles(reaction_smiles: str) -> str:
         reaction = rdChemReactions.ReactionFromSmarts(reaction_smiles,
                                                       useSmiles=True)
         if not reaction:
-            raise ValueError(f'reaction SMILES could not be parsed')
+            raise ValueError('reaction SMILES could not be parsed')
         rdChemReactions.SanitizeRxn(reaction)
         _, num_errors = reaction.Validate()
         if num_errors:

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -463,7 +463,7 @@ def validate_reaction_smiles(reaction_smiles: str) -> str:
         _, num_errors = reaction.Validate()
         if num_errors:
             raise ValueError('reaction SMILES contains errors')
-    except ValueError as error:
+    except (RuntimeError, ValueError) as error:
         raise ValueError(
             f'bad reaction SMILES ({str(error)}): {reaction_smiles}') from error
     return rdChemReactions.ReactionToSmiles(reaction)

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -457,14 +457,41 @@ def validate_reaction_smiles(reaction_smiles: str) -> str:
     try:
         reaction = rdChemReactions.ReactionFromSmarts(reaction_smiles,
                                                       useSmiles=True)
+        if not reaction:
+            raise ValueError(f'reaction SMILES could not be parsed')
         rdChemReactions.SanitizeRxn(reaction)
+        _, num_errors = reaction.Validate()
+        if num_errors:
+            raise ValueError('reaction SMILES contains errors')
     except ValueError as error:
-        raise ValueError(
-            f'reaction contains errors: {reaction_smiles}') from error
-    _, num_errors = reaction.Validate()
-    if num_errors:
-        raise ValueError(f'reaction contains errors: {reaction_smiles}')
+        raise ValueError(f'bad reaction SMILES: {reaction_smiles}') from error
     return rdChemReactions.ReactionToSmiles(reaction)
+
+
+def reaction_from_smiles(reaction_smiles):
+    """Builds a Reaction by splitting a reaction SMILES."""
+    reaction = rdChemReactions.ReactionFromSmarts(reaction_smiles,
+                                                  useSmiles=True)
+    rdChemReactions.RemoveMappingNumbersFromReactions(reaction)
+    message = reaction_pb2.Reaction()
+    message.identifiers.add(value=reaction_smiles, type='REACTION_SMILES')
+    reaction_input = message.inputs['from_reaction_smiles']
+    for mol in reaction.GetReactants():
+        component = reaction_input.components.add()
+        component.identifiers.add(value=Chem.MolToSmiles(mol), type='SMILES')
+        component.reaction_role = reaction_pb2.ReactionRole.REACTANT
+    for smiles in reaction_smiles.split('>')[1].split('.'):
+        if not smiles:
+            continue
+        component = reaction_input.components.add()
+        component.identifiers.add(value=smiles, type='SMILES')
+        component.reaction_role = reaction_pb2.ReactionRole.REAGENT
+    outcome = message.outcomes.add()
+    for mol in reaction.GetProducts():
+        component = outcome.products.add()
+        component.identifiers.add(value=Chem.MolToSmiles(mol), type='SMILES')
+        component.reaction_role = reaction_pb2.ReactionRole.PRODUCT
+    return message
 
 
 def get_product_yield(product: reaction_pb2.ProductCompound,

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -163,10 +163,34 @@ class MessageHelpersTest(parameterized.TestCase, absltest.TestCase):
         reaction.outcomes.add().products.add(
             reaction_role='PRODUCT').identifiers.add(value='invalid',
                                                      type='SMILES')
-        with self.assertRaisesRegex(ValueError, 'reaction contains errors'):
+        with self.assertRaisesRegex(ValueError, 'bad reaction SMILES'):
             message_helpers.get_reaction_smiles(reaction,
                                                 generate_if_missing=True,
                                                 allow_incomplete=False)
+
+    def test_reaction_from_smiles(self):
+        reaction_smiles = '[C:1].N>O>F.Cl'
+        expected = reaction_pb2.Reaction()
+        expected.identifiers.add(value=reaction_smiles, type='REACTION_SMILES')
+        this_input = expected.inputs['from_reaction_smiles']
+        c_component = this_input.components.add()
+        c_component.identifiers.add(value='C', type='SMILES')
+        c_component.reaction_role = reaction_pb2.ReactionRole.REACTANT
+        n_component = this_input.components.add()
+        n_component.identifiers.add(value='N', type='SMILES')
+        n_component.reaction_role = reaction_pb2.ReactionRole.REACTANT
+        o_component = this_input.components.add()
+        o_component.identifiers.add(value='O', type='SMILES')
+        o_component.reaction_role = reaction_pb2.ReactionRole.REAGENT
+        outcome = expected.outcomes.add()
+        f_component = outcome.products.add()
+        f_component.identifiers.add(value='F', type='SMILES')
+        f_component.reaction_role = reaction_pb2.ReactionRole.PRODUCT
+        cl_component = outcome.products.add()
+        cl_component.identifiers.add(value='Cl', type='SMILES')
+        cl_component.reaction_role = reaction_pb2.ReactionRole.PRODUCT
+        self.assertEqual(message_helpers.reaction_from_smiles(reaction_smiles),
+                         expected)
 
     @parameterized.named_parameters(
         ('url', 'https://dx.doi.org/10.1021/acscatal.0c02247',

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -24,7 +24,6 @@ from absl import logging
 from dateutil import parser
 from rdkit import Chem
 from rdkit import __version__ as RDKIT_VERSION
-from rdkit.Chem import rdChemReactions
 
 import ord_schema
 from ord_schema import message_helpers

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -453,12 +453,7 @@ def validate_reaction_identifier(message: reaction_pb2.ReactionIdentifier):
         else:
             smiles = message.value
         try:
-            rxn = rdChemReactions.ReactionFromSmarts(smiles, useSmiles=True)
-            if rxn is None:
-                warnings.warn(
-                    f'RDKit {RDKIT_VERSION} could not validate'
-                    f' REACTION_{{CX}}SMILES identifier {message.value}',
-                    ValidationError)
+            message_helpers.validate_reaction_smiles(smiles)
         except ValueError as error:
             warnings.warn(str(error), ValidationError)
     if not message.value:

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -192,7 +192,7 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         message = reaction_pb2.Reaction()
         message.identifiers.add(value='test', type='REACTION_SMILES')
         with self.assertRaisesRegex(validations.ValidationError,
-                                    'requires at least two > characters'):
+                                    'bad reaction SMILES'):
             self._run_validation(message)
 
     # pylint: disable=too-many-statements

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -192,7 +192,7 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         message = reaction_pb2.Reaction()
         message.identifiers.add(value='test', type='REACTION_SMILES')
         with self.assertRaisesRegex(validations.ValidationError,
-                                    'bad reaction SMILES'):
+                                    'requires at least two > characters'):
             self._run_validation(message)
 
     # pylint: disable=too-many-statements

--- a/ord_schema/visualization/filters.py
+++ b/ord_schema/visualization/filters.py
@@ -372,11 +372,12 @@ def _compound_svg(compound: reaction_pb2.Compound,
         if mol:
             svg = drawing.mol_to_svg(mol, bond_length=bond_length)
             if svg is None:
-                return '[Compound]'
+                return (message_helpers.get_compound_smiles(compound) or
+                        '[Compound]')
             return svg
     except ValueError:
         pass
-    return '[Compound]'
+    return message_helpers.get_compound_smiles(compound) or '[Compound]'
 
 
 def _compound_png(compound: reaction_pb2.Compound) -> str:
@@ -397,7 +398,7 @@ def _compound_png(compound: reaction_pb2.Compound) -> str:
             return drawing.mol_to_png(mol)
     except ValueError:
         pass
-    return '[Compound]'
+    return message_helpers.get_compound_smiles(compound) or '[Compound]'
 
 
 def _compound_amount(compound: reaction_pb2.Compound) -> Optional[str]:

--- a/ord_schema/visualization/generate_text.py
+++ b/ord_schema/visualization/generate_text.py
@@ -18,6 +18,7 @@ import re
 
 import jinja2
 
+from ord_schema import message_helpers
 from ord_schema.proto import reaction_pb2
 from ord_schema.visualization import filters
 
@@ -59,6 +60,10 @@ def generate_text(reaction: reaction_pb2.Reaction) -> str:
 
 def generate_html(reaction: reaction_pb2.Reaction, compact=False) -> str:
     """Generates an HTML reaction description."""
+    # Special handling for e.g. USPTO reactions.
+    reaction_smiles = message_helpers.get_reaction_smiles(reaction)
+    if reaction_smiles and not reaction.inputs and not reaction.outcomes:
+        reaction = message_helpers.reaction_from_smiles(reaction_smiles)
     with open(os.path.join(os.path.dirname(__file__), 'template.html'),
               'r') as f:
         template = f.read()

--- a/ord_schema/visualization/generate_text_test.py
+++ b/ord_schema/visualization/generate_text_test.py
@@ -90,6 +90,12 @@ class GenerateTextTest(absltest.TestCase):
         self.assertNotRegex(html, 'solvent')
         self.assertNotRegex(html, '100 °C')
 
+    def test_reaction_smiles_html(self):
+        reaction = reaction_pb2.Reaction()
+        reaction.identifiers.add(value='C>C>C', type='REACTION_SMILES')
+        html = generate_text.generate_html(reaction)
+        self.assertIsNotNone(html)
+
 
 if __name__ == '__main__':
     absltest.main()


### PR DESCRIPTION
* Adds a function `message_helpers.reaction_from_smiles` to generate a Reaction proto from a reaction SMILES
* Automatically calls this new function in `generate_text.generate_html` to render reactions from only reaction SMILES
* Updates validations to use the existing `message_helpers.validate_reaction_smiles`
* Uses the compound SMILES instead of `[Compound]` when rendering fails (where possible)