### PR TITLE
Do not resolve NAME identifiers during submission

### DIFF
--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -18,7 +18,6 @@ import re
 from typing import Mapping
 import uuid
 
-from ord_schema import resolvers
 from ord_schema.proto import dataset_pb2
 from ord_schema.proto import reaction_pb2
 
@@ -40,8 +39,6 @@ def update_reaction(reaction: reaction_pb2.Reaction) -> Mapping[str, str]:
     Current updates:
       * Sets reaction_id if not already set.
       * Adds a record modification event to the provenance.
-      * Resolves compound identifier names if no structural identifiers are
-        defined for a given compound.
 
     Args:
         reaction: reaction_pb2.Reaction message.
@@ -111,6 +108,4 @@ def update_dataset(dataset: dataset_pb2.Dataset):
 
 
 # Standard updates.
-_UPDATES = [
-    resolvers.resolve_names,
-]
+_UPDATES = []

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -37,17 +37,6 @@ class UpdateReactionTest(absltest.TestCase):
         updates.update_reaction(copied)
         self.assertEqual(copied, message)
 
-    def test_with_resolve_names(self):
-        reaction = reaction_pb2.Reaction()
-        component = reaction.inputs['ethylamine'].components.add()
-        component.identifiers.add(type='NAME', value='ethylamine')
-        updates.update_reaction(reaction)
-        self.assertLen(component.identifiers, 2)
-        self.assertEqual(component.identifiers[1].value, 'CCN')
-        self.assertEqual(component.identifiers[1].type,
-                         reaction_pb2.CompoundIdentifier.IdentifierType.SMILES)
-        self.assertRegex(component.identifiers[1].details, 'NAME resolved')
-
     def test_add_reaction_id(self):
         message = reaction_pb2.Reaction()
         updates.update_reaction(message)


### PR DESCRIPTION
We're hitting the resolution servers millions of times in https://github.com/open-reaction-database/ord-data/pull/59 (if I hadn't stopped the job early).