### PR TITLE
Fix problem of generating dataset when having `reaction_id` in the template (#697)

### DIFF
--- a/ord_schema/scripts/enumerate_dataset_test.py
+++ b/ord_schema/scripts/enumerate_dataset_test.py
@@ -78,6 +78,7 @@ def setup(tmp_path) -> tuple[str, str, str]:
             }
         }
     }
+    reaction_id: "ord-d73a86df4d0d4a32a23007aeff1a94e4"
     """
     template_filename = os.path.join(dirname, "template.pbtxt")
     with open(template_filename, "w") as f:

--- a/ord_schema/templating.py
+++ b/ord_schema/templating.py
@@ -148,6 +148,10 @@ def generate_dataset(template_string: str, df: pd.DataFrame, validate: bool = Tr
     reactions = []
     for _, substitutions in df[list(placeholders)].iterrows():
         reaction = _fill_template(template_string, substitutions)
+        # remove the reaction id field if reaction exits to avoid id conflicts
+        if reaction.reaction_id:
+            reaction.ClearField("reaction_id")
+
         if validate:
             output = validations.validate_message(reaction, raise_on_error=False)
             if output.errors:


### PR DESCRIPTION
The PR is an attempt to fix #697 by filtering out the line with reaction_id.