### PR TITLE
Updates for reaction landing pages

### DIFF
--- a/ord_schema/visualization/filters.py
+++ b/ord_schema/visualization/filters.py
@@ -403,12 +403,12 @@ def _compound_png(compound: reaction_pb2.Compound) -> str:
     return message_helpers.get_compound_smiles(compound) or '[Compound]'
 
 
-def _compound_amount(compound: reaction_pb2.Compound) -> Optional[str]:
-    """Returns a string describing the compound amount, if defined."""
-    kind = compound.amount.WhichOneof('kind')
+def _amount(amount: reaction_pb2.Amount) -> Optional[str]:
+    """Returns a string representing an Amount."""
+    kind = amount.WhichOneof('kind')
     if not kind:
         return ''
-    return units.format_message(getattr(compound.amount, kind))
+    return units.format_message(getattr(amount, kind))
 
 
 def _compound_name(compound: reaction_pb2.Compound) -> str:
@@ -701,7 +701,7 @@ def _product_measurement_value(message) -> str:
     if isinstance(message, str):
         return message
     if isinstance(message, reaction_pb2.Amount):
-        return _compound_amount(message) or ''
+        return _amount(message) or ''
     return ''
 
 
@@ -757,7 +757,7 @@ TEMPLATE_FILTERS = {
     'input_addition': _input_addition,
     'compound_svg': _compound_svg,
     'compound_png': _compound_png,
-    'compound_amount': _compound_amount,
+    'amount': _amount,
     'compound_name': _compound_name,
     'compound_smiles': _compound_smiles,
     'compound_role': _compound_role,

--- a/ord_schema/visualization/generate_text.py
+++ b/ord_schema/visualization/generate_text.py
@@ -83,11 +83,11 @@ def generate_html(reaction: reaction_pb2.Reaction,
 
 
 def generate_summary(reaction: reaction_pb2.Reaction,
-                     dataset_id: Optional[str] = None) -> str:
+                     dataset_id: Optional[str] = None,
+                     bond_length: int = 20) -> str:
     """Generates an HTML reaction summary."""
     with open(os.path.join(os.path.dirname(__file__), 'reaction.html')) as f:
         template = f.read()
-    bond_length = 20
     reaction_summary = generate_html(reaction, bond_length=bond_length)
     return _generate(reaction,
                      template_string=template,

--- a/ord_schema/visualization/generate_text.py
+++ b/ord_schema/visualization/generate_text.py
@@ -59,7 +59,9 @@ def generate_text(reaction: reaction_pb2.Reaction) -> str:
     return _generate(reaction, template_string=template, line_breaks=False)
 
 
-def generate_html(reaction: reaction_pb2.Reaction, compact=False) -> str:
+def generate_html(reaction: reaction_pb2.Reaction,
+                  compact=False,
+                  bond_length: Optional[int] = None) -> str:
     """Generates an HTML reaction description."""
     # Special handling for e.g. USPTO reactions.
     reaction_smiles = message_helpers.get_reaction_smiles(reaction)
@@ -68,13 +70,16 @@ def generate_html(reaction: reaction_pb2.Reaction, compact=False) -> str:
     with open(os.path.join(os.path.dirname(__file__), 'template.html'),
               'r') as f:
         template = f.read()
-    kwargs = {'compact': compact}
-    if compact:
-        kwargs['bond_length'] = 18
+    if not bond_length:
+        if compact:
+            bond_length = 18
+        else:
+            bond_length = 25
     return _generate(reaction,
                      template_string=template,
                      line_breaks=True,
-                     **kwargs)
+                     compact=compact,
+                     bond_length=bond_length)
 
 
 def generate_summary(reaction: reaction_pb2.Reaction,
@@ -82,9 +87,11 @@ def generate_summary(reaction: reaction_pb2.Reaction,
     """Generates an HTML reaction summary."""
     with open(os.path.join(os.path.dirname(__file__), 'reaction.html')) as f:
         template = f.read()
-    reaction_summary = generate_html(reaction, compact=True)
+    bond_length = 20
+    reaction_summary = generate_html(reaction, bond_length=bond_length)
     return _generate(reaction,
                      template_string=template,
                      line_breaks=True,
                      dataset_id=dataset_id,
-                     reaction_summary=reaction_summary)
+                     reaction_summary=reaction_summary,
+                     bond_length=bond_length)

--- a/ord_schema/visualization/reaction.html
+++ b/ord_schema/visualization/reaction.html
@@ -59,6 +59,11 @@
           padding: 0 10px 0 10px;
       }
 
+      .components td {
+          border-top: 1px solid black;
+          border-bottom: 1px solid black;
+      }
+
       table.components {
           margin-top: 10px;
       }
@@ -71,8 +76,11 @@
           border-bottom: 1px solid black;
       }
 
