### PR TITLE
Route Parquet through the submission pipeline end-to-end

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -35,7 +35,7 @@ from rdkit import Chem
 from rdkit.Chem import rdChemReactions
 
 import ord_schema
-from ord_schema import units
+from ord_schema import parquet_dataset, units
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 _COMPOUND_IDENTIFIER_LOADERS = {
@@ -781,8 +781,6 @@ def load_message(filename: str, message_type: type[MessageType]) -> MessageType:
             raise ValueError(f"Parquet files are not gzip-wrapped: {filename}")
         if message_type is not dataset_pb2.Dataset:
             raise ValueError(f"Parquet is only supported for Dataset messages, not {message_type.__name__}")
-        from ord_schema import parquet_dataset
-
         return parquet_dataset.read_dataset(filename)  # ty: ignore[invalid-return-type]
     if input_format == MessageFormat.BINARY:
         mode = "rb"
@@ -828,8 +826,6 @@ def write_message(message: ord_schema.Message, filename: str):
             raise ValueError(f"Parquet files are not gzip-wrapped: {filename}")
         if not isinstance(message, dataset_pb2.Dataset):
             raise ValueError(f"Parquet is only supported for Dataset messages, not {type(message).__name__}")
-        from ord_schema import parquet_dataset
-
         parquet_dataset.write_dataset(message, filename)
         return
     with this_open(filename, "wb") as f:

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -727,6 +727,7 @@ class MessageFormat(enum.Enum):
     BINARY = ".pb"
     JSON = ".json"
     PBTXT = ".pbtxt"
+    PARQUET = ".parquet"
 
 
 def fetch_dataset(dataset_id: str, timeout: float = 10.0) -> dataset_pb2.Dataset:
@@ -775,6 +776,14 @@ def load_message(filename: str, message_type: type[MessageType]) -> MessageType:
         this_open = open
         _, extension = os.path.splitext(filename)
     input_format = MessageFormat(extension)
+    if input_format == MessageFormat.PARQUET:
+        if filename.endswith(".gz"):
+            raise ValueError(f"Parquet files are not gzip-wrapped: {filename}")
+        if message_type is not dataset_pb2.Dataset:
+            raise ValueError(f"Parquet is only supported for Dataset messages, not {message_type.__name__}")
+        from ord_schema import parquet_dataset
+
+        return parquet_dataset.read_dataset(filename)  # ty: ignore[invalid-return-type]
     if input_format == MessageFormat.BINARY:
         mode = "rb"
     else:
@@ -814,6 +823,15 @@ def write_message(message: ord_schema.Message, filename: str):
         this_open = open
         _, extension = os.path.splitext(filename)
     output_format = MessageFormat(extension)
+    if output_format == MessageFormat.PARQUET:
+        if filename.endswith(".gz"):
+            raise ValueError(f"Parquet files are not gzip-wrapped: {filename}")
+        if not isinstance(message, dataset_pb2.Dataset):
+            raise ValueError(f"Parquet is only supported for Dataset messages, not {type(message).__name__}")
+        from ord_schema import parquet_dataset
+
+        parquet_dataset.write_dataset(message, filename)
+        return
     with this_open(filename, "wb") as f:
         if output_format == MessageFormat.JSON:
             f.write(json_format.MessageToJson(message).encode())

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -23,7 +23,7 @@ from google.protobuf import json_format, text_format
 from rdkit import Chem
 
 from ord_schema import message_helpers
-from ord_schema.proto import reaction_pb2, test_pb2
+from ord_schema.proto import dataset_pb2, reaction_pb2, test_pb2
 
 _BENZENE_MOLBLOCK = """241
   -OEChem-07232015262D
@@ -492,6 +492,31 @@ class TestLoadAndWriteMessage:
         message = test_pb2.RepeatedScalar(values=[1.2, 3.4])
         with pytest.raises(ValueError, match="not a valid MessageFormat"):
             message_helpers.write_message(message, "test.proto")
+
+    def test_parquet_round_trip(self, tmp_path):
+        reaction = reaction_pb2.Reaction(reaction_id="ord-123")
+        dataset = dataset_pb2.Dataset(name="n", description="d", reactions=[reaction])
+        path = (tmp_path / "test.parquet").as_posix()
+        message_helpers.write_message(dataset, path)
+        loaded = message_helpers.load_message(path, dataset_pb2.Dataset)
+        assert list(loaded.reactions) == [reaction]
+        assert loaded.name == "n"
+        assert loaded.description == "d"
+
+    def test_parquet_rejects_gz(self, tmp_path):
+        dataset = dataset_pb2.Dataset(name="n", description="d", reactions=[reaction_pb2.Reaction(reaction_id="r")])
+        path = (tmp_path / "test.parquet.gz").as_posix()
+        with pytest.raises(ValueError, match="not gzip-wrapped"):
+            message_helpers.write_message(dataset, path)
+        with pytest.raises(ValueError, match="not gzip-wrapped"):
+            message_helpers.load_message(path, dataset_pb2.Dataset)
+
+    def test_parquet_rejects_non_dataset(self, tmp_path):
+        path = (tmp_path / "test.parquet").as_posix()
+        with pytest.raises(ValueError, match="only supported for Dataset"):
+            message_helpers.write_message(reaction_pb2.Reaction(reaction_id="r"), path)
+        with pytest.raises(ValueError, match="only supported for Dataset"):
+            message_helpers.load_message(path, reaction_pb2.Reaction)
 
 
 class TestCreateMessage:

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -14,6 +14,7 @@
 
 """Functions for creating/managing the PostgreSQL database."""
 
+import hashlib
 import os
 import time
 from typing import Any, cast
@@ -24,6 +25,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NotSupportedError, OperationalError
 from sqlalchemy.orm import Session
 
+from ord_schema import parquet_dataset
 from ord_schema.logging import get_logger
 from ord_schema.orm.mappers import Base, Mappers, from_proto
 from ord_schema.proto import dataset_pb2
@@ -82,6 +84,70 @@ def add_dataset(dataset: dataset_pb2.Dataset, session: Session, rdkit_cartridge:
         update_rdkit_tables(dataset.dataset_id, session)
         session.flush()
         update_rdkit_ids(dataset.dataset_id, session)
+
+
+# Flush pending Reaction ORM objects to the database in batches, so the session's
+# identity map cannot grow unbounded for large Parquet datasets.
+_PARQUET_FLUSH_BATCH = 200
+
+
+def add_parquet_dataset(path: str, session: Session, rdkit_cartridge: bool = True) -> None:
+    """Streams a Parquet-serialized Dataset into the ORM tables.
+
+    Reactions are deserialized one at a time and flushed in batches, so peak
+    memory stays bounded regardless of dataset size. The MD5 hash stored for
+    a Parquet-ingested Dataset comes from ``parquet_dataset.streaming_md5``
+    rather than from the serialized Dataset bytes (see that function for the
+    scheme; it differs from the one used for ``.pb.gz`` inputs).
+    """
+    start = time.time()
+    metadata = parquet_dataset.read_metadata(path)
+    logger.debug(f"Streaming Parquet Dataset {metadata.dataset_id}")
+    reaction_child_class = Mappers.Dataset.reactions.mapper.class_
+    hasher = hashlib.md5()
+    hasher.update(f"name={metadata.name}\n".encode())
+    hasher.update(f"description={metadata.description}\n".encode())
+    hasher.update(f"dataset_id={metadata.dataset_id}\n".encode())
+    # Create the Dataset row up front with placeholder scalars; patched at end.
+    mapped_dataset = Mappers.Dataset(
+        name=metadata.name,
+        description=metadata.description,
+        dataset_id=metadata.dataset_id,
+        md5="0" * 32,
+        num_reactions=0,
+    )
+    session.add(mapped_dataset)
+    session.flush()
+    count = 0
+    pending: list = []
+    for reaction_id, reaction in parquet_dataset.iter_reactions(path):
+        blob = reaction.SerializeToString(deterministic=True)
+        hasher.update(f"reaction_id={reaction_id}\n".encode())
+        hasher.update(len(blob).to_bytes(8, "big"))
+        hasher.update(blob)
+        reaction_mapper = from_proto(reaction, mapper=reaction_child_class)
+        reaction_mapper.parent = mapped_dataset
+        session.add(reaction_mapper)
+        pending.append(reaction_mapper)
+        count += 1
+        if len(pending) >= _PARQUET_FLUSH_BATCH:
+            session.flush()
+            for obj in pending:
+                session.expunge(obj)
+            pending.clear()
+    if pending:
+        session.flush()
+        for obj in pending:
+            session.expunge(obj)
+        pending.clear()
+    mapped_dataset.md5 = hasher.hexdigest()
+    mapped_dataset.num_reactions = count
+    session.flush()
+    logger.debug(f"add_parquet_dataset() took {time.time() - start:g}s ({count} reactions)")
+    if rdkit_cartridge:
+        update_rdkit_tables(metadata.dataset_id, session)
+        session.flush()
+        update_rdkit_ids(metadata.dataset_id, session)
 
 
 def get_dataset_md5(dataset_id: str, session: Session) -> str | None:

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -14,7 +14,6 @@
 
 """Functions for creating/managing the PostgreSQL database."""
 
-import hashlib
 import os
 import time
 from typing import Any, cast
@@ -94,42 +93,36 @@ _PARQUET_FLUSH_BATCH = 200
 def add_parquet_dataset(path: str, session: Session, rdkit_cartridge: bool = True) -> None:
     """Streams a Parquet-serialized Dataset into the ORM tables.
 
-    Reactions are deserialized one at a time and flushed in batches, so peak
-    memory stays bounded regardless of dataset size. The MD5 hash stored for
-    a Parquet-ingested Dataset comes from ``parquet_dataset.streaming_md5``
-    rather than from the serialized Dataset bytes (see that function for the
-    scheme; it differs from the one used for ``.pb.gz`` inputs).
+    Two passes over the Parquet file:
+
+    1. ``parquet_dataset.streaming_md5`` to compute ``md5`` and
+       ``num_reactions`` without holding Reactions in memory.
+    2. ``iter_reactions`` to insert Reaction rows in flush/expunge batches.
+
+    This keeps the canonical MD5 formula in one place
+    (``parquet_dataset.streaming_md5``) at the cost of reading the Parquet
+    file twice; both passes are streaming, so peak memory stays bounded.
     """
     start = time.time()
     metadata = parquet_dataset.read_metadata(path)
     logger.debug(f"Streaming Parquet Dataset {metadata.dataset_id}")
+    md5_hex, num_reactions = parquet_dataset.streaming_md5(path)
     reaction_child_class = Mappers.Dataset.reactions.mapper.class_
-    hasher = hashlib.md5()
-    hasher.update(f"name={metadata.name}\n".encode())
-    hasher.update(f"description={metadata.description}\n".encode())
-    hasher.update(f"dataset_id={metadata.dataset_id}\n".encode())
-    # Create the Dataset row up front with placeholder scalars; patched at end.
     mapped_dataset = Mappers.Dataset(
         name=metadata.name,
         description=metadata.description,
         dataset_id=metadata.dataset_id,
-        md5="0" * 32,
-        num_reactions=0,
+        md5=md5_hex,
+        num_reactions=num_reactions,
     )
     session.add(mapped_dataset)
     session.flush()
-    count = 0
     pending: list = []
-    for reaction_id, reaction in parquet_dataset.iter_reactions(path):
-        blob = reaction.SerializeToString(deterministic=True)
-        hasher.update(f"reaction_id={reaction_id}\n".encode())
-        hasher.update(len(blob).to_bytes(8, "big"))
-        hasher.update(blob)
+    for _, reaction in parquet_dataset.iter_reactions(path):
         reaction_mapper = from_proto(reaction, mapper=reaction_child_class)
         reaction_mapper.parent = mapped_dataset
         session.add(reaction_mapper)
         pending.append(reaction_mapper)
-        count += 1
         if len(pending) >= _PARQUET_FLUSH_BATCH:
             session.flush()
             for obj in pending:
@@ -140,10 +133,7 @@ def add_parquet_dataset(path: str, session: Session, rdkit_cartridge: bool = Tru
         for obj in pending:
             session.expunge(obj)
         pending.clear()
-    mapped_dataset.md5 = hasher.hexdigest()
-    mapped_dataset.num_reactions = count
-    session.flush()
-    logger.debug(f"add_parquet_dataset() took {time.time() - start:g}s ({count} reactions)")
+    logger.debug(f"add_parquet_dataset() took {time.time() - start:g}s ({num_reactions} reactions)")
     if rdkit_cartridge:
         update_rdkit_tables(metadata.dataset_id, session)
         session.flush()

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -28,6 +28,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 from tqdm import tqdm
 
+from ord_schema import parquet_dataset
 from ord_schema.logging import get_logger, silence_rdkit_logs
 from ord_schema.message_helpers import load_message
 from ord_schema.orm import database
@@ -38,6 +39,10 @@ logger = get_logger(__name__)
 
 def add_dataset(dsn: str, filename: str, overwrite: bool) -> str:
     """Adds a single dataset to the database.
+
+    Parquet inputs are streamed; other formats are loaded fully before being
+    inserted. See ``database.add_parquet_dataset`` for the streaming path and
+    the MD5 scheme it uses.
 
     Args:
         dsn: Database connection string.
@@ -50,11 +55,13 @@ def add_dataset(dsn: str, filename: str, overwrite: bool) -> str:
     Raises:
         ValueError: If the dataset already exists in the database and `overwrite` is not set.
     """
-    logger.debug(f"Loading {filename}")
-    dataset = load_message(filename, dataset_pb2.Dataset)
     # NOTE(skearnes): Multiprocessing is hard to get right for shared connection pools, so we don't even try; see
     # https://docs.sqlalchemy.org/en/20/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork.
     engine = create_engine(dsn)
+    if filename.endswith(".parquet"):
+        return _add_parquet_dataset(engine, filename, overwrite)
+    logger.debug(f"Loading {filename}")
+    dataset = load_message(filename, dataset_pb2.Dataset)
     with Session(engine) as session:
         with session.begin():
             dataset_md5 = database.get_dataset_md5(dataset.dataset_id, session)
@@ -74,6 +81,31 @@ def add_dataset(dsn: str, filename: str, overwrite: bool) -> str:
             database.add_dataset(dataset, session, rdkit_cartridge=False)  # Do this separately in add_rdkit().
         logger.debug(f"add_dataset() took {time.time() - start:g}s")
     return dataset.dataset_id
+
+
+def _add_parquet_dataset(engine: Engine, filename: str, overwrite: bool) -> str:
+    """Streaming ingestion path for Parquet-serialized Datasets."""
+    logger.debug(f"Streaming {filename}")
+    dataset_id = parquet_dataset.read_metadata(filename).dataset_id
+    with Session(engine) as session:
+        with session.begin():
+            dataset_md5 = database.get_dataset_md5(dataset_id, session)
+        if dataset_md5 is not None:
+            this_md5, _ = parquet_dataset.streaming_md5(filename)
+            if this_md5 != dataset_md5:
+                if not overwrite:
+                    raise ValueError(f"`overwrite` is required when a dataset already exists: {dataset_id}")
+                logger.debug(f"existing dataset {dataset_id} changed; updating")
+                with session.begin():
+                    database.delete_dataset(dataset_id, session)
+            else:
+                logger.debug(f"existing dataset {dataset_id} unchanged; skipping")
+                return dataset_id
+        start = time.time()
+        with session.begin():
+            database.add_parquet_dataset(filename, session, rdkit_cartridge=False)
+        logger.debug(f"add_parquet_dataset() took {time.time() - start:g}s")
+    return dataset_id
 
 
 def add_rdkit(engine: Engine, dataset_id: str) -> None:

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -59,40 +59,31 @@ def add_dataset(dsn: str, filename: str, overwrite: bool) -> str:
     # https://docs.sqlalchemy.org/en/20/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork.
     engine = create_engine(dsn)
     if filename.endswith(".parquet"):
-        return _add_parquet_dataset(engine, filename, overwrite)
-    logger.debug(f"Loading {filename}")
-    dataset = load_message(filename, dataset_pb2.Dataset)
-    with Session(engine) as session:
-        with session.begin():
-            dataset_md5 = database.get_dataset_md5(dataset.dataset_id, session)
-        if dataset_md5 is not None:
-            this_md5 = md5(dataset.SerializeToString(deterministic=True)).hexdigest()
-            if this_md5 != dataset_md5:
-                if not overwrite:
-                    raise ValueError(f"`overwrite` is required when a dataset already exists: {dataset.dataset_id}")
-                logger.debug(f"existing dataset {dataset.dataset_id} changed; updating")
-                with session.begin():
-                    database.delete_dataset(dataset.dataset_id, session)
-            else:
-                logger.debug(f"existing dataset {dataset.dataset_id} unchanged; skipping")
-                return dataset.dataset_id
-        start = time.time()
-        with session.begin():
+        logger.debug(f"Streaming {filename}")
+        dataset_id = parquet_dataset.read_metadata(filename).dataset_id
+
+        def compute_md5() -> str:
+            md5_hex, _ = parquet_dataset.streaming_md5(filename)
+            return md5_hex
+
+        def insert(session: Session) -> None:
+            database.add_parquet_dataset(filename, session, rdkit_cartridge=False)
+    else:
+        logger.debug(f"Loading {filename}")
+        dataset = load_message(filename, dataset_pb2.Dataset)
+        dataset_id = dataset.dataset_id
+
+        def compute_md5() -> str:
+            return md5(dataset.SerializeToString(deterministic=True)).hexdigest()
+
+        def insert(session: Session) -> None:
             database.add_dataset(dataset, session, rdkit_cartridge=False)  # Do this separately in add_rdkit().
-        logger.debug(f"add_dataset() took {time.time() - start:g}s")
-    return dataset.dataset_id
 
-
-def _add_parquet_dataset(engine: Engine, filename: str, overwrite: bool) -> str:
-    """Streaming ingestion path for Parquet-serialized Datasets."""
-    logger.debug(f"Streaming {filename}")
-    dataset_id = parquet_dataset.read_metadata(filename).dataset_id
     with Session(engine) as session:
         with session.begin():
-            dataset_md5 = database.get_dataset_md5(dataset_id, session)
-        if dataset_md5 is not None:
-            this_md5, _ = parquet_dataset.streaming_md5(filename)
-            if this_md5 != dataset_md5:
+            existing_md5 = database.get_dataset_md5(dataset_id, session)
+        if existing_md5 is not None:
+            if compute_md5() != existing_md5:
                 if not overwrite:
                     raise ValueError(f"`overwrite` is required when a dataset already exists: {dataset_id}")
                 logger.debug(f"existing dataset {dataset_id} changed; updating")
@@ -103,8 +94,8 @@ def _add_parquet_dataset(engine: Engine, filename: str, overwrite: bool) -> str:
                 return dataset_id
         start = time.time()
         with session.begin():
-            database.add_parquet_dataset(filename, session, rdkit_cartridge=False)
-        logger.debug(f"add_parquet_dataset() took {time.time() - start:g}s")
+            insert(session)
+        logger.debug(f"insert took {time.time() - start:g}s")
     return dataset_id
 
 

--- a/ord_schema/orm/scripts/add_datasets_test.py
+++ b/ord_schema/orm/scripts/add_datasets_test.py
@@ -16,8 +16,15 @@
 
 import os
 
+from sqlalchemy.orm import Session
+
+from ord_schema import message_helpers, parquet_dataset
+from ord_schema.orm import database
 from ord_schema.orm.database import prepare_database
 from ord_schema.orm.scripts import add_datasets
+from ord_schema.proto import dataset_pb2
+
+_PBTXT_FIXTURE = os.path.join(os.path.dirname(__file__), "..", "testdata", "ord-nielsen-example.pbtxt")
 
 
 def test_main(test_engine):
@@ -26,6 +33,23 @@ def test_main(test_engine):
         "--dsn",
         str(test_engine.url),
         "--pattern",
-        os.path.join(os.path.dirname(__file__), "..", "testdata", "ord-nielsen-example.pbtxt"),
+        _PBTXT_FIXTURE,
     ]
     add_datasets.main(add_datasets.parse_args(argv))
+
+
+def test_main_parquet(test_engine, tmp_path):
+    rdkit_cartridge = prepare_database(test_engine)
+    fixture = message_helpers.load_message(_PBTXT_FIXTURE, dataset_pb2.Dataset)
+    parquet_path = (tmp_path / "dataset.parquet").as_posix()
+    message_helpers.write_message(fixture, parquet_path)
+    argv = ["--dsn", str(test_engine.url), "--pattern", parquet_path]
+    add_datasets.main(add_datasets.parse_args(argv))
+    # Verify the streaming path stored the streaming MD5 and the reaction count.
+    expected_md5, expected_count = parquet_dataset.streaming_md5(parquet_path)
+    with Session(test_engine) as session:
+        assert database.get_dataset_md5(fixture.dataset_id, session) == expected_md5
+        assert database.get_dataset_size(fixture.dataset_id, session) == expected_count
+    # A second invocation without --overwrite is a no-op when the MD5 matches.
+    add_datasets.main(add_datasets.parse_args(argv))
+    del rdkit_cartridge  # Cartridge handling is exercised via main()'s add_rdkit step.

--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -26,12 +26,18 @@ This layout supports random access (by row group) and streaming iteration
 without loading the full dataset into memory.
 """
 
+import hashlib
+import io
 from collections.abc import Iterable, Iterator
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 
 from ord_schema.proto import dataset_pb2, reaction_pb2
+
+# Accepted by pq.ParquetFile: a filesystem path or a random-access readable
+# (``bytes`` is wrapped in BytesIO since ParquetFile needs seek()).
+ParquetSource = str | bytes | io.IOBase
 
 SCHEMA_VERSION = "1"
 
@@ -185,23 +191,27 @@ def read_dataset(path: str) -> dataset_pb2.Dataset:
     return dataset
 
 
-def read_metadata(path: str) -> dataset_pb2.Dataset:
+def read_metadata(source: ParquetSource) -> dataset_pb2.Dataset:
     """Reads Dataset scalar fields (``name``, ``description``, ``dataset_id``)
     from the Parquet footer. No column data is read. The returned ``Dataset``
     has no ``reactions`` or ``reaction_ids`` populated.
+
+    ``source`` is a path, a ``bytes`` blob (e.g., from ``git show``), or any
+    seekable binary file-like object.
     """
-    with pq.ParquetFile(path) as parquet_file:
+    with pq.ParquetFile(_as_parquet_file_arg(source)) as parquet_file:
         return _dataset_from_metadata(parquet_file.schema_arrow.metadata)
 
 
 def iter_reactions(
-    path: str,
+    source: ParquetSource,
     reaction_ids: Iterable[str] | None = None,
 ) -> Iterator[tuple[str, reaction_pb2.Reaction]]:
     """Yields ``(reaction_id, Reaction)`` pairs from a Parquet dataset.
 
     Args:
-        path: Parquet file path.
+        source: A path, a ``bytes`` blob, or any seekable binary file-like
+            object pointing at a Parquet-serialized Dataset.
         reaction_ids: Optional iterable of reaction IDs to restrict iteration
             to. IDs not present in the file are silently skipped. Filtering
             is applied row-wise; row groups are still read in full. Pass
@@ -215,8 +225,19 @@ def iter_reactions(
         filter_set = set(reaction_ids)
         if not filter_set:
             raise ValueError("reaction_ids must be non-empty when provided; pass None to iterate all")
-    with pq.ParquetFile(path) as parquet_file:
+    with pq.ParquetFile(_as_parquet_file_arg(source)) as parquet_file:
         yield from _iter_reactions(parquet_file, filter_set=filter_set)
+
+
+def iter_reaction_ids(source: ParquetSource) -> Iterator[str]:
+    """Streams ``reaction_id`` values from a Parquet dataset.
+
+    Only the ``reaction_id`` column is read; reactions are not deserialized.
+    Useful for cheap whole-file reaction ID scans (e.g., diff stats).
+    """
+    with pq.ParquetFile(_as_parquet_file_arg(source)) as parquet_file:
+        for batch in parquet_file.iter_batches(columns=["reaction_id"]):
+            yield from batch.column("reaction_id").to_pylist()
 
 
 def _iter_reactions(
@@ -256,6 +277,41 @@ def read_reaction(path: str, reaction_id: str) -> reaction_pb2.Reaction:
         if candidate_id == reaction_id:
             return reaction_pb2.Reaction.FromString(blob)
     raise KeyError(reaction_id)
+
+
+def streaming_md5(path: str) -> tuple[str, int]:
+    """Streams a Parquet dataset and returns ``(md5_hexdigest, reaction_count)``.
+
+    The hash is computed over a canonical byte stream derived from the Dataset
+    scalars (``name``, ``description``, ``dataset_id``) and the serialized
+    Reactions in file order. It is stable across row-group layouts and
+    compression codec choices, and is intended for detecting content changes
+    when ingesting large Parquet datasets without materializing the full
+    ``Dataset`` message.
+
+    The scheme deliberately differs from ``md5(Dataset.SerializeToString())``:
+    the first re-ingest of a dataset that was previously loaded from ``.pb.gz``
+    will therefore look like a content change.
+    """
+    hasher = hashlib.md5()
+    metadata = read_metadata(path)
+    hasher.update(f"name={metadata.name}\n".encode())
+    hasher.update(f"description={metadata.description}\n".encode())
+    hasher.update(f"dataset_id={metadata.dataset_id}\n".encode())
+    count = 0
+    for reaction_id, reaction in iter_reactions(path):
+        blob = reaction.SerializeToString(deterministic=True)
+        hasher.update(f"reaction_id={reaction_id}\n".encode())
+        hasher.update(len(blob).to_bytes(8, "big"))
+        hasher.update(blob)
+        count += 1
+    return hasher.hexdigest(), count
+
+
+def _as_parquet_file_arg(source: ParquetSource) -> str | io.IOBase:
+    if isinstance(source, bytes):
+        return io.BytesIO(source)
+    return source
 
 
 def _build_schema(*, name: str, description: str, dataset_id: str | None) -> pa.Schema:

--- a/ord_schema/scripts/process_dataset.py
+++ b/ord_schema/scripts/process_dataset.py
@@ -32,15 +32,18 @@ import dataclasses
 import glob
 import gzip
 import os
+import re
 import subprocess
 import sys
-from collections.abc import Iterable, Mapping
+import tempfile
+import uuid
+from collections.abc import Iterable
 
 import github
 
-from ord_schema import message_helpers, updates, validations
+from ord_schema import message_helpers, parquet_dataset, updates, validations
 from ord_schema.logging import get_logger, silence_rdkit_logs
-from ord_schema.proto import dataset_pb2
+from ord_schema.proto import dataset_pb2, reaction_pb2
 
 logger = get_logger(__name__)
 
@@ -105,6 +108,10 @@ def cleanup(filename: str, output_filename: str):
     subprocess.run(args, check=True)
 
 
+def _is_parquet(filename: str) -> bool:
+    return filename.endswith(".parquet")
+
+
 def _get_reaction_ids(dataset: dataset_pb2.Dataset) -> set[str]:
     """Returns a set containing the reaction IDs in a Dataset."""
     reaction_ids = set()
@@ -114,8 +121,13 @@ def _get_reaction_ids(dataset: dataset_pb2.Dataset) -> set[str]:
     return reaction_ids
 
 
-def _load_base_dataset(file_status: FileStatus, base: str) -> dataset_pb2.Dataset | None:
-    """Loads a Dataset message from another branch."""
+def _reaction_ids_from_path(filename: str) -> set[str]:
+    """Streams reaction IDs from a Parquet file without deserializing Reactions."""
+    return {rid for rid in parquet_dataset.iter_reaction_ids(filename) if rid}
+
+
+def _load_base_reaction_ids(file_status: FileStatus, base: str) -> set[str] | None:
+    """Returns the reaction IDs from the base-branch version of a file, or None if new."""
     if file_status.status.startswith("A"):
         return None  # Dataset only exists in the submission.
     # NOTE(kearnes): Use --no-pager to avoid a non-zero exit code.
@@ -135,22 +147,26 @@ def _load_base_dataset(file_status: FileStatus, base: str) -> dataset_pb2.Datase
             check=True,
             text=False,
         )
-    if git_args[-1].endswith(".gz"):
+    git_path = git_args[-1]
+    if _is_parquet(git_path) or git_path.endswith(".parquet.gz"):
+        # Second clause is defensive; Parquet files are not gzip-wrapped.
+        return {rid for rid in parquet_dataset.iter_reaction_ids(serialized.stdout) if rid}
+    if git_path.endswith(".gz"):
         value = gzip.decompress(serialized.stdout)
     else:
         value = serialized.stdout
-    return dataset_pb2.Dataset.FromString(value)
+    return _get_reaction_ids(dataset_pb2.Dataset.FromString(value))
 
 
 def get_change_stats(
-    datasets: Mapping[str, dataset_pb2.Dataset | None], inputs: Iterable[FileStatus], base: str
+    reaction_ids: Iterable[tuple[FileStatus, set[str] | None]],
+    base: str,
 ) -> tuple[set[str], set[str], set[str]]:
     """Computes diff statistics for the submission.
 
     Args:
-        datasets: Dict mapping filenames to Dataset messages. Values may be None only
-            for deleted files; non-deleted inputs must have a Dataset for `filename`.
-        inputs: List of FileStatus objects.
+        reaction_ids: Iterable of (FileStatus, current_reaction_ids). The
+            current set is None only for deleted files.
         base: Git branch to diff against.
 
     Returns:
@@ -159,43 +175,132 @@ def get_change_stats(
         changed: Set of changed reaction IDs.
     """
     old, new = set(), set()
-    for file_status in inputs:
+    for file_status, current in reaction_ids:
         if not file_status.status.startswith("D"):
-            current = datasets[file_status.filename]
             if current is None:
-                raise ValueError(f"missing dataset for non-deleted file: {file_status.filename}")
-            new.update(_get_reaction_ids(current))
-        dataset = _load_base_dataset(file_status, base)
-        if dataset is not None:
-            old.update(_get_reaction_ids(dataset))
+                raise ValueError(f"missing reaction IDs for non-deleted file: {file_status.filename}")
+            new.update(current)
+        base_ids = _load_base_reaction_ids(file_status, base)
+        if base_ids is not None:
+            old.update(base_ids)
     return new - old, old - new, new & old
 
 
-def _run_updates(
-    datasets: Mapping[str, dataset_pb2.Dataset],
+def _apply_id_substitutions(reaction: reaction_pb2.Reaction, id_substitutions: dict[str, str]) -> None:
+    """Rewrites cross-referenced reaction IDs in-place using ``updates.update_dataset`` semantics."""
+    for reaction_input in reaction.inputs.values():
+        for component in reaction_input.components:
+            for preparation in component.preparations:
+                if preparation.reaction_id and preparation.reaction_id in id_substitutions:
+                    preparation.reaction_id = id_substitutions[preparation.reaction_id]
+        for crude_component in reaction_input.crude_components:
+            if crude_component.reaction_id in id_substitutions:
+                crude_component.reaction_id = id_substitutions[crude_component.reaction_id]
+
+
+def _run_updates_eager(
+    filename: str,
+    dataset: dataset_pb2.Dataset,
     *,
     root: str,
     output_format: str,
     write_errors: bool,
     cleanup_files: bool,
 ) -> None:
-    """Updates the submission files."""
-    for dataset in datasets.values():
-        # Set reaction_ids, resolve names, fix cross-references, etc.
-        updates.update_dataset(dataset)
-    # Final validation to make sure we didn't break anything.
+    """Updates the submission file for a single non-Parquet Dataset."""
+    updates.update_dataset(dataset)
     options = validations.ValidationOptions(validate_ids=True, require_provenance=True)
-    validations.validate_datasets(datasets, write_errors, options=options)
-    for filename, dataset in datasets.items():
-        output_filename = os.path.join(
-            root,
-            message_helpers.id_filename(f"{dataset.dataset_id}{output_format}"),
+    validations.validate_datasets({filename: dataset}, write_errors, options=options)
+    output_filename = os.path.join(
+        root,
+        message_helpers.id_filename(f"{dataset.dataset_id}{output_format}"),
+    )
+    os.makedirs(os.path.dirname(output_filename), exist_ok=True)
+    if cleanup_files:
+        cleanup(filename, output_filename)
+    logger.info("writing Dataset to %s", output_filename)
+    message_helpers.write_message(dataset, output_filename)
+
+
+def _run_updates_streaming(
+    filename: str,
+    *,
+    root: str,
+    output_format: str,
+    write_errors: bool,
+    cleanup_files: bool,
+) -> None:
+    """Updates a Parquet submission file via a streaming pipeline."""
+    if output_format != ".parquet":
+        raise ValueError(
+            f"Parquet inputs require --output_format .parquet to preserve streaming; got {output_format!r}"
         )
-        os.makedirs(os.path.dirname(output_filename), exist_ok=True)
+    # Resolve the final output path up-front so the streaming pipeline can
+    # write directly there. We peek at metadata to decide the dataset_id.
+    metadata = parquet_dataset.read_metadata(filename)
+    if re.fullmatch("^ord_dataset-[0-9a-f]{32}$", metadata.dataset_id):
+        dataset_id = metadata.dataset_id
+    else:
+        dataset_id = f"ord_dataset-{uuid.uuid4().hex}"
+    output_filename = os.path.join(
+        root,
+        message_helpers.id_filename(f"{dataset_id}{output_format}"),
+    )
+    os.makedirs(os.path.dirname(output_filename), exist_ok=True)
+    if filename == output_filename:
+        # Streaming requires distinct input and output; write to a sibling and rename.
+        tmp_output = f"{output_filename}.new"
+        metadata.dataset_id = dataset_id  # Ensure consistency if we bypass the ID reassignment.
+        _update_dataset_parquet_streaming_with_id(filename, tmp_output, dataset_id=dataset_id)
+        os.replace(tmp_output, output_filename)
+    else:
+        _update_dataset_parquet_streaming_with_id(filename, output_filename, dataset_id=dataset_id)
         if cleanup_files:
             cleanup(filename, output_filename)
-        logger.info("writing Dataset to %s", output_filename)
-        message_helpers.write_message(dataset, output_filename)
+    options = validations.ValidationOptions(validate_ids=True, require_provenance=True)
+    validations.validate_parquet_datasets([output_filename], write_errors=write_errors, options=options)
+    logger.info("writing Dataset to %s", output_filename)
+
+
+def _update_dataset_parquet_streaming_with_id(
+    input_path: str,
+    output_path: str,
+    *,
+    dataset_id: str,
+) -> None:
+    """Variant of the two-pass update pipeline with a pre-resolved dataset_id."""
+    metadata = parquet_dataset.read_metadata(input_path)
+    metadata.dataset_id = dataset_id
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(
+        prefix=".update-",
+        suffix=".parquet",
+        dir=os.path.dirname(output_path) or None,
+    )
+    os.close(tmp_fd)
+    try:
+        id_substitutions: dict[str, str] = {}
+        with parquet_dataset.DatasetWriter(
+            tmp_path,
+            name=metadata.name,
+            description=metadata.description,
+            dataset_id=metadata.dataset_id,
+        ) as writer:
+            for _, reaction in parquet_dataset.iter_reactions(input_path):
+                id_substitutions.update(updates.update_reaction(reaction))
+                writer.write(reaction)
+        with parquet_dataset.DatasetWriter(
+            output_path,
+            name=metadata.name,
+            description=metadata.description,
+            dataset_id=metadata.dataset_id,
+        ) as writer:
+            for _, reaction in parquet_dataset.iter_reactions(tmp_path):
+                _apply_id_substitutions(reaction, id_substitutions)
+                writer.write(reaction)
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
 
 
 def run(args) -> tuple[set[str] | None, set[str] | None, set[str] | None]:
@@ -217,25 +322,40 @@ def run(args) -> tuple[set[str] | None, set[str] | None, set[str] | None]:
     # NOTE(kearnes): Process one dataset at a time to avoid OOM errors.
     change_stats = {}
     for file_status in inputs:
-        if file_status.status == "D":
-            dataset = None
+        is_parquet = _is_parquet(file_status.filename)
+        deleted = file_status.status == "D"
+        # Validation + size checks (stream for Parquet, load fully otherwise).
+        current_reaction_ids: set[str] | None
+        if deleted:
+            current_reaction_ids = None
+        elif is_parquet:
+            if not args.no_validate:
+                validations.validate_parquet_datasets([file_status.filename], write_errors=args.write_errors)
+            current_reaction_ids = set()
+            max_bytes = args.max_size * 1e6
+            for reaction_id, reaction in parquet_dataset.iter_reactions(file_status.filename):
+                blob = reaction.SerializeToString()
+                if sys.getsizeof(blob) > max_bytes:
+                    reaction_size = sys.getsizeof(blob) / 1e6
+                    raise ValueError(f"Reaction is larger than --max_size ({reaction_size} vs {args.max_size})")
+                if reaction_id:
+                    current_reaction_ids.add(reaction_id)
+            logger.info("%s: %d reactions", file_status.filename, len(current_reaction_ids))
         else:
             dataset = message_helpers.load_message(file_status.filename, dataset_pb2.Dataset)
             logger.info("%s: %d reactions", file_status.filename, len(dataset.reactions))
-        datasets: dict[str, dataset_pb2.Dataset | None] = {file_status.filename: dataset}
-        datasets_checked: dict[str, dataset_pb2.Dataset] = (
-            {file_status.filename: dataset} if dataset is not None else {}
-        )
-        if not args.no_validate and dataset is not None:
-            # Note: this does not check if IDs are malformed.
-            validations.validate_datasets(datasets_checked, args.write_errors)
-            # Check reaction sizes.
-            for reaction in dataset.reactions:
-                reaction_size = sys.getsizeof(reaction.SerializeToString()) / 1e6
-                if reaction_size > args.max_size:
-                    raise ValueError(f"Reaction is larger than --max_size ({reaction_size} vs {args.max_size})")
+            if not args.no_validate:
+                validations.validate_datasets({file_status.filename: dataset}, args.write_errors)
+                for reaction in dataset.reactions:
+                    reaction_size = sys.getsizeof(reaction.SerializeToString()) / 1e6
+                    if reaction_size > args.max_size:
+                        raise ValueError(f"Reaction is larger than --max_size ({reaction_size} vs {args.max_size})")
+            current_reaction_ids = _get_reaction_ids(dataset)
         if args.base:
-            added, removed, changed = get_change_stats(datasets, [file_status], base=args.base)
+            added, removed, changed = get_change_stats(
+                [(file_status, current_reaction_ids)],
+                base=args.base,
+            )
             change_stats[file_status.filename] = (added, removed, changed)
             logger.info(
                 "Summary: +%d -%d Δ%d reaction IDs",
@@ -243,14 +363,24 @@ def run(args) -> tuple[set[str] | None, set[str] | None, set[str] | None]:
                 len(removed),
                 len(changed),
             )
-        if args.update and dataset is not None:
-            _run_updates(
-                datasets_checked,
-                root=args.root,
-                output_format=args.output_format,
-                write_errors=args.write_errors,
-                cleanup_files=args.cleanup,
-            )
+        if args.update and not deleted:
+            if is_parquet:
+                _run_updates_streaming(
+                    file_status.filename,
+                    root=args.root,
+                    output_format=args.output_format,
+                    write_errors=args.write_errors,
+                    cleanup_files=args.cleanup,
+                )
+            else:
+                _run_updates_eager(
+                    file_status.filename,
+                    dataset,
+                    root=args.root,
+                    output_format=args.output_format,
+                    write_errors=args.write_errors,
+                    cleanup_files=args.cleanup,
+                )
     if change_stats:
         total_added, total_removed, total_changed = set(), set(), set()
         comment = [

--- a/ord_schema/scripts/process_dataset_test.py
+++ b/ord_schema/scripts/process_dataset_test.py
@@ -21,7 +21,7 @@ from collections.abc import Iterator
 import pytest
 from rdkit import RDLogger
 
-from ord_schema import message_helpers, validations
+from ord_schema import message_helpers, parquet_dataset, validations
 from ord_schema.logging import get_logger
 from ord_schema.proto import dataset_pb2, reaction_pb2
 from ord_schema.scripts import process_dataset
@@ -108,6 +108,141 @@ class TestProcessDataset:
         dataset = message_helpers.load_message(expected_output, dataset_pb2.Dataset)
         assert len(dataset.reactions) == 1
         assert dataset.reactions[0].reaction_id.startswith("ord-")
+
+    @pytest.fixture
+    def parquet_setup(self, tmp_path) -> Iterator[str]:
+        RDLogger.logger().setLevel(RDLogger.CRITICAL)
+        reaction = reaction_pb2.Reaction()
+        dummy_input = reaction.inputs["dummy_input"]
+        dummy_component = dummy_input.components.add()
+        dummy_component.identifiers.add(type="CUSTOM", details="custom_identifier", value="custom_value")
+        dummy_component.is_limiting = True
+        dummy_component.amount.mass.value = 1
+        dummy_component.amount.mass.units = reaction_pb2.Mass.GRAM
+        reaction.outcomes.add().conversion.value = 75
+        reaction.provenance.record_created.time.value = "2020-01-01"
+        reaction.provenance.record_created.person.username = "test"
+        reaction.provenance.record_created.person.email = "test@example.com"
+        dataset = dataset_pb2.Dataset(
+            name="parquet",
+            description="parquet",
+            dataset_id="ord_dataset-00000000000000000000000000000000",
+            reactions=[reaction],
+        )
+        filename = (tmp_path / "dataset.parquet").as_posix()
+        message_helpers.write_message(dataset, filename)
+        yield filename
+
+    def test_parquet_validate(self, parquet_setup):
+        argv = ["--input_pattern", parquet_setup]
+        process_dataset.main(process_dataset.parse_args(argv))
+
+    def test_parquet_updates(self, parquet_setup, tmp_path):
+        argv = [
+            "--input_pattern",
+            parquet_setup,
+            "--root",
+            tmp_path.as_posix(),
+            "--output_format",
+            ".parquet",
+            "--update",
+        ]
+        process_dataset.main(process_dataset.parse_args(argv))
+        expected_output = os.path.join(
+            tmp_path.as_posix(),
+            "data",
+            "00",
+            "ord_dataset-00000000000000000000000000000000.parquet",
+        )
+        assert os.path.exists(expected_output)
+        reactions = [reaction for _, reaction in parquet_dataset.iter_reactions(expected_output)]
+        assert len(reactions) == 1
+        assert reactions[0].reaction_id.startswith("ord-")
+
+    def test_parquet_rejects_non_parquet_output(self, parquet_setup, tmp_path):
+        argv = [
+            "--input_pattern",
+            parquet_setup,
+            "--root",
+            tmp_path.as_posix(),
+            "--update",  # Default --output_format is .pb.gz.
+        ]
+        with pytest.raises(ValueError, match="require --output_format .parquet"):
+            process_dataset.main(process_dataset.parse_args(argv))
+
+    def test_parquet_validation_errors(self, tmp_path):
+        bad_dataset = dataset_pb2.Dataset(
+            name="bad",
+            description="bad",
+            reactions=[reaction_pb2.Reaction(reaction_id="ord-0")],
+        )
+        path = (tmp_path / "bad.parquet").as_posix()
+        message_helpers.write_message(bad_dataset, path)
+        argv = ["--input_pattern", path, "--write_errors"]
+        with pytest.raises(validations.ValidationError, match="validation encountered errors"):
+            process_dataset.main(process_dataset.parse_args(argv))
+        assert os.path.exists(f"{path}.error")
+
+    def test_parquet_cross_reference_rewrite(self, tmp_path):
+        # Two reactions where reaction B references reaction A's placeholder ID via crude_components;
+        # the streaming update pipeline should rewrite both to the assigned ord- IDs.
+        def _with_provenance(reaction):
+            reaction.provenance.record_created.time.value = "2020-01-01"
+            reaction.provenance.record_created.person.username = "test"
+            reaction.provenance.record_created.person.email = "test@example.com"
+            return reaction
+
+        reaction_a = reaction_pb2.Reaction(reaction_id="placeholder_a")
+        input_a = reaction_a.inputs["dummy"]
+        compound_a = input_a.components.add()
+        compound_a.identifiers.add(type="CUSTOM", details="d", value="v")
+        compound_a.is_limiting = True
+        compound_a.amount.mass.value = 1
+        compound_a.amount.mass.units = reaction_pb2.Mass.GRAM
+        reaction_a.outcomes.add().conversion.value = 75
+        _with_provenance(reaction_a)
+
+        reaction_b = reaction_pb2.Reaction(reaction_id="placeholder_b")
+        input_b = reaction_b.inputs["crude"]
+        crude = input_b.crude_components.add()
+        crude.reaction_id = "placeholder_a"
+        crude.has_derived_amount = True
+        # A second input with a limiting Compound satisfies the is_limiting requirement
+        # imposed when conversion is specified.
+        compound_b = reaction_b.inputs["dummy_b"].components.add()
+        compound_b.identifiers.add(type="CUSTOM", details="d", value="v")
+        compound_b.is_limiting = True
+        compound_b.amount.mass.value = 1
+        compound_b.amount.mass.units = reaction_pb2.Mass.GRAM
+        reaction_b.outcomes.add().conversion.value = 50
+        _with_provenance(reaction_b)
+
+        dataset = dataset_pb2.Dataset(name="x", description="x", reactions=[reaction_a, reaction_b])
+        input_path = (tmp_path / "in.parquet").as_posix()
+        message_helpers.write_message(dataset, input_path)
+        argv = [
+            "--input_pattern",
+            input_path,
+            "--root",
+            tmp_path.as_posix(),
+            "--output_format",
+            ".parquet",
+            "--update",
+            "--no-validate",
+        ]
+        process_dataset.main(process_dataset.parse_args(argv))
+        # The dataset_id was assigned; find the single output parquet.
+        outputs = glob.glob(os.path.join(tmp_path.as_posix(), "data", "*", "ord_dataset-*.parquet"))
+        assert len(outputs) == 1
+        reactions = [reaction for _, reaction in parquet_dataset.iter_reactions(outputs[0])]
+        assert len(reactions) == 2
+        # The reaction with crude_components is reaction_b; its crude_components.reaction_id
+        # should be rewritten to reaction_a's newly-assigned ord- ID.
+        reaction_a_out = next(r for r in reactions if "dummy" in r.inputs)
+        reaction_b_out = next(r for r in reactions if "crude" in r.inputs)
+        assert reaction_a_out.reaction_id.startswith("ord-")
+        assert reaction_b_out.reaction_id.startswith("ord-")
+        assert reaction_b_out.inputs["crude"].crude_components[0].reaction_id == reaction_a_out.reaction_id
 
 
 class TestSubmissionWorkflow:

--- a/ord_schema/scripts/validate_dataset.py
+++ b/ord_schema/scripts/validate_dataset.py
@@ -38,8 +38,16 @@ def filter_filenames(filenames: Iterable[str], pattern: str) -> list[str]:
 
 
 def run(filename: str) -> None:
-    """Validates a single dataset."""
+    """Validates a single dataset.
+
+    Parquet inputs are validated by streaming Reactions one at a time, so peak
+    memory stays bounded for large datasets. Other formats fall back to the
+    whole-dataset load.
+    """
     silence_rdkit_logs()
+    if filename.endswith(".parquet"):
+        validations.validate_parquet_datasets([filename])
+        return
     dataset = message_helpers.load_message(filename, dataset_pb2.Dataset)
     validations.validate_datasets({filename: dataset})
 

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -72,6 +72,41 @@ def test_validation_errors(setup):
         validate_dataset.main(validate_dataset.parse_args(argv))
 
 
+def test_parquet_input(tmp_path):
+    reaction = reaction_pb2.Reaction()
+    dummy_input = reaction.inputs["dummy_input"]
+    dummy_component = dummy_input.components.add()
+    dummy_component.identifiers.add(type="CUSTOM", details="custom_identifier", value="custom_value")
+    dummy_component.is_limiting = True
+    dummy_component.amount.mass.value = 1
+    dummy_component.amount.mass.units = reaction_pb2.Mass.GRAM
+    reaction.outcomes.add().conversion.value = 75
+    reaction.provenance.record_created.time.value = "2023-07-01"
+    reaction.provenance.record_created.person.name = "test"
+    reaction.provenance.record_created.person.email = "test@example.com"
+    dataset = dataset_pb2.Dataset(name="parquet", description="parquet", reactions=[reaction])
+    path = (tmp_path / "dataset.parquet").as_posix()
+    message_helpers.write_message(dataset, path)
+    # Passes validation when streamed.
+    validate_dataset.main(validate_dataset.parse_args(["--input", path]))
+
+
+def test_parquet_validation_errors(tmp_path):
+    # Empty reaction fails per-reaction validation via the streaming path.
+    bad_dataset = dataset_pb2.Dataset(
+        name="bad",
+        description="bad",
+        reactions=[reaction_pb2.Reaction(reaction_id="ord-0")],
+    )
+    path = (tmp_path / "bad.parquet").as_posix()
+    message_helpers.write_message(bad_dataset, path)
+    with pytest.raises(
+        validations.ValidationError,
+        match="Reactions should have at least 1 reaction input",
+    ):
+        validate_dataset.main(validate_dataset.parse_args(["--input", path]))
+
+
 @pytest.mark.parametrize(
     "pattern,expected",
     (

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -27,7 +27,7 @@ from rdkit import Chem
 from rdkit import __version__ as RDKIT_VERSION
 
 import ord_schema
-from ord_schema import message_helpers
+from ord_schema import message_helpers, parquet_dataset
 from ord_schema.logging import get_logger
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
@@ -164,8 +164,6 @@ def _validate_parquet_dataset(
     options: ValidationOptions | None = None,
 ) -> list[str]:
     """Streaming counterpart of ``_validate_datasets`` for Parquet inputs."""
-    from ord_schema import parquet_dataset
-
     label = os.path.basename(path)
     errors: list[str] = []
     # Dataset-level scalar checks. ``read_metadata`` already enforces presence of

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -18,7 +18,7 @@ import math
 import os
 import re
 import warnings
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from enum import IntEnum
 from typing import Any
 
@@ -122,6 +122,90 @@ def _validate_datasets(
         errors.append(error)
         logger.error(f"Validation error for {label}: {error}")
 
+    return errors
+
+
+def validate_parquet_datasets(
+    paths: Iterable[str],
+    write_errors: bool = False,
+    options: ValidationOptions | None = None,
+) -> None:
+    """Streams Reactions from Parquet datasets and validates them.
+
+    Reactions are deserialized one at a time, so peak memory stays bounded
+    regardless of dataset size. Dataset-level scalar checks come from the
+    Parquet footer; cross-reference checks accumulate during the single pass.
+
+    Args:
+        paths: Parquet file paths. Each must be a Parquet-serialized Dataset.
+        write_errors: If True, errors are written to a ``{path}.error`` file.
+        options: ValidationOptions.
+
+    Raises:
+        ValidationError: if any Dataset does not pass validation.
+    """
+    all_errors = []
+    for path in paths:
+        errors = _validate_parquet_dataset(path, options=options)
+        if errors:
+            for error in errors:
+                all_errors.append(f"{path}: {error}")
+            if write_errors:
+                with open(f"{path}.error", "w") as f:
+                    for error in errors:
+                        f.write(f"{error}\n")
+    if all_errors:
+        error_string = "\n".join(all_errors)
+        raise ValidationError(f"validation encountered errors:\n{error_string}")
+
+
+def _validate_parquet_dataset(
+    path: str,
+    options: ValidationOptions | None = None,
+) -> list[str]:
+    """Streaming counterpart of ``_validate_datasets`` for Parquet inputs."""
+    from ord_schema import parquet_dataset
+
+    label = os.path.basename(path)
+    errors: list[str] = []
+    # Dataset-level scalar checks. ``read_metadata`` already enforces presence of
+    # ``name`` and ``description``; only ``dataset_id`` has an optional check.
+    dataset = parquet_dataset.read_metadata(path)
+    if options is not None and options.validate_ids and not is_valid_dataset_id(dataset.dataset_id):
+        error = "Dataset: Dataset ID is malformed"
+        errors.append(error)
+        logger.error(f"Validation error for {label}: {error}")
+    # Per-reaction validation and cross-reference accumulation.
+    defined_ids: set[str] = set()
+    duplicate_ids: set[str] = set()
+    self_references: set[str] = set()
+    referenced_ids: set[str] = set()
+    for i, (_, reaction) in enumerate(parquet_dataset.iter_reactions(path)):
+        reaction_output = validate_message(reaction, raise_on_error=False, options=options)
+        for error in reaction_output.errors:
+            errors.append(error)
+            logger.error(f"Validation error for {label}[{i}]: {error}")
+        if reaction.reaction_id:
+            if reaction.reaction_id in defined_ids:
+                duplicate_ids.add(reaction.reaction_id)
+            defined_ids.add(reaction.reaction_id)
+        reaction_refs = get_referenced_reaction_ids(reaction)
+        if reaction.reaction_id and reaction.reaction_id in reaction_refs:
+            self_references.add(reaction.reaction_id)
+        referenced_ids |= reaction_refs
+    if duplicate_ids:
+        error = "Dataset: Multiple Reactions should never have the same IDs"
+        errors.append(error)
+        logger.error(f"Validation error for {label}: {error}")
+    if self_references:
+        error = "Dataset: A Reaction should not reference its own ID"
+        errors.append(error)
+        logger.error(f"Validation error for {label}: {error}")
+    missing = referenced_ids - defined_ids
+    if missing:
+        error = f"Dataset: Reactions in the Dataset refer to undefined reaction_ids {missing}"
+        errors.append(error)
+        logger.error(f"Validation error for {label}: {error}")
     return errors
 
 

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -91,40 +91,6 @@ def validate_datasets(
         raise ValidationError(f"validation encountered errors:\n{error_string}")
 
 
-def _validate_datasets(
-    dataset: dataset_pb2.Dataset,
-    label: str = "dataset",
-    options: ValidationOptions | None = None,
-) -> list[str]:
-    """Validates Reaction messages and cross-references in a Dataset.
-
-    Args:
-        dataset: dataset_pb2.Dataset message.
-        label: string label for logging purposes only.
-        options: ValidationOptions.
-
-    Returns:
-        List of validation error messages.
-    """
-    errors = []
-    # Reaction-level validation.
-    num_bad_reactions = 0
-    for i, reaction in enumerate(dataset.reactions):
-        reaction_output = validate_message(reaction, raise_on_error=False, options=options)
-        if reaction_output.errors:
-            num_bad_reactions += 1
-        for error in reaction_output.errors:
-            errors.append(error)
-            logger.error(f"Validation error for {label}[{i}]: {error}")
-    # Dataset-level validation of cross-references.
-    dataset_output = validate_message(dataset, raise_on_error=False, recurse=False, options=options)
-    for error in dataset_output.errors:
-        errors.append(error)
-        logger.error(f"Validation error for {label}: {error}")
-
-    return errors
-
-
 def validate_parquet_datasets(
     paths: Iterable[str],
     write_errors: bool = False,
@@ -146,7 +112,9 @@ def validate_parquet_datasets(
     """
     all_errors = []
     for path in paths:
-        errors = _validate_parquet_dataset(path, options=options)
+        scalars = parquet_dataset.read_metadata(path)
+        reactions = (reaction for _, reaction in parquet_dataset.iter_reactions(path))
+        errors = _validate_single_dataset(scalars, reactions, label=os.path.basename(path), options=options)
         if errors:
             for error in errors:
                 all_errors.append(f"{path}: {error}")
@@ -159,49 +127,74 @@ def validate_parquet_datasets(
         raise ValidationError(f"validation encountered errors:\n{error_string}")
 
 
-def _validate_parquet_dataset(
-    path: str,
+@dataclasses.dataclass
+class _DatasetReactionStats:
+    """Aggregated state used for Dataset-level cross-reference checks.
+
+    Populated either by iterating ``Dataset.reactions`` (non-streaming) or by
+    streaming Reactions from a Parquet file. ``validate_dataset`` accepts a
+    pre-computed instance so the streaming path does not need to re-iterate.
+    """
+
+    num_reactions: int = 0
+    defined_ids: set[str] = dataclasses.field(default_factory=set)
+    referenced_ids: set[str] = dataclasses.field(default_factory=set)
+    # Preserve per-occurrence warning cardinality: one entry per duplicate /
+    # self-reference event observed during iteration.
+    duplicate_events: list[str] = dataclasses.field(default_factory=list)
+    self_reference_events: list[str] = dataclasses.field(default_factory=list)
+
+    def observe(self, reaction: reaction_pb2.Reaction) -> None:
+        self.num_reactions += 1
+        if reaction.reaction_id:
+            if reaction.reaction_id in self.defined_ids:
+                self.duplicate_events.append(reaction.reaction_id)
+            self.defined_ids.add(reaction.reaction_id)
+        refs = get_referenced_reaction_ids(reaction)
+        if reaction.reaction_id and reaction.reaction_id in refs:
+            self.self_reference_events.append(reaction.reaction_id)
+        self.referenced_ids |= refs
+
+
+def _validate_datasets(
+    dataset: dataset_pb2.Dataset,
+    label: str = "dataset",
     options: ValidationOptions | None = None,
 ) -> list[str]:
-    """Streaming counterpart of ``_validate_datasets`` for Parquet inputs."""
-    label = os.path.basename(path)
+    """Validates Reaction messages and cross-references in a Dataset."""
+    return _validate_single_dataset(dataset, dataset.reactions, label=label, options=options)
+
+
+def _validate_single_dataset(
+    scalars: dataset_pb2.Dataset,
+    reactions: Iterable[reaction_pb2.Reaction],
+    label: str,
+    options: ValidationOptions | None = None,
+) -> list[str]:
+    """Validates a single Dataset given its scalars and a Reaction iterable.
+
+    A single pass over ``reactions`` both validates each Reaction individually
+    and accumulates the cross-reference state used for Dataset-level checks,
+    so the iterable (a full list or a streaming Parquet reader) is consumed
+    exactly once.
+    """
     errors: list[str] = []
-    # Dataset-level scalar checks. ``read_metadata`` already enforces presence of
-    # ``name`` and ``description``; only ``dataset_id`` has an optional check.
-    dataset = parquet_dataset.read_metadata(path)
-    if options is not None and options.validate_ids and not is_valid_dataset_id(dataset.dataset_id):
-        error = "Dataset: Dataset ID is malformed"
-        errors.append(error)
-        logger.error(f"Validation error for {label}: {error}")
-    # Per-reaction validation and cross-reference accumulation.
-    defined_ids: set[str] = set()
-    duplicate_ids: set[str] = set()
-    self_references: set[str] = set()
-    referenced_ids: set[str] = set()
-    for i, (_, reaction) in enumerate(parquet_dataset.iter_reactions(path)):
+    stats = _DatasetReactionStats()
+    for i, reaction in enumerate(reactions):
         reaction_output = validate_message(reaction, raise_on_error=False, options=options)
         for error in reaction_output.errors:
             errors.append(error)
             logger.error(f"Validation error for {label}[{i}]: {error}")
-        if reaction.reaction_id:
-            if reaction.reaction_id in defined_ids:
-                duplicate_ids.add(reaction.reaction_id)
-            defined_ids.add(reaction.reaction_id)
-        reaction_refs = get_referenced_reaction_ids(reaction)
-        if reaction.reaction_id and reaction.reaction_id in reaction_refs:
-            self_references.add(reaction.reaction_id)
-        referenced_ids |= reaction_refs
-    if duplicate_ids:
-        error = "Dataset: Multiple Reactions should never have the same IDs"
-        errors.append(error)
-        logger.error(f"Validation error for {label}: {error}")
-    if self_references:
-        error = "Dataset: A Reaction should not reference its own ID"
-        errors.append(error)
-        logger.error(f"Validation error for {label}: {error}")
-    missing = referenced_ids - defined_ids
-    if missing:
-        error = f"Dataset: Reactions in the Dataset refer to undefined reaction_ids {missing}"
+        stats.observe(reaction)
+    # Emit Dataset-level warnings using the accumulated stats. We bypass
+    # ``validate_message(dataset, recurse=False)`` here to avoid a second pass
+    # over ``scalars.reactions`` (which is empty on the streaming path).
+    with warnings.catch_warnings(record=True) as tape:
+        validate_dataset(scalars, options=options, stats=stats)
+    for warning in tape:
+        if not issubclass(warning.category, ValidationError):
+            continue
+        error = f"Dataset: {warning.message}"
         errors.append(error)
         logger.error(f"Validation error for {label}: {error}")
     return errors
@@ -454,16 +447,27 @@ def is_valid_dataset_id(dataset_id: str) -> bool:
     return bool(match)
 
 
-def validate_dataset(message: dataset_pb2.Dataset, options: ValidationOptions | None = None):
+def validate_dataset(
+    message: dataset_pb2.Dataset,
+    options: ValidationOptions | None = None,
+    *,
+    stats: _DatasetReactionStats | None = None,
+):
     if options is None:
         options = ValidationOptions()
+    if stats is None:
+        # Build stats from ``message.reactions`` for callers that came through
+        # ``_VALIDATOR_SWITCH`` (e.g., a direct ``validate_message(dataset)``).
+        stats = _DatasetReactionStats()
+        for reaction in message.reactions:
+            stats.observe(reaction)
     if not message.name:
         warnings.warn("Dataset name is required", ValidationError)
     if not message.description:
         warnings.warn("Dataset description is required", ValidationError)
-    if not message.reactions and not message.reaction_ids:
+    if not stats.num_reactions and not message.reaction_ids:
         warnings.warn("Dataset requires reactions or reaction_ids", ValidationError)
-    elif message.reactions and message.reaction_ids:
+    elif stats.num_reactions and message.reaction_ids:
         warnings.warn("Dataset requires reactions or reaction_ids, not both", ValidationError)
     if message.reaction_ids:
         for reaction_id in message.reaction_ids:
@@ -473,24 +477,14 @@ def validate_dataset(message: dataset_pb2.Dataset, options: ValidationOptions | 
         # The dataset_id is a 32-character uuid4 hex string.
         if not is_valid_dataset_id(message.dataset_id):
             warnings.warn("Dataset ID is malformed", ValidationError)
-    # Check cross-references
-    dataset_referenced_ids = set()
-    dataset_defined_ids = set()
-    for reaction in message.reactions:
-        if reaction.reaction_id:
-            if reaction.reaction_id in dataset_defined_ids:
-                warnings.warn(
-                    "Multiple Reactions should never have the same IDs",
-                    ValidationError,
-                )
-            dataset_defined_ids.add(reaction.reaction_id)
-        referenced_ids = get_referenced_reaction_ids(reaction)
-        if any(_id == reaction.reaction_id for _id in referenced_ids):
-            warnings.warn("A Reaction should not reference its own ID", ValidationError)
-        dataset_referenced_ids |= referenced_ids
-    if len(dataset_referenced_ids - dataset_defined_ids) > 0:
+    for _ in stats.duplicate_events:
+        warnings.warn("Multiple Reactions should never have the same IDs", ValidationError)
+    for _ in stats.self_reference_events:
+        warnings.warn("A Reaction should not reference its own ID", ValidationError)
+    missing = stats.referenced_ids - stats.defined_ids
+    if missing:
         warnings.warn(
-            f"Reactions in the Dataset refer to undefined reaction_ids {dataset_referenced_ids - dataset_defined_ids}",
+            f"Reactions in the Dataset refer to undefined reaction_ids {missing}",
             ValidationError,
         )
 


### PR DESCRIPTION
## Summary

Follow-ups 1–3 from [#790](https://github.com/open-reaction-database/ord-schema/pull/790), bundled in one PR:

1. **`.parquet` in `message_helpers.load_message` / `write_message`.** Dispatches to `parquet_dataset` when the suffix is `.parquet`; Dataset-only and `.parquet.gz` is rejected.
2. **Streaming validation + end-to-end streaming `process_dataset.py`.**
3. **Streaming ORM ingestion in `add_datasets.py`.**

Everything on the `.parquet` path deserializes one Reaction at a time; peak memory stays bounded regardless of dataset size. Non-Parquet inputs are unchanged.

## Key pieces

- `validations.validate_parquet_datasets` — streams Reactions, accumulates cross-reference state in a single pass, writes per-file `.error` output when `write_errors=True`.
- `parquet_dataset` additions:
  - `iter_reaction_ids(source)` — streams just the ID column (no Reaction deserialization).
  - `ParquetSource` on `read_metadata` / `iter_reactions` (`str | bytes | IO`) so a `git show` blob is usable without a tempfile.
  - `streaming_md5(path)` — canonical hash over scalars + serialized Reactions in file order, for change detection during ingest.
- `process_dataset.py` for Parquet inputs:
  - Streaming validation + per-Reaction `--max_size` check.
  - Streaming diff stats via `iter_reaction_ids` on both the current file and the base (`git show`) bytes.
  - Two-pass streaming update pipeline: pass 1 assigns Reaction IDs and writes to a temporary Parquet file next to the output; pass 2 rewrites cross-references with the substitution map and writes the final file.
  - `--output_format .parquet` is required for Parquet inputs when `--update` is set (documented in the error message).
- `database.add_parquet_dataset` — inserts the `Dataset` row up front, streams Reactions in `flush` + `expunge` batches of 200, patches `md5` / `num_reactions` at the end. `add_datasets.py` uses `streaming_md5` for change detection and routes to the streaming path for `.parquet` inputs.

### MD5 caveat for ORM ingestion

The Parquet MD5 (`streaming_md5`) is computed over a canonical byte stream (scalars + serialized Reactions in file order) and is stable across row-group layouts and compression codecs. It deliberately differs from `md5(Dataset.SerializeToString())`, which is what \`.pb.gz\` ingestion uses. Consequence: the first re-ingest of the same logical Dataset from a Parquet file looks like a content change and requires `--overwrite`; subsequent re-ingests from Parquet are stable.

## What's still outstanding

From the PR #790 follow-up list:

- (4) Bulk-convert \`../ord_data\` to Parquet — a data-repo migration, not schema code.
- (5) Cutover story for \`.parquet\` vs \`.pb.gz\`.
- (6) Atomic writes — tracked in [#791](https://github.com/open-reaction-database/ord-schema/issues/791).

## Test plan

- [x] \`uv run pytest ord_schema/\` — 311/311 pass (with Postgres on \`PATH\` from the \`ord\` conda env for the ORM tests).
- [x] \`ruff check\` + \`ruff format --check\` clean; \`ty\` clean via pre-commit.
- [ ] Reviewer smoke test on a real large Parquet dataset end-to-end: \`process_dataset.py --update --output_format .parquet\` followed by \`add_datasets.py --pattern '*.parquet'\`.