### PR TITLE
Unique entries in rdkit tables

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -430,7 +430,7 @@ def get_reaction_smiles(
     if validate:
         if allow_incomplete:
             raise ValueError("validate is mutually exclusive with allow_incomplete")
-        reaction_smiles = validate_reaction_smiles(reaction_smiles)
+        validate_reaction_smiles(reaction_smiles)
     if canonical:
         reaction_smiles = rdChemReactions.ReactionToSmiles(
             rdChemReactions.ReactionFromSmarts(reaction_smiles, useSmiles=True)

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -148,7 +148,7 @@ class TestMessageHelpers:
         with pytest.raises(ValueError, match="must contain at least one"):
             message_helpers.get_reaction_smiles(reaction, generate_if_missing=True, allow_incomplete=False)
         reaction.outcomes.add().products.add(reaction_role="PRODUCT").identifiers.add(value="invalid", type="SMILES")
-        with pytest.raises(ValueError, match="bad reaction SMILES"):
+        with pytest.raises(ValueError, match="Cannot parse SMILES"):
             message_helpers.get_reaction_smiles(reaction, generate_if_missing=True, allow_incomplete=False)
 
     def test_reaction_from_smiles(self):

--- a/ord_schema/orm/conftest.py
+++ b/ord_schema/orm/conftest.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm import Session
 from testing.postgresql import Postgresql
 
 from ord_schema.message_helpers import load_message
-from ord_schema.orm.database import add_dataset, add_rdkit, prepare_database
+from ord_schema.orm.database import add_dataset, prepare_database, update_rdkit
 from ord_schema.proto import dataset_pb2
 
 
@@ -36,9 +36,9 @@ def test_session() -> Iterator[Session]:
         rdkit_cartridge = prepare_database(engine)
         with Session(engine) as session:
             add_dataset(dataset, session)
-            session.flush()
+            session.commit()
             if rdkit_cartridge:
-                add_rdkit(session)
+                update_rdkit(dataset.dataset_id, session)
             session.commit()
         with Session(engine) as session:
             yield session

--- a/ord_schema/orm/conftest.py
+++ b/ord_schema/orm/conftest.py
@@ -32,11 +32,11 @@ def test_session() -> Iterator[Session]:
         os.path.join(os.path.dirname(__file__), "testdata", "ord-nielsen-example.pbtxt"), dataset_pb2.Dataset
     )
     with Postgresql() as postgres:
-        engine = create_engine(postgres.url(), future=True, echo=True)
+        engine = create_engine(postgres.url(), future=True)
         rdkit_cartridge = prepare_database(engine)
         with Session(engine) as session:
             add_dataset(dataset, session)
-            session.commit()
+            session.flush()
             if rdkit_cartridge:
                 update_rdkit(dataset.dataset_id, session)
             session.commit()

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -107,7 +107,7 @@ def update_rdkit(dataset_id: str, session: Session) -> None:
             ["reaction_smiles"],
             select(Mappers.Reaction.reaction_smiles)
             .join(Mappers.Dataset)
-            .where(Mappers.Dataset.dataset_id == dataset_id)
+            .where(Mappers.Dataset.dataset_id == dataset_id, Mappers.Reaction.reaction_smiles.is_not(None))
             .distinct(),
         )
         .on_conflict_do_nothing(index_elements=["reaction_smiles"])
@@ -132,6 +132,7 @@ def update_rdkit(dataset_id: str, session: Session) -> None:
             .join(Mappers.Dataset)
             .where(
                 Mappers.Dataset.dataset_id == dataset_id,
+                Mappers.Compound.smiles.is_not(None),
                 # See https://github.com/open-reaction-database/ord-schema/issues/672.
                 Mappers.Compound.smiles.not_like("%[Ti+5]%"),
             )
@@ -147,7 +148,7 @@ def update_rdkit(dataset_id: str, session: Session) -> None:
             .join(Mappers.ReactionOutcome)
             .join(Mappers.Reaction)
             .join(Mappers.Dataset)