+      .hidden {
+          visibility: hidden;
+      }
+
       .raw {
-          display: none;
           white-space: pre-wrap;
       }
 
@@ -80,8 +88,18 @@
           display: inline-block;
       }
 
+      .toggle_raw {
+          text-align: center;
+          padding-top: 10px;
+      }
+
       .ui-tabs {
           width: fit-content;
+      }
+
+      button {
+          font-family: Roboto, sans-serif;
+          font-size: 1em;
       }
   </style>
 </head>
@@ -210,14 +228,14 @@
                     {% else %}
                   <tr>
                 {% endif %}
-              <td style="text-align: center;">{{ compound|compound_svg(18) }}</td>
-              <td>{{ compound|compound_amount }}</td>
+              <td style="text-align: center;">{{ compound|compound_svg(bond_length) }}</td>
+              <td>{{ compound.amount|amount }}</td>
               <td>{{ compound|compound_role }}</td>
               <td>
-                <div>
-                  <button class="toggle_raw">Show</button>
+                <div class="toggle_raw">
+                  <button class="toggle_raw_button">Show</button>
                 </div>
-                <pre class="raw">{{ compound|pbtxt }}</pre>
+                <pre class="raw hidden">{{ compound|pbtxt }}</pre>
               </td>
               </tr>
               {% endfor %}
@@ -738,7 +756,7 @@
             </ul>
             {% for product in outcome.products %}
               <div id="outcome-{{ outcome_loop.index }}_product-{{ loop.index }}">
-                <table>
+                <table class="components">
                   <thead>
                   <tr>
                     <th>Compound</th>
@@ -748,13 +766,13 @@
                   </thead>
                   <tbody>
                   <tr>
-                    <td style="text-align: center;">{{ product|compound_svg(18) }}</td>
+                    <td style="text-align: center;">{{ product|compound_svg(bond_length) }}</td>
                     <td>{{ product|compound_role }}</td>
                     <td>
-                      <div>
-                        <button class="toggle_raw">Show</button>
+                      <div class="toggle_raw">
+                        <button class="toggle_raw_button">Show</button>
                       </div>
-                      <pre class="raw">{{ product|product_pbtxt }}</pre>
+                      <pre class="raw hidden">{{ product|product_pbtxt }}</pre>
                     </td>
                   </tr>
                   </tbody>
@@ -779,10 +797,10 @@
                         <td>{{ measurement|oneof('value')|product_measurement_value }}</td>
                         <td>{{ measurement.analysis_key }}</td>
                         <td>
-                          <div>
-                            <button class="toggle_raw">Show</button>
+                          <div class="toggle_raw">
+                            <button class="toggle_raw_button">Show</button>
                           </div>
-                          <pre class="raw">{{ measurement|pbtxt }}</pre>
+                          <pre class="raw hidden">{{ measurement|pbtxt }}</pre>
                         </td>
                       </tr>
                     {% endfor %}
@@ -814,10 +832,10 @@
                     <tr>
                       <td>Raw</td>
                       <td>
-                        <div>
-                          <button class="toggle_raw">Show</button>
+                        <div class="toggle_raw">
+                          <button class="toggle_raw_button">Show</button>
                         </div>
