### PR TITLE
Add PROTEIN_SEQUENCE compound identifier type

### DIFF
--- a/ord_schema/proto/reaction.proto
+++ b/ord_schema/proto/reaction.proto
@@ -333,7 +333,9 @@ message CompoundIdentifier {
     // Protein data bank ID (for enzymes)
     PDB_ID = 14;
     // Amino acid sequence (for enzymes).
-    PROTEIN_SEQUENCE = 15;
+    AMINO_ACID_SEQUENCE = 15;
+    // HELM; https://www.pistoiaalliance.org/helm-notation/.
+    HELM = 16;
   }
   IdentifierType type = 1;
   string details = 2;

--- a/ord_schema/proto/reaction.proto
+++ b/ord_schema/proto/reaction.proto
@@ -332,6 +332,8 @@ message CompoundIdentifier {
     UNIPROT_ID = 13;
     // Protein data bank ID (for enzymes)
     PDB_ID = 14;
+    // Amino acid sequence (for enzymes).
+    PROTEIN_SEQUENCE = 15;
   }
   IdentifierType type = 1;
   string details = 2;


### PR DESCRIPTION
Resolves #554 

I went back and forth on things like `SEQUENCE`, `FASTA`, etc. but I think this probably hits the mark pretty well. I'd also be fine with `AMINO_ACID_SEQUENCE`. WDYT?