### PR TITLE
Drop Werkzeug dependency

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -17,6 +17,7 @@ import enum
 import functools
 import gzip
 import os
+import posixpath
 import re
 import urllib.parse
 import warnings
@@ -32,7 +33,6 @@ from google.protobuf import (
 from google.protobuf.message import DecodeError
 from rdkit import Chem
 from rdkit.Chem import rdChemReactions
-from werkzeug import security
 
 import ord_schema
 from ord_schema import units
@@ -839,9 +839,11 @@ def id_filename(filename: str) -> str:
     prefix, suffix = basename.split("-")
     if not prefix.startswith("ord"):
         raise ValueError(f'basename does not have the required "ord" prefix: {basename}')
-    joined = security.safe_join("data", suffix[:2], basename)
-    assert joined is not None  # Type hint.
-    return joined
+    shard = suffix[:2]
+    # Reject anything that could let the shard escape the "data/" root (e.g. "..", "/x").
+    if not shard.isalnum():
+        raise ValueError(f"basename shard must be alphanumeric: {basename}")
+    return posixpath.join("data", shard, basename)
 
 
 def create_message(message_name: str) -> ord_schema.Message:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "Werkzeug>=3.0.3",
     "docopt>=0.6.2",
     "inflection>=0.5.1",
     "joblib>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2468,7 +2468,6 @@ dependencies = [
     { name = "rdkit" },
     { name = "sqlalchemy" },
     { name = "tqdm" },
-    { name = "werkzeug" },
 ]
 
 [package.optional-dependencies]
@@ -2534,7 +2533,6 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.61.2" },
     { name = "treon", marker = "extra == 'tests'", specifier = ">=0.1.3" },
     { name = "ty", marker = "extra == 'tests'", specifier = ">=0.0.28" },
-    { name = "werkzeug", specifier = ">=3.0.3" },
     { name = "wget", marker = "extra == 'examples'", specifier = ">=3.2" },
 ]
 provides-extras = ["docs", "examples", "tests"]


### PR DESCRIPTION
## Summary

The only use of Werkzeug in `ord-schema` was `werkzeug.security.safe_join` in [`id_filename()`](ord_schema/message_helpers.py), which builds a `data/{shard}/{basename}` path for dataset storage. Pulling in a web framework for one `join` call is excessive — replace it with `posixpath.join` plus an `isalnum()` check on the shard.

- Removes `Werkzeug>=3.0.3` from `[project.dependencies]`
- `id_filename()` now uses `posixpath.join("data", shard, basename)` after verifying the shard is alphanumeric (stricter than `safe_join` and matches our hex-like dataset ID shape)

Werkzeug remains available transitively via `tensorboard` for the `examples` extra, so anyone who needs it for experimentation still gets it — it just isn't a required runtime dep of `ord-schema` anymore.

## Test plan

- [x] `pytest ord_schema/message_helpers_test.py ord_schema/scripts/process_dataset_test.py` — 94 passed locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)