### PR TITLE
Stream Parquet validation via a DatasetView wrapper; add message_helpers.write_dataset

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -35,7 +35,7 @@ from rdkit import Chem
 from rdkit.Chem import rdChemReactions
 
 import ord_schema
-from ord_schema import parquet_dataset, units
+from ord_schema import units
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 _COMPOUND_IDENTIFIER_LOADERS = {
@@ -727,7 +727,6 @@ class MessageFormat(enum.Enum):
     BINARY = ".pb"
     JSON = ".json"
     PBTXT = ".pbtxt"
-    PARQUET = ".parquet"
 
 
 def fetch_dataset(dataset_id: str, timeout: float = 10.0) -> dataset_pb2.Dataset:
@@ -776,12 +775,6 @@ def load_message(filename: str, message_type: type[MessageType]) -> MessageType:
         this_open = open
         _, extension = os.path.splitext(filename)
     input_format = MessageFormat(extension)
-    if input_format == MessageFormat.PARQUET:
-        if filename.endswith(".gz"):
-            raise ValueError(f"Parquet files are not gzip-wrapped: {filename}")
-        if message_type is not dataset_pb2.Dataset:
-            raise ValueError(f"Parquet is only supported for Dataset messages, not {message_type.__name__}")
-        return parquet_dataset.read_dataset(filename)  # ty: ignore[invalid-return-type]
     if input_format == MessageFormat.BINARY:
         mode = "rb"
     else:
@@ -821,13 +814,6 @@ def write_message(message: ord_schema.Message, filename: str):
         this_open = open
         _, extension = os.path.splitext(filename)
     output_format = MessageFormat(extension)
-    if output_format == MessageFormat.PARQUET:
-        if filename.endswith(".gz"):
-            raise ValueError(f"Parquet files are not gzip-wrapped: {filename}")
-        if not isinstance(message, dataset_pb2.Dataset):
-            raise ValueError(f"Parquet is only supported for Dataset messages, not {type(message).__name__}")
-        parquet_dataset.write_dataset(message, filename)
-        return
     with this_open(filename, "wb") as f:
         if output_format == MessageFormat.JSON:
             f.write(json_format.MessageToJson(message).encode())

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -35,7 +35,7 @@ from rdkit import Chem
 from rdkit.Chem import rdChemReactions
 
 import ord_schema
-from ord_schema import units
+from ord_schema import parquet_dataset, units
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 _COMPOUND_IDENTIFIER_LOADERS = {
@@ -824,6 +824,18 @@ def write_message(message: ord_schema.Message, filename: str):
             f.write(text_format.MessageToString(message).encode("utf-8"))
         elif output_format == MessageFormat.BINARY:
             f.write(message.SerializeToString(deterministic=True))
+
+
+def write_dataset(dataset: dataset_pb2.Dataset, filename: str) -> None:
+    """Writes a Dataset to disk, dispatching on filename suffix.
+
+    ``.parquet`` routes to ``parquet_dataset.write_dataset``; other suffixes
+    go through ``write_message``.
+    """
+    if filename.endswith(".parquet"):
+        parquet_dataset.write_dataset(dataset, filename)
+        return
+    write_message(dataset, filename)
 
 
 def id_filename(filename: str) -> str:

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -35,7 +35,7 @@ from rdkit import Chem
 from rdkit.Chem import rdChemReactions
 
 import ord_schema
-from ord_schema import units
+from ord_schema import parquet_dataset, units
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 _COMPOUND_IDENTIFIER_LOADERS = {
@@ -727,6 +727,7 @@ class MessageFormat(enum.Enum):
     BINARY = ".pb"
     JSON = ".json"
     PBTXT = ".pbtxt"
+    PARQUET = ".parquet"
 
 
 def fetch_dataset(dataset_id: str, timeout: float = 10.0) -> dataset_pb2.Dataset:
@@ -775,6 +776,12 @@ def load_message(filename: str, message_type: type[MessageType]) -> MessageType:
         this_open = open
         _, extension = os.path.splitext(filename)
     input_format = MessageFormat(extension)
+    if input_format == MessageFormat.PARQUET:
+        if filename.endswith(".gz"):
+            raise ValueError(f"Parquet files are not gzip-wrapped: {filename}")
+        if message_type is not dataset_pb2.Dataset:
+            raise ValueError(f"Parquet is only supported for Dataset messages, not {message_type.__name__}")
+        return parquet_dataset.read_dataset(filename)  # ty: ignore[invalid-return-type]
     if input_format == MessageFormat.BINARY:
         mode = "rb"
     else:
@@ -814,6 +821,13 @@ def write_message(message: ord_schema.Message, filename: str):
         this_open = open
         _, extension = os.path.splitext(filename)
     output_format = MessageFormat(extension)
+    if output_format == MessageFormat.PARQUET:
+        if filename.endswith(".gz"):
+            raise ValueError(f"Parquet files are not gzip-wrapped: {filename}")
+        if not isinstance(message, dataset_pb2.Dataset):
+            raise ValueError(f"Parquet is only supported for Dataset messages, not {type(message).__name__}")
+        parquet_dataset.write_dataset(message, filename)
+        return
     with this_open(filename, "wb") as f:
         if output_format == MessageFormat.JSON:
             f.write(json_format.MessageToJson(message).encode())

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -23,7 +23,7 @@ from google.protobuf import json_format, text_format
 from rdkit import Chem
 
 from ord_schema import message_helpers
-from ord_schema.proto import dataset_pb2, reaction_pb2, test_pb2
+from ord_schema.proto import reaction_pb2, test_pb2
 
 _BENZENE_MOLBLOCK = """241
   -OEChem-07232015262D
@@ -492,31 +492,6 @@ class TestLoadAndWriteMessage:
         message = test_pb2.RepeatedScalar(values=[1.2, 3.4])
         with pytest.raises(ValueError, match="not a valid MessageFormat"):
             message_helpers.write_message(message, "test.proto")
-
-    def test_parquet_round_trip(self, tmp_path):
-        reaction = reaction_pb2.Reaction(reaction_id="ord-123")
-        dataset = dataset_pb2.Dataset(name="n", description="d", reactions=[reaction])
-        path = (tmp_path / "test.parquet").as_posix()
-        message_helpers.write_message(dataset, path)
-        loaded = message_helpers.load_message(path, dataset_pb2.Dataset)
-        assert list(loaded.reactions) == [reaction]
-        assert loaded.name == "n"
-        assert loaded.description == "d"
-
-    def test_parquet_rejects_gz(self, tmp_path):
-        dataset = dataset_pb2.Dataset(name="n", description="d", reactions=[reaction_pb2.Reaction(reaction_id="r")])
-        path = (tmp_path / "test.parquet.gz").as_posix()
-        with pytest.raises(ValueError, match="not gzip-wrapped"):
-            message_helpers.write_message(dataset, path)
-        with pytest.raises(ValueError, match="not gzip-wrapped"):
-            message_helpers.load_message(path, dataset_pb2.Dataset)
-
-    def test_parquet_rejects_non_dataset(self, tmp_path):
-        path = (tmp_path / "test.parquet").as_posix()
-        with pytest.raises(ValueError, match="only supported for Dataset"):
-            message_helpers.write_message(reaction_pb2.Reaction(reaction_id="r"), path)
-        with pytest.raises(ValueError, match="only supported for Dataset"):
-            message_helpers.load_message(path, reaction_pb2.Reaction)
 
 
 class TestCreateMessage:

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -23,7 +23,7 @@ from google.protobuf import json_format, text_format
 from rdkit import Chem
 
 from ord_schema import message_helpers
-from ord_schema.proto import reaction_pb2, test_pb2
+from ord_schema.proto import dataset_pb2, reaction_pb2, test_pb2
 
 _BENZENE_MOLBLOCK = """241
   -OEChem-07232015262D
@@ -492,6 +492,31 @@ class TestLoadAndWriteMessage:
         message = test_pb2.RepeatedScalar(values=[1.2, 3.4])
         with pytest.raises(ValueError, match="not a valid MessageFormat"):
             message_helpers.write_message(message, "test.proto")
+
+    def test_parquet_round_trip(self, tmp_path):
+        reaction = reaction_pb2.Reaction(reaction_id="ord-123")
+        dataset = dataset_pb2.Dataset(name="n", description="d", reactions=[reaction])
+        path = (tmp_path / "test.parquet").as_posix()
+        message_helpers.write_message(dataset, path)
+        loaded = message_helpers.load_message(path, dataset_pb2.Dataset)
+        assert list(loaded.reactions) == [reaction]
+        assert loaded.name == "n"
+        assert loaded.description == "d"
+
+    def test_parquet_rejects_gz(self, tmp_path):
+        dataset = dataset_pb2.Dataset(name="n", description="d", reactions=[reaction_pb2.Reaction(reaction_id="r")])
+        path = (tmp_path / "test.parquet.gz").as_posix()
+        with pytest.raises(ValueError, match="not gzip-wrapped"):
+            message_helpers.write_message(dataset, path)
+        with pytest.raises(ValueError, match="not gzip-wrapped"):
+            message_helpers.load_message(path, dataset_pb2.Dataset)
+
+    def test_parquet_rejects_non_dataset(self, tmp_path):
+        path = (tmp_path / "test.parquet").as_posix()
+        with pytest.raises(ValueError, match="only supported for Dataset"):
+            message_helpers.write_message(reaction_pb2.Reaction(reaction_id="r"), path)
+        with pytest.raises(ValueError, match="only supported for Dataset"):
+            message_helpers.load_message(path, reaction_pb2.Reaction)
 
 
 class TestCreateMessage:

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -22,8 +22,8 @@ import pytest
 from google.protobuf import json_format, text_format
 from rdkit import Chem
 
-from ord_schema import message_helpers
-from ord_schema.proto import reaction_pb2, test_pb2
+from ord_schema import message_helpers, parquet_dataset
+from ord_schema.proto import dataset_pb2, reaction_pb2, test_pb2
 
 _BENZENE_MOLBLOCK = """241
   -OEChem-07232015262D
@@ -492,6 +492,23 @@ class TestLoadAndWriteMessage:
         message = test_pb2.RepeatedScalar(values=[1.2, 3.4])
         with pytest.raises(ValueError, match="not a valid MessageFormat"):
             message_helpers.write_message(message, "test.proto")
+
+    @pytest.mark.parametrize("suffix", (".pbtxt", ".pb", ".pb.gz", ".json", ".parquet"))
+    def test_write_dataset(self, suffix, tmp_path):
+        dataset = dataset_pb2.Dataset(
+            name="n",
+            description="d",
+            reactions=[reaction_pb2.Reaction(reaction_id="ord-0")],
+        )
+        path = (tmp_path / f"ds{suffix}").as_posix()
+        message_helpers.write_dataset(dataset, path)
+        if suffix == ".parquet":
+            loaded = parquet_dataset.read_dataset(path)
+        else:
+            loaded = message_helpers.load_message(path, dataset_pb2.Dataset)
+        assert loaded.name == "n"
+        assert loaded.description == "d"
+        assert list(loaded.reactions) == list(dataset.reactions)
 
 
 class TestCreateMessage:

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -502,8 +502,10 @@ class TestLoadAndWriteMessage:
         )
         path = (tmp_path / f"ds{suffix}").as_posix()
         message_helpers.write_dataset(dataset, path)
+        # For .parquet, exercise the DatasetView entry point callers will use;
+        # for other formats, use the generic load_message.
         if suffix == ".parquet":
-            loaded = parquet_dataset.read_dataset(path)
+            loaded = parquet_dataset.DatasetView(path)
         else:
             loaded = message_helpers.load_message(path, dataset_pb2.Dataset)
         assert loaded.name == "n"

--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -172,29 +172,52 @@ def write_dataset(
         writer.write_all(dataset.reactions)
 
 
+class _ReactionStream:
+    """Re-iterable Reaction stream with a known length.
+
+    Each iteration opens a fresh read over the backing Parquet file so
+    callers that iterate more than once stay memory-bounded. ``__len__``
+    and ``__bool__`` come from the footer row count, so emptiness checks
+    (e.g., ``if not dataset.reactions``) behave like a list instead of
+    always being truthy the way a bare generator would be.
+    """
+
+    def __init__(self, path: str, num_reactions: int):
+        self._path = path
+        self._num_reactions = num_reactions
+
+    def __iter__(self) -> Iterator[reaction_pb2.Reaction]:
+        for _, reaction in iter_reactions(self._path):
+            yield reaction
+
+    def __len__(self) -> int:
+        return self._num_reactions
+
+    def __bool__(self) -> bool:
+        return self._num_reactions > 0
+
+
 class DatasetView:
     """A read-only, streaming view of a Parquet-serialized Dataset.
 
     Quacks like a ``dataset_pb2.Dataset`` for the read-only attributes used
     during validation: ``name``, ``description``, and ``dataset_id`` come
     from the Parquet footer; ``reaction_ids`` is always empty (Parquet does
-    not persist it); and ``reactions`` is a re-iterable property that opens
-    a fresh stream over the file on each access, so callers that iterate
-    more than once (e.g., ``_validate_datasets``) stay memory-bounded.
+    not persist it); and ``reactions`` is a re-iterable ``_ReactionStream``
+    that opens a fresh read on each iteration and reports its length from
+    the footer, so emptiness/length checks behave like a list.
     """
 
     def __init__(self, path: str):
         self._path = path
-        metadata = read_metadata(path)
-        self.name = metadata.name
-        self.description = metadata.description
-        self.dataset_id = metadata.dataset_id
+        with pq.ParquetFile(path) as parquet_file:
+            scalars = _dataset_from_metadata(parquet_file.schema_arrow.metadata)
+            num_rows = parquet_file.metadata.num_rows
+        self.name = scalars.name
+        self.description = scalars.description
+        self.dataset_id = scalars.dataset_id
         self.reaction_ids: list[str] = []
-
-    @property
-    def reactions(self) -> Iterator[reaction_pb2.Reaction]:
-        for _, reaction in iter_reactions(self._path):
-            yield reaction
+        self.reactions = _ReactionStream(path, num_rows)
 
 
 def read_dataset(path: str) -> dataset_pb2.Dataset:

--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -205,7 +205,8 @@ class DatasetView:
     from the Parquet footer; ``reaction_ids`` is always empty (Parquet does
     not persist it); and ``reactions`` is a re-iterable ``_ReactionStream``
     that opens a fresh read on each iteration and reports its length from
-    the footer, so emptiness/length checks behave like a list.
+    the footer, so emptiness/length checks behave like a list. ``reactions``
+    is exposed as a read-only property so accidental rebinding raises.
     """
 
     def __init__(self, path: str):
@@ -217,7 +218,11 @@ class DatasetView:
         self.description = scalars.description
         self.dataset_id = scalars.dataset_id
         self.reaction_ids: list[str] = []
-        self.reactions = _ReactionStream(path, num_rows)
+        self._reactions = _ReactionStream(path, num_rows)
+
+    @property
+    def reactions(self) -> _ReactionStream:
+        return self._reactions
 
 
 def read_dataset(path: str) -> dataset_pb2.Dataset:

--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -172,6 +172,31 @@ def write_dataset(
         writer.write_all(dataset.reactions)
 
 
+class DatasetView:
+    """A read-only, streaming view of a Parquet-serialized Dataset.
+
+    Quacks like a ``dataset_pb2.Dataset`` for the read-only attributes used
+    during validation: ``name``, ``description``, and ``dataset_id`` come
+    from the Parquet footer; ``reaction_ids`` is always empty (Parquet does
+    not persist it); and ``reactions`` is a re-iterable property that opens
+    a fresh stream over the file on each access, so callers that iterate
+    more than once (e.g., ``_validate_datasets``) stay memory-bounded.
+    """
+
+    def __init__(self, path: str):
+        self._path = path
+        metadata = read_metadata(path)
+        self.name = metadata.name
+        self.description = metadata.description
+        self.dataset_id = metadata.dataset_id
+        self.reaction_ids: list[str] = []
+
+    @property
+    def reactions(self) -> Iterator[reaction_pb2.Reaction]:
+        for _, reaction in iter_reactions(self._path):
+            yield reaction
+
+
 def read_dataset(path: str) -> dataset_pb2.Dataset:
     """Reads a full Dataset from a Parquet file.
 

--- a/ord_schema/parquet_dataset_test.py
+++ b/ord_schema/parquet_dataset_test.py
@@ -260,3 +260,37 @@ def test_writer_close_propagates_flush_error(tmp_path):
         # Restore so pyarrow's GC-time close doesn't resurrect CloseError.
         writer._writer.close = original_parquet_close  # ty: ignore[invalid-assignment]
         writer._writer.close()
+
+
+def test_dataset_view_exposes_all_dataset_fields(tmp_path):
+    """DatasetView must expose every field declared on the Dataset proto.
+
+    Fails if a new field is added to the proto without a matching attribute
+    on DatasetView, so the view stays a drop-in stand-in for validation.
+    """
+    path = os.path.join(tmp_path, "ds.parquet")
+    dataset.write_dataset(_make_dataset(n=1), path)
+    view = dataset.DatasetView(path)
+    descriptor = dataset_pb2.Dataset.DESCRIPTOR
+    assert descriptor is not None  # Type hint.
+    missing = {field.name for field in descriptor.fields} - set(dir(view))
+    assert not missing, f"DatasetView is missing Dataset fields: {sorted(missing)}"
+
+
+def test_dataset_view_values_round_trip(tmp_path):
+    """DatasetView scalars and re-iterated Reactions match the source Dataset.
+
+    Scalars come from the footer; ``.reactions`` opens a fresh stream on
+    each access, so two validation passes iterate it twice.
+    """
+    source = _make_dataset(n=3, dataset_id="ord_dataset-abc", name="n", description="d")
+    path = os.path.join(tmp_path, "ds.parquet")
+    dataset.write_dataset(source, path)
+    view = dataset.DatasetView(path)
+    assert view.name == source.name
+    assert view.description == source.description
+    assert view.dataset_id == source.dataset_id
+    assert list(view.reaction_ids) == []  # Not persisted in Parquet.
+    assert list(view.reactions) == list(source.reactions)
+    # Re-iterating must yield the same sequence (each access re-streams).
+    assert list(view.reactions) == list(source.reactions)

--- a/ord_schema/parquet_dataset_test.py
+++ b/ord_schema/parquet_dataset_test.py
@@ -308,6 +308,7 @@ def test_dataset_view_values_round_trip(tmp_path):
     assert view.description == source.description
     assert view.dataset_id == source.dataset_id
     assert list(view.reaction_ids) == []  # Not persisted in Parquet.
+    assert len(view.reactions) == len(source.reactions)
     assert list(view.reactions) == list(source.reactions)
     # Re-iterating must yield the same sequence (each access re-streams).
     assert list(view.reactions) == list(source.reactions)

--- a/ord_schema/parquet_dataset_test.py
+++ b/ord_schema/parquet_dataset_test.py
@@ -277,6 +277,15 @@ def test_dataset_view_exposes_all_dataset_fields(tmp_path):
     assert not missing, f"DatasetView is missing Dataset fields: {sorted(missing)}"
 
 
+def test_dataset_view_reactions_is_read_only(tmp_path):
+    """Rebinding ``view.reactions`` must raise so the stream can't be swapped."""
+    path = os.path.join(tmp_path, "ds.parquet")
+    dataset.write_dataset(_make_dataset(n=1), path)
+    view = dataset.DatasetView(path)
+    with pytest.raises(AttributeError):
+        view.reactions = []  # ty: ignore[invalid-assignment]
+
+
 def test_dataset_view_empty_parquet_is_falsy(tmp_path):
     """DatasetView.reactions reports length 0 / False for an empty Parquet.
 

--- a/ord_schema/parquet_dataset_test.py
+++ b/ord_schema/parquet_dataset_test.py
@@ -277,6 +277,23 @@ def test_dataset_view_exposes_all_dataset_fields(tmp_path):
     assert not missing, f"DatasetView is missing Dataset fields: {sorted(missing)}"
 
 
+def test_dataset_view_empty_parquet_is_falsy(tmp_path):
+    """DatasetView.reactions reports length 0 / False for an empty Parquet.
+
+    ``validate_dataset``'s "Dataset requires reactions or reaction_ids"
+    warning uses ``if not message.reactions`` — this test guards against
+    that branch going dead when a bare generator would be truthy.
+    """
+    path = os.path.join(tmp_path, "empty.parquet")
+    # DatasetWriter (unlike write_dataset) permits zero reactions.
+    with dataset.DatasetWriter(path, name="n", description="d"):
+        pass
+    view = dataset.DatasetView(path)
+    assert not view.reactions
+    assert len(view.reactions) == 0
+    assert list(view.reactions) == []
+
+
 def test_dataset_view_values_round_trip(tmp_path):
     """DatasetView scalars and re-iterated Reactions match the source Dataset.
 

--- a/ord_schema/scripts/validate_dataset.py
+++ b/ord_schema/scripts/validate_dataset.py
@@ -38,8 +38,16 @@ def filter_filenames(filenames: Iterable[str], pattern: str) -> list[str]:
 
 
 def run(filename: str) -> None:
-    """Validates a single dataset."""
+    """Validates a single dataset.
+
+    Parquet inputs are validated by streaming Reactions one at a time, so peak
+    memory stays bounded for large datasets. Other formats fall back to the
+    whole-dataset load.
+    """
     silence_rdkit_logs()
+    if filename.endswith(".parquet"):
+        validations.validate_parquet_datasets([filename])
+        return
     dataset = message_helpers.load_message(filename, dataset_pb2.Dataset)
     validations.validate_datasets({filename: dataset})
 

--- a/ord_schema/scripts/validate_dataset.py
+++ b/ord_schema/scripts/validate_dataset.py
@@ -21,7 +21,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 
 from tqdm import tqdm
 
-from ord_schema import message_helpers, validations
+from ord_schema import message_helpers, parquet_dataset, validations
 from ord_schema.logging import get_logger, silence_rdkit_logs
 from ord_schema.proto import dataset_pb2
 
@@ -40,15 +40,15 @@ def filter_filenames(filenames: Iterable[str], pattern: str) -> list[str]:
 def run(filename: str) -> None:
     """Validates a single dataset.
 
-    Parquet inputs are validated by streaming Reactions one at a time, so peak
-    memory stays bounded for large datasets. Other formats fall back to the
-    whole-dataset load.
+    Parquet inputs are wrapped in a ``DatasetView`` that streams Reactions
+    one at a time, so peak memory stays bounded for large datasets. Other
+    formats are loaded fully.
     """
     silence_rdkit_logs()
     if filename.endswith(".parquet"):
-        validations.validate_parquet_datasets([filename])
-        return
-    dataset = message_helpers.load_message(filename, dataset_pb2.Dataset)
+        dataset = parquet_dataset.DatasetView(filename)
+    else:
+        dataset = message_helpers.load_message(filename, dataset_pb2.Dataset)
     validations.validate_datasets({filename: dataset})
 
 

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -23,8 +23,12 @@ from ord_schema.proto import dataset_pb2, reaction_pb2
 from ord_schema.scripts import validate_dataset
 
 
-@pytest.fixture
-def setup(tmp_path) -> Iterator[str]:
+@pytest.fixture(params=[".pbtxt", ".parquet"])
+def setup(request, tmp_path) -> Iterator[tuple[str, str]]:
+    """Writes dataset1 and dataset2 to ``tmp_path`` using the parametrized
+    on-disk format; yields ``(tmp_path, suffix)``.
+    """
+    suffix = request.param
     test_subdirectory = tmp_path.as_posix()
     reaction1 = reaction_pb2.Reaction()
     dummy_input = reaction1.inputs["dummy_input"]
@@ -40,70 +44,34 @@ def setup(tmp_path) -> Iterator[str]:
     reaction1.provenance.record_created.person.name = "test"
     reaction1.provenance.record_created.person.email = "test@example.com"
     dataset1 = dataset_pb2.Dataset(name="test1", description="test1", reactions=[reaction1])
-    dataset1_filename = os.path.join(test_subdirectory, "dataset1.pbtxt")
-    message_helpers.write_message(dataset1, dataset1_filename)
+    message_helpers.write_message(dataset1, os.path.join(test_subdirectory, f"dataset1{suffix}"))
     # reaction2 is empty.
     reaction2 = reaction_pb2.Reaction()
     dataset2 = dataset_pb2.Dataset(name="test2", description="test2", reactions=[reaction1, reaction2])
-    dataset2_filename = os.path.join(test_subdirectory, "dataset2.pbtxt")
-    message_helpers.write_message(dataset2, dataset2_filename)
-    yield test_subdirectory
+    message_helpers.write_message(dataset2, os.path.join(test_subdirectory, f"dataset2{suffix}"))
+    yield test_subdirectory, suffix
 
 
 def test_simple(setup):
-    test_subdirectory = setup
-    argv = ["--input", os.path.join(test_subdirectory, "dataset1.pbtxt")]
+    test_subdirectory, suffix = setup
+    argv = ["--input", os.path.join(test_subdirectory, f"dataset1{suffix}")]
     validate_dataset.main(validate_dataset.parse_args(argv))
 
 
 def test_filter(setup):
-    test_subdirectory = setup
-    argv = ["--input", os.path.join(test_subdirectory, "dataset1.pbtxt"), "--filter", "dataset"]
+    test_subdirectory, suffix = setup
+    argv = ["--input", os.path.join(test_subdirectory, f"dataset1{suffix}"), "--filter", "dataset"]
     validate_dataset.main(validate_dataset.parse_args(argv))
 
 
 def test_validation_errors(setup):
-    test_subdirectory = setup
-    argv = ["--input", os.path.join(test_subdirectory, "dataset*.pbtxt")]
+    test_subdirectory, suffix = setup
+    argv = ["--input", os.path.join(test_subdirectory, f"dataset*{suffix}")]
     with pytest.raises(
         validations.ValidationError,
         match="Reactions should have at least 1 reaction input",
     ):
         validate_dataset.main(validate_dataset.parse_args(argv))
-
-
-def test_parquet_input(tmp_path):
-    reaction = reaction_pb2.Reaction()
-    dummy_input = reaction.inputs["dummy_input"]
-    dummy_component = dummy_input.components.add()
-    dummy_component.identifiers.add(type="CUSTOM", details="custom_identifier", value="custom_value")
-    dummy_component.is_limiting = True
-    dummy_component.amount.mass.value = 1
-    dummy_component.amount.mass.units = reaction_pb2.Mass.GRAM
-    reaction.outcomes.add().conversion.value = 75
-    reaction.provenance.record_created.time.value = "2023-07-01"
-    reaction.provenance.record_created.person.name = "test"
-    reaction.provenance.record_created.person.email = "test@example.com"
-    dataset = dataset_pb2.Dataset(name="parquet", description="parquet", reactions=[reaction])
-    path = (tmp_path / "dataset.parquet").as_posix()
-    message_helpers.write_message(dataset, path)
-    validate_dataset.main(validate_dataset.parse_args(["--input", path]))
-
-
-def test_parquet_validation_errors(tmp_path):
-    # Empty reaction fails per-reaction validation via the streaming path.
-    bad_dataset = dataset_pb2.Dataset(
-        name="bad",
-        description="bad",
-        reactions=[reaction_pb2.Reaction(reaction_id="ord-0")],
-    )
-    path = (tmp_path / "bad.parquet").as_posix()
-    message_helpers.write_message(bad_dataset, path)
-    with pytest.raises(
-        validations.ValidationError,
-        match="Reactions should have at least 1 reaction input",
-    ):
-        validate_dataset.main(validate_dataset.parse_args(["--input", path]))
 
 
 @pytest.mark.parametrize(

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -72,6 +72,40 @@ def test_validation_errors(setup):
         validate_dataset.main(validate_dataset.parse_args(argv))
 
 
+def test_parquet_input(tmp_path):
+    reaction = reaction_pb2.Reaction()
+    dummy_input = reaction.inputs["dummy_input"]
+    dummy_component = dummy_input.components.add()
+    dummy_component.identifiers.add(type="CUSTOM", details="custom_identifier", value="custom_value")
+    dummy_component.is_limiting = True
+    dummy_component.amount.mass.value = 1
+    dummy_component.amount.mass.units = reaction_pb2.Mass.GRAM
+    reaction.outcomes.add().conversion.value = 75
+    reaction.provenance.record_created.time.value = "2023-07-01"
+    reaction.provenance.record_created.person.name = "test"
+    reaction.provenance.record_created.person.email = "test@example.com"
+    dataset = dataset_pb2.Dataset(name="parquet", description="parquet", reactions=[reaction])
+    path = (tmp_path / "dataset.parquet").as_posix()
+    message_helpers.write_message(dataset, path)
+    validate_dataset.main(validate_dataset.parse_args(["--input", path]))
+
+
+def test_parquet_validation_errors(tmp_path):
+    # Empty reaction fails per-reaction validation via the streaming path.
+    bad_dataset = dataset_pb2.Dataset(
+        name="bad",
+        description="bad",
+        reactions=[reaction_pb2.Reaction(reaction_id="ord-0")],
+    )
+    path = (tmp_path / "bad.parquet").as_posix()
+    message_helpers.write_message(bad_dataset, path)
+    with pytest.raises(
+        validations.ValidationError,
+        match="Reactions should have at least 1 reaction input",
+    ):
+        validate_dataset.main(validate_dataset.parse_args(["--input", path]))
+
+
 @pytest.mark.parametrize(
     "pattern,expected",
     (

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -18,17 +18,9 @@ from collections.abc import Iterator
 
 import pytest
 
-from ord_schema import message_helpers, parquet_dataset, validations
+from ord_schema import message_helpers, validations
 from ord_schema.proto import dataset_pb2, reaction_pb2
 from ord_schema.scripts import validate_dataset
-
-
-def _write_dataset(dataset: dataset_pb2.Dataset, path: str) -> None:
-    """Writes ``dataset`` to ``path``, dispatching on suffix."""
-    if path.endswith(".parquet"):
-        parquet_dataset.write_dataset(dataset, path)
-    else:
-        message_helpers.write_message(dataset, path)
 
 
 @pytest.fixture(params=[".pbtxt", ".parquet"])
@@ -53,11 +45,11 @@ def setup(request, tmp_path) -> Iterator[tuple[str, str]]:
     reaction1.provenance.record_created.person.name = "test"
     reaction1.provenance.record_created.person.email = "test@example.com"
     dataset1 = dataset_pb2.Dataset(name="test1", description="test1", reactions=[reaction1])
-    _write_dataset(dataset1, os.path.join(test_subdirectory, f"dataset1{suffix}"))
+    message_helpers.write_dataset(dataset1, os.path.join(test_subdirectory, f"dataset1{suffix}"))
     # reaction2 is empty.
     reaction2 = reaction_pb2.Reaction()
     dataset2 = dataset_pb2.Dataset(name="test2", description="test2", reactions=[reaction1, reaction2])
-    _write_dataset(dataset2, os.path.join(test_subdirectory, f"dataset2{suffix}"))
+    message_helpers.write_dataset(dataset2, os.path.join(test_subdirectory, f"dataset2{suffix}"))
     yield test_subdirectory, suffix
 
 

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -18,15 +18,24 @@ from collections.abc import Iterator
 
 import pytest
 
-from ord_schema import message_helpers, validations
+from ord_schema import message_helpers, parquet_dataset, validations
 from ord_schema.proto import dataset_pb2, reaction_pb2
 from ord_schema.scripts import validate_dataset
 
 
+def _write_dataset(dataset: dataset_pb2.Dataset, path: str) -> None:
+    """Writes ``dataset`` to ``path``, dispatching on suffix."""
+    if path.endswith(".parquet"):
+        parquet_dataset.write_dataset(dataset, path)
+    else:
+        message_helpers.write_message(dataset, path)
+
+
 @pytest.fixture(params=[".pbtxt", ".parquet"])
 def setup(request, tmp_path) -> Iterator[tuple[str, str]]:
-    """Writes dataset1 and dataset2 to ``tmp_path`` using the parametrized
-    on-disk format; yields ``(tmp_path, suffix)``.
+    """Writes dataset1 and dataset2 to ``tmp_path`` in the parametrized format.
+
+    Yields ``(tmp_path, suffix)``.
     """
     suffix = request.param
     test_subdirectory = tmp_path.as_posix()
@@ -44,11 +53,11 @@ def setup(request, tmp_path) -> Iterator[tuple[str, str]]:
     reaction1.provenance.record_created.person.name = "test"
     reaction1.provenance.record_created.person.email = "test@example.com"
     dataset1 = dataset_pb2.Dataset(name="test1", description="test1", reactions=[reaction1])
-    message_helpers.write_message(dataset1, os.path.join(test_subdirectory, f"dataset1{suffix}"))
+    _write_dataset(dataset1, os.path.join(test_subdirectory, f"dataset1{suffix}"))
     # reaction2 is empty.
     reaction2 = reaction_pb2.Reaction()
     dataset2 = dataset_pb2.Dataset(name="test2", description="test2", reactions=[reaction1, reaction2])
-    message_helpers.write_message(dataset2, os.path.join(test_subdirectory, f"dataset2{suffix}"))
+    _write_dataset(dataset2, os.path.join(test_subdirectory, f"dataset2{suffix}"))
     yield test_subdirectory, suffix
 
 

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -18,7 +18,7 @@ import math
 import os
 import re
 import warnings
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from enum import IntEnum
 from typing import Any
 
@@ -27,7 +27,7 @@ from rdkit import Chem
 from rdkit import __version__ as RDKIT_VERSION
 
 import ord_schema
-from ord_schema import message_helpers
+from ord_schema import message_helpers, parquet_dataset
 from ord_schema.logging import get_logger
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
@@ -91,37 +91,112 @@ def validate_datasets(
         raise ValidationError(f"validation encountered errors:\n{error_string}")
 
 
+def validate_parquet_datasets(
+    paths: Iterable[str],
+    write_errors: bool = False,
+    options: ValidationOptions | None = None,
+) -> None:
+    """Streams Reactions from Parquet datasets and validates them.
+
+    Reactions are deserialized one at a time, so peak memory stays bounded
+    regardless of dataset size. Dataset-level scalar checks come from the
+    Parquet footer; cross-reference state accumulates during the single pass.
+
+    Args:
+        paths: Parquet file paths. Each must be a Parquet-serialized Dataset.
+        write_errors: If True, errors are written to a ``{path}.error`` file.
+        options: ValidationOptions.
+
+    Raises:
+        ValidationError: if any Dataset does not pass validation.
+    """
+    all_errors = []
+    for path in paths:
+        scalars = parquet_dataset.read_metadata(path)
+        reactions = (reaction for _, reaction in parquet_dataset.iter_reactions(path))
+        errors = _validate_single_dataset(scalars, reactions, label=os.path.basename(path), options=options)
+        if errors:
+            for error in errors:
+                all_errors.append(f"{path}: {error}")
+            if write_errors:
+                with open(f"{path}.error", "w") as f:
+                    for error in errors:
+                        f.write(f"{error}\n")
+    if all_errors:
+        error_string = "\n".join(all_errors)
+        raise ValidationError(f"validation encountered errors:\n{error_string}")
+
+
+@dataclasses.dataclass
+class _DatasetReactionStats:
+    """Aggregated state for Dataset-level cross-reference checks.
+
+    Populated either by iterating ``Dataset.reactions`` (non-streaming) or by
+    streaming Reactions from a Parquet file. ``validate_dataset`` accepts a
+    pre-computed instance so the streaming path does not re-iterate.
+    """
+
+    num_reactions: int = 0
+    defined_ids: set[str] = dataclasses.field(default_factory=set)
+    referenced_ids: set[str] = dataclasses.field(default_factory=set)
+    # Preserve per-occurrence warning cardinality: one entry per duplicate /
+    # self-reference event observed during iteration.
+    duplicate_events: list[str] = dataclasses.field(default_factory=list)
+    self_reference_events: list[str] = dataclasses.field(default_factory=list)
+
+    def observe(self, reaction: reaction_pb2.Reaction) -> None:
+        self.num_reactions += 1
+        if reaction.reaction_id:
+            if reaction.reaction_id in self.defined_ids:
+                self.duplicate_events.append(reaction.reaction_id)
+            self.defined_ids.add(reaction.reaction_id)
+        refs = get_referenced_reaction_ids(reaction)
+        if reaction.reaction_id and reaction.reaction_id in refs:
+            self.self_reference_events.append(reaction.reaction_id)
+        self.referenced_ids |= refs
+
+
 def _validate_datasets(
     dataset: dataset_pb2.Dataset,
     label: str = "dataset",
     options: ValidationOptions | None = None,
 ) -> list[str]:
-    """Validates Reaction messages and cross-references in a Dataset.
+    """Validates Reaction messages and cross-references in a Dataset."""
+    return _validate_single_dataset(dataset, dataset.reactions, label=label, options=options)
 
-    Args:
-        dataset: dataset_pb2.Dataset message.
-        label: string label for logging purposes only.
-        options: ValidationOptions.
 
-    Returns:
-        List of validation error messages.
+def _validate_single_dataset(
+    scalars: dataset_pb2.Dataset,
+    reactions: Iterable[reaction_pb2.Reaction],
+    label: str,
+    options: ValidationOptions | None = None,
+) -> list[str]:
+    """Validates a single Dataset given its scalars and a Reaction iterable.
+
+    A single pass over ``reactions`` both validates each Reaction individually
+    and accumulates the cross-reference state used for Dataset-level checks,
+    so the iterable (a full list or a streaming Parquet reader) is consumed
+    exactly once.
     """
-    errors = []
-    # Reaction-level validation.
-    num_bad_reactions = 0
-    for i, reaction in enumerate(dataset.reactions):
+    errors: list[str] = []
+    stats = _DatasetReactionStats()
+    for i, reaction in enumerate(reactions):
         reaction_output = validate_message(reaction, raise_on_error=False, options=options)
-        if reaction_output.errors:
-            num_bad_reactions += 1
         for error in reaction_output.errors:
             errors.append(error)
             logger.error(f"Validation error for {label}[{i}]: {error}")
-    # Dataset-level validation of cross-references.
-    dataset_output = validate_message(dataset, raise_on_error=False, recurse=False, options=options)
-    for error in dataset_output.errors:
+        stats.observe(reaction)
+    # Emit Dataset-level warnings using the accumulated stats. We bypass
+    # ``validate_message(dataset, recurse=False)`` here to avoid a second pass
+    # over ``scalars.reactions`` (which is empty on the streaming path).
+    with warnings.catch_warnings(record=True) as tape:
+        validate_dataset(scalars, options=options, stats=stats)
+    for warning in tape:
+        if not issubclass(warning.category, ValidationError):
+            continue
+        error = f"Dataset: {warning.message}"
         errors.append(error)
         logger.error(f"Validation error for {label}: {error}")
-
     return errors
 
 
@@ -372,16 +447,27 @@ def is_valid_dataset_id(dataset_id: str) -> bool:
     return bool(match)
 
 
-def validate_dataset(message: dataset_pb2.Dataset, options: ValidationOptions | None = None):
+def validate_dataset(
+    message: dataset_pb2.Dataset,
+    options: ValidationOptions | None = None,
+    *,
+    stats: _DatasetReactionStats | None = None,
+):
     if options is None:
         options = ValidationOptions()
+    if stats is None:
+        # Build stats from ``message.reactions`` for callers that came through
+        # ``_VALIDATOR_SWITCH`` (e.g., a direct ``validate_message(dataset)``).
+        stats = _DatasetReactionStats()
+        for reaction in message.reactions:
+            stats.observe(reaction)
     if not message.name:
         warnings.warn("Dataset name is required", ValidationError)
     if not message.description:
         warnings.warn("Dataset description is required", ValidationError)
-    if not message.reactions and not message.reaction_ids:
+    if not stats.num_reactions and not message.reaction_ids:
         warnings.warn("Dataset requires reactions or reaction_ids", ValidationError)
-    elif message.reactions and message.reaction_ids:
+    elif stats.num_reactions and message.reaction_ids:
         warnings.warn("Dataset requires reactions or reaction_ids, not both", ValidationError)
     if message.reaction_ids:
         for reaction_id in message.reaction_ids:
@@ -391,24 +477,14 @@ def validate_dataset(message: dataset_pb2.Dataset, options: ValidationOptions | 
         # The dataset_id is a 32-character uuid4 hex string.
         if not is_valid_dataset_id(message.dataset_id):
             warnings.warn("Dataset ID is malformed", ValidationError)
-    # Check cross-references
-    dataset_referenced_ids = set()
-    dataset_defined_ids = set()
-    for reaction in message.reactions:
-        if reaction.reaction_id:
-            if reaction.reaction_id in dataset_defined_ids:
-                warnings.warn(
-                    "Multiple Reactions should never have the same IDs",
-                    ValidationError,
-                )
-            dataset_defined_ids.add(reaction.reaction_id)
-        referenced_ids = get_referenced_reaction_ids(reaction)
-        if any(_id == reaction.reaction_id for _id in referenced_ids):
-            warnings.warn("A Reaction should not reference its own ID", ValidationError)
-        dataset_referenced_ids |= referenced_ids
-    if len(dataset_referenced_ids - dataset_defined_ids) > 0:
+    for _ in stats.duplicate_events:
+        warnings.warn("Multiple Reactions should never have the same IDs", ValidationError)
+    for _ in stats.self_reference_events:
+        warnings.warn("A Reaction should not reference its own ID", ValidationError)
+    missing = stats.referenced_ids - stats.defined_ids
+    if missing:
         warnings.warn(
-            f"Reactions in the Dataset refer to undefined reaction_ids {dataset_referenced_ids - dataset_defined_ids}",
+            f"Reactions in the Dataset refer to undefined reaction_ids {missing}",
             ValidationError,
         )
 

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -98,12 +98,10 @@ def _validate_datasets(
 ) -> list[str]:
     """Validates Reaction messages and cross-references in a Dataset.
 
-    ``dataset`` may be a ``dataset_pb2.Dataset`` or any duck-typed stand-in
-    (e.g., ``parquet_dataset.DatasetView``) that exposes the same ``name``,
-    ``description``, ``dataset_id``, ``reaction_ids``, and ``reactions``
-    attributes. The ``reactions`` attribute is iterated twice — once for
-    per-Reaction validation and once inside ``validate_dataset`` for the
-    cross-reference checks — so streaming stand-ins must be re-iterable.
+    ``dataset`` may be a ``dataset_pb2.Dataset`` or a
+    ``parquet_dataset.DatasetView``; the view re-iterates ``.reactions``
+    from disk on each access, so the two iterations below (per-Reaction +
+    cross-reference) both stream.
 
     Args:
         dataset: Dataset message or compatible stand-in.
@@ -126,7 +124,7 @@ def _validate_datasets(
     # Dataset-level validation of cross-references. Call ``validate_dataset``
     # directly rather than going through ``validate_message``, which insists
     # on a proto type (``_VALIDATOR_SWITCH`` lookup, ``DESCRIPTOR`` access) and
-    # would reject a duck-typed stand-in like ``DatasetView``.
+    # would reject a non-proto stand-in like ``DatasetView``.
     with warnings.catch_warnings(record=True) as tape:
         validate_dataset(dataset, options=options)
     for warning in tape:

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -18,7 +18,7 @@ import math
 import os
 import re
 import warnings
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Mapping
 from enum import IntEnum
 from typing import Any
 
@@ -59,7 +59,7 @@ class ValidationOutput:
 
 
 def validate_datasets(
-    datasets: Mapping[str, dataset_pb2.Dataset],
+    datasets: Mapping[str, dataset_pb2.Dataset | parquet_dataset.DatasetView],
     write_errors: bool = False,
     options: ValidationOptions | None = None,
 ) -> None:
@@ -91,112 +91,51 @@ def validate_datasets(
         raise ValidationError(f"validation encountered errors:\n{error_string}")
 
 
-def validate_parquet_datasets(
-    paths: Iterable[str],
-    write_errors: bool = False,
-    options: ValidationOptions | None = None,
-) -> None:
-    """Streams Reactions from Parquet datasets and validates them.
-
-    Reactions are deserialized one at a time, so peak memory stays bounded
-    regardless of dataset size. Dataset-level scalar checks come from the
-    Parquet footer; cross-reference state accumulates during the single pass.
-
-    Args:
-        paths: Parquet file paths. Each must be a Parquet-serialized Dataset.
-        write_errors: If True, errors are written to a ``{path}.error`` file.
-        options: ValidationOptions.
-
-    Raises:
-        ValidationError: if any Dataset does not pass validation.
-    """
-    all_errors = []
-    for path in paths:
-        scalars = parquet_dataset.read_metadata(path)
-        reactions = (reaction for _, reaction in parquet_dataset.iter_reactions(path))
-        errors = _validate_single_dataset(scalars, reactions, label=os.path.basename(path), options=options)
-        if errors:
-            for error in errors:
-                all_errors.append(f"{path}: {error}")
-            if write_errors:
-                with open(f"{path}.error", "w") as f:
-                    for error in errors:
-                        f.write(f"{error}\n")
-    if all_errors:
-        error_string = "\n".join(all_errors)
-        raise ValidationError(f"validation encountered errors:\n{error_string}")
-
-
-@dataclasses.dataclass
-class _DatasetReactionStats:
-    """Aggregated state for Dataset-level cross-reference checks.
-
-    Populated either by iterating ``Dataset.reactions`` (non-streaming) or by
-    streaming Reactions from a Parquet file. ``validate_dataset`` accepts a
-    pre-computed instance so the streaming path does not re-iterate.
-    """
-
-    num_reactions: int = 0
-    defined_ids: set[str] = dataclasses.field(default_factory=set)
-    referenced_ids: set[str] = dataclasses.field(default_factory=set)
-    # Preserve per-occurrence warning cardinality: one entry per duplicate /
-    # self-reference event observed during iteration.
-    duplicate_events: list[str] = dataclasses.field(default_factory=list)
-    self_reference_events: list[str] = dataclasses.field(default_factory=list)
-
-    def observe(self, reaction: reaction_pb2.Reaction) -> None:
-        self.num_reactions += 1
-        if reaction.reaction_id:
-            if reaction.reaction_id in self.defined_ids:
-                self.duplicate_events.append(reaction.reaction_id)
-            self.defined_ids.add(reaction.reaction_id)
-        refs = get_referenced_reaction_ids(reaction)
-        if reaction.reaction_id and reaction.reaction_id in refs:
-            self.self_reference_events.append(reaction.reaction_id)
-        self.referenced_ids |= refs
-
-
 def _validate_datasets(
-    dataset: dataset_pb2.Dataset,
+    dataset: dataset_pb2.Dataset | parquet_dataset.DatasetView,
     label: str = "dataset",
     options: ValidationOptions | None = None,
 ) -> list[str]:
-    """Validates Reaction messages and cross-references in a Dataset."""
-    return _validate_single_dataset(dataset, dataset.reactions, label=label, options=options)
+    """Validates Reaction messages and cross-references in a Dataset.
 
+    ``dataset`` may be a ``dataset_pb2.Dataset`` or any duck-typed stand-in
+    (e.g., ``parquet_dataset.DatasetView``) that exposes the same ``name``,
+    ``description``, ``dataset_id``, ``reaction_ids``, and ``reactions``
+    attributes. The ``reactions`` attribute is iterated twice — once for
+    per-Reaction validation and once inside ``validate_dataset`` for the
+    cross-reference checks — so streaming stand-ins must be re-iterable.
 
-def _validate_single_dataset(
-    scalars: dataset_pb2.Dataset,
-    reactions: Iterable[reaction_pb2.Reaction],
-    label: str,
-    options: ValidationOptions | None = None,
-) -> list[str]:
-    """Validates a single Dataset given its scalars and a Reaction iterable.
+    Args:
+        dataset: Dataset message or compatible stand-in.
+        label: string label for logging purposes only.
+        options: ValidationOptions.
 
-    A single pass over ``reactions`` both validates each Reaction individually
-    and accumulates the cross-reference state used for Dataset-level checks,
-    so the iterable (a full list or a streaming Parquet reader) is consumed
-    exactly once.
+    Returns:
+        List of validation error messages.
     """
-    errors: list[str] = []
-    stats = _DatasetReactionStats()
-    for i, reaction in enumerate(reactions):
+    errors = []
+    # Reaction-level validation.
+    num_bad_reactions = 0
+    for i, reaction in enumerate(dataset.reactions):
         reaction_output = validate_message(reaction, raise_on_error=False, options=options)
+        if reaction_output.errors:
+            num_bad_reactions += 1
         for error in reaction_output.errors:
             errors.append(error)
             logger.error(f"Validation error for {label}[{i}]: {error}")
-        stats.observe(reaction)
-    # Emit Dataset-level warnings using the accumulated stats. We bypass
-    # ``validate_message(dataset, recurse=False)`` here to avoid a second pass
-    # over ``scalars.reactions`` (which is empty on the streaming path).
+    # Dataset-level validation of cross-references. Call ``validate_dataset``
+    # directly rather than going through ``validate_message``, which insists
+    # on a proto type (``_VALIDATOR_SWITCH`` lookup, ``DESCRIPTOR`` access) and
+    # would reject a duck-typed stand-in like ``DatasetView``.
     with warnings.catch_warnings(record=True) as tape:
-        validate_dataset(scalars, options=options, stats=stats)
+        validate_dataset(dataset, options=options)
     for warning in tape:
         if not issubclass(warning.category, ValidationError):
             continue
         error = f"Dataset: {warning.message}"
         errors.append(error)
         logger.error(f"Validation error for {label}: {error}")
+
     return errors
 
 
@@ -448,26 +387,18 @@ def is_valid_dataset_id(dataset_id: str) -> bool:
 
 
 def validate_dataset(
-    message: dataset_pb2.Dataset,
+    message: dataset_pb2.Dataset | parquet_dataset.DatasetView,
     options: ValidationOptions | None = None,
-    *,
-    stats: _DatasetReactionStats | None = None,
 ):
     if options is None:
         options = ValidationOptions()
-    if stats is None:
-        # Build stats from ``message.reactions`` for callers that came through
-        # ``_VALIDATOR_SWITCH`` (e.g., a direct ``validate_message(dataset)``).
-        stats = _DatasetReactionStats()
-        for reaction in message.reactions:
-            stats.observe(reaction)
     if not message.name:
         warnings.warn("Dataset name is required", ValidationError)
     if not message.description:
         warnings.warn("Dataset description is required", ValidationError)
-    if not stats.num_reactions and not message.reaction_ids:
+    if not message.reactions and not message.reaction_ids:
         warnings.warn("Dataset requires reactions or reaction_ids", ValidationError)
-    elif stats.num_reactions and message.reaction_ids:
+    elif message.reactions and message.reaction_ids:
         warnings.warn("Dataset requires reactions or reaction_ids, not both", ValidationError)
     if message.reaction_ids:
         for reaction_id in message.reaction_ids:
@@ -477,14 +408,24 @@ def validate_dataset(
         # The dataset_id is a 32-character uuid4 hex string.
         if not is_valid_dataset_id(message.dataset_id):
             warnings.warn("Dataset ID is malformed", ValidationError)
-    for _ in stats.duplicate_events:
-        warnings.warn("Multiple Reactions should never have the same IDs", ValidationError)
-    for _ in stats.self_reference_events:
-        warnings.warn("A Reaction should not reference its own ID", ValidationError)
-    missing = stats.referenced_ids - stats.defined_ids
-    if missing:
+    # Check cross-references
+    dataset_referenced_ids = set()
+    dataset_defined_ids = set()
+    for reaction in message.reactions:
+        if reaction.reaction_id:
+            if reaction.reaction_id in dataset_defined_ids:
+                warnings.warn(
+                    "Multiple Reactions should never have the same IDs",
+                    ValidationError,
+                )
+            dataset_defined_ids.add(reaction.reaction_id)
+        referenced_ids = get_referenced_reaction_ids(reaction)
+        if any(_id == reaction.reaction_id for _id in referenced_ids):
+            warnings.warn("A Reaction should not reference its own ID", ValidationError)
+        dataset_referenced_ids |= referenced_ids
+    if len(dataset_referenced_ids - dataset_defined_ids) > 0:
         warnings.warn(
-            f"Reactions in the Dataset refer to undefined reaction_ids {missing}",
+            f"Reactions in the Dataset refer to undefined reaction_ids {dataset_referenced_ids - dataset_defined_ids}",
             ValidationError,
         )
 


### PR DESCRIPTION
## Summary

Streams validation for Parquet-serialized Datasets, plus a top-level `write_dataset` helper that dispatches by filename suffix. This is the `validate_dataset.py` piece of follow-up #2 from [#790](https://github.com/open-reaction-database/ord-schema/pull/790).

### What's in here

- **`parquet_dataset.DatasetView`** — a read-only, streaming stand-in for `dataset_pb2.Dataset`. Exposes `name`, `description`, `dataset_id` from the Parquet footer (read once on construction); `reaction_ids` is always empty (Parquet doesn't persist it); `reactions` is a read-only `@property` over a `_ReactionStream` that:
  - opens a fresh read on each iteration so callers stay memory-bounded,
  - reports `len()` / `bool()` from the footer's `num_rows`, so emptiness checks behave like a list instead of being always-truthy the way a bare generator would be.
- **`_validate_datasets`** now calls `validate_dataset` directly inside `catch_warnings` for the Dataset-level check instead of going through `validate_message(dataset, recurse=False)`. `validate_message` insists on a proto type (`_VALIDATOR_SWITCH` lookup, `DESCRIPTOR` access) and would reject a non-proto stand-in like `DatasetView`; the direct call preserves the same warning-capture behavior for both real `Dataset`s and `DatasetView`s.
- **`validate_dataset.py::run`** wraps `.parquet` inputs in `DatasetView` before handing off to `validate_datasets`, so the streaming path shares the whole validation body with in-memory `Dataset`s.
- **`message_helpers.write_dataset(dataset, path)`** — dispatches by suffix: `.parquet` routes to `parquet_dataset.write_dataset`, everything else to `write_message`. Gives callers one place to write a Dataset regardless of format.

### Not in this PR

- **Routing `.parquet` through `message_helpers.load_message`.** `DatasetView` isn't a proto, so returning one from `load_message` would break its generic `MessageType` contract for callers that mutate or `SerializeToString`. Callers that want streaming use `parquet_dataset.DatasetView` directly.
- **`process_dataset.py` Parquet support** (rest of follow-up #2) — deferred; will land as a separate PR.

## Test plan

- [x] `uv run pytest ord_schema/` — 312/312 pass (Postgres on `PATH` for ORM tests).
- [x] `test_dataset_view_exposes_all_dataset_fields` — regression guard: fails if a Dataset proto field is added without a matching attribute on `DatasetView`.
- [x] `test_dataset_view_empty_parquet_is_falsy` — guards the `__len__`/`__bool__` contract so `validate_dataset`'s "Dataset requires reactions or reaction_ids" check still fires for empty Parquet.
- [x] `test_dataset_view_reactions_is_read_only` — pins the read-only `@property` so accidental rebinding raises.
- [x] `test_dataset_view_values_round_trip` — scalars, `len(reactions)`, full iteration, and re-iteration.
- [x] `validate_dataset_test::setup` parametrized over `(.pbtxt, .parquet)` — existing `test_simple` / `test_filter` / `test_validation_errors` each run against both formats.
- [x] `test_write_dataset` parametrized over all 5 write formats, reading `.parquet` back via `DatasetView`.
- [x] `ruff check` + `ruff format --check` clean; `ty` clean via pre-commit.

Supersedes the over-scoped #793 (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)