### PR TITLE
Relax protobuf version to allow versions <5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
         "numpy>=1.26.4",
         "openpyxl>=3.0.5",
         "pandas>=1.0.4",
-        "protobuf==4.22.3",
+        "protobuf>=4.22.3,<5",
         "psycopg[binary,pool]>=3",
         "pygithub>=1.51",
         "python-dateutil>=1.10.0",


### PR DESCRIPTION
Relax protobuf requirements to allow versions between (the currently hard pinned) 4.22.3 and 5.0 (not included).

Protobuf [docs](https://protobuf.dev/support/version-support/#changes):

> Minor or patch releases should only contain purely additive or source-compatible

 