### PR TITLE
Fix bug of parsing of reactants in building the reaction SMILES

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -26,16 +26,15 @@ from typing import Optional, Type, TypeVar, Union
 import pandas as pd
 import requests
 from google import protobuf  # pytype: disable=import-error
-from google.protobuf import text_format  # pytype: disable=import-error
 from google.protobuf import json_format
+from google.protobuf import text_format  # pytype: disable=import-error
 from rdkit import Chem
 from rdkit.Chem import rdChemReactions
 from werkzeug import security
 
 import ord_schema
 from ord_schema import units
-from ord_schema.proto import dataset_pb2
-from ord_schema.proto import reaction_pb2
+from ord_schema.proto import dataset_pb2, reaction_pb2
 
 _COMPOUND_IDENTIFIER_LOADERS = {
     reaction_pb2.CompoundIdentifier.SMILES: Chem.MolFromSmiles,
@@ -741,7 +740,8 @@ def fetch_dataset(dataset_id: str, timeout: float = 10.0) -> dataset_pb2.Dataset
         RuntimeError: If the request fails.
         ValueError: If the dataset ID is invalid.
     """
-    from ord_schema import validations  # Avoid circular import; pylint: disable=import-outside-toplevel.
+    from ord_schema import \
+        validations  # Avoid circular import; pylint: disable=import-outside-toplevel.
 
     if not validations.is_valid_dataset_id(dataset_id):
         raise ValueError(f"Invalid dataset ID: {dataset_id}")

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -34,7 +34,8 @@ from werkzeug import security
 
 import ord_schema
 from ord_schema import units
-from ord_schema.proto import dataset_pb2, reaction_pb2
+from ord_schema.proto import dataset_pb2
+from ord_schema.proto import reaction_pb2
 
 _COMPOUND_IDENTIFIER_LOADERS = {
     reaction_pb2.CompoundIdentifier.SMILES: Chem.MolFromSmiles,
@@ -740,8 +741,7 @@ def fetch_dataset(dataset_id: str, timeout: float = 10.0) -> dataset_pb2.Dataset
         RuntimeError: If the request fails.
         ValueError: If the dataset ID is invalid.
     """
-    # Avoid circular import; pylint: disable=import-outside-toplevel.
-    from ord_schema import validations
+    from ord_schema import validations  # Avoid circular import; pylint: disable=import-outside-toplevel.
 
     if not validations.is_valid_dataset_id(dataset_id):
         raise ValueError(f"Invalid dataset ID: {dataset_id}")

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -385,7 +385,7 @@ def get_reaction_smiles(
     if not generate_if_missing:
         return None
 
-    reactants, reagents, products = set(), set(), set()
+    reactants, agents, products = set(), set(), set()
     roles = reaction_pb2.ReactionRole
     for key in sorted(message.inputs):
         for compound in message.inputs[key].components:
@@ -396,7 +396,7 @@ def get_reaction_smiles(
                     continue
                 raise error
             if compound.reaction_role in [roles.REAGENT, roles.SOLVENT, roles.CATALYST]:
-                reagents.add(smiles)
+                agents.add(smiles)
             elif compound.reaction_role == roles.REACTANT:
                 reactants.add(smiles)
             else:
@@ -425,7 +425,7 @@ def get_reaction_smiles(
         raise ValueError("reaction contains no valid reactants or products")
     components = [
         ".".join(sorted(reactants)),
-        ".".join(sorted(reagents)),
+        ".".join(sorted(agents)),
         ".".join(sorted(products)),
     ]
     reaction_smiles = ">".join(components)

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -740,8 +740,7 @@ def fetch_dataset(dataset_id: str, timeout: float = 10.0) -> dataset_pb2.Dataset
         RuntimeError: If the request fails.
         ValueError: If the dataset ID is invalid.
     """
-    from ord_schema import \
-        validations  # Avoid circular import; pylint: disable=import-outside-toplevel.
+    from ord_schema import validations  # Avoid circular import; pylint: disable=import-outside-toplevel.
 
     if not validations.is_valid_dataset_id(dataset_id):
         raise ValueError(f"Invalid dataset ID: {dataset_id}")

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -34,7 +34,8 @@ from werkzeug import security
 
 import ord_schema
 from ord_schema import units
-from ord_schema.proto import dataset_pb2, reaction_pb2
+from ord_schema.proto import dataset_pb2
+from ord_schema.proto import reaction_pb2
 
 _COMPOUND_IDENTIFIER_LOADERS = {
     reaction_pb2.CompoundIdentifier.SMILES: Chem.MolFromSmiles,

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -23,7 +23,8 @@ from google.protobuf import text_format
 from rdkit import Chem
 
 from ord_schema import message_helpers
-from ord_schema.proto import reaction_pb2, test_pb2
+from ord_schema.proto import reaction_pb2
+from ord_schema.proto import test_pb2
 
 _BENZENE_MOLBLOCK = """241
   -OEChem-07232015262D

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -18,7 +18,8 @@ import time
 
 import pandas as pd
 import pytest
-from google.protobuf import json_format, text_format
+from google.protobuf import json_format
+from google.protobuf import text_format
 from rdkit import Chem
 
 from ord_schema import message_helpers

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -18,13 +18,11 @@ import time
 
 import pandas as pd
 import pytest
-from google.protobuf import json_format
-from google.protobuf import text_format
+from google.protobuf import json_format, text_format
 from rdkit import Chem
 
 from ord_schema import message_helpers
-from ord_schema.proto import reaction_pb2
-from ord_schema.proto import test_pb2
+from ord_schema.proto import reaction_pb2, test_pb2
 
 _BENZENE_MOLBLOCK = """241
   -OEChem-07232015262D
@@ -130,6 +128,7 @@ class TestMessageHelpers:
         reactant1 = reaction.inputs["reactant1"]
         reactant1.components.add(reaction_role="REACTANT").identifiers.add(value="c1ccccc1", type="SMILES")
         reactant1.components.add(reaction_role="SOLVENT").identifiers.add(value="N", type="SMILES")
+        reactant1.components.add(reaction_role="WORKUP").identifiers.add(value="O", type="SMILES")
         assert message_helpers.get_reaction_smiles(reaction, generate_if_missing=True) == "c1ccccc1>N>"
         reactant2 = reaction.inputs["reactant2"]
         reactant2.components.add(reaction_role="REACTANT").identifiers.add(value="Cc1ccccc1", type="SMILES")


### PR DESCRIPTION
The original codes would take anything other than REAGENT, SOLVENT, CATALYST, INTERNAL_STANDARD, PRODUCT as reactant, which is problematic. Because AUTHENTIC_STANDARD, BYPRODUCT, SIDE_PRODUCT are not reactants.

Also fixed the imports, duplicates and cleaning up.