### PR TITLE
Require provenance by default

### DIFF
--- a/ord_schema/scripts/build_dataset_test.py
+++ b/ord_schema/scripts/build_dataset_test.py
@@ -36,6 +36,9 @@ def dirname(tmp_path) -> str:
     dummy_component.amount.mass.value = 1
     dummy_component.amount.mass.units = reaction_pb2.Mass.GRAM
     reaction1.outcomes.add().conversion.value = 75
+    reaction1.provenance.record_created.time.value = "2023-07-01"
+    reaction1.provenance.record_created.person.name = "test"
+    reaction1.provenance.record_created.person.email = "test@example.com"
     dirname = tmp_path.as_posix()
     message_helpers.write_message(reaction1, os.path.join(dirname, "reaction-1.pbtxt"))
     # reaction2 is empty.

--- a/ord_schema/scripts/enumerate_dataset_test.py
+++ b/ord_schema/scripts/enumerate_dataset_test.py
@@ -67,6 +67,17 @@ def setup(tmp_path) -> tuple[str, str, str]:
             }
         }
     }
+    provenance {
+        record_created {
+            time {
+                value: "2023-07-01"
+            }
+            person {
+                name: "test"
+                email: "test@example.com"
+            }
+        }
+    }
     """
     template_filename = os.path.join(dirname, "template.pbtxt")
     with open(template_filename, "w") as f:
@@ -90,6 +101,9 @@ def setup(tmp_path) -> tuple[str, str, str]:
     reaction1_product1.identifiers.add(value="CO", type="SMILES")
     reaction1_product1.measurements.add(analysis_key="my_analysis", type="YIELD", percentage=dict(value=7.8))
     reaction1.outcomes[0].analyses["my_analysis"].type = reaction_pb2.Analysis.WEIGHT
+    reaction1.provenance.record_created.time.value = "2023-07-01"
+    reaction1.provenance.record_created.person.name = "test"
+    reaction1.provenance.record_created.person.email = "test@example.com"
     reaction2 = expected.reactions.add()
     reaction2_compound1 = reaction2.inputs["test"].components.add()
     reaction2_compound1.identifiers.add(value="CC", type="SMILES")
@@ -98,6 +112,9 @@ def setup(tmp_path) -> tuple[str, str, str]:
     reaction2_product1.identifiers.add(value="CCO", type="SMILES")
     reaction2_product1.measurements.add(analysis_key="my_analysis", type="YIELD", percentage=dict(value=9.0))
     reaction2.outcomes[0].analyses["my_analysis"].type = reaction_pb2.Analysis.WEIGHT
+    reaction2.provenance.record_created.time.value = "2023-07-01"
+    reaction2.provenance.record_created.person.name = "test"
+    reaction2.provenance.record_created.person.email = "test@example.com"
     reaction3 = expected.reactions.add()
     reaction3_compound1 = reaction3.inputs["test"].components.add()
     reaction3_compound1.identifiers.add(value="CCC", type="SMILES")
@@ -106,6 +123,9 @@ def setup(tmp_path) -> tuple[str, str, str]:
     reaction3_product1.identifiers.add(value="CCCO", type="SMILES")
     reaction3_product1.measurements.add(analysis_key="my_analysis", type="YIELD", percentage=dict(value=8.7))
     reaction3.outcomes[0].analyses["my_analysis"].type = reaction_pb2.Analysis.WEIGHT
+    reaction3.provenance.record_created.time.value = "2023-07-01"
+    reaction3.provenance.record_created.person.name = "test"
+    reaction3.provenance.record_created.person.email = "test@example.com"
     yield template_filename, spreadsheet_filename, expected
 
 

--- a/ord_schema/scripts/process_dataset_test.py
+++ b/ord_schema/scripts/process_dataset_test.py
@@ -85,6 +85,7 @@ class TestProcessDataset:
         expected_output = [
             "Reaction: Reactions should have at least 1 reaction input\n",
             "Reaction: Reactions should have at least 1 reaction outcome\n",
+            "Reaction: Reaction requires provenance\n",
         ]
         with open(error_filename) as f:
             assert f.readlines() == expected_output
@@ -406,6 +407,9 @@ class TestSubmissionWorkflow:
         image = reaction.observations.add().image
         image.bytes_value = b"test data value"
         image.format = "png"
+        reaction.provenance.record_created.time.value = "2023-07-01"
+        reaction.provenance.record_created.person.name = "test"
+        reaction.provenance.record_created.person.email = "test@example.com"
         dataset = dataset_pb2.Dataset(reactions=[reaction])
         dataset_filename = os.path.join(test_subdirectory, "test.pbtxt")
         message_helpers.write_message(dataset, dataset_filename)

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -37,6 +37,9 @@ def setup(tmp_path) -> str:
     dummy_component.amount.mass.value = 1
     dummy_component.amount.mass.units = reaction_pb2.Mass.GRAM
     reaction1.outcomes.add().conversion.value = 75
+    reaction1.provenance.record_created.time.value = "2023-07-01"
+    reaction1.provenance.record_created.person.name = "test"
+    reaction1.provenance.record_created.person.email = "test@example.com"
     dataset1 = dataset_pb2.Dataset(reactions=[reaction1])
     dataset1_filename = os.path.join(test_subdirectory, "dataset1.pbtxt")
     message_helpers.write_message(dataset1, dataset1_filename)

--- a/ord_schema/templating_test.py
+++ b/ord_schema/templating_test.py
@@ -35,6 +35,9 @@ def valid_reaction() -> reaction_pb2.Reaction:
     component.amount.mass.units = reaction_pb2.Mass.GRAM
     outcome.conversion.value = 75
     outcome.conversion.precision = 99
+    message.provenance.record_created.time.value = "2023-07-01"
+    message.provenance.record_created.person.name = "test"
+    message.provenance.record_created.person.email = "test@example.com"
     yield message
 
 
@@ -121,6 +124,9 @@ def test_missing_values(tmp_path):
     # pylint: disable=too-many-locals
     # Build a template reaction.
     reaction = reaction_pb2.Reaction()
+    reaction.provenance.record_created.time.value = "2023-07-01"
+    reaction.provenance.record_created.person.name = "test"
+    reaction.provenance.record_created.person.email = "test@example.com"
     input1 = reaction.inputs["one"]
     input1_component1 = input1.components.add()
     input1_component1.identifiers.add(value="CCO", type="SMILES")

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -43,7 +43,7 @@ class ValidationOptions:
     # Check that Dataset and Reaction IDs are well-formed.
     validate_ids: bool = False
     # Require ReactionProvenance for Reactions.
-    require_provenance: bool = False
+    require_provenance: bool = True
     # Allow reactions with valid reaction SMILES and nothing else.
     allow_reaction_smiles_only: bool = True
 

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -49,6 +49,8 @@ def setup():
 def _run_validation(message, **kwargs):
     original = type(message)()
     original.CopyFrom(message)
+    if "options" not in kwargs:
+        kwargs["options"] = validations.ValidationOptions(require_provenance=False)
     output = validations.validate_message(message, **kwargs)
     # Verify that `message` is unchanged by the validation process.
     assert original == message
@@ -362,7 +364,7 @@ def test_reaction_id():
     _ = message.inputs["test"]
     message.outcomes.add()
     message.reaction_id = "ord-c0bbd41f095a44a78b6221135961d809"
-    options = validations.ValidationOptions(validate_ids=True)
+    options = validations.ValidationOptions(validate_ids=True, require_provenance=False)
     output = _run_validation(message, recurse=False, options=options)
     assert len(output.errors) == 0
     assert len(output.warnings) == 0


### PR DESCRIPTION
We've had a couple submissions recently that were missing provenance information but didn't throw any validation errors.