### PR TITLE
Faster rdkit operations in the ORM

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -165,7 +165,8 @@ def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
                         UNION
                         SELECT smiles
                             FROM ord.product_compound
-                            JOIN ord.reaction_outcome ON ord.product_compound.reaction_outcome_id = ord.reaction_outcome.id
+                            JOIN ord.reaction_outcome
+                                ON ord.product_compound.reaction_outcome_id = ord.reaction_outcome.id
                             JOIN ord.reaction ON ord.reaction_outcome.reaction_id = ord.reaction.id
                             JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
                             WHERE ord.dataset.dataset_id = :dataset_id
@@ -177,7 +178,7 @@ def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
                     -- See https://github.com/open-reaction-database/ord-schema/issues/672.
                     WHERE smiles NOT LIKE '%[Ti+5]%'
                 ) mol_subquery
-            )
+            ) fp_subquery
             ON CONFLICT (smiles) DO NOTHING
             """
         ),

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -224,6 +224,7 @@ def update_rdkit_ids(dataset_id: str, session: Session) -> None:
                     JOIN rdkit.reactions USING (reaction_smiles)
                     JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
                     WHERE ord.dataset.dataset_id = :dataset_id
+                      AND ord.reaction.rdkit_reaction_id IS NULL
             ) AS subquery
             WHERE ord.reaction.id = subquery.id
             """
@@ -244,6 +245,7 @@ def update_rdkit_ids(dataset_id: str, session: Session) -> None:
                     JOIN ord.reaction ON ord.reaction_input.reaction_id = ord.reaction.id
                     JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
                     WHERE ord.dataset.dataset_id = :dataset_id
+                      AND ord.compound.rdkit_mol_id IS NULL
             ) AS subquery
             WHERE ord.compound.id = subquery.id
             """
@@ -263,6 +265,7 @@ def update_rdkit_ids(dataset_id: str, session: Session) -> None:
                     JOIN ord.reaction ON ord.reaction_outcome.reaction_id = ord.reaction.id
                     JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
                     WHERE ord.dataset.dataset_id = :dataset_id
+                      AND ord.product_compound.rdkit_mol_id IS NULL
             ) AS subquery
             WHERE ord.product_compound.id = subquery.id
             """

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -126,6 +126,7 @@ def _update_rdkit_reactions(dataset_id: str, session: Session) -> None:
                 FROM ord.reaction
                 JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
                 WHERE ord.dataset.dataset_id = :dataset_id
+                  AND ord.reaction.rdkit_reaction_id IS NULL
             EXCEPT
             SELECT reaction_smiles
                 FROM rdkit.reactions
@@ -167,6 +168,7 @@ def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
                         JOIN ord.reaction ON ord.reaction_input.reaction_id = ord.reaction.id
                         JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
                         WHERE ord.dataset.dataset_id = :dataset_id
+                          AND ord.compound.rdkit_mol_id IS NULL
                     UNION
                     SELECT smiles
                         FROM ord.product_compound
@@ -174,6 +176,7 @@ def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
                         JOIN ord.reaction ON ord.reaction_outcome.reaction_id = ord.reaction.id
                         JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
                         WHERE ord.dataset.dataset_id = :dataset_id
+                          AND ord.product_compound.rdkit_mol_id IS NULL
                 )
                 EXCEPT SELECT smiles FROM rdkit.mols
             ) subquery

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -151,7 +151,7 @@ def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
             FROM (
                 SELECT smiles, mol, morganbv_fp(mol) AS morgan_bfp, morgan_fp(mol) AS morgan_sfp
                 FROM (
-                    SELECT smiles, mol_from_smiles(smiles::cstring)
+                    SELECT smiles, mol_from_smiles(smiles::cstring) AS mol
                     FROM (
                         SELECT smiles
                             -- NOTE(skearnes): This join path does not include non-input compounds like workups, 

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -17,15 +17,13 @@ import os
 import time
 from unittest.mock import patch
 
-from sqlalchemy import cast, delete, func, select, text, update
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy import delete, select, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NotSupportedError, OperationalError
 from sqlalchemy.orm import Session
 
 from ord_schema.logging import get_logger
 from ord_schema.orm.mappers import Base, Mappers, from_proto
-from ord_schema.orm.rdkit_mappers import CString, FingerprintType, RDKitMols, RDKitReactions
 from ord_schema.proto import dataset_pb2
 
 logger = get_logger(__name__)
@@ -153,7 +151,6 @@ def _update_rdkit_reactions(dataset_id: str, session: Session) -> None:
 def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
     """Updates the RDKit mols table."""
     logger.debug("Updating RDKit mols")
-    assert hasattr(RDKitMols, "__table__")  # Type hint.
     start = time.time()
     session.execute(text("CREATE TEMPORARY TABLE temp_mols (LIKE rdkit.mols INCLUDING DEFAULTS)"))
     result = session.execute(

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -156,7 +156,6 @@ def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
     assert hasattr(RDKitMols, "__table__")  # Type hint.
     start = time.time()
     session.execute(text("CREATE TEMPORARY TABLE temp_mols (LIKE rdkit.mols INCLUDING DEFAULTS)"))
-    # NOTE(skearnes): This join path does not include non-input compounds like workups, internal standards, etc.
     result = session.execute(
         text(
             """
@@ -164,6 +163,8 @@ def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
             SELECT smiles FROM (
                 (
                     SELECT smiles
+                        -- NOTE(skearnes): This join path does not include non-input compounds like workups, 
+                        -- internal standards, etc.
                         FROM ord.compound
                         JOIN ord.reaction_input ON ord.compound.reaction_input_id = ord.reaction_input.id
                         JOIN ord.reaction ON ord.reaction_input.reaction_id = ord.reaction.id

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -28,7 +28,9 @@ Options:
     --host=<str>            Database host [default: localhost]
     --port=<int>            Database port [default: 5432]
     --n_jobs=<int>          Number of parallel workers [default: 1]
+    --debug                 Enable debug logging.
 """
+import logging
 import os
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from glob import glob
@@ -101,7 +103,9 @@ def add_rdkit(dataset_id: str) -> None:
 
 def main(**kwargs):
     RDLogger.DisableLog("rdApp.*")
-    if kwargs.get("--url"):
+    if kwargs["--debug"]:
+        get_logger(database.__name__, level=logging.DEBUG)
+    if kwargs["--url"]:
         url = kwargs["--url"]
     else:
         url = database.get_connection_string(


### PR DESCRIPTION
Rewrites the RDKit table operations to use subqueries and combined queries. This makes each dataset faster while also making it much easier to rerun the add_datasets.py script without redoing work.