### PR TITLE
Catch ValueError in parse_doi

### DIFF
--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -964,12 +964,15 @@ def validate_reaction_provenance(message: reaction_pb2.ReactionProvenance):
         if not record.person.email:
             warnings.warn("User email is required for record_modified", ValidationError)
     if message.doi:
-        parsed_doi = message_helpers.parse_doi(message.doi)
-        if message.doi != parsed_doi:
-            warnings.warn(
-                f"DOI should be trimmed ({message.doi} -> {parsed_doi})",
-                ValidationError,
-            )
+        try:
+            parsed_doi = message_helpers.parse_doi(message.doi)
+            if message.doi != parsed_doi:
+                warnings.warn(
+                    f"DOI should be trimmed ({message.doi} -> {parsed_doi})",
+                    ValidationError,
+                )
+        except ValueError as error:
+            warnings.warn(str(error), ValidationError)
     # TODO(ccoley) could check if publication_url is valid, etc.
 
 

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -482,6 +482,16 @@ def test_missing_provenance():
         _run_validation(message, recurse=False, options=options)
 
 
+def test_bad_doi():
+    message = reaction_pb2.ReactionProvenance()
+    message.record_created.time.value = "2023-07-01"
+    message.record_created.person.email = "test@example.com"
+    message.doi = "149"
+    options = validations.ValidationOptions(require_provenance=True)
+    with pytest.raises(validations.ValidationError, match="could not parse DOI"):
+        _run_validation(message, recurse=False, options=options)
+
+
 def test_data():
     message = reaction_pb2.Data()
     with pytest.raises(validations.ValidationError, match="requires one of"):


### PR DESCRIPTION
Fixes a bug where a bad DOI raises an uncaught ValueError instead of a ValidationError.