### PR TITLE
Replace dead name resolvers with OPSIN; retry PubChem on 503

### DIFF
--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -19,6 +19,7 @@ import urllib.parse
 import urllib.request
 
 from rdkit import Chem
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_random_exponential
 
 import ord_schema
 from ord_schema import message_helpers
@@ -102,6 +103,19 @@ def resolve_names(message: ord_schema.Message) -> bool:
     return modified
 
 
+def _is_pubchem_busy(exception: BaseException) -> bool:
+    # PubChem returns 503 PUGREST.ServerBusy when its service-wide concurrent
+    # request load is shedding (independent of any per-IP quota). Retry only
+    # that case; 404 (unknown name) and other 4xx codes should fall through.
+    return isinstance(exception, urllib.error.HTTPError) and exception.code == 503
+
+
+@retry(
+    retry=retry_if_exception(_is_pubchem_busy),
+    stop=stop_after_attempt(5),
+    wait=wait_random_exponential(multiplier=1, max=8),
+    reraise=True,
+)
 def _pubchem_resolve(value_type: str, value: str) -> str:
     """Resolves compound identifiers to SMILES via the PubChem REST API."""
     with urllib.request.urlopen(

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -111,6 +111,18 @@ def _pubchem_resolve(value_type: str, value: str) -> str:
         return response.read().decode().strip()
 
 
+def _opsin_resolve(value_type: str, value: str) -> str:
+    """Resolves systematic IUPAC names to SMILES via the OPSIN web service.
+
+    OPSIN is a parser for systematic IUPAC nomenclature, not a lookup service:
+    it will refuse trade names, trivial names, and abbreviations (e.g. "aspirin",
+    "THF") with an HTTP 404. Treat it strictly as a complement to PubChem.
+    """
+    del value_type  # OPSIN only supports names.
+    with urllib.request.urlopen(f"https://www.ebi.ac.uk/opsin/ws/{urllib.parse.quote(value)}.smi") as response:
+        return response.read().decode().strip()
+
+
 def resolve_input(input_string: str) -> reaction_pb2.ReactionInput:
     """Resolve a text-based description of an input in one of the following
     formats:
@@ -155,11 +167,17 @@ def resolve_input(input_string: str) -> reaction_pb2.ReactionInput:
     return reaction_input
 
 
-# Standard name resolvers. PubChem is currently the only one that works:
-#  - NCI/CADD's /chemical/structure endpoint has been returning 503 for every query
-#    and the project blog has been silent since 2013.
-#  - eMolecules' public /lookup?q= endpoint now always replies "__END__", including
-#    for raw SMILES; their current API requires authentication.
+# Standard name resolvers.
+#
+# PubChem handles the bulk of inputs (trade names, trivial names, abbreviations,
+# CAS numbers), and OPSIN is a reliable fallback for systematic IUPAC names when
+# PubChem is unavailable or rate-limited.
+#
+# Previously also included NCI/CADD (cactus.nci.nih.gov) and eMolecules, which
+# are both effectively dead: cactus has been returning uniform 503s with a silent
+# blog since 2013, and eMolecules' public /lookup?q= endpoint now always replies
+# "__END__" (their current API requires authentication).
 _NAME_RESOLVERS = {
     "PubChem API": _pubchem_resolve,
+    "OPSIN": _opsin_resolve,
 }

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Name/string resolution to structured messages or identifiers."""
 
-import email.message
 import re
 import urllib.error
 import urllib.parse
@@ -112,25 +111,6 @@ def _pubchem_resolve(value_type: str, value: str) -> str:
         return response.read().decode().strip()
 
 
-def _cactus_resolve(value_type: str, value: str) -> str:
-    """Resolves compound identifiers to SMILES via the CACTUS API."""
-    del value_type  # Unused.
-    with urllib.request.urlopen(
-        f"https://cactus.nci.nih.gov/chemical/structure/{urllib.parse.quote(value)}/smiles"
-    ) as response:
-        return response.read().decode().strip()
-
-
-def _emolecules_resolve(value_type: str, value: str) -> str:
-    """Resolves compound identifiers to SMILES via the eMolecules API."""
-    del value_type  # Unused.
-    with urllib.request.urlopen(f"https://www.emolecules.com/lookup?q={urllib.parse.quote(value)}") as response:
-        response_text = response.read().decode().strip()
-    if response_text == "__END__":
-        raise urllib.error.HTTPError("", 404, "eMolecules lookup unsuccessful", email.message.Message(), None)
-    return response_text.split("\t")[0]
-
-
 def resolve_input(input_string: str) -> reaction_pb2.ReactionInput:
     """Resolve a text-based description of an input in one of the following
     formats:
@@ -175,9 +155,11 @@ def resolve_input(input_string: str) -> reaction_pb2.ReactionInput:
     return reaction_input
 
 
-# Standard name resolvers.
+# Standard name resolvers. PubChem is currently the only one that works:
+#  - NCI/CADD's /chemical/structure endpoint has been returning 503 for every query
+#    and the project blog has been silent since 2013.
+#  - eMolecules' public /lookup?q= endpoint now always replies "__END__", including
+#    for raw SMILES; their current API requires authentication.
 _NAME_RESOLVERS = {
     "PubChem API": _pubchem_resolve,
-    "NCI/CADD Chemical Identifier Resolver": _cactus_resolve,
-    "eMolecules Lookup Service": _emolecules_resolve,
 }

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 """Tests for ord_schema.units."""
 
+import urllib.error
+from unittest import mock
+
 import pytest
 from rdkit import Chem
 
@@ -77,3 +80,40 @@ class TestInputResolvers:
     def test_input_resolve_should_fail(self, string, expected):
         with pytest.raises((KeyError, ValueError), match=expected):
             resolvers.resolve_input(string)
+
+
+class TestPubChemRetry:
+    """Tests for the tenacity-driven retry on PubChem 503 ServerBusy."""
+
+    @staticmethod
+    def _busy_error() -> urllib.error.HTTPError:
+        return urllib.error.HTTPError("", 503, "PUGREST.ServerBusy", hdrs=None, fp=None)  # ty: ignore[invalid-argument-type]
+
+    @staticmethod
+    def _ok_response() -> mock.MagicMock:
+        response = mock.MagicMock()
+        response.read.return_value = b"CC(=O)Oc1ccccc1C(=O)O\n"
+        response.__enter__.return_value = response
+        return response
+
+    def test_retries_then_succeeds(self, monkeypatch):
+        # Two 503s then a successful response — the decorator should swallow both
+        # 503s without surfacing them and return the eventual SMILES.
+        responses = [self._busy_error(), self._busy_error(), self._ok_response()]
+        urlopen = mock.MagicMock(side_effect=responses)
+        monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
+        # Drop tenacity's wait so the test runs in milliseconds, not seconds.
+        # tenacity attaches a Retrying object to the wrapped function as .retry;
+        # ty's stubs don't model this, hence the ignore.
+        monkeypatch.setattr(resolvers._pubchem_resolve.retry, "wait", lambda *_, **__: 0)  # ty: ignore[unresolved-attribute]
+        assert resolvers._pubchem_resolve("name", "aspirin") == "CC(=O)Oc1ccccc1C(=O)O"
+        assert urlopen.call_count == 3
+
+    def test_does_not_retry_404(self, monkeypatch):
+        # 404 means "no such compound" — must not be retried.
+        not_found = urllib.error.HTTPError("", 404, "Not Found", hdrs=None, fp=None)  # ty: ignore[invalid-argument-type]
+        urlopen = mock.MagicMock(side_effect=not_found)
+        monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
+        with pytest.raises(urllib.error.HTTPError):
+            resolvers._pubchem_resolve("name", "definitely-not-a-compound")
+        assert urlopen.call_count == 1

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -82,12 +82,14 @@ class TestInputResolvers:
             resolvers.resolve_input(string)
 
 
+def _http_error(code: int, msg: str) -> urllib.error.HTTPError:
+    # urllib's HTTPError stub declares hdrs/fp as non-Optional, but the runtime
+    # accepts None for both — fine for tests where we never read them.
+    return urllib.error.HTTPError("", code, msg, hdrs=None, fp=None)  # ty: ignore[invalid-argument-type]
+
+
 class TestPubChemRetry:
     """Tests for the tenacity-driven retry on PubChem 503 ServerBusy."""
-
-    @staticmethod
-    def _busy_error() -> urllib.error.HTTPError:
-        return urllib.error.HTTPError("", 503, "PUGREST.ServerBusy", hdrs=None, fp=None)  # ty: ignore[invalid-argument-type]
 
     @staticmethod
     def _ok_response() -> mock.MagicMock:
@@ -99,7 +101,11 @@ class TestPubChemRetry:
     def test_retries_then_succeeds(self, monkeypatch):
         # Two 503s then a successful response — the decorator should swallow both
         # 503s without surfacing them and return the eventual SMILES.
-        responses = [self._busy_error(), self._busy_error(), self._ok_response()]
+        responses = [
+            _http_error(503, "PUGREST.ServerBusy"),
+            _http_error(503, "PUGREST.ServerBusy"),
+            self._ok_response(),
+        ]
         urlopen = mock.MagicMock(side_effect=responses)
         monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
         # Drop tenacity's wait so the test runs in milliseconds, not seconds.
@@ -111,8 +117,7 @@ class TestPubChemRetry:
 
     def test_does_not_retry_404(self, monkeypatch):
         # 404 means "no such compound" — must not be retried.
-        not_found = urllib.error.HTTPError("", 404, "Not Found", hdrs=None, fp=None)  # ty: ignore[invalid-argument-type]
-        urlopen = mock.MagicMock(side_effect=not_found)
+        urlopen = mock.MagicMock(side_effect=_http_error(404, "Not Found"))
         monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
         with pytest.raises(urllib.error.HTTPError):
             resolvers._pubchem_resolve("name", "definitely-not-a-compound")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "python-dateutil>=1.10.0",
     "rdkit>=2021.9.5",
     "sqlalchemy>=2",
+    "tenacity>=8.0.0",
     "tqdm>=4.61.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,9 @@ dependencies = [
     "python-dateutil>=1.10.0",
     "rdkit>=2021.9.5",
     "sqlalchemy>=2",
-    "tenacity>=8.0.0",
+    # Pinned <10 because we read _pubchem_resolve.retry to monkeypatch the wait
+    # in tests; tenacity 10 may rework that introspection surface.
+    "tenacity>=8.0.0,<10",
     "tqdm>=4.61.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2530,7 +2530,7 @@ requires-dist = [
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=1.1.1" },
     { name = "sphinx-tabs", marker = "extra == 'docs'", specifier = ">=3.4.0" },
     { name = "sqlalchemy", specifier = ">=2" },
-    { name = "tenacity", specifier = ">=8.0.0" },
+    { name = "tenacity", specifier = ">=8.0.0,<10" },
     { name = "tensorflow", marker = "extra == 'examples'", specifier = ">=2.4.1" },
     { name = "testing-postgresql", marker = "extra == 'tests'", specifier = ">=1.3.0" },
     { name = "tqdm", specifier = ">=4.61.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2467,6 +2467,7 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "rdkit" },
     { name = "sqlalchemy" },
+    { name = "tenacity" },
     { name = "tqdm" },
     { name = "werkzeug" },
 ]
@@ -2529,6 +2530,7 @@ requires-dist = [
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=1.1.1" },
     { name = "sphinx-tabs", marker = "extra == 'docs'", specifier = ">=3.4.0" },
     { name = "sqlalchemy", specifier = ">=2" },
+    { name = "tenacity", specifier = ">=8.0.0" },
     { name = "tensorflow", marker = "extra == 'examples'", specifier = ">=2.4.1" },
     { name = "testing-postgresql", marker = "extra == 'tests'", specifier = ">=1.3.0" },
     { name = "tqdm", specifier = ">=4.61.2" },
@@ -4133,6 +4135,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Three changes to [`resolvers.py`](ord_schema/resolvers.py):

1. **Drop two dead backends**: cactus (NCI/CADD) and eMolecules.
2. **Add OPSIN** as a fallback for systematic IUPAC names.
3. **Retry PubChem on 503 ServerBusy** via tenacity, so transient PubChem load-shed doesn't blow up CI.

### 1. Drop dead backends

**NCI/CADD cactus**
- The `/chemical/structure/<name>/smiles` endpoint returns a uniform `503 "maintenance downtime or capacity problems"` for every query I tested (benzene, aspirin, caffeine, water, ethanol, THF). Same canned Apache body, same status. About half the requests additionally hang past 20s.
- The project's own blog at [cactus.nci.nih.gov/blog](https://cactus.nci.nih.gov/blog/) has had **no posts since January 2013** — 13 years of silence.
- No successor endpoint or migration notice has been announced.

**eMolecules**
- The free public `/lookup?q=` endpoint that the resolver calls now returns `__END__` for **every** input — including a raw SMILES like `c1ccccc1` (literal benzene). It's the "no match" sentinel, returned unconditionally.
- Their current programmatic access is a gated commercial API that requires requesting a key from `orders@emolecules.com`.

### 2. Add OPSIN as fallback

[OPSIN](https://www.ebi.ac.uk/opsin/) (Open Parser for Systematic IUPAC Nomenclature, Cambridge) is free, no-auth, well-maintained. GET `https://www.ebi.ac.uk/opsin/ws/<name>.smi` returns a plain SMILES on success, HTTP 404 on failure — exactly the shape `name_resolve()` already handles.

Tested live against the EBI mirror:

```
benzene           → C1=CC=CC=C1
tetrahydrofuran   → O1CCCC1
caffeine          → N1(C)C(=O)N(C)C=2N=CN(C)C2C1=O
sodium hydroxide  → [OH-].[Na+]
water             → O
aspirin           → 404 "uninterpretable"
THF               → 404 "uninterpretable"
```

**OPSIN is a parser, not a lookup.** It refuses trade names, trivial names, and abbreviations with 404 — PubChem still handles those. The point is that OPSIN's catalog has no rate limiter, so when PubChem is load-shedding, any systematic IUPAC name still resolves cleanly through OPSIN instead of falling through to `ValueError`.

I evaluated several other candidates (ChEMBL, Wikidata SPARQL, openmolecules.org, UniChem, ChemSpider, SciFinder) — all are either gated, fuzzy in dangerous ways, or unreachable. PubChem + OPSIN is the cleanest combination I could find.

### 3. Retry PubChem on 503

PubChem's `X-Throttling-Control` header has three counters: per-IP request count, per-IP request time, and a **service-wide concurrency** counter. When the service-wide one goes black, PubChem returns `503 PUGREST.ServerBusy` to **everyone** until load drops, regardless of how slowly individual clients are calling. That's the failure mode behind the recent CI flake — one isolated request, immediate 503, because PubChem itself was overloaded.

`_pubchem_resolve` is now wrapped with `@tenacity.retry`:

```python
@retry(
    retry=retry_if_exception(_is_pubchem_busy),
    stop=stop_after_attempt(5),
    wait=wait_random_exponential(multiplier=1, max=8),
    reraise=True,
)
```

Only `503` is retried; `404` (unknown compound) and other errors fall through immediately.

**Why tenacity, not an inline loop:** I started with a 10-line manual retry, but a runtime dependency that does exactly this is small (~60KB), well-tested, widely used, and removes the need for us to maintain backoff/jitter logic of our own. Adds `tenacity>=8.0.0` to `[project.dependencies]`.

### Tests

- New `TestPubChemRetry` class with two cases that mock `urllib.request.urlopen`:
  - `test_retries_then_succeeds`: two 503s followed by a successful response → tenacity swallows both 503s and returns the eventual SMILES (wait monkeypatched to zero so the test runs instantly).
  - `test_does_not_retry_404`: a 404 is surfaced after a single attempt.
- The existing live-network tests are **kept in CI** as canaries — if PubChem changes its API or OPSIN goes away, we want to know.

## Test plan

- [x] `pytest ord_schema/resolvers_test.py` — 6 passed locally (4 live-network + 2 mocked retry)
- [x] OPSIN live-tested against 7 inputs; systematic names resolve, trivial/trade names 404 as expected
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)