### PR TITLE
Add rdkit extensions for reactions

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -24,7 +24,7 @@ from sqlalchemy.orm import Session
 
 from ord_schema.logging import get_logger
 from ord_schema.orm.mappers import Base, Mappers, from_proto
-from ord_schema.orm.rdkit_mappers import CString, FingerprintType, RDKitCompound, RDKitReaction
+from ord_schema.orm.rdkit_mappers import CString, FingerprintType, RDKitMol, RDKitReaction
 from ord_schema.proto import dataset_pb2
 
 logger = get_logger(__name__)
@@ -96,9 +96,9 @@ def add_rdkit(session: Session) -> None:
         .values(reaction=func.rdkit.reaction_from_smiles(cast(table.c.reaction_smiles, CString)))
     )
     logger.info(f"Adding reaction took {time.time() - start}s")
-    logger.info("Populating RDKit compound columns")
-    assert hasattr(RDKitCompound, "__table__")  # Type hint.
-    table = RDKitCompound.__table__
+    logger.info("Populating RDKit mol columns")
+    assert hasattr(RDKitMol, "__table__")  # Type hint.
+    table = RDKitMol.__table__
     start = time.time()
     session.execute(
         update(table).where(table.c.mol.is_(None)).values(mol=func.rdkit.mol_from_smiles(cast(table.c.smiles, CString)))

--- a/ord_schema/orm/rdkit_mappers.py
+++ b/ord_schema/orm/rdkit_mappers.py
@@ -148,7 +148,7 @@ class FingerprintType(Enum):
         return table_args
 
 
-class RDKitCompound(Base):
+class RDKitMol(Base):
     """Table for storing compound structures and associated RDKit cartridge data.
 
     Notes:
@@ -159,7 +159,7 @@ class RDKitCompound(Base):
       * Objects with this type are added to the ORM in from_proto() using the `structure` field.
     """
 
-    __tablename__ = "compounds"
+    __tablename__ = "mols"
     id = Column(Integer, primary_key=True)
     smiles = Column(Text)
     mol = Column(_RDKitMol)
@@ -173,7 +173,7 @@ class RDKitCompound(Base):
     _polymorphic_type = Column(Text, nullable=False)
     __mapper_args__ = {
         "polymorphic_on": _polymorphic_type,
-        "polymorphic_identity": "compounds",
+        "polymorphic_identity": "mols",
         "with_polymorphic": "*",
     }
 
@@ -182,7 +182,7 @@ class RDKitCompound(Base):
         return func.rdkit.tanimoto_sml(getattr(cls, fp_type.name.lower()), fp_type(other))
 
 
-class _CompoundRDKit(RDKitCompound):
+class _CompoundRDKit(RDKitMol):
     compound_id = Column(Integer, ForeignKey("compound.id", ondelete="CASCADE"))
 
     __mapper_args__ = {
@@ -190,7 +190,7 @@ class _CompoundRDKit(RDKitCompound):
     }
 
 
-class _ProductCompoundRDKit(RDKitCompound):
+class _ProductCompoundRDKit(RDKitMol):
     product_compound_id = Column(Integer, ForeignKey("product_compound.id", ondelete="CASCADE"))
 
     __mapper_args__ = {

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -16,7 +16,7 @@
 import pytest
 from sqlalchemy import select
 from ord_schema.orm.mappers import Mappers
-from ord_schema.orm.structure import FingerprintType, Structure
+from ord_schema.orm.rdkit_mappers import FingerprintType, RDKitCompound
 
 
 def test_tanimoto_operator(test_session):
@@ -24,8 +24,8 @@ def test_tanimoto_operator(test_session):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
-        .join(Structure)
-        .where(Structure.morgan_bfp % FingerprintType.MORGAN_BFP("c1ccccc1CCC(O)C"))
+        .join(RDKitCompound)
+        .where(RDKitCompound.morgan_bfp % FingerprintType.MORGAN_BFP("c1ccccc1CCC(O)C"))
     )
     results = test_session.execute(query)
     assert len(results.fetchall()) == 20
@@ -37,8 +37,8 @@ def test_tanimoto(test_session, fp_type):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
-        .join(Structure)
-        .where(Structure.tanimoto("c1ccccc1CCC(O)C", fp_type=fp_type) > 0.5)
+        .join(RDKitCompound)
+        .where(RDKitCompound.tanimoto("c1ccccc1CCC(O)C", fp_type=fp_type) > 0.5)
     )
     results = test_session.execute(query)
     assert len(results.fetchall()) == 20

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -16,7 +16,7 @@
 import pytest
 from sqlalchemy import select
 from ord_schema.orm.mappers import Mappers
-from ord_schema.orm.rdkit_mappers import FingerprintType, RDKitCompound
+from ord_schema.orm.rdkit_mappers import FingerprintType, RDKitMol
 
 
 def test_tanimoto_operator(test_session):
@@ -24,8 +24,8 @@ def test_tanimoto_operator(test_session):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
-        .join(RDKitCompound)
-        .where(RDKitCompound.morgan_bfp % FingerprintType.MORGAN_BFP("c1ccccc1CCC(O)C"))
+        .join(RDKitMol)
+        .where(RDKitMol.morgan_bfp % FingerprintType.MORGAN_BFP("c1ccccc1CCC(O)C"))
     )
     results = test_session.execute(query)
     assert len(results.fetchall()) == 20
@@ -37,8 +37,8 @@ def test_tanimoto(test_session, fp_type):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
-        .join(RDKitCompound)
-        .where(RDKitCompound.tanimoto("c1ccccc1CCC(O)C", fp_type=fp_type) > 0.5)
+        .join(RDKitMol)
+        .where(RDKitMol.tanimoto("c1ccccc1CCC(O)C", fp_type=fp_type) > 0.5)
     )
     results = test_session.execute(query)
     assert len(results.fetchall()) == 20


### PR DESCRIPTION
* Rename `structure.py` to `rdkit_mappers.py`.
* Rename `rdkit.structure` table to `rdkit.mols`.
* Rename `structure` attribute for Compound/ProductCompound mappers to `rdkit`.
* Add `rdkit.reactions` table and associated mappers.