### PR TITLE
Update ReactionRole use in get_reaction_smiles

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash -l {0}
         run: |
           coverage erase
-          pytest -n auto -vv --cov=ord_schema --durations=0 --durations-min=1
+          pytest -vv --cov=ord_schema --durations=0 --durations-min=1
           coverage xml
       - uses: codecov/codecov-action@v1
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           # NOTE(skearnes): conda is only used for postgres (not python).
           # NOTE(skearnes): rdkit-postgresql may not be available for ARM.
-          conda install -c rdkit rdkit-postgresql==2020.03.3.0 || conda install -c conda-forge postgresql
+          conda install -c rdkit rdkit-postgresql || conda install -c conda-forge postgresql
           initdb
       - uses: actions/setup-python@v4
         with:

--- a/ord_schema/logging.py
+++ b/ord_schema/logging.py
@@ -15,7 +15,7 @@
 import logging
 
 
-def get_logger(name: str, level: int = logging.INFO) -> logging.Logger:
+def get_logger(name: str, level: int = logging.DEBUG) -> logging.Logger:
     """Creates a Logger."""
     if not get_logger.initialized:
         logging.basicConfig(format="%(levelname)s %(asctime)s %(filename)s:%(lineno)d: %(message)s")

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -396,7 +396,7 @@ def get_reaction_smiles(
                 raise error
             if compound.reaction_role in [roles.REAGENT, roles.SOLVENT, roles.CATALYST]:
                 agents.add(smiles)
-            elif compound.reaction_role == roles.REACTANT:
+            elif compound.reaction_role in [roles.REACTANT, roles.UNSPECIFIED]:
                 reactants.add(smiles)
             else:
                 continue
@@ -409,7 +409,7 @@ def get_reaction_smiles(
                 if allow_incomplete:
                     continue
                 raise error
-            if product.reaction_role == roles.PRODUCT:
+            if product.reaction_role in [roles.PRODUCT, roles.UNSPECIFIED]:
                 products.add(smiles)
             elif product.reaction_role in [
                 roles.REAGENT,

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -133,8 +133,13 @@ class TestMessageHelpers:
         reactant2 = reaction.inputs["reactant2"]
         reactant2.components.add(reaction_role="REACTANT").identifiers.add(value="Cc1ccccc1", type="SMILES")
         reactant2.components.add(reaction_role="SOLVENT").identifiers.add(value="N", type="SMILES")
-        reaction.outcomes.add().products.add(reaction_role="PRODUCT").identifiers.add(value="O=C=O", type="SMILES")
+        reaction.outcomes.add().products.add().identifiers.add(value="O=C=O", type="SMILES")
         assert message_helpers.get_reaction_smiles(reaction, generate_if_missing=True) == "Cc1ccccc1.c1ccccc1>N>O=C=O"
+        reaction.outcomes.add().products.add(reaction_role="PRODUCT").identifiers.add(value="O=CC=O", type="SMILES")
+        assert (
+            message_helpers.get_reaction_smiles(reaction, generate_if_missing=True, allow_unspecified_roles=False)
+            == "Cc1ccccc1.c1ccccc1>N>O=CC=O"
+        )
 
     def test_get_reaction_smiles_failure(self):
         reaction = reaction_pb2.Reaction()

--- a/ord_schema/orm/__init__.py
+++ b/ord_schema/orm/__init__.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 """Base ORM objects."""
+from rdkit import RDLogger
 from sqlalchemy.orm import declarative_base
 
+RDLogger.DisableLog("rdApp.*")
 Base = declarative_base()

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -41,5 +41,5 @@ def test_delete_dataset(test_session):
 
 
 def test_get_dataset_md5(test_session):
-    assert get_dataset_md5("test_dataset", test_session) == "42c687cafd247fd72d2a78c550b0b054"
+    assert get_dataset_md5("test_dataset", test_session) == "0343d39a98d38eb39abd69d899af2bdf"
     assert get_dataset_md5("other_dataset", test_session) is None

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -271,6 +271,7 @@ def from_proto(  # pylint: disable=too-many-branches
                 message, generate_if_missing=True, allow_incomplete=False, validate=True
             )
         except ValueError as error:
+            assert hasattr(message, "reaction_id")  # Type hint.
             logger.debug(f"Error generating reaction SMILES for {message.reaction_id}: {error}")
             reaction_smiles = None
         if reaction_smiles is not None:

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -270,7 +270,8 @@ def from_proto(  # pylint: disable=too-many-branches
             reaction_smiles = message_helpers.get_reaction_smiles(
                 message, generate_if_missing=True, allow_incomplete=False, validate=True
             )
-        except ValueError:
+        except ValueError as error:
+            logger.debug(f"Error generating reaction SMILES for {message.reaction_id}: {error}")
             reaction_smiles = None
         if reaction_smiles is not None:
             kwargs["reaction_smiles"] = reaction_smiles.split()[0]  # Handle CXSMILES.

--- a/ord_schema/orm/rdkit_mappers.py
+++ b/ord_schema/orm/rdkit_mappers.py
@@ -117,7 +117,7 @@ class CString(UserDefinedType):
 class FingerprintType(Enum):
     """RDKit PostgreSQL fingerprint types."""
 
-    # NOTE(skearnes): Add Column and Index entries for each member to RDKMol.
+    # NOTE(skearnes): Add Column and Index entries for each member to RDKitMol below.
     MORGAN_BFP = func.morganbv_fp
     MORGAN_SFP = func.morgan_fp
 

--- a/ord_schema/orm/rdkit_mappers.py
+++ b/ord_schema/orm/rdkit_mappers.py
@@ -137,8 +137,8 @@ class RDKitMol(Base):
 
     __table_args__ = (
         Index("mol_index", "mol", postgresql_using="gist"),
-        Index(f"morgan_bfp_index", "morgan_bfp", postgresql_using="gist"),
-        Index(f"morgan_sfp_index", "morgan_sfp", postgresql_using="gist"),
+        Index("morgan_bfp_index", "morgan_bfp", postgresql_using="gist"),
+        Index("morgan_sfp_index", "morgan_sfp", postgresql_using="gist"),
         {"schema": "rdkit"},
     )
 

--- a/ord_schema/orm/rdkit_mappers.py
+++ b/ord_schema/orm/rdkit_mappers.py
@@ -147,11 +147,11 @@ class RDKitMol(Base):
         return func.tanimoto_sml(getattr(cls, fp_type.name.lower()), fp_type(other))
 
     @classmethod
-    def substructure(cls, pattern: str) -> ColumnElement[bool]:
+    def check_substructure(cls, pattern: str) -> ColumnElement[bool]:
         return func.substruct(cls.mol, pattern)
 
     @classmethod
-    def smarts(cls, pattern: str) -> ColumnElement[bool]:
+    def check_smarts(cls, pattern: str) -> ColumnElement[bool]:
         return func.substruct(cls.mol, func.qmol_from_smarts(pattern))
 
 
@@ -169,5 +169,5 @@ class RDKitReaction(Base):
     )
 
     @classmethod
-    def smarts(cls, pattern: str) -> ColumnElement[bool]:
+    def check_smarts(cls, pattern: str) -> ColumnElement[bool]:
         return func.substruct(cls.reaction, func.reaction_from_smarts(pattern))

--- a/ord_schema/orm/rdkit_mappers.py
+++ b/ord_schema/orm/rdkit_mappers.py
@@ -27,7 +27,7 @@ import os
 from distutils.util import strtobool  # pylint: disable=deprecated-module
 from enum import Enum
 
-from sqlalchemy import Column, Index, Integer, Text, func
+from sqlalchemy import Column, Index, Integer, Text, cast, func
 from sqlalchemy.sql.expression import ColumnElement
 from sqlalchemy.types import UserDefinedType
 
@@ -152,7 +152,7 @@ class RDKitMol(Base):
 
     @classmethod
     def matches_smarts(cls, pattern: str) -> ColumnElement[bool]:
-        return func.substruct(cls.mol, func.qmol_from_smarts(pattern))
+        return func.substruct(cls.mol, func.qmol_from_smarts(cast(pattern, CString)))
 
 
 class RDKitReaction(Base):
@@ -170,4 +170,4 @@ class RDKitReaction(Base):
 
     @classmethod
     def matches_smarts(cls, pattern: str) -> ColumnElement[bool]:
-        return func.substruct(cls.reaction, func.reaction_from_smarts(pattern))
+        return func.substruct(cls.reaction, func.reaction_from_smarts(cast(pattern, CString)))

--- a/ord_schema/orm/rdkit_mappers.py
+++ b/ord_schema/orm/rdkit_mappers.py
@@ -54,21 +54,6 @@ class _RDKitMol(UserDefinedType):
         return "mol" if rdkit_cartridge() else "bytea"
 
 
-class _RDKitQMol(UserDefinedType):
-    """https://github.com/rdkit/rdkit/blob/master/Code/PgSQL/rdkit/rdkit.sql.in#L42."""
-
-    cache_ok = True
-
-    @property
-    def python_type(self):
-        raise NotImplementedError
-
-    def get_col_spec(self, **kwargs):
-        """Returns the column type."""
-        del kwargs  # Unused.
-        return "qmol" if rdkit_cartridge() else "bytea"
-
-
 class _RDKitReaction(UserDefinedType):
     """https://github.com/rdkit/rdkit/blob/master/Code/PgSQL/rdkit/rdkit.sql.in#L129."""
 

--- a/ord_schema/orm/rdkit_mappers.py
+++ b/ord_schema/orm/rdkit_mappers.py
@@ -147,11 +147,11 @@ class RDKitMol(Base):
         return func.tanimoto_sml(getattr(cls, fp_type.name.lower()), fp_type(other))
 
     @classmethod
-    def check_substructure(cls, pattern: str) -> ColumnElement[bool]:
+    def contains_substructure(cls, pattern: str) -> ColumnElement[bool]:
         return func.substruct(cls.mol, pattern)
 
     @classmethod
-    def check_smarts(cls, pattern: str) -> ColumnElement[bool]:
+    def matches_smarts(cls, pattern: str) -> ColumnElement[bool]:
         return func.substruct(cls.mol, func.qmol_from_smarts(pattern))
 
 
@@ -169,5 +169,5 @@ class RDKitReaction(Base):
     )
 
     @classmethod
-    def check_smarts(cls, pattern: str) -> ColumnElement[bool]:
+    def matches_smarts(cls, pattern: str) -> ColumnElement[bool]:
         return func.substruct(cls.reaction, func.reaction_from_smarts(pattern))

--- a/ord_schema/orm/rdkit_mappers.py
+++ b/ord_schema/orm/rdkit_mappers.py
@@ -182,3 +182,7 @@ class RDKitReaction(Base):
         Index("reaction_index", "reaction", postgresql_using="gist"),
         {"schema": "rdkit"},
     )
+
+    @classmethod
+    def smarts(cls, pattern: str) -> ColumnElement[bool]:
+        return func.substruct(cls.reaction, func.reaction_from_smarts(pattern))

--- a/ord_schema/orm/rdkit_mappers.py
+++ b/ord_schema/orm/rdkit_mappers.py
@@ -27,7 +27,7 @@ import os
 from distutils.util import strtobool  # pylint: disable=deprecated-module
 from enum import Enum
 
-from sqlalchemy import Column, Index, Integer, Text, func, cast
+from sqlalchemy import Column, Index, Integer, Text, func
 from sqlalchemy.sql.expression import ColumnElement
 from sqlalchemy.types import UserDefinedType
 
@@ -167,7 +167,7 @@ class RDKitMol(Base):
 
     @classmethod
     def smarts(cls, pattern: str) -> ColumnElement[bool]:
-        return func.substruct(cls.mol, cast(pattern, _RDKitQMol))
+        return func.substruct(cls.mol, func.qmol_from_smarts(pattern))
 
 
 class RDKitReaction(Base):

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -99,7 +99,7 @@ def test_smarts(test_session):
 
 def test_reaction_smarts(test_session):
     try:
-        query = select(Mappers.Reaction).join(RDKitReaction).where(RDKitReaction.smarts("[#8:1].[#9:2]>>[#8:1][#9:2]"))
+        query = select(Mappers.Reaction).join(RDKitReaction).where(RDKitReaction.smarts("[#6:1].[#9:2]>>[#6:1][#9:2]"))
         results = test_session.execute(query)
         assert len(results.fetchall()) == 20
     except ProgrammingError as error:

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -65,3 +65,33 @@ def test_substructure_operator(test_session):
         assert len(results.fetchall()) == 20
     except ProgrammingError as error:
         pytest.skip(f"RDKit cartridge is required: {error}")
+
+
+def test_substructure(test_session):
+    try:
+        query = (
+            select(Mappers.Reaction)
+            .join(Mappers.ReactionInput)
+            .join(Mappers.Compound)
+            .join(RDKitMol)
+            .where(RDKitMol.substructure("c1ccccc1CCC(O)C"))
+        )
+        results = test_session.execute(query)
+        assert len(results.fetchall()) == 20
+    except ProgrammingError as error:
+        pytest.skip(f"RDKit cartridge is required: {error}")
+
+
+# def test_smarts(test_session):
+#     try:
+#         query = (
+#             select(Mappers.Reaction)
+#             .join(Mappers.ReactionInput)
+#             .join(Mappers.Compound)
+#             .join(RDKitMol)
+#             .where(RDKitMol.smarts("c1ccccc1CCC(O)C"))
+#         )
+#         results = test_session.execute(query)
+#         assert len(results.fetchall()) == 20
+#     except ProgrammingError as error:
+#         pytest.skip(f"RDKit cartridge is required: {error}")

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -74,7 +74,7 @@ def test_substructure(test_session):
             .join(Mappers.ReactionInput)
             .join(Mappers.Compound)
             .join(RDKitMol)
-            .where(RDKitMol.substructure("c1ccccc1CCC(O)C"))
+            .where(RDKitMol.check_substructure("c1ccccc1CCC(O)C"))
         )
         results = test_session.execute(query)
         assert len(results.fetchall()) == 20
