### PR TITLE
Install rdkit from pypi by default

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install ord-schema
         run: |
           cd "${GITHUB_WORKSPACE}"
-          python -m pip install .[rdkit,tests]
+          python -m pip install .[tests]
       - name: Run black
         run: |
           cd "${GITHUB_WORKSPACE}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+# Copyright 2022 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    if: github.repository == 'open-reaction-database/ord-schema'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create release
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          generate_release_notes: true

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install ord_schema
         run: |
           cd "${GITHUB_WORKSPACE}"
-          python -m pip install .[rdkit,tests]
+          python -m pip install .[tests]
       - name: Run tests
         run: |
           cd "${GITHUB_WORKSPACE}"
@@ -46,7 +46,7 @@ jobs:
       - name: Install ord_schema
         run: |
           cd "${GITHUB_WORKSPACE}"
-          python -m pip install .[examples,rdkit,tests]
+          python -m pip install .[examples,tests]
       - name: Test notebooks
         run: |
           cd "${GITHUB_WORKSPACE}"

--- a/README.md
+++ b/README.md
@@ -12,14 +12,6 @@ designed to store the database schema and tools for creating, validating, and su
 
 ## Installation
 
-If you have __not__ previously installed rdkit via conda:
-
-```shell
-$ pip install ord-schema[rdkit]
-```
-
-Otherwise:
-
 ```shell
 $ pip install ord-schema
 ```
@@ -29,7 +21,7 @@ To install in editable/development mode:
 ```shell
 $ git clone https://github.com/open-reaction-database/ord-schema.git
 $ cd ord-schema
-$ pip install -e .  # Or `pip install -e .[rdkit]`.
+$ pip install -e .  # Or `pip install -e .`.
 ```
 
 If you make changes to the protocol buffer definitions, [install](https://grpc.io/docs/protoc-installation/) `protoc` 

--- a/postBuild
+++ b/postBuild
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 # postBuild for binder
-# ord-schema must be installed after protoc
 
 set -ex
 
-python setup.py install
+pip install -e .[examples]

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setuptools.setup(
         "protobuf<3.20,>=3.13.0",
         "pygithub>=1.51",
         "python-dateutil>=1.10.0",
+        "rdkit>=2021.9.5",
         "xlrd>=2.0.1",
         "xlwt>=1.3.0",
     ],
@@ -62,9 +63,6 @@ setuptools.setup(
             "tensorflow>=2.4.1",
             "tqdm>=4.61.2",
             "wget>=3.2",
-        ],
-        "rdkit": [
-            "rdkit-pypi>=2021.9.5",
         ],
         "tests": [
             "black[jupyter]>=22.3.0",


### PR DESCRIPTION
See https://github.com/rdkit/rdkit/pull/5373

* Also adds an action to create a release for the new version tag
* Updates binder build (supersedes #635)