### PR TITLE
Added RDKit UGM video back in and updated Greg's affiliation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,9 @@ underrepresented areas).
 
 .. raw:: html
 
+ <b>Presentation of the ORD to the RDKit UGM on 7th October 2020</b>
+ <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/UyHVwJUBDIk?start=3" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 .. toctree::
    :hidden:
    :caption: Tools

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -177,7 +177,7 @@ Advisory Board is:
 * Matthew Gaunt (Cambridge, SynTech)
 * Alex Godfrey (NCATS Consultant)
 * Mimi Hii (Imperial, ROAR)
-* Greg Landrum (T5 Informatics)
+* Greg Landrum (ETH Zurich)
 * Fabio Lima (Novartis)
 * Christos Nicolaou (Recursion)
 * Sarah Reisman (Caltech, `C-CAS <https://ccas.nd.edu/>`__)


### PR DESCRIPTION
Added the RDKit UGM video back in now that it is public. Added a title above the video to give context.

Also updated @greglandrum affiliation to ETH Zurich.