@@ -89,7 +89,7 @@ def test_smarts(test_session):
             .join(Mappers.ReactionInput)
             .join(Mappers.Compound)
             .join(RDKitMol)
-            .where(RDKitMol.smarts("c1ccccc1CCC(O)[#6]"))
+            .where(RDKitMol.check_smarts("c1ccccc1CCC(O)[#6]"))
         )
         results = test_session.execute(query)
         assert len(results.fetchall()) == 20
@@ -99,7 +99,7 @@ def test_smarts(test_session):
 
 def test_reaction_smarts(test_session):
     try:
-        query = select(Mappers.Reaction).join(RDKitReaction).where(RDKitReaction.smarts("[#6:1].[#9:2]>>[#6:1][#9:2]"))
+        query = select(Mappers.Reaction).join(RDKitReaction).where(RDKitReaction.check_smarts("[#6]>>[#6]"))
         results = test_session.execute(query)
         assert len(results.fetchall()) == 20
     except ProgrammingError as error:

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -13,126 +13,103 @@
 # limitations under the License.
 
 """Tests for ord_schema.orm.rdkit_mappers."""
+import platform
+
 import pytest
 from sqlalchemy import func, select
-from sqlalchemy.exc import ProgrammingError
 
 from ord_schema.orm.mappers import Mappers
 from ord_schema.orm.rdkit_mappers import FingerprintType, RDKitMol, RDKitReaction
 
