### PR TITLE
put rdkit functions in the public schema

### DIFF
--- a/ord_schema/orm/README.md
+++ b/ord_schema/orm/README.md
@@ -160,7 +160,7 @@ python scripts/add_datasets.py \
 ```
 
 Note that the database password will be read from the `PGPASSWORD` environment variable if `--password` is not
-specified on the command line. To update an existing dataset in the database, use the `--update` flag.
+specified on the command line. To update an existing dataset in the database, use the `--overwrite` flag.
 
 ### Run queries
 

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -136,6 +136,7 @@ def build_mapper(  # pylint: disable=too-many-branches
         "__tablename__": underscore(message_type.DESCRIPTOR.name),
         "id": Column(Integer, primary_key=True),
         "ord_schema_context": Column(Text, nullable=False),
+        "__table_args__": ({"schema": "ord"},),
     }
     attrs["__mapper_args__"] = {
         "polymorphic_on": attrs["ord_schema_context"],
@@ -182,13 +183,13 @@ def build_mapper(  # pylint: disable=too-many-branches
         kwargs = {}
         if message_type == reaction_pb2.CrudeComponent:
             kwargs["nullable"] = False
-        attrs["reaction_id"] = Column(Text, ForeignKey("reaction.reaction_id", ondelete="CASCADE"), **kwargs)
+        attrs["reaction_id"] = Column(Text, ForeignKey("ord.reaction.reaction_id", ondelete="CASCADE"), **kwargs)
     logger.debug(f"Creating mapper {message_type.DESCRIPTOR.name}: {attrs}")
     mapper_class = type(message_type.DESCRIPTOR.name, (Base,), attrs)
     # Create polymorphic child classes.
     for parent_type, field_name, _ in parents[message_type]:
         foreign_table_name = underscore(parent_type.DESCRIPTOR.name)
-        foreign_key = f"{foreign_table_name}.id"
+        foreign_key = f"ord.{foreign_table_name}.id"
         child_attrs = {
             "__mapper_args__": {"polymorphic_identity": f"{parent_type.DESCRIPTOR.name}.{field_name}"},
             # Use get() to avoid column conflicts; see

--- a/ord_schema/orm/rdkit_mappers.py
+++ b/ord_schema/orm/rdkit_mappers.py
@@ -50,7 +50,7 @@ class _RDKitMol(UserDefinedType):
     def get_col_spec(self, **kwargs):
         """Returns the column type."""
         del kwargs  # Unused.
-        return "rdkit.mol" if rdkit_cartridge() else "bytea"
+        return "mol" if rdkit_cartridge() else "bytea"
 
 
 class _RDKitReaction(UserDefinedType):
@@ -65,7 +65,7 @@ class _RDKitReaction(UserDefinedType):
     def get_col_spec(self, **kwargs):
         """Returns the column type."""
         del kwargs  # Unused.
-        return "rdkit.reaction" if rdkit_cartridge() else "bytea"
+        return "reaction" if rdkit_cartridge() else "bytea"
 
 
 class _RDKitBfp(UserDefinedType):
@@ -80,13 +80,7 @@ class _RDKitBfp(UserDefinedType):
     def get_col_spec(self, **kwargs):
         """Returns the column type."""
         del kwargs  # Unused.
-        return "rdkit.bfp" if rdkit_cartridge() else "bytea"
-
-    class comparator_factory(  # pylint: disable=abstract-method,invalid-name
-        UserDefinedType.Comparator  # pytype: disable=attribute-error
-    ):
-        def __mod__(self, other):
-            return self.bool_op("operator(rdkit.%)")(other)
+        return "bfp" if rdkit_cartridge() else "bytea"
 
 
 class _RDKitSfp(UserDefinedType):
@@ -101,13 +95,7 @@ class _RDKitSfp(UserDefinedType):
     def get_col_spec(self, **kwargs):
         """Returns the column type."""
         del kwargs  # Unused.
-        return "rdkit.sfp" if rdkit_cartridge() else "bytea"
-
-    class comparator_factory(  # pylint: disable=abstract-method,invalid-name
-        UserDefinedType.Comparator  # pytype: disable=attribute-error
-    ):
-        def __mod__(self, other):
-            return self.bool_op("operator(rdkit.%)")(other)
+        return "sfp" if rdkit_cartridge() else "bytea"
 
 
 class CString(UserDefinedType):
@@ -128,8 +116,8 @@ class CString(UserDefinedType):
 class FingerprintType(Enum):
     """RDKit PostgreSQL fingerprint types."""
 
-    MORGAN_BFP = func.rdkit.morganbv_fp
-    MORGAN_SFP = func.rdkit.morgan_fp
+    MORGAN_BFP = func.morganbv_fp
+    MORGAN_SFP = func.morgan_fp
 
     def __call__(self, *args, **kwargs):
         return self.value(*args, **kwargs)
@@ -179,11 +167,11 @@ class RDKitMol(Base):
 
     @classmethod
     def tanimoto(cls, other: str, fp_type: FingerprintType = FingerprintType.MORGAN_BFP):
-        return func.rdkit.tanimoto_sml(getattr(cls, fp_type.name.lower()), fp_type(other))
+        return func.tanimoto_sml(getattr(cls, fp_type.name.lower()), fp_type(other))
 
 
 class _CompoundRDKit(RDKitMol):
-    compound_id = Column(Integer, ForeignKey("compound.id", ondelete="CASCADE"))
+    compound_id = Column(Integer, ForeignKey("ord.compound.id", ondelete="CASCADE"))
 
     __mapper_args__ = {
         "polymorphic_identity": "Compound.rdkit",
@@ -191,7 +179,7 @@ class _CompoundRDKit(RDKitMol):
 
 
 class _ProductCompoundRDKit(RDKitMol):
-    product_compound_id = Column(Integer, ForeignKey("product_compound.id", ondelete="CASCADE"))
+    product_compound_id = Column(Integer, ForeignKey("ord.product_compound.id", ondelete="CASCADE"))
 
     __mapper_args__ = {
         "polymorphic_identity": "ProductCompound.rdkit",
@@ -220,7 +208,7 @@ class RDKitReaction(Base):
 
 
 class _ReactionRDKit(RDKitReaction):
-    reaction_id = Column(Integer, ForeignKey("reaction.id", ondelete="CASCADE"))
+    reaction_id = Column(Integer, ForeignKey("ord.reaction.id", ondelete="CASCADE"))
 
     __mapper_args__ = {
         "polymorphic_identity": "Reaction.rdkit",

--- a/ord_schema/orm/scripts/add_datasets_test.py
+++ b/ord_schema/orm/scripts/add_datasets_test.py
@@ -16,7 +16,6 @@
 import os
 
 import docopt
-import pytest
 from sqlalchemy import create_engine
 from testing.postgresql import Postgresql
 
@@ -34,8 +33,4 @@ def test_main():
             "--pattern",
             os.path.join(os.path.dirname(__file__), "..", "testdata", "ord-nielsen-example.pbtxt"),
         ]
-        add_datasets.main(**docopt.docopt(add_datasets.__doc__, argv))
-        with pytest.raises(ValueError, match="`overwrite` is required"):
-            add_datasets.main(**docopt.docopt(add_datasets.__doc__, argv))
-        argv.append("--overwrite")
         add_datasets.main(**docopt.docopt(add_datasets.__doc__, argv))


### PR DESCRIPTION
The latest version of the rdkit extension includes some implicit casts that fail unless the extension is loaded in the public schema (see https://github.com/rdkit/rdkit/pull/5875/files#r1257400659).
* Move ORD tables out of `public` into a new `ord` schema.
* Load the rdkit extension in the `public` schema.
* Keep the rdkit-related tables in the `rdkit` schema.