### PR TITLE
ci: npm OIDC publishing, Node 24 in workflows, and Codecov fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write  # Required for OIDC.
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,16 +57,12 @@ jobs:
           python -m twine check dist/*
           python -m twine upload dist/*
       - name: Build and upload to NPM
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd js/ord-schema
           npm install
           npm run build
           npm publish
       - name: Build and upload to NPM (protobufjs)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd js/ord-schema-protobufjs
           npm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,8 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Trusted publishing requires Node >= 22.14 and npm >= 11.5.1 (https://docs.npmjs.com/trusted-publishers)
+          node-version: '24'
           # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
           registry-url: 'https://registry.npmjs.org'
       - name: Bump patch version

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -55,13 +55,13 @@ jobs:
           uv run coverage erase
           uv run pytest -vv --cov=ord_schema --durations=20
           uv run coverage xml
-      # Codecov v4+ uses CODECOV_TOKEN when set. Fork PRs often upload tokenless; do not fail
-      # the job on upload errors there so external contributors are not blocked.
-      # If you add workflow_dispatch, merge_group, etc., revisit fail_ci_if_error for each event.
-      - uses: codecov/codecov-action@v4
+      # Codecov uses CODECOV_TOKEN when set. Do not fail the job when uploads cannot authenticate:
+      # fork PRs (tokenless), Dependabot PRs (no repo secrets + protected dependabot/* branches).
+      # Pushes to main and normal same-repo PRs stay strict.
+      - uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
-          fail_ci_if_error: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          fail_ci_if_error: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot/')) }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
   test_notebooks:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -93,7 +93,7 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: '24'
       - name: Install protoc
         run: |
           mkdir protoc
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Test NPM package
         run: |
           cd js/ord-schema

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -139,7 +139,8 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          # Trusted publishing requires Node >= 22.14 and npm >= 11.5.1 (https://docs.npmjs.com/trusted-publishers)
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - name: Verify bump2version config (dry-run)
         run: |
@@ -154,6 +155,12 @@ jobs:
       - name: Test javascript
         run: |
           cd js/ord-schema
+          npm install
+          npm run build
+          npm publish --dry-run
+      - name: Test javascript (protobufjs)
+        run: |
+          cd js/ord-schema-protobufjs
           npm install
           npm run build
           npm publish --dry-run


### PR DESCRIPTION
CI updates for **npm trusted publishing**, **Node 24** across JS-related jobs, and **Codecov** behavior on Dependabot/fork PRs.

### `publish.yml` ([npm trusted publishers](https://docs.npmjs.com/trusted-publishers))
- Add `id-token: write` for GitHub Actions OIDC.
- Remove `NODE_AUTH_TOKEN` / `secrets.NPM_TOKEN` from both `npm publish` steps (token-based publish was failing with E404).
- Set `node-version: '24'` so the bundled npm meets the trusted-publishing CLI requirement (**npm ≥ 11.5.1**, **Node ≥ 22.14**).

### `run_tests.yml`
- **Node 24** in `test_proto_wrappers`, `test_js`, and `test_publish` (aligned with publish).
- **`test_publish`:** `npm publish --dry-run` for **`js/ord-schema-protobufjs`** as well as `js/ord-schema`; **no** `id-token` on this job.
- **Codecov:** `codecov/codecov-action@v5` and adjusted `fail_ci_if_error` so **fork** and **`dependabot/*`** PRs do not fail when Codecov cannot use `CODECOV_TOKEN` (Dependabot has no repo secrets; those branches are protected on Codecov). Pushes to `main` and normal same-repo PRs still fail the job on upload errors.

### Before merge
On npmjs.com, add **trusted publishers** for **`ord-schema`** and **`ord-schema-protobufjs`**: repo `open-reaction-database/ord-schema`, workflow **`publish.yml`**. If npm references a GitHub **environment**, add matching `environment:` on the publish job.

*PR description drafted with assistance from Cursor.*