+pytestmark = pytest.mark.skipif(platform.machine() != "x86_64", reason="RDKit cartridge is required")
+
 
 def test_tanimoto_operator(test_session):
-    try:
-        query = (
-            select(Mappers.Reaction)
-            .join(Mappers.ReactionInput)
-            .join(Mappers.Compound)
-            .join(RDKitMol)
-            .where(RDKitMol.morgan_bfp % FingerprintType.MORGAN_BFP("c1ccccc1CCC(O)C"))
-        )
-        results = test_session.execute(query)
-        assert len(results.fetchall()) == 20
-    except ProgrammingError as error:
-        pytest.skip(f"RDKit cartridge is required: {error}")
+    query = (
+        select(Mappers.Reaction)
+        .join(Mappers.ReactionInput)
+        .join(Mappers.Compound)
+        .join(RDKitMol)
+        .where(RDKitMol.morgan_bfp % FingerprintType.MORGAN_BFP("c1ccccc1CCC(O)C"))
+    )
+    results = test_session.execute(query)
+    assert len(results.fetchall()) == 20
 
 
 @pytest.mark.parametrize("fp_type", list(FingerprintType))
 def test_tanimoto(test_session, fp_type):
-    try:
-        query = (
-            select(Mappers.Reaction)
-            .join(Mappers.ReactionInput)
-            .join(Mappers.Compound)
-            .join(RDKitMol)
-            .where(RDKitMol.tanimoto("c1ccccc1CCC(O)C", fp_type=fp_type) > 0.5)
-        )
-        results = test_session.execute(query)
-        assert len(results.fetchall()) == 20
-    except ProgrammingError as error:
-        pytest.skip(f"RDKit cartridge is required: {error}")
+    query = (
+        select(Mappers.Reaction)
+        .join(Mappers.ReactionInput)
+        .join(Mappers.Compound)
+        .join(RDKitMol)
+        .where(RDKitMol.tanimoto("c1ccccc1CCC(O)C", fp_type=fp_type) > 0.5)
+    )
+    results = test_session.execute(query)
+    assert len(results.fetchall()) == 20
 
 
 def test_substructure_operator(test_session):
