### PR TITLE
Let PR titles opt into minor/major release bumps

### DIFF
--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -15,27 +15,67 @@
 name: Lint PR title
 
 on:
-  pull_request:
+  # `pull_request_target` so fork PRs also get write access for the sticky
+  # comment. Safe here because we only read `github.event.pull_request.title`
+  # and never check out the PR's code.
+  pull_request_target:
     types: [opened, edited, reopened]
     branches:
       - main
+
+permissions:
+  pull-requests: write
 
 jobs:
   bump-tag:
     if: github.repository == 'open-reaction-database/ord-schema'
     runs-on: ubuntu-latest
     steps:
-      - name: Validate "[bump ...]" tag in PR title
+      - name: Validate and resolve bump tag in PR title
+        id: bump
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # The release workflow on main reads the PR title (squash-merge
-          # subject) for `[bump minor]` or `[bump major]` to opt into a larger
-          # release. Catch typos here, before merge: post-merge the release
-          # has already shipped at the wrong level and can't be undone.
+          # Fail on a malformed tag (e.g. [bump mionor]) so the author can fix
+          # it pre-merge; the release workflow otherwise silently falls back
+          # to patch and the bad release has already shipped.
           unrecognized="$(printf '%s' "$TITLE" | grep -oiE '\[bump[[:space:]]+[a-zA-Z]+\]' | grep -viE '\[bump[[:space:]]+(major|minor|patch)\]' || true)"
           if [ -n "$unrecognized" ]; then
             echo "::error::Unrecognized bump tag(s) in PR title: $(printf '%s' "$unrecognized" | tr '\n' ' '). Valid: [bump major], [bump minor], [bump patch]. See CONTRIBUTING.md."
             exit 1
           fi
