### PR TITLE
Only check type and details for non-empty messages

### DIFF
--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -258,6 +258,12 @@ class ValidationWarning(Warning):
     pass
 
 
+def is_empty(message: ord_schema.Message):
+    """Returns whether the given message is empty."""
+    empty = type(message)().SerializeToString()
+    return message.SerializeToString(deterministic=True) == empty
+
+
 # pylint: disable=missing-function-docstring
 def ensure_float_nonnegative(message: ord_schema.Message, field: str):
     if getattr(message, field) < 0:
@@ -291,6 +297,8 @@ def check_value_and_units(message: ord_schema.UnitMessage):
 
 def check_type_and_details(message: ord_schema.TypeDetailsMessage):
     """Checks that type/details messages are complete."""
+    if is_empty(message):
+        return
     if message.type == message.UNSPECIFIED:
         warnings.warn(f'{type(message)} requires `type` to be set',
                       ValidationError)

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -66,6 +66,20 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         return output
 
     @parameterized.named_parameters(
+        ('clean', reaction_pb2.ReactionNotes()),
+        ('default1', reaction_pb2.StirringConditions(type='UNSPECIFIED')),
+        ('default2', reaction_pb2.ReactionNotes(safety_notes='')))
+    def test_is_empty(self, message):
+        self.assertTrue(validations.is_empty(message))
+
+    @parameterized.named_parameters(
+        ('not_empty', reaction_pb2.StirringConditions(type='STIR_BAR')),
+        ('optional1', reaction_pb2.ReactionNotes(is_heterogeneous=False)),
+        ('optional2', reaction_pb2.ReactionNotes(is_heterogeneous=True)))
+    def test_is_not_empty(self, message):
+        self.assertFalse(validations.is_empty(message))
+
+    @parameterized.named_parameters(
         ('volume',
          reaction_pb2.Volume(value=15.0, units=reaction_pb2.Volume.MILLILITER)),
         ('time', reaction_pb2.Time(value=24, units=reaction_pb2.Time.HOUR)),


### PR DESCRIPTION
The editor is currently flagging e.g. IlluminationConditions for new reactions since it has a default UNSPECIFIED type. We only want these messages to be validated if they are non-empty.

Alternatively, we could change things on the editor side so only non-empty messages are sent for validation for these message types.