-    try:
-        query = (
-            select(Mappers.Reaction)
-            .join(Mappers.ReactionInput)
-            .join(Mappers.Compound)
-            .join(RDKitMol)
-            .where(RDKitMol.mol.op("@>")("c1ccccc1CCC(O)C"))
-        )
-        results = test_session.execute(query)
-        assert len(results.fetchall()) == 20
-    except ProgrammingError as error:
-        pytest.skip(f"RDKit cartridge is required: {error}")
+    query = (
+        select(Mappers.Reaction)
+        .join(Mappers.ReactionInput)
+        .join(Mappers.Compound)
+        .join(RDKitMol)
+        .where(RDKitMol.mol.op("@>")("c1ccccc1CCC(O)C"))
+    )
+    results = test_session.execute(query)
+    assert len(results.fetchall()) == 20
 
 
 def test_contains_substructure(test_session):
-    try:
-        query = (
-            select(Mappers.Reaction)
-            .join(Mappers.ReactionInput)
-            .join(Mappers.Compound)
-            .join(RDKitMol)
-            .where(RDKitMol.contains_substructure("c1ccccc1CCC(O)C"))
-        )
-        results = test_session.execute(query)
-        assert len(results.fetchall()) == 20
-    except ProgrammingError as error:
-        pytest.skip(f"RDKit cartridge is required: {error}")
+    query = (
+        select(Mappers.Reaction)
+        .join(Mappers.ReactionInput)
+        .join(Mappers.Compound)
+        .join(RDKitMol)
+        .where(RDKitMol.contains_substructure("c1ccccc1CCC(O)C"))
+    )
+    results = test_session.execute(query)
+    assert len(results.fetchall()) == 20
 
 
 def test_smarts_operator(test_session):