-                        <pre class="raw">{{ value|pbtxt }}</pre>
+                        <pre class="raw hidden">{{ value|pbtxt }}</pre>
                       </td>
                     </tr>
                   </table>
@@ -952,13 +970,18 @@
   </div>
   <div id="record">
     <h2>Full Record</h2>
-    <div id="pbtxt" style="font-family: monospace; white-space: pre-wrap;">{{ reaction|pbtxt }}</div>
+    <div>
+      <button class="toggle_raw_button">Show</button>
+    </div>
+    <pre class="raw hidden">{{ reaction|pbtxt }}</pre>
   </div>
 </div>
 <script>
     document.body.onload = function () {
         $('.tabs').tabs({
-            heightStyle: 'auto',
+            heightStyle: 'content',
+            hide: false,
+            show: true,
         });
         $('.navSection').click(event => {
             const section = $(event.target).attr('data-section');
@@ -968,14 +991,14 @@
             const section = location.hash.replace('#', '');
             $('#' + section)[0].scrollIntoView({behavior: 'smooth'});
         }
-        $('.toggle_raw').on('click', function () {
+        $('.toggle_raw_button').on('click', function () {
             const element = $(this);
             const target = element.parent().siblings('.raw');
             if (element.text() === 'Show') {
-                target.show();
+                target.css('visibility', 'visible');
                 element.text('Hide');
             } else {
-                target.hide();
+                target.css('visibility', 'hidden');
                 element.text('Show');
             }
         });

--- a/ord_schema/visualization/template.html
+++ b/ord_schema/visualization/template.html
@@ -27,24 +27,24 @@
       white-space: nowrap;
     }
     .autogen_reaction_table td.divide {
-      border-top: 0px;
-      border-bottom: 0px;
+      border-top: 0;
+      border-bottom: 0;
       border-left: 1px solid black;
       border-right: 1px solid black;
     }
     .autogen_reaction_table td.clean {
-      border: 0px;
+      border: 0;
     }
     .autogen_reaction_table td.left {
-      border: 0px;
+      border: 0;
       border-left: 1px solid black;
     }
     .autogen_reaction_table td.right {
-      border: 0px;
+      border: 0;
       border-right: 1px solid black;
     }
     .autogen_reaction_table td.both {
-      border: 0px;
+      border: 0;
       border-left: 1px solid black;
       border-right: 1px solid black;
     }
@@ -75,7 +75,7 @@
     <tr>
         {% for key, input in reaction.inputs|sort_addition_order %}
             {% for compound, border in input.components|get_input_borders %}
-                <td class="{{ border }}">{{ compound|compound_svg }}</td>
+                <td class="{{ border }}">{{ compound|compound_svg(bond_length) }}</td>
             {% endfor %}
         {% endfor %}
         <td class="clean">
@@ -96,7 +96,7 @@
         </td>
         {% for outcome in reaction.outcomes %}
             {% for product in outcome.products %}
-                <td class="clean">{{ product|compound_svg }}</td>
+                <td class="clean">{{ product|compound_svg(bond_length) }}</td>
             {% endfor %}
         {% endfor %}
     </tr>
@@ -143,7 +143,7 @@
     <tr>
         {% for key, input in reaction.inputs|sort_addition_order %}
             {% for compound, border in input.components|get_input_borders %}
-                <td class="{{ border }}">{{ compound|compound_amount }}</td>
+                <td class="{{ border }}">{{ compound.amount|amount }}</td>
             {% endfor %}
         {% endfor %}
         <td class="clean"></td>

--- a/ord_schema/visualization/template.txt
+++ b/ord_schema/visualization/template.txt
@@ -29,7 +29,7 @@ added
         {% for compound in input.components %}
 
             {# COMPOUND DETAILS #}
-            {{ compound|compound_amount }}
+            {{ compound.amount|amount }}
             {{ compound|compound_name }} 
             {{ compound|compound_role(text=True) }}
             {{ compound|compound_source_prep }} 


### PR DESCRIPTION
* Hide the full record by default
* Use the full reaction scheme instead of the "compact" one
* Fix a bug in handling ProductMeasurement amounts