### PR TITLE
Refactor migrate_schema.py so it can be used in scripts

### DIFF
--- a/ord_schema/scripts/migrate_schema.py
+++ b/ord_schema/scripts/migrate_schema.py
@@ -207,7 +207,6 @@ def main(argv):
     del argv  # Only used by app.run().
     filenames = glob.glob(FLAGS.input_pattern)
     logging.info('Found %d datasets', len(filenames))
-    os.makedirs(FLAGS.output_dir, exist_ok=True)
     for filename in filenames:
         logging.info(filename)
         old_dataset = message_helpers.load_message(filename,
@@ -215,6 +214,7 @@ def main(argv):
         new_dataset, num_changed = migrate_dataset(old_dataset)
         logging.info('Changes: %d/%d', num_changed, len(old_dataset.reactions))
         if num_changed:
+            os.makedirs(FLAGS.output_dir, exist_ok=True)
             new_filename = os.path.join(FLAGS.output_dir,
                                         os.path.basename(filename))
             logging.info('Saving to %s', new_filename)

--- a/ord_schema/scripts/migrate_schema.py
+++ b/ord_schema/scripts/migrate_schema.py
@@ -163,54 +163,58 @@ def migrate_workup(old: reaction_old_pb2.ReactionWorkup,
         migrate_stirring_conditions(old.stirring, new.stirring)
 
 
+def migrate_dataset(
+        old_dataset: dataset_old_pb2.Dataset) -> dataset_pb2.Dataset:
+    """Migrates a single Dataset."""
+    new_dataset = dataset_pb2.Dataset()
+
+    # Copy unchanged dataset-level information.
+    migrate_scalars(old_dataset, new_dataset,
+                    ('name', 'description', 'dataset_id'))
+    new_dataset.reaction_ids.extend(old_dataset.reaction_ids)
+
+    num_changed = 0
+    for old in old_dataset.reactions:
+        new = new_dataset.reactions.add()
+        # Copy over unchanged fields.
+        migrate_repeated_messages(old, new,
+                                  ('identifiers', 'observations', 'outcomes'))
+        for key, value in old.inputs.items():
+            migrate_message(value, new.inputs[key])
+        migrate_messages(old, new, ('notes', 'provenance'))
+        migrate_scalars(old, new, ('reaction_id',))
+
+        # Migrate changed messages.
+        if old.HasField('setup'):
+            migrate_setup(old.setup, new.setup)
+        if old.HasField('conditions'):
+            migrate_conditions(old.conditions, new.conditions)
+        for workup in old.workups:
+            migrate_workup(workup, new.workups.add())
+
+        if (new.SerializeToString(deterministic=True) !=
+                old.SerializeToString(deterministic=True)):
+            num_changed += 1
+            # Add a record_modified event.
+            new.provenance.record_modified.add(
+                time=dict(value=str(datetime.datetime.now())),
+                person=dict(username='skearnes', email='kearnes@google.com'),
+                details='Automatic migration from schema v0.2.15 to v0.3.0')
+    return new_dataset, num_changed
+
+
 def main(argv):
     del argv  # Only used by app.run().
     filenames = glob.glob(FLAGS.input_pattern)
     logging.info('Found %d datasets', len(filenames))
+    os.makedirs(FLAGS.output_dir, exist_ok=True)
     for filename in filenames:
         logging.info(filename)
         old_dataset = message_helpers.load_message(filename,
                                                    dataset_old_pb2.Dataset)
-        new_dataset = dataset_pb2.Dataset()
-
-        # Copy unchanged dataset-level information.
-        migrate_scalars(old_dataset, new_dataset,
-                        ('name', 'description', 'dataset_id'))
-        new_dataset.reaction_ids.extend(old_dataset.reaction_ids)
-
-        num_changed = 0
-        for old in old_dataset.reactions:
-            new = new_dataset.reactions.add()
-            # Copy over unchanged fields.
-            migrate_repeated_messages(
-                old, new, ('identifiers', 'observations', 'outcomes'))
-            for key, value in old.inputs.items():
-                migrate_message(value, new.inputs[key])
-            migrate_messages(old, new, ('notes', 'provenance'))
-            migrate_scalars(old, new, ('reaction_id',))
-
-            # Migrate changed messages.
-            if old.HasField('setup'):
-                migrate_setup(old.setup, new.setup)
-            if old.HasField('conditions'):
-                migrate_conditions(old.conditions, new.conditions)
-            for workup in old.workups:
-                migrate_workup(workup, new.workups.add())
-
-            if (new.SerializeToString(deterministic=True) !=
-                    old.SerializeToString(deterministic=True)):
-                num_changed += 1
-                # Add a record_modified event.
-                new.provenance.record_modified.add(
-                    time=dict(value=str(datetime.datetime.now())),
-                    person=dict(username='skearnes',
-                                email='kearnes@google.com'),
-                    details='Automatic migration from schema v0.2.15 to v0.3.0')
-
-        # Save
+        new_dataset, num_changed = migrate_dataset(old_dataset)
         logging.info('Changes: %d/%d', num_changed, len(old_dataset.reactions))
         if num_changed:
-            os.makedirs(FLAGS.output_dir, exist_ok=True)
             new_filename = os.path.join(FLAGS.output_dir,
                                         os.path.basename(filename))
             logging.info('Saving to %s', new_filename)


### PR DESCRIPTION
Being able to import `migrate_dataset` will be useful for the editor migration.