-    try:
-        query = (
-            select(Mappers.Reaction)
-            .join(Mappers.ReactionInput)
-            .join(Mappers.Compound)
-            .join(RDKitMol)
-            .where(RDKitMol.mol.op("@>")(func.qmol_from_smarts("c1ccccc1CCC(O)[#6]")))
-        )
-        results = test_session.execute(query)
-        assert len(results.fetchall()) == 20
-    except ProgrammingError as error:
-        pytest.skip(f"RDKit cartridge is required: {error}")
+    query = (
+        select(Mappers.Reaction)
+        .join(Mappers.ReactionInput)
+        .join(Mappers.Compound)
+        .join(RDKitMol)
+        .where(RDKitMol.mol.op("@>")(func.qmol_from_smarts("c1ccccc1CCC(O)[#6]")))
+    )
+    results = test_session.execute(query)
+    assert len(results.fetchall()) == 20
 
 
 def test_matches_smarts(test_session):
-    try:
-        query = (
-            select(Mappers.Reaction)
-            .join(Mappers.ReactionInput)
-            .join(Mappers.Compound)
-            .join(RDKitMol)
-            .where(RDKitMol.matches_smarts("c1ccccc1CCC(O)[#6]"))
-        )
-        results = test_session.execute(query)
-        assert len(results.fetchall()) == 20
-    except ProgrammingError as error:
-        pytest.skip(f"RDKit cartridge is required: {error}")
+    query = (
+        select(Mappers.Reaction)
+        .join(Mappers.ReactionInput)
+        .join(Mappers.Compound)
+        .join(RDKitMol)
+        .where(RDKitMol.matches_smarts("c1ccccc1CCC(O)[#6]"))
+    )
+    results = test_session.execute(query)
+    assert len(results.fetchall()) == 20
 
 
 def test_reaction_smarts_operator(test_session):
