### PR TITLE
Relaxing workup validations

### DIFF
--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -726,8 +726,9 @@ def validate_reaction_workup(message: reaction_pb2.ReactionWorkup):
             warnings.warn('Aliquot workup step missing volume/mass amount',
                           ValidationWarning)
         elif message.amount.WhichOneof('kind') not in ['mass', 'volume']:
-            warnings.warn('Aliquot amounts should be specified by mass or '
-                         'volume', ValidationWarning)
+            warnings.warn(
+                'Aliquot amounts should be specified by mass or '
+                'volume', ValidationWarning)
         if message.amount.HasField('volume_includes_solutes'):
             warnings.warn(
                 'volume_includes_solutes should only '

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -234,7 +234,7 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
     def test_bad_reaction_workup(self, workup_text, error_msg):
         message = text_format.Parse(workup_text, reaction_pb2.ReactionWorkup())
         output = self._run_validation(message)
-        self.assertEquals(len(output.warnings), 1)
+        self.assertLen(output.warnings, 1)
         self.assertRegex(output.warnings[0], error_msg)
 
     # pylint: disable=too-many-statements

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -170,8 +170,8 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         message = reaction_pb2.ProductMeasurement(analysis_key='my_analysis',
                                                   type='YIELD',
                                                   float_value=dict(value=60))
-        with self.assertRaisesRegex(validations.ValidationError, 'percentage'):
-            self._run_validation(message)
+        output = self._run_validation(message)
+        self.assertRegex(output.warnings[0], 'percentage')
         message = reaction_pb2.ProductMeasurement(analysis_key='my_analysis',
                                                   type='AREA',
                                                   string_value='35.221')
@@ -233,8 +233,9 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
     )
     def test_bad_reaction_workup(self, workup_text, error_msg):
         message = text_format.Parse(workup_text, reaction_pb2.ReactionWorkup())
-        with self.assertRaisesRegex(validations.ValidationError, error_msg):
-            self._run_validation(message)
+        output = self._run_validation(message)
+        self.assertEquals(len(output.warnings), 1)
+        self.assertRegex(output.warnings[0], error_msg)
 
     # pylint: disable=too-many-statements
     def test_reaction_recursive(self):
@@ -326,9 +327,8 @@ class ValidationsTest(parameterized.TestCase, absltest.TestCase):
         expected = [
             ('Reaction.inputs["dummy_input"].components[0]: '
              'Compounds must have at least one identifier'),
-            ('Reaction.inputs["dummy_input"]: '
-             'Reaction input components require an amount'),
             'Reaction: Reactions should have at least 1 reaction outcome',
+            'Reaction: All reaction input components require an amount',
         ]
         self.assertEqual(output.errors, expected)
         self.assertLen(output.warnings, 1)


### PR DESCRIPTION
- No longer requiring an amount to be defined for an input
- Changing everything to ValidationWarning, since workup procedures
  are often defined with less-than-ideal specifity
- Unfortunate side effect: checking that ReactionInput components
  have a defined amount now has to occur at the Reaction level,
  not the ReactionInput level, since the inputs used in workup
  steps are also ReactionInputs but should not have this check.
  This makes the trace a little less interpretable (as seen for
  the examples in validations_test.py)