-          echo "PR title bump tag (if any) is valid."
+          if printf '%s' "$TITLE" | grep -qiE '\[bump[[:space:]]+major\]'; then
+            level=major
+          elif printf '%s' "$TITLE" | grep -qiE '\[bump[[:space:]]+minor\]'; then
+            level=minor
+          else
+            level=patch
+          fi
+          echo "level=$level" >> "$GITHUB_OUTPUT"
+          echo "Bump level: $level"
+          echo "- **Bump level on merge:** \`$level\`" >> "$GITHUB_STEP_SUMMARY"
+      - name: Upsert bump-level comment on the PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LEVEL: ${{ steps.bump.outputs.level }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          MARKER='<!-- bump-tag-comment -->'
+          case "$LEVEL" in
+            patch) detail='default — add [bump minor] or [bump major] to the PR title to change' ;;
+            minor) detail='set by [bump minor] in the PR title' ;;
+            major) detail='set by [bump major] in the PR title' ;;
+          esac
+          body="$MARKER
+
+          On merge, this PR will trigger a **\`$LEVEL\`** release bump ($detail)
+
+          _See [CONTRIBUTING.md](https://github.com/$REPO/blob/main/CONTRIBUTING.md#release-bumps)._"
+          existing="$(gh api -X GET "/repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+                      --jq "[.[] | select(.body | startswith(\"$MARKER\"))] | last | .id // empty")"
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "/repos/$REPO/issues/comments/$existing" -f body="$body" --silent
+          else
+            gh api -X POST "/repos/$REPO/issues/$PR_NUMBER/comments" -f body="$body" --silent
+          fi

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -1,0 +1,41 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Lint PR title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+    branches:
+      - main
+
+jobs:
+  bump-tag:
+    if: github.repository == 'open-reaction-database/ord-schema'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate "[bump ...]" tag in PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # The release workflow on main reads the PR title (squash-merge
+          # subject) for `[bump minor]` or `[bump major]` to opt into a larger
+          # release. Catch typos here, before merge: post-merge the release
+          # has already shipped at the wrong level and can't be undone.
+          unrecognized="$(printf '%s' "$TITLE" | grep -oiE '\[bump[[:space:]]+[a-zA-Z]+\]' | grep -viE '\[bump[[:space:]]+(major|minor|patch)\]' || true)"
+          if [ -n "$unrecognized" ]; then
+            echo "::error::Unrecognized bump tag(s) in PR title: $(printf '%s' "$unrecognized" | tr '\n' ' '). Valid: [bump major], [bump minor], [bump patch]. See CONTRIBUTING.md."
+            exit 1
+          fi
+          echo "PR title bump tag (if any) is valid."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
           # main — we only scan that subject, not the body, so the tag has to
           # be visible on the PR page itself. `[bump major]` wins over
           # `[bump minor]`. Typo-checking happens pre-merge in
-          # .github/workflows/lint_pr_title.yml so malformed tags can't reach
+          # .github/workflows/release_bump.yml so malformed tags can't reach
           # this point from a merged PR.
           subject="$(git log -1 --format=%s)"
           if printf '%s' "$subject" | grep -qiE '\[bump[[:space:]]+major\]'; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,11 +37,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.ACTIONS_PUSH }}
-          # Full history so "Determine bump level" can read every commit added
-          # in the push, not just the HEAD commit. Matters for merge-commit and
-          # rebase-merge strategies where the [bump ...] tag may live in a
-          # branch commit rather than in HEAD.
-          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -57,33 +52,24 @@ jobs:
       - name: Determine bump level
         id: bump
         run: |
-          # Default to patch. Allow any commit added in this push to opt into
-          # a larger bump via `[bump minor]` or `[bump major]` (case-
-          # insensitive). Supports all GitHub merge strategies:
-          #   * squash-merge: HEAD's message carries PR title + body.
-          #   * merge-commit: HEAD is the auto-generated merge; the tag lives
-          #     in a branch commit brought in by the merge.
-          #   * rebase-merge: HEAD is the last branch commit; the tag may be
-          #     in any of the rebased commits.
+          # Default to patch. A `[bump minor]` or `[bump major]` tag in the PR
+          # title (case-insensitive) opts into a larger release. The PR title
+          # lives in the subject line of the squash-merge commit that lands on
+          # main — we only scan that subject, not the body, so the tag has to
+          # be visible on the PR page itself.
           # `[bump major]` wins over `[bump minor]`.
-          before='${{ github.event.before }}'
-          after='${{ github.sha }}'
-          if [ -n "$before" ] && [ "$before" != "0000000000000000000000000000000000000000" ] && git cat-file -e "$before" 2>/dev/null; then
-            msg="$(git log "$before..$after" --format=%B)"
-          else
-            msg="$(git log -1 "$after" --format=%B)"
-          fi
-          if printf '%s' "$msg" | grep -qiE '\[bump[[:space:]]+major\]'; then
+          subject="$(git log -1 --format=%s)"
+          if printf '%s' "$subject" | grep -qiE '\[bump[[:space:]]+major\]'; then
             level=major
-          elif printf '%s' "$msg" | grep -qiE '\[bump[[:space:]]+minor\]'; then
+          elif printf '%s' "$subject" | grep -qiE '\[bump[[:space:]]+minor\]'; then
             level=minor
           else
             level=patch
           fi
           # Warn on `[bump WORD]` where WORD isn't a valid level (typo guard).
-          unrecognized="$(printf '%s' "$msg" | grep -oiE '\[bump[[:space:]]+[a-zA-Z]+\]' | grep -viE '\[bump[[:space:]]+(major|minor|patch)\]' || true)"
+          unrecognized="$(printf '%s' "$subject" | grep -oiE '\[bump[[:space:]]+[a-zA-Z]+\]' | grep -viE '\[bump[[:space:]]+(major|minor|patch)\]' || true)"
           if [ -n "$unrecognized" ]; then
-            echo "::warning::Unrecognized bump tag(s) in commit message; using level='$level'. Valid: [bump major|minor|patch]. Found: $(printf '%s' "$unrecognized" | tr '\n' ' ')"
+            echo "::warning::Unrecognized bump tag(s) in PR title; using level='$level'. Valid: [bump major|minor|patch]. Found: $(printf '%s' "$unrecognized" | tr '\n' ' ')"
           fi
           echo "level=$level" >> "$GITHUB_OUTPUT"
           echo "Bump level: $level"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.ACTIONS_PUSH }}
+          # Full history so "Determine bump level" can read every commit added
+          # in the push, not just the HEAD commit. Matters for merge-commit and
+          # rebase-merge strategies where the [bump ...] tag may live in a
+          # branch commit rather than in HEAD.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -52,17 +57,33 @@ jobs:
       - name: Determine bump level
         id: bump
         run: |
-          # Default to patch. Allow a merge commit to opt into a larger bump
-          # via `[bump minor]` or `[bump major]` anywhere in its message.
-          # Squash-merges carry the PR title and body into the commit, so the
-          # tag can live in either. `[bump major]` wins over `[bump minor]`.
-          msg="$(git log -1 --format=%B)"
+          # Default to patch. Allow any commit added in this push to opt into
+          # a larger bump via `[bump minor]` or `[bump major]` (case-
+          # insensitive). Supports all GitHub merge strategies:
+          #   * squash-merge: HEAD's message carries PR title + body.
+          #   * merge-commit: HEAD is the auto-generated merge; the tag lives
+          #     in a branch commit brought in by the merge.
+          #   * rebase-merge: HEAD is the last branch commit; the tag may be
+          #     in any of the rebased commits.
+          # `[bump major]` wins over `[bump minor]`.
+          before='${{ github.event.before }}'
+          after='${{ github.sha }}'
+          if [ -n "$before" ] && [ "$before" != "0000000000000000000000000000000000000000" ] && git cat-file -e "$before" 2>/dev/null; then
+            msg="$(git log "$before..$after" --format=%B)"
+          else
+            msg="$(git log -1 "$after" --format=%B)"
+          fi
           if printf '%s' "$msg" | grep -qiE '\[bump[[:space:]]+major\]'; then
             level=major
           elif printf '%s' "$msg" | grep -qiE '\[bump[[:space:]]+minor\]'; then
             level=minor
           else
             level=patch
+          fi
+          # Warn on `[bump WORD]` where WORD isn't a valid level (typo guard).
+          unrecognized="$(printf '%s' "$msg" | grep -oiE '\[bump[[:space:]]+[a-zA-Z]+\]' | grep -viE '\[bump[[:space:]]+(major|minor|patch)\]' || true)"
+          if [ -n "$unrecognized" ]; then
+            echo "::warning::Unrecognized bump tag(s) in commit message; using level='$level'. Valid: [bump major|minor|patch]. Found: $(printf '%s' "$unrecognized" | tr '\n' ' ')"
           fi
           echo "level=$level" >> "$GITHUB_OUTPUT"
           echo "Bump level: $level"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,12 +49,29 @@ jobs:
           node-version: '24'
           # https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
           registry-url: 'https://registry.npmjs.org'
-      - name: Bump patch version
+      - name: Determine bump level
+        id: bump
+        run: |
+          # Default to patch. Allow a merge commit to opt into a larger bump
+          # via `[bump minor]` or `[bump major]` anywhere in its message.
+          # Squash-merges carry the PR title and body into the commit, so the
+          # tag can live in either. `[bump major]` wins over `[bump minor]`.
+          msg="$(git log -1 --format=%B)"
+          if printf '%s' "$msg" | grep -qiE '\[bump[[:space:]]+major\]'; then
+            level=major
+          elif printf '%s' "$msg" | grep -qiE '\[bump[[:space:]]+minor\]'; then
+            level=minor
+          else
+            level=patch
+          fi
+          echo "level=$level" >> "$GITHUB_OUTPUT"
+          echo "Bump level: $level"
+      - name: Bump version
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
           uv pip install bump2version
-          bump2version patch --verbose
+          bump2version "${{ steps.bump.outputs.level }}" --verbose
       # PyPI Trusted Publishing (OIDC); configure at https://docs.pypi.org/trusted-publishers/
       # for this repo + workflow file publish.yml (no PYPI_API_TOKEN / legacy upload).
       - name: Build Python distributions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,8 +56,10 @@ jobs:
           # title (case-insensitive) opts into a larger release. The PR title
           # lives in the subject line of the squash-merge commit that lands on
           # main — we only scan that subject, not the body, so the tag has to
-          # be visible on the PR page itself.
-          # `[bump major]` wins over `[bump minor]`.
+          # be visible on the PR page itself. `[bump major]` wins over
+          # `[bump minor]`. Typo-checking happens pre-merge in
+          # .github/workflows/lint_pr_title.yml so malformed tags can't reach
+          # this point from a merged PR.
           subject="$(git log -1 --format=%s)"
           if printf '%s' "$subject" | grep -qiE '\[bump[[:space:]]+major\]'; then
             level=major
@@ -65,11 +67,6 @@ jobs:
             level=minor
           else
             level=patch
-          fi
-          # Warn on `[bump WORD]` where WORD isn't a valid level (typo guard).
-          unrecognized="$(printf '%s' "$subject" | grep -oiE '\[bump[[:space:]]+[a-zA-Z]+\]' | grep -viE '\[bump[[:space:]]+(major|minor|patch)\]' || true)"
-          if [ -n "$unrecognized" ]; then
-            echo "::warning::Unrecognized bump tag(s) in PR title; using level='$level'. Valid: [bump major|minor|patch]. Found: $(printf '%s' "$unrecognized" | tr '\n' ' ')"
           fi
           echo "level=$level" >> "$GITHUB_OUTPUT"
           echo "Bump level: $level"

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Lint PR title
+name: Release bump
 
 on:
   # `pull_request_target` so fork PRs also get write access for the sticky
@@ -62,18 +62,27 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           MARKER='<!-- bump-tag-comment -->'
+          existing="$(gh api -X GET "/repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+                      --jq "[.[] | select(.body | startswith(\"$MARKER\"))] | last | .id // empty")"
+          # Only comment when the level opts into something bigger than the
+          # default (patch). Keeps the bot quiet on the majority of PRs. If a
+          # maintainer adds and then removes the tag, clean up the stale
+          # comment so the PR no longer misrepresents the release.
+          if [ "$LEVEL" = "patch" ]; then
+            if [ -n "$existing" ]; then
+              gh api -X DELETE "/repos/$REPO/issues/comments/$existing" --silent
+            fi
+            exit 0
+          fi
           case "$LEVEL" in
-            patch) detail='default — add [bump minor] or [bump major] to the PR title to change' ;;
-            minor) detail='set by [bump minor] in the PR title' ;;
-            major) detail='set by [bump major] in the PR title' ;;
+            minor) detail='set by `[bump minor]` in the PR title' ;;
+            major) detail='set by `[bump major]` in the PR title' ;;
           esac
           body="$MARKER
 
-          On merge, this PR will trigger a **\`$LEVEL\`** release bump ($detail)
+          On merge, this PR will trigger a **\`$LEVEL\`** release bump ($detail).
 
           _See [CONTRIBUTING.md](https://github.com/$REPO/blob/main/CONTRIBUTING.md#release-bumps)._"
-          existing="$(gh api -X GET "/repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
-                      --jq "[.[] | select(.body | startswith(\"$MARKER\"))] | last | .id // empty")"
           if [ -n "$existing" ]; then
             gh api -X PATCH "/repos/$REPO/issues/comments/$existing" -f body="$body" --silent
           else

--- a/.github/workflows/release_bump.yml
+++ b/.github/workflows/release_bump.yml
@@ -27,7 +27,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  bump-tag:
+  validate-bump-tag:
     if: github.repository == 'open-reaction-database/ord-schema'
     runs-on: ubuntu-latest
     steps:
@@ -75,8 +75,8 @@ jobs:
             exit 0
           fi
           case "$LEVEL" in
-            minor) detail='set by `[bump minor]` in the PR title' ;;
-            major) detail='set by `[bump major]` in the PR title' ;;
+            minor) detail='from the `[bump minor]` tag in the PR title' ;;
+            major) detail='from the `[bump major]` tag in the PR title' ;;
           esac
           body="$MARKER
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,24 @@ Excellent! There are a few steps you'll need to follow to get ready to submit ch
    reviewer comments and automated tests. Once the reviewers have approved your changes, they will merge
    them into the official repository.
 
+## Release bumps
+
+When a pull request merges to `main`, the publish workflow automatically bumps the version, tags a
+release, and publishes to PyPI and npm. The default bump is **patch**; a maintainer can promote a
+release to **minor** or **major** by including a tag in the **PR title**:
+
+- `[bump minor]` — new features, backward-compatible additions (e.g., a new module or public API).
+- `[bump major]` — breaking changes (removed or renamed public APIs, incompatible behavior shifts).
+- No tag — patch release.
+
+The tag is case-insensitive (`[BUMP MINOR]` is fine) and must live in the PR title itself — that's
+the squash-merge subject line that lands on `main`, and the only text the release workflow reads.
+If both `[bump major]` and `[bump minor]` appear, `major` wins.
+
+A separate CI check ([lint_pr_title.yml](.github/workflows/lint_pr_title.yml)) runs on every PR and
+fails if the title contains a `[bump WORD]` pattern where `WORD` isn't `major`, `minor`, or `patch`,
+so typos are caught before merge rather than after the release has shipped.
+
 ## Terms of Use
 
 By submitting Contributions (as defined below) to this project, you agree that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,11 +90,12 @@ The tag is case-insensitive (`[BUMP MINOR]` is fine) and must live in the PR tit
 the squash-merge subject line that lands on `main`, and the only text the release workflow reads.
 If both `[bump major]` and `[bump minor]` appear, `major` wins.
 
-A separate CI check ([lint_pr_title.yml](.github/workflows/lint_pr_title.yml)) runs on every PR and
+A separate CI check ([release_bump.yml](.github/workflows/release_bump.yml)) runs on every PR and
 fails if the title contains a `[bump WORD]` pattern where `WORD` isn't `major`, `minor`, or `patch`,
-so typos are caught before merge rather than after the release has shipped. The same workflow
-posts (and keeps updated) a sticky comment on the PR showing the resolved bump level, so reviewers
-can see the intended release type without clicking into the check details.
+so typos are caught before merge rather than after the release has shipped. When the title opts
+into a non-default bump (`[bump minor]` or `[bump major]`), the same workflow posts (and keeps
+updated) a sticky comment on the PR showing the resolved level; default-patch PRs get no comment
+so the bot stays quiet in the common case.
 
 ## Terms of Use
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,9 @@ If both `[bump major]` and `[bump minor]` appear, `major` wins.
 
 A separate CI check ([lint_pr_title.yml](.github/workflows/lint_pr_title.yml)) runs on every PR and
 fails if the title contains a `[bump WORD]` pattern where `WORD` isn't `major`, `minor`, or `patch`,
-so typos are caught before merge rather than after the release has shipped.
+so typos are caught before merge rather than after the release has shipped. The same workflow
+posts (and keeps updated) a sticky comment on the PR showing the resolved bump level, so reviewers
+can see the intended release type without clicking into the check details.
 
 ## Terms of Use
 


### PR DESCRIPTION
## Summary

The `publish.yml` workflow auto-bumps the version on every push to `main`, but it always runs `bump2version patch`. That means any feature — even one that warrants a minor or major bump — currently ships as a patch release. For example, #790 adds a new public module (`ord_schema.parquet_dataset`) plus a new CLI script, which would reasonably be a minor bump but would otherwise ship as `0.4.8`.

This PR adds an opt-in signal: if a PR's **title** contains `[bump minor]` or `[bump major]` (case-insensitive), the workflow passes that level to `bump2version` instead of `patch`. Default stays `patch`, so nothing changes for the common case.

## Usage

Put `[bump minor]` or `[bump major]` in the PR title. Example:

> Add Parquet-based Dataset serialization `[bump minor]`

Merging on top of `0.4.7` → workflow reads the squash-merge subject, bumps to `0.5.0`, tags, and releases.

## Why the PR title (and only the title)?

- It's visible on the PR page, so reviewers can see the intended release level without opening the commit details.
- For squash-merges (the repo's convention), GitHub puts the PR title in the subject line of the merge commit. `git log -1 --format=%s` gives us exactly that — no history walks, no range scans, no extra checkout depth.
- Couples to squash-merge: if the repo ever switches to merge-commit or rebase-merge, this logic would need to be revisited.

## Behavior details

- **Case-insensitive.** `[BUMP MINOR]`, `[Bump Major]`, `[bump  minor]` (multiple spaces) all match.
- **`[bump major]` beats `[bump minor]`** if both appear.
- **Typo guard.** If a `[bump WORD]` tag is found in the title but `WORD` isn't `major` / `minor` / `patch`, the workflow emits a GitHub Actions `::warning::` naming the offending tag. The chosen level (from any valid tag that's also present, or patch) still applies. Stops `[bump mionor]` from silently downgrading the release.
- **No tag → patch**, matching today's behavior.
- **The bump commit itself carries `[skip actions]`** via `.bumpversion.cfg`, so the workflow doesn't re-trigger on its own bump.

## Test plan

- [x] Local sanity check of the bash detection logic against: plain / `[bump minor]` / uppercase `[BUMP MAJOR]` / explicit `[bump patch]` / both `[bump minor]+[bump major]` / typo `[bump mionor]` / typo-plus-valid / multi-space `[bump   major]` / lookalike `[bumpminor]` (no separator). All chose the correct level and warned only when appropriate.
- [ ] Live verification happens on the next merge to `main`. For #790 (with `[bump minor]` in its title post-merge), expect `0.4.7 → 0.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