-    try:
-        query = (
-            select(Mappers.Reaction)
-            .join(RDKitReaction)
-            .where(RDKitReaction.reaction.op("@>")(func.reaction_from_smarts("[#6:1].[#9:2]>>[#6:1][#9:2]")))
-        )
-        results = test_session.execute(query)
-        assert len(results.fetchall()) == 79  # One reaction has a BYPRODUCT outcome, so no reaction SMILES.
-    except ProgrammingError as error:
-        pytest.skip(f"RDKit cartridge is required: {error}")
+    query = (
+        select(Mappers.Reaction)
+        .join(RDKitReaction)
+        .where(RDKitReaction.reaction.op("@>")(func.reaction_from_smarts("[#6:1].[#9:2]>>[#6:1][#9:2]")))
+    )
+    results = test_session.execute(query)
+    assert len(results.fetchall()) == 79  # One reaction has a BYPRODUCT outcome, so no reaction SMILES.
 
 
 def test_reaction_matches_smarts(test_session):
-    try:
-        query = (
-            select(Mappers.Reaction)
-            .join(RDKitReaction)
-            .where(RDKitReaction.matches_smarts("[#6:1].[#9:2]>>[#6:1][#9:2]"))
-        )
-        results = test_session.execute(query)
-        assert len(results.fetchall()) == 79  # One reaction has a BYPRODUCT outcome, so no reaction SMILES.
-    except ProgrammingError as error:
-        pytest.skip(f"RDKit cartridge is required: {error}")
+    query = (
+        select(Mappers.Reaction).join(RDKitReaction).where(RDKitReaction.matches_smarts("[#6:1].[#9:2]>>[#6:1][#9:2]"))
+    )
+    results = test_session.execute(query)
+    assert len(results.fetchall()) == 79  # One reaction has a BYPRODUCT outcome, so no reaction SMILES.

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -67,14 +67,14 @@ def test_substructure_operator(test_session):
         pytest.skip(f"RDKit cartridge is required: {error}")
 
 
