### PR TITLE
Fix a bug in ID reference replacements

### DIFF
--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -99,10 +99,10 @@ def update_dataset(dataset: dataset_pb2.Dataset):
         for reaction_input in reaction.inputs.values():
             for component in reaction_input.components:
                 for preparation in component.preparations:
-                    if preparation.reaction_id:
-                        if preparation.reaction_id in id_substitutions:
-                            preparation.reaction_id = (
-                                id_substitutions[preparation.reaction_id])
+                    if (preparation.reaction_id and
+                            preparation.reaction_id in id_substitutions):
+                        preparation.reaction_id = (
+                            id_substitutions[preparation.reaction_id])
             for crude_component in reaction_input.crude_components:
                 if crude_component.reaction_id in id_substitutions:
                     crude_component.reaction_id = (

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -100,11 +100,13 @@ def update_dataset(dataset: dataset_pb2.Dataset):
             for component in reaction_input.components:
                 for preparation in component.preparations:
                     if preparation.reaction_id:
-                        preparation.reaction_id = id_substitutions[
-                            preparation.reaction_id]
+                        if preparation.reaction_id in id_substitutions:
+                            preparation.reaction_id = (
+                                id_substitutions[preparation.reaction_id])
             for crude_component in reaction_input.crude_components:
-                crude_component.reaction_id = id_substitutions[
-                    crude_component.reaction_id]
+                if crude_component.reaction_id in id_substitutions:
+                    crude_component.reaction_id = (
+                        id_substitutions[crude_component.reaction_id])
 
 
 # Standard updates.


### PR DESCRIPTION
Resolves #602 (note that we will need to update the ord-schema version used by ord-data before https://github.com/open-reaction-database/ord-data/pull/94 can be submitted).

The issue is that the `id_substitutions` dict is only being populated when the reaction ID is not "proper". This PR checks whether IDs are proper before trying to look up a replacement in the `id_substitutions` dict.