### PR TITLE
ci: publish to PyPI with trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,12 +20,19 @@ on:
       - main
 
 jobs:
+  # PyPA recommends splitting build (low privilege) from publish (OIDC). We keep one job because
+  # bump2version commits locally and we only push to main after PyPI + npm succeed; a second job
+  # cannot check out that unpublished commit without pushing first or shipping a full repo artifact.
   publish:
     if: github.repository == 'open-reaction-database/ord-schema'
     runs-on: ubuntu-latest
+    # Optional on PyPI: if the trusted publisher names a GitHub environment, add matching:
+    #   environment:
+    #     name: pypi
+    #     url: https://pypi.org/project/ord-schema/
     permissions:
       contents: write
-      id-token: write  # Required for OIDC.
+      id-token: write  # PyPI + npm trusted publishing (OIDC).
     steps:
       - uses: actions/checkout@v4
         with:
@@ -52,13 +59,14 @@ jobs:
       # for this repo + workflow file publish.yml (no PYPI_API_TOKEN / legacy upload).
       - name: Build Python distributions
         run: |
-          uv pip install build twine
+          uv pip install build twine wheel
           python -m build
           python -m twine check dist/*
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
           packages-dir: dist/
+          verify-metadata: false
       - name: Build and upload to NPM
         run: |
           cd js/ord-schema

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,15 +48,17 @@ jobs:
           git config user.email github-actions@github.com
           uv pip install bump2version
           bump2version patch --verbose
-      - name: Build and upload to PyPI
-        env:
-          TWINE_USERNAME: '__token__'
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      # PyPI Trusted Publishing (OIDC); configure at https://docs.pypi.org/trusted-publishers/
+      # for this repo + workflow file publish.yml (no PYPI_API_TOKEN / legacy upload).
+      - name: Build Python distributions
         run: |
-          uv pip install build twine wheel
+          uv pip install build twine
           python -m build
           python -m twine check dist/*
-          python -m twine upload dist/*
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
       - name: Build and upload to NPM
         run: |
           cd js/ord-schema


### PR DESCRIPTION
## Summary

Switch the `Publish` workflow from `twine upload` (PyPI legacy upload URL + `PYPI_API_TOKEN`) to [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish) so uploads use **PyPI Trusted Publishing** and the job\u0027s existing `id-token: write` permission.

## Changes

- Build step unchanged in practice: `uv pip install build twine`, `python -m build`, `twine check`.
- New publish step: `pypa/gh-action-pypi-publish@release/v1` with `packages-dir: dist/`.

## Before merge

Configure a **trusted publisher** on PyPI for **ord-schema**: GitHub → `open-reaction-database/ord-schema` → workflow file `publish.yml`. If PyPI references a **GitHub environment**, add the matching `environment:` block on the publish job.

After a successful OIDC publish, you can revoke the old PyPI API token if it is no longer needed.

*PR description drafted with assistance from Cursor.*

Made with [Cursor](https://cursor.com)