-def test_substructure(test_session):
+def test_check_substructure(test_session):
     try:
         query = (
             select(Mappers.Reaction)
             .join(Mappers.ReactionInput)
             .join(Mappers.Compound)
             .join(RDKitMol)
-            .where(RDKitMol.check_substructure("c1ccccc1CCC(O)C"))
+            .where(RDKitMol.contains_substructure("c1ccccc1CCC(O)C"))
         )
         results = test_session.execute(query)
         assert len(results.fetchall()) == 20
@@ -82,14 +82,14 @@ def test_substructure(test_session):
         pytest.skip(f"RDKit cartridge is required: {error}")
 
 
-def test_smarts(test_session):
+def test_check_smarts(test_session):
     try:
         query = (
             select(Mappers.Reaction)
             .join(Mappers.ReactionInput)
             .join(Mappers.Compound)
             .join(RDKitMol)
-            .where(RDKitMol.check_smarts("c1ccccc1CCC(O)[#6]"))
+            .where(RDKitMol.matches_smarts("c1ccccc1CCC(O)[#6]"))
         )
         results = test_session.execute(query)
         assert len(results.fetchall()) == 20
@@ -97,9 +97,9 @@ def test_smarts(test_session):
         pytest.skip(f"RDKit cartridge is required: {error}")
 
 
-def test_reaction_smarts(test_session):
+def test_reaction_check_smarts(test_session):
     try:
-        query = select(Mappers.Reaction).join(RDKitReaction).where(RDKitReaction.check_smarts("[#6]>>[#6]"))
+        query = select(Mappers.Reaction).join(RDKitReaction).where(RDKitReaction.matches_smarts("[#6]>>[#6]"))
         results = test_session.execute(query)
         assert len(results.fetchall()) == 20
     except ProgrammingError as error:

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -99,7 +99,7 @@ def test_smarts(test_session):
 
 def test_reaction_smarts(test_session):
     try:
-        query = select(Mappers.Reaction).join(RDKitReaction).where(RDKitReaction.smarts("[#6:1].[#6:2]>>[#6:1][#6:2]"))
+        query = select(Mappers.Reaction).join(RDKitReaction).where(RDKitReaction.smarts("[#8:1].[#9:2]>>[#8:1][#9:2]"))
         results = test_session.execute(query)
         assert len(results.fetchall()) == 20
     except ProgrammingError as error:

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -18,7 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import ProgrammingError
 
 from ord_schema.orm.mappers import Mappers
-from ord_schema.orm.rdkit_mappers import FingerprintType, RDKitMol
+from ord_schema.orm.rdkit_mappers import FingerprintType, RDKitMol, RDKitReaction
 
 
 def test_tanimoto_operator(test_session):
@@ -99,13 +99,7 @@ def test_smarts(test_session):
 
 def test_reaction_smarts(test_session):
     try:
-        query = (
-            select(Mappers.Reaction)
-            .join(Mappers.ReactionInput)
-            .join(Mappers.Compound)
-            .join(RDKitMol)
-            .where(RDKitMol.smarts("[#6:1].[#6:2]>>[#6:1][#6:2]"))
-        )
+        query = select(Mappers.Reaction).join(RDKitReaction).where(RDKitReaction.smarts("[#6:1].[#6:2]>>[#6:1][#6:2]"))
         results = test_session.execute(query)
         assert len(results.fetchall()) == 20
     except ProgrammingError as error:

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -50,3 +50,18 @@ def test_tanimoto(test_session, fp_type):
         assert len(results.fetchall()) == 20
     except ProgrammingError as error:
         pytest.skip(f"RDKit cartridge is required: {error}")
+
+
+def test_substructure_operator(test_session):
+    try:
+        query = (
+            select(Mappers.Reaction)
+            .join(Mappers.ReactionInput)
+            .join(Mappers.Compound)
+            .join(RDKitMol)
+            .where(RDKitMol.mol.op("@>")("c1ccccc1CCC(O)C"))
+        )
+        results = test_session.execute(query)
+        assert len(results.fetchall()) == 20
+    except ProgrammingError as error:
+        pytest.skip(f"RDKit cartridge is required: {error}")

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -95,3 +95,18 @@ def test_smarts(test_session):
         assert len(results.fetchall()) == 20
     except ProgrammingError as error:
         pytest.skip(f"RDKit cartridge is required: {error}")
+
+
+def test_reaction_smarts(test_session):
+    try:
+        query = (
+            select(Mappers.Reaction)
+            .join(Mappers.ReactionInput)
+            .join(Mappers.Compound)
+            .join(RDKitMol)
+            .where(RDKitMol.smarts("[#6:1].[#6:2]>>[#6:1][#6:2]"))
+        )
+        results = test_session.execute(query)
+        assert len(results.fetchall()) == 20
+    except ProgrammingError as error:
+        pytest.skip(f"RDKit cartridge is required: {error}")

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -120,7 +120,7 @@ def test_reaction_smarts_operator(test_session):
             .where(RDKitReaction.reaction.op("@>")(func.reaction_from_smarts("[#6:1].[#9:2]>>[#6:1][#9:2]")))
         )
         results = test_session.execute(query)
-        assert len(results.fetchall()) == 80
+        assert len(results.fetchall()) == 79  # One reaction has a BYPRODUCT outcome, so no reaction SMILES.
     except ProgrammingError as error:
         pytest.skip(f"RDKit cartridge is required: {error}")
 
@@ -133,6 +133,6 @@ def test_reaction_matches_smarts(test_session):
             .where(RDKitReaction.matches_smarts("[#6:1].[#9:2]>>[#6:1][#9:2]"))
         )
         results = test_session.execute(query)
-        assert len(results.fetchall()) == 80
+        assert len(results.fetchall()) == 79  # One reaction has a BYPRODUCT outcome, so no reaction SMILES.
     except ProgrammingError as error:
         pytest.skip(f"RDKit cartridge is required: {error}")

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -82,16 +82,16 @@ def test_substructure(test_session):
         pytest.skip(f"RDKit cartridge is required: {error}")
 
 
-# def test_smarts(test_session):
-#     try:
-#         query = (
-#             select(Mappers.Reaction)
-#             .join(Mappers.ReactionInput)
-#             .join(Mappers.Compound)
-#             .join(RDKitMol)
-#             .where(RDKitMol.smarts("c1ccccc1CCC(O)C"))
-#         )
-#         results = test_session.execute(query)
-#         assert len(results.fetchall()) == 20
-#     except ProgrammingError as error:
-#         pytest.skip(f"RDKit cartridge is required: {error}")
+def test_smarts(test_session):
+    try:
+        query = (
+            select(Mappers.Reaction)
+            .join(Mappers.ReactionInput)
+            .join(Mappers.Compound)
+            .join(RDKitMol)
+            .where(RDKitMol.smarts("c1ccccc1CCC(O)[#6]"))
+        )
+        results = test_session.execute(query)
+        assert len(results.fetchall()) == 20
+    except ProgrammingError as error:
+        pytest.skip(f"RDKit cartridge is required: {error}")

--- a/ord_schema/orm/testdata/ord-nielsen-example.pbtxt
+++ b/ord_schema/orm/testdata/ord-nielsen-example.pbtxt
@@ -237,6 +237,7 @@ reactions {
         analysis_key: "19f nmr of crude"
         type: IDENTITY
       }
+      reaction_role: BYPRODUCT
     }
     analyses {
       key: "19f nmr of crude"


### PR DESCRIPTION
* Updates `get_reaction_smiles` to accept `ReactionRole.UNSPECIFIED` as a marker for reactants and/or products. The test dataset does not have product reaction roles set, and this was causing reaction SMARTS queries to fail since reaction SMILES were not being generated as part of the dataset creation (and thus the rdkit.reactions table was empty).
* Adds examples of additional chemistry-aware search functions.
* Makes `RDKitMol` table fingerprint columns explicit in the ORM mapper for improved readability and IDE inference.
* Silence RDKit logging when the ORM is imported.
* Set the default log level to DEBUG.