### PR TITLE
Update protocol complier usage because of protobuf updates

### DIFF
--- a/compile_proto_wrappers.sh
+++ b/compile_proto_wrappers.sh
@@ -17,7 +17,6 @@
 # Make sure you have protoc in your PATH; see https://grpc.io/docs/protoc-installation/.
 set -ex
 protoc \
-  --experimental_allow_proto3_optional \
   --proto_path=.. \
   --python_out=. \
   --js_out=import_style=commonjs,binary:js \


### PR DESCRIPTION
Optional fields for proto3 are enabled by default, and no longer require the --experimental_allow_proto3_optional flag,
https://github.com/protocolbuffers/protobuf/releases/tag/v3.15.0. We are using 22.3 and it should be safe to remove this option.