-            .where(Mappers.Dataset.dataset_id == dataset_id)
+            .where(Mappers.Dataset.dataset_id == dataset_id, Mappers.ProductCompound.smiles.is_not(None))
             .distinct(),
         )
         .on_conflict_do_nothing(index_elements=["smiles"])

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -268,7 +268,8 @@ def from_proto(  # pylint: disable=too-many-branches
             reaction_smiles = message_helpers.get_reaction_smiles(
                 message, generate_if_missing=True, allow_incomplete=False, validate=True
             )
-            kwargs["reaction_smiles"] = reaction_smiles.split()[0]  # Handle CXSMILES.
+            if reaction_smiles is not None:
+                kwargs["reaction_smiles"] = reaction_smiles.split()[0]  # Handle CXSMILES.
         except ValueError:
             pass
     elif isinstance(message, (reaction_pb2.Compound, reaction_pb2.ProductCompound)):

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -265,7 +265,9 @@ def from_proto(  # pylint: disable=too-many-branches
     elif isinstance(message, reaction_pb2.Reaction):
         kwargs["proto"] = message.SerializeToString(deterministic=True)
         try:
-            reaction_smiles = message_helpers.get_reaction_smiles(message, generate_if_missing=True)
+            reaction_smiles = message_helpers.get_reaction_smiles(
+                message, generate_if_missing=True, allow_incomplete=False, validate=True
+            )
             kwargs["reaction_smiles"] = reaction_smiles.split()[0]  # Handle CXSMILES.
         except ValueError:
             pass

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -268,10 +268,10 @@ def from_proto(  # pylint: disable=too-many-branches
             reaction_smiles = message_helpers.get_reaction_smiles(
                 message, generate_if_missing=True, allow_incomplete=False, validate=True
             )
-            if reaction_smiles is not None:
-                kwargs["reaction_smiles"] = reaction_smiles.split()[0]  # Handle CXSMILES.
         except ValueError:
-            pass
+            reaction_smiles = None
+        if reaction_smiles is not None:
+            kwargs["reaction_smiles"] = reaction_smiles.split()[0]  # Handle CXSMILES.
     elif isinstance(message, (reaction_pb2.Compound, reaction_pb2.ProductCompound)):
         try:
             kwargs["smiles"] = message_helpers.smiles_from_compound(message)

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -24,8 +24,11 @@ def test_tanimoto_operator(test_session):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
-        .join(RDKitMol)
-        .where(RDKitMol.morgan_bfp % FingerprintType.MORGAN_BFP("c1ccccc1CCC(O)C"))
+        .where(
+            Mappers.Compound.smiles.in_(
+                select(RDKitMol.smiles).where(RDKitMol.morgan_bfp % FingerprintType.MORGAN_BFP("c1ccccc1CCC(O)C"))
+            )
+        )
     )
     results = test_session.execute(query)
     assert len(results.fetchall()) == 20
@@ -37,8 +40,11 @@ def test_tanimoto(test_session, fp_type):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
-        .join(RDKitMol)
-        .where(RDKitMol.tanimoto("c1ccccc1CCC(O)C", fp_type=fp_type) > 0.5)
+        .where(
+            Mappers.Compound.smiles.in_(
+                select(RDKitMol.smiles).where(RDKitMol.tanimoto("c1ccccc1CCC(O)C", fp_type=fp_type) > 0.5)
+            )
+        )
     )
     results = test_session.execute(query)
     assert len(results.fetchall()) == 20

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -77,6 +77,8 @@ def _add_dataset(filename: str, url: str, overwrite: bool) -> None:
                 logger.info(f"existing dataset {dataset.dataset_id} unchanged; skipping")
                 return
         add_dataset(dataset, session)
+        session.flush()
+        update_rdkit(dataset.dataset_id, session=session)
         start = time.time()
         session.commit()
         logger.info(f"session.commit() took {time.time() - start}s")
@@ -98,12 +100,6 @@ def main(**kwargs):
     with ProcessPoolExecutor(max_workers=int(kwargs["--n_jobs"])) as executor:
         for _ in executor.map(function, filenames):
             pass  # Must iterate over results to raise exceptions.
-    engine = create_engine(url, future=True)
-    with Session(engine) as session:
-        update_rdkit(session)
-        start = time.time()
-        session.commit()
-        logger.info(f"session.commit() took {time.time() - start}s")
 
 
 if __name__ == "__main__":

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -62,7 +62,7 @@ def _add_dataset(filename: str, url: str, overwrite: bool) -> None:
     logger.info(f"Loading {filename}")
     start = time.time()
     dataset = load_message(filename, dataset_pb2.Dataset)
-    logger.info(f"load_message() took {time.time() - start}s")
+    logger.info(f"load_message() took {time.time() - start:g}s")
     engine = create_engine(url, future=True)
     with Session(engine) as session:
         dataset_md5 = get_dataset_md5(dataset.dataset_id, session)
@@ -81,7 +81,7 @@ def _add_dataset(filename: str, url: str, overwrite: bool) -> None:
         update_rdkit(dataset.dataset_id, session=session)
         start = time.time()
         session.commit()
-        logger.info(f"session.commit() took {time.time() - start}s")
+        logger.info(f"session.commit() took {time.time() - start:g}s")
 
 
 def main(**kwargs):

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -42,7 +42,7 @@ from sqlalchemy.orm import Session
 
 from ord_schema.logging import get_logger
 from ord_schema.message_helpers import load_message
-from ord_schema.orm.database import add_dataset, add_rdkit, delete_dataset, get_connection_string, get_dataset_md5
+from ord_schema.orm.database import add_dataset, delete_dataset, get_connection_string, get_dataset_md5, update_rdkit
 from ord_schema.proto import dataset_pb2
 
 logger = get_logger(__name__)
@@ -100,7 +100,7 @@ def main(**kwargs):
             pass  # Must iterate over results to raise exceptions.
     engine = create_engine(url, future=True)
     with Session(engine) as session:
-        add_rdkit(session)
+        update_rdkit(session)
         start = time.time()
         session.commit()
         logger.info(f"session.commit() took {time.time() - start}s")

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -37,6 +37,7 @@ from hashlib import md5
 from concurrent.futures import ProcessPoolExecutor
 
 from docopt import docopt
+from rdkit import RDLogger
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
@@ -85,6 +86,7 @@ def _add_dataset(filename: str, url: str, overwrite: bool) -> None:
 
 
 def main(**kwargs):
+    RDLogger.DisableLog("rdApp.*")
     if kwargs.get("--url"):
         url = kwargs["--url"]
     else:


### PR DESCRIPTION
There are a ton of duplicated entries in the rdkit tables; this slows down dataset ingestion and searching.

* Add `reaction_smiles` column to the `reaction` table
* Add `smiles` column to the `compound` and `product_compound` tables
* Enforce unique smiles in the rdkit mols and reactions tables

Note that this changes the search logic: now you must query the rdkit tables and then query the matched smiles in the ORD tables (instead of joining those tables directly).