### PR TITLE
Stream Parquet dataset updates in process_dataset.py with atomic temp-then-rename

### DIFF
--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -222,6 +222,7 @@ class DatasetView:
 
     @property
     def path(self) -> str:
+        """Path to the backing Parquet file (read-only)."""
         return self._path
 
     @property
@@ -297,8 +298,12 @@ def iter_reaction_ids(path: str) -> Iterator[str]:
     cheap even for very large files. Iteration order matches ``iter_reactions``.
     """
     with pq.ParquetFile(path) as parquet_file:
-        for batch in parquet_file.iter_batches(columns=["reaction_id"]):
-            yield from batch.column("reaction_id").to_pylist()
+        yield from _iter_reaction_ids(parquet_file)
+
+
+def _iter_reaction_ids(parquet_file: pq.ParquetFile) -> Iterator[str]:
+    for batch in parquet_file.iter_batches(columns=["reaction_id"]):
+        yield from batch.column("reaction_id").to_pylist()
 
 
 def read_reaction(path: str, reaction_id: str) -> reaction_pb2.Reaction:

--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -298,12 +298,8 @@ def iter_reaction_ids(path: str) -> Iterator[str]:
     cheap even for very large files. Iteration order matches ``iter_reactions``.
     """
     with pq.ParquetFile(path) as parquet_file:
-        yield from _iter_reaction_ids(parquet_file)
-
-
-def _iter_reaction_ids(parquet_file: pq.ParquetFile) -> Iterator[str]:
-    for batch in parquet_file.iter_batches(columns=["reaction_id"]):
-        yield from batch.column("reaction_id").to_pylist()
+        for batch in parquet_file.iter_batches(columns=["reaction_id"]):
+            yield from batch.column("reaction_id").to_pylist()
 
 
 def read_reaction(path: str, reaction_id: str) -> reaction_pb2.Reaction:

--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -221,6 +221,10 @@ class DatasetView:
         self._reactions = _ReactionStream(path, num_rows)
 
     @property
+    def path(self) -> str:
+        return self._path
+
+    @property
     def reactions(self) -> _ReactionStream:
         return self._reactions
 
@@ -284,6 +288,17 @@ def _iter_reactions(
             if filter_set is not None and reaction_id not in filter_set:
                 continue
             yield reaction_id, reaction_pb2.Reaction.FromString(blob)
+
+
+def iter_reaction_ids(path: str) -> Iterator[str]:
+    """Yields ``reaction_id`` values from a Parquet dataset without decoding Reaction blobs.
+
+    Reads only the ``reaction_id`` column row-group at a time, so this is
+    cheap even for very large files. Iteration order matches ``iter_reactions``.
+    """
+    with pq.ParquetFile(path) as parquet_file:
+        for batch in parquet_file.iter_batches(columns=["reaction_id"]):
+            yield from batch.column("reaction_id").to_pylist()
 
 
 def read_reaction(path: str, reaction_id: str) -> reaction_pb2.Reaction:

--- a/ord_schema/scripts/process_dataset.py
+++ b/ord_schema/scripts/process_dataset.py
@@ -92,7 +92,14 @@ def _get_inputs(args) -> list[FileStatus]:
 
 
 def cleanup(filename: str, output_filename: str):
-    """Removes and/or renames the input Dataset files.
+    """Reflects the (input → output) submission move in git's index.
+
+    If ``output_filename`` does not exist yet (the in-memory write path runs
+    cleanup before writing), do ``git mv`` so git records the rename and the
+    subsequent write overwrites the destination. If ``output_filename``
+    already exists (the streaming path publishes via atomic ``os.replace``
+    first), the move is already on disk; ``git rm`` removes the input from
+    git's index and ``git diff -M`` detects the rename via content similarity.
 
     Args:
         filename: Original dataset filename.
@@ -101,7 +108,10 @@ def cleanup(filename: str, output_filename: str):
     if filename == output_filename:
         logger.info("editing an existing dataset; no cleanup needed")
         return  # Reuse the existing dataset ID.
-    args = ["git", "mv", filename, output_filename]
+    if os.path.exists(output_filename):
+        args = ["git", "rm", "-f", filename]
+    else:
+        args = ["git", "mv", filename, output_filename]
     logger.info("Running command: %s", " ".join(args))
     subprocess.run(args, check=True)
 
@@ -216,9 +226,11 @@ def _run_updates(
             )
             os.makedirs(os.path.dirname(output_filename), exist_ok=True)
             temp_filename = output_filename + ".tmp"
-            # Order matters: cleanup runs `git mv input → output_filename`,
-            # which removes input from disk. update_parquet_dataset reads
-            # input, so cleanup must happen *after* the streaming pass.
+            # Atomic publish: stream-write to a temp, validate it, then rename
+            # over output_filename. The try guards everything up to and
+            # including os.replace so a failure leaves no `.tmp` lying around;
+            # cleanup runs after the publish so output_filename is guaranteed
+            # to exist before we touch git's index.
             try:
                 updates.update_parquet_dataset(input_filename, temp_filename, dataset_id=dataset.dataset_id)
                 validations.validate_datasets(
@@ -226,14 +238,14 @@ def _run_updates(
                     write_errors,
                     options=options,
                 )
-                if cleanup_files:
-                    cleanup(input_filename, output_filename)
                 logger.info("writing Dataset to %s", output_filename)
                 os.replace(temp_filename, output_filename)
             except Exception:
                 if os.path.exists(temp_filename):
                     os.unlink(temp_filename)
                 raise
+            if cleanup_files:
+                cleanup(input_filename, output_filename)
             continue
         # In-memory path: materialize a Parquet input if the requested output
         # format is not Parquet (so we can mutate via update_dataset).

--- a/ord_schema/scripts/process_dataset.py
+++ b/ord_schema/scripts/process_dataset.py
@@ -219,7 +219,7 @@ def _run_updates(
                 cleanup(input_filename, output_filename)
             temp_filename = output_filename + ".tmp"
             try:
-                updates.update_dataset_parquet(input_filename, temp_filename, dataset_id=dataset.dataset_id)
+                updates.update_parquet_dataset(input_filename, temp_filename, dataset_id=dataset.dataset_id)
                 validations.validate_datasets(
                     {input_filename: parquet_dataset.DatasetView(temp_filename)},
                     write_errors,

--- a/ord_schema/scripts/process_dataset.py
+++ b/ord_schema/scripts/process_dataset.py
@@ -215,9 +215,10 @@ def _run_updates(
                 message_helpers.id_filename(f"{dataset.dataset_id}{output_format}"),
             )
             os.makedirs(os.path.dirname(output_filename), exist_ok=True)
-            if cleanup_files:
-                cleanup(input_filename, output_filename)
             temp_filename = output_filename + ".tmp"
+            # Order matters: cleanup runs `git mv input → output_filename`,
+            # which removes input from disk. update_parquet_dataset reads
+            # input, so cleanup must happen *after* the streaming pass.
             try:
                 updates.update_parquet_dataset(input_filename, temp_filename, dataset_id=dataset.dataset_id)
                 validations.validate_datasets(
@@ -225,12 +226,14 @@ def _run_updates(
                     write_errors,
                     options=options,
                 )
-            except BaseException:
+                if cleanup_files:
+                    cleanup(input_filename, output_filename)
+                logger.info("writing Dataset to %s", output_filename)
+                os.replace(temp_filename, output_filename)
+            except Exception:
                 if os.path.exists(temp_filename):
                     os.unlink(temp_filename)
                 raise
-            logger.info("writing Dataset to %s", output_filename)
-            os.replace(temp_filename, output_filename)
             continue
         # In-memory path: materialize a Parquet input if the requested output
         # format is not Parquet (so we can mutate via update_dataset).

--- a/ord_schema/scripts/process_dataset.py
+++ b/ord_schema/scripts/process_dataset.py
@@ -34,11 +34,12 @@ import gzip
 import os
 import subprocess
 import sys
+import tempfile
 from collections.abc import Iterable, Mapping
 
 import github
 
-from ord_schema import message_helpers, updates, validations
+from ord_schema import message_helpers, parquet_dataset, updates, validations
 from ord_schema.logging import get_logger, silence_rdkit_logs
 from ord_schema.proto import dataset_pb2
 
@@ -105,17 +106,25 @@ def cleanup(filename: str, output_filename: str):
     subprocess.run(args, check=True)
 
 
-def _get_reaction_ids(dataset: dataset_pb2.Dataset) -> set[str]:
-    """Returns a set containing the reaction IDs in a Dataset."""
-    reaction_ids = set()
-    for reaction in dataset.reactions:
-        if reaction.reaction_id:
-            reaction_ids.add(reaction.reaction_id)
-    return reaction_ids
+def _get_reaction_ids(dataset: dataset_pb2.Dataset | parquet_dataset.DatasetView) -> set[str]:
+    """Returns a set containing the reaction IDs in a Dataset.
+
+    For ``DatasetView``, the ``reaction_id`` column is read directly from the
+    Parquet file so we never decode Reaction blobs just to collect IDs.
+    """
+    if isinstance(dataset, parquet_dataset.DatasetView):
+        return {rid for rid in parquet_dataset.iter_reaction_ids(dataset.path) if rid}
+    return {reaction.reaction_id for reaction in dataset.reactions if reaction.reaction_id}
 
 
-def _load_base_dataset(file_status: FileStatus, base: str) -> dataset_pb2.Dataset | None:
-    """Loads a Dataset message from another branch."""
+def _load_base_dataset(file_status: FileStatus, base: str) -> dataset_pb2.Dataset | parquet_dataset.DatasetView | None:
+    """Loads a Dataset from another git branch.
+
+    Parquet inputs are spilled to a temp file and wrapped in a ``DatasetView``
+    so the diff path can scan the ``reaction_id`` column without decoding any
+    Reaction blobs. The temp file outlives the view (process-lifetime leak),
+    which is fine for this CLI script — the OS reclaims it on exit.
+    """
     if file_status.status.startswith("A"):
         return None  # Dataset only exists in the submission.
     # NOTE(kearnes): Use --no-pager to avoid a non-zero exit code.
@@ -135,6 +144,11 @@ def _load_base_dataset(file_status: FileStatus, base: str) -> dataset_pb2.Datase
             check=True,
             text=False,
         )
+    if git_args[-1].endswith(".parquet"):
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as temp:
+            temp.write(serialized.stdout)
+            temp_path = temp.name
+        return parquet_dataset.DatasetView(temp_path)
     if git_args[-1].endswith(".gz"):
         value = gzip.decompress(serialized.stdout)
     else:
@@ -143,7 +157,9 @@ def _load_base_dataset(file_status: FileStatus, base: str) -> dataset_pb2.Datase
 
 
 def get_change_stats(
-    datasets: Mapping[str, dataset_pb2.Dataset | None], inputs: Iterable[FileStatus], base: str
+    datasets: Mapping[str, dataset_pb2.Dataset | parquet_dataset.DatasetView | None],
+    inputs: Iterable[FileStatus],
+    base: str,
 ) -> tuple[set[str], set[str], set[str]]:
     """Computes diff statistics for the submission.
 
@@ -172,30 +188,65 @@ def get_change_stats(
 
 
 def _run_updates(
-    datasets: Mapping[str, dataset_pb2.Dataset],
+    datasets: Mapping[str, dataset_pb2.Dataset | parquet_dataset.DatasetView],
     *,
     root: str,
     output_format: str,
     write_errors: bool,
     cleanup_files: bool,
 ) -> None:
-    """Updates the submission files."""
-    for dataset in datasets.values():
-        # Set reaction_ids, resolve names, fix cross-references, etc.
-        updates.update_dataset(dataset)
-    # Final validation to make sure we didn't break anything.
+    """Updates the submission files.
+
+    When the input is a ``DatasetView`` and the output is also Parquet, the
+    update runs as a streaming two-pass over the input file with an atomic
+    temp-then-rename publish (validation runs against the temp before the
+    rename). Otherwise the in-memory path mutates the Dataset in place,
+    validates, and writes through ``message_helpers.write_dataset``.
+    """
     options = validations.ValidationOptions(validate_ids=True, require_provenance=True)
-    validations.validate_datasets(datasets, write_errors, options=options)
-    for filename, dataset in datasets.items():
+    for input_filename, dataset in datasets.items():
+        is_parquet_stream = isinstance(dataset, parquet_dataset.DatasetView) and output_format == ".parquet"
+        if is_parquet_stream:
+            # Resolve dataset_id up-front so the output filename is known
+            # before we open the streaming writer.
+            updates.assign_dataset_id(dataset)
+            output_filename = os.path.join(
+                root,
+                message_helpers.id_filename(f"{dataset.dataset_id}{output_format}"),
+            )
+            os.makedirs(os.path.dirname(output_filename), exist_ok=True)
+            if cleanup_files:
+                cleanup(input_filename, output_filename)
+            temp_filename = output_filename + ".tmp"
+            try:
+                updates.update_dataset_parquet(input_filename, temp_filename, dataset_id=dataset.dataset_id)
+                validations.validate_datasets(
+                    {input_filename: parquet_dataset.DatasetView(temp_filename)},
+                    write_errors,
+                    options=options,
+                )
+            except BaseException:
+                if os.path.exists(temp_filename):
+                    os.unlink(temp_filename)
+                raise
+            logger.info("writing Dataset to %s", output_filename)
+            os.replace(temp_filename, output_filename)
+            continue
+        # In-memory path: materialize a Parquet input if the requested output
+        # format is not Parquet (so we can mutate via update_dataset).
+        if isinstance(dataset, parquet_dataset.DatasetView):
+            dataset = parquet_dataset.read_dataset(input_filename)
+        updates.update_dataset(dataset)
+        validations.validate_datasets({input_filename: dataset}, write_errors, options=options)
         output_filename = os.path.join(
             root,
             message_helpers.id_filename(f"{dataset.dataset_id}{output_format}"),
         )
         os.makedirs(os.path.dirname(output_filename), exist_ok=True)
         if cleanup_files:
-            cleanup(filename, output_filename)
+            cleanup(input_filename, output_filename)
         logger.info("writing Dataset to %s", output_filename)
-        message_helpers.write_message(dataset, output_filename)
+        message_helpers.write_dataset(dataset, output_filename)
 
 
 def run(args) -> tuple[set[str] | None, set[str] | None, set[str] | None]:
@@ -217,13 +268,17 @@ def run(args) -> tuple[set[str] | None, set[str] | None, set[str] | None]:
     # NOTE(kearnes): Process one dataset at a time to avoid OOM errors.
     change_stats = {}
     for file_status in inputs:
+        dataset: dataset_pb2.Dataset | parquet_dataset.DatasetView | None
         if file_status.status == "D":
             dataset = None
+        elif file_status.filename.endswith(".parquet"):
+            dataset = parquet_dataset.DatasetView(file_status.filename)
+            logger.info("%s: %d reactions", file_status.filename, len(dataset.reactions))
         else:
             dataset = message_helpers.load_message(file_status.filename, dataset_pb2.Dataset)
             logger.info("%s: %d reactions", file_status.filename, len(dataset.reactions))
-        datasets: dict[str, dataset_pb2.Dataset | None] = {file_status.filename: dataset}
-        datasets_checked: dict[str, dataset_pb2.Dataset] = (
+        datasets: dict[str, dataset_pb2.Dataset | parquet_dataset.DatasetView | None] = {file_status.filename: dataset}
+        datasets_checked: dict[str, dataset_pb2.Dataset | parquet_dataset.DatasetView] = (
             {file_status.filename: dataset} if dataset is not None else {}
         )
         if not args.no_validate and dataset is not None:

--- a/ord_schema/scripts/process_dataset_test.py
+++ b/ord_schema/scripts/process_dataset_test.py
@@ -282,14 +282,11 @@ class TestSubmissionWorkflow:
         """
         # These commands will fail if there are no files to match for a given
         # pattern, so run them separately to make sure we pick up changes.
-        try:
-            subprocess.run(["git", "add", "*.pb*"], check=True)
-        except subprocess.CalledProcessError as error:
-            logger.info(error)
-        try:
-            subprocess.run(["git", "add", "data/*/*.pb*"], check=True)
-        except subprocess.CalledProcessError as error:
-            logger.info(error)
+        for pattern in ("*.pb*", "data/*/*.pb*", "*.parquet", "data/*/*.parquet"):
+            try:
+                subprocess.run(["git", "add", pattern], check=True)
+            except subprocess.CalledProcessError as error:
+                logger.info(error)
         changed = subprocess.run(
             ["git", "diff", "--name-status", self._DEFAULT_BRANCH],
             check=True,
@@ -312,6 +309,7 @@ class TestSubmissionWorkflow:
             argv.extend(extra_argv)
         added, removed, changed = process_dataset.run(process_dataset.parse_args(argv))
         filenames = glob.glob(os.path.join(test_subdirectory, "**/*.pb*"), recursive=True)
+        filenames += glob.glob(os.path.join(test_subdirectory, "**/*.parquet"), recursive=True)
         return added, removed, changed, filenames
 
     def test_add_dataset(self, setup):
@@ -346,6 +344,39 @@ class TestSubmissionWorkflow:
         assert dataset.reactions[0].reaction_id
         # Check for binary output.
         assert filenames[0].endswith(".pb.gz")
+
+    def test_add_dataset_parquet_with_cleanup(self, setup):
+        # Exercises --cleanup + .parquet input + .parquet output: the
+        # streaming pass must read input *before* cleanup runs `git mv`.
+        test_subdirectory, dataset_filename = setup
+        reaction = reaction_pb2.Reaction()
+        ethylamine = reaction.inputs["ethylamine"]
+        component = ethylamine.components.add()
+        component.identifiers.add(type="SMILES", value="CCN")
+        component.is_limiting = True
+        component.amount.moles.value = 2
+        component.amount.moles.units = reaction_pb2.Moles.MILLIMOLE
+        reaction.outcomes.add().conversion.value = 25
+        reaction.provenance.record_created.time.value = "2020-01-01"
+        reaction.provenance.record_created.person.username = "test"
+        reaction.provenance.record_created.person.email = "test@example.com"
+        reaction.reaction_id = "test"
+        dataset = dataset_pb2.Dataset(name="test", description="test", reactions=[reaction])
+        this_dataset_filename = os.path.join(test_subdirectory, "test.parquet")
+        parquet_dataset.write_dataset(dataset, this_dataset_filename)
+        added, removed, changed, filenames = self._run(test_subdirectory, ["--output_format", ".parquet"])
+        assert added == {"test"}
+        assert not removed
+        assert not changed
+        # cleanup ran (input no longer at top level); atomic publish completed.
+        assert not os.path.exists(this_dataset_filename)
+        parquet_files = [f for f in filenames if f.endswith(".parquet")]
+        assert len(parquet_files) == 1
+        assert not os.path.exists(parquet_files[0] + ".tmp")
+        result = parquet_dataset.read_dataset(parquet_files[0])
+        assert result.dataset_id.startswith("ord_dataset-")
+        assert len(result.reactions) == 1
+        assert result.reactions[0].reaction_id.startswith("ord-")
 
     def test_add_sharded_dataset(self, setup):
         test_subdirectory, dataset_filename = setup

--- a/ord_schema/scripts/process_dataset_test.py
+++ b/ord_schema/scripts/process_dataset_test.py
@@ -345,7 +345,7 @@ class TestSubmissionWorkflow:
         # Check for binary output.
         assert filenames[0].endswith(".pb.gz")
 
-    def test_add_dataset_parquet_with_cleanup(self, setup):
+    def test_add_parquet_dataset_with_cleanup(self, setup):
         # Exercises --cleanup + .parquet input + .parquet output: the
         # streaming pass must read input *before* cleanup runs `git mv`.
         test_subdirectory, dataset_filename = setup

--- a/ord_schema/scripts/process_dataset_test.py
+++ b/ord_schema/scripts/process_dataset_test.py
@@ -110,7 +110,7 @@ class TestProcessDataset:
         assert dataset.reactions[0].reaction_id.startswith("ord-")
 
 
-class TestProcessDatasetParquet:
+class TestProcessParquetDataset:
     """Parquet input/output flows: load via DatasetView, streaming update."""
 
     @pytest.fixture

--- a/ord_schema/scripts/process_dataset_test.py
+++ b/ord_schema/scripts/process_dataset_test.py
@@ -21,7 +21,7 @@ from collections.abc import Iterator
 import pytest
 from rdkit import RDLogger
 
-from ord_schema import message_helpers, validations
+from ord_schema import message_helpers, parquet_dataset, validations
 from ord_schema.logging import get_logger
 from ord_schema.proto import dataset_pb2, reaction_pb2
 from ord_schema.scripts import process_dataset
@@ -108,6 +108,119 @@ class TestProcessDataset:
         dataset = message_helpers.load_message(expected_output, dataset_pb2.Dataset)
         assert len(dataset.reactions) == 1
         assert dataset.reactions[0].reaction_id.startswith("ord-")
+
+
+class TestProcessDatasetParquet:
+    """Parquet input/output flows: load via DatasetView, streaming update."""
+
+    @pytest.fixture
+    def parquet_dataset_filename(self, tmp_path) -> Iterator[str]:
+        RDLogger.logger().setLevel(RDLogger.CRITICAL)
+        reaction = reaction_pb2.Reaction()
+        component = reaction.inputs["x"].components.add()
+        component.identifiers.add(type="CUSTOM", details="custom_identifier", value="v")
+        component.is_limiting = True
+        component.amount.mass.value = 1
+        component.amount.mass.units = reaction_pb2.Mass.GRAM
+        reaction.outcomes.add().conversion.value = 75
+        reaction.provenance.record_created.time.value = "2020-01-01"
+        reaction.provenance.record_created.person.username = "test"
+        reaction.provenance.record_created.person.email = "test@example.com"
+        dataset = dataset_pb2.Dataset(
+            name="parquet_test",
+            description="parquet_test",
+            dataset_id="ord_dataset-00000000000000000000000000000000",
+            reactions=[reaction],
+        )
+        filename = (tmp_path / "ds.parquet").as_posix()
+        parquet_dataset.write_dataset(dataset, filename)
+        yield filename
+
+    def test_main_with_parquet_input(self, parquet_dataset_filename):
+        # No --update: loads via DatasetView, runs validation + size check.
+        argv = ["--input_pattern", parquet_dataset_filename]
+        process_dataset.main(process_dataset.parse_args(argv))
+
+    def test_main_with_streaming_update(self, parquet_dataset_filename, tmp_path):
+        argv = [
+            "--input_pattern",
+            parquet_dataset_filename,
+            "--root",
+            tmp_path.as_posix(),
+            "--update",
+            "--output_format",
+            ".parquet",
+        ]
+        process_dataset.main(process_dataset.parse_args(argv))
+        expected_output = os.path.join(
+            tmp_path.as_posix(), "data", "00", "ord_dataset-00000000000000000000000000000000.parquet"
+        )
+        assert os.path.exists(expected_output)
+        # Atomic-rename guarantee: the .tmp sibling must not be left behind.
+        assert not os.path.exists(expected_output + ".tmp")
+        result = parquet_dataset.read_dataset(expected_output)
+        assert len(result.reactions) == 1
+        assert result.reactions[0].reaction_id.startswith("ord-")
+        # Streaming path exercises apply_reaction_updates → record_modified.
+        assert len(result.reactions[0].provenance.record_modified) == 1
+
+    def test_streaming_update_cleans_up_temp_on_validation_failure(self, tmp_path):
+        # Reaction is missing required provenance, so the post-stream validation
+        # (which runs with require_provenance=True) will raise. The .tmp file
+        # written during streaming must be cleaned up.
+        reaction = reaction_pb2.Reaction()
+        component = reaction.inputs["x"].components.add()
+        component.identifiers.add(type="CUSTOM", details="custom_identifier", value="v")
+        component.is_limiting = True
+        component.amount.mass.value = 1
+        component.amount.mass.units = reaction_pb2.Mass.GRAM
+        reaction.outcomes.add().conversion.value = 75
+        # Note: no provenance.record_created → fails require_provenance=True.
+        dataset = dataset_pb2.Dataset(
+            name="bad",
+            description="bad",
+            dataset_id="ord_dataset-00000000000000000000000000000000",
+            reactions=[reaction],
+        )
+        filename = (tmp_path / "bad.parquet").as_posix()
+        parquet_dataset.write_dataset(dataset, filename)
+        argv = [
+            "--input_pattern",
+            filename,
+            "--root",
+            tmp_path.as_posix(),
+            "--no-validate",  # Skip the pre-update validation so we hit the post-stream path.
+            "--update",
+            "--output_format",
+            ".parquet",
+        ]
+        with pytest.raises(validations.ValidationError):
+            process_dataset.main(process_dataset.parse_args(argv))
+        expected_output = os.path.join(
+            tmp_path.as_posix(), "data", "00", "ord_dataset-00000000000000000000000000000000.parquet"
+        )
+        assert not os.path.exists(expected_output + ".tmp")
+        assert not os.path.exists(expected_output)
+
+    def test_main_with_parquet_input_pbgz_output(self, parquet_dataset_filename, tmp_path):
+        # Parquet input + non-parquet output falls back to in-memory materialize.
+        argv = [
+            "--input_pattern",
+            parquet_dataset_filename,
+            "--root",
+            tmp_path.as_posix(),
+            "--update",
+            "--output_format",
+            ".pb.gz",
+        ]
+        process_dataset.main(process_dataset.parse_args(argv))
+        expected_output = os.path.join(
+            tmp_path.as_posix(), "data", "00", "ord_dataset-00000000000000000000000000000000.pb.gz"
+        )
+        assert os.path.exists(expected_output)
+        result = message_helpers.load_message(expected_output, dataset_pb2.Dataset)
+        assert len(result.reactions) == 1
+        assert result.reactions[0].reaction_id.startswith("ord-")
 
 
 class TestSubmissionWorkflow:

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -120,31 +120,14 @@ def apply_cross_reference_substitutions(reaction: reaction_pb2.Reaction, id_subs
                 crude_component.reaction_id = id_substitutions[crude_component.reaction_id]
 
 
-def update_reaction(reaction: reaction_pb2.Reaction) -> dict[str, str]:
-    """Updates a Reaction message.
-
-    Current updates:
-      * Sets reaction_id if not already set.
-      * Adds a record modification event to the provenance.
-
-    Args:
-        reaction: reaction_pb2.Reaction message.
-
-    Returns:
-        A dictionary mapping placeholder reaction_ids to newly-assigned
-            reaction_ids.
-    """
-    new_ids, id_substitutions = assign_id_substitutions([reaction.reaction_id])
-    apply_reaction_updates(reaction, new_id=new_ids[0])
-    return id_substitutions
-
-
 def update_dataset(dataset: dataset_pb2.Dataset):
     """Updates a Dataset message.
 
     Current updates:
-      * All reaction-level updates in update_reaction.
-      * reaction_id cross-references between Reactions in the dataset.
+      * Sets dataset_id if not already canonical.
+      * Sets reaction_id on each Reaction if not already canonical, and
+        appends a record_modified provenance event for any modified Reaction.
+      * Rewrites reaction_id cross-references between Reactions in the dataset.
 
     Args:
         dataset: dataset_pb2.Dataset message.
@@ -162,7 +145,7 @@ def update_dataset(dataset: dataset_pb2.Dataset):
         apply_cross_reference_substitutions(reaction, id_substitutions)
 
 
-def update_dataset_parquet(input_path: str, output_path: str, *, dataset_id: str) -> None:
+def update_parquet_dataset(input_path: str, output_path: str, *, dataset_id: str) -> None:
     """Stream-applies ``update_dataset`` to a Parquet input, writing the result to ``output_path``.
 
     Two passes over ``input_path``:

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -16,11 +16,107 @@
 import datetime
 import re
 import uuid
+from collections.abc import Iterable
 
+from ord_schema import parquet_dataset
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 _USERNAME = "github-actions"
 _EMAIL = "github-actions@github.com"
+
+_REACTION_ID_RE = re.compile("^ord-[0-9a-f]{32}$")
+_DATASET_ID_RE = re.compile("^ord_dataset-[0-9a-f]{32}$")
+
+
+def assign_dataset_id(dataset: dataset_pb2.Dataset | parquet_dataset.DatasetView) -> str:
+    """Assigns a canonical ``dataset_id`` if the existing one is missing or non-canonical.
+
+    Mutates ``dataset.dataset_id`` in place. Works for both ``Dataset`` and
+    ``DatasetView`` (which exposes ``dataset_id`` as a writable attribute).
+
+    Returns:
+        The (possibly newly-assigned) dataset_id.
+    """
+    if not _DATASET_ID_RE.fullmatch(dataset.dataset_id):
+        dataset.dataset_id = f"ord_dataset-{uuid.uuid4().hex}"
+    return dataset.dataset_id
+
+
+def assign_id_substitutions(old_ids: Iterable[str]) -> tuple[list[str | None], dict[str, str]]:
+    """Pre-allocates canonical reaction IDs for a sequence of old IDs.
+
+    A reaction's ID is replaced when the existing one is missing or does not
+    match the canonical ``ord-{32 hex}`` pattern. Cross-reference rewriting
+    only applies to old IDs that were non-empty (i.e., user-supplied
+    placeholders); reactions whose old ID was empty get a new ID but no
+    substitution entry, since nothing else could have referenced them.
+
+    Args:
+        old_ids: Reaction IDs in the order they appear in the dataset.
+
+    Returns:
+        new_ids: List parallel to ``old_ids``; entry is the new reaction_id
+            to assign, or ``None`` if the old ID was already canonical.
+        id_substitutions: Map of ``old_id -> new_id`` for entries where the
+            old ID was a non-empty placeholder. Used to rewrite cross-references.
+    """
+    new_ids: list[str | None] = []
+    id_substitutions: dict[str, str] = {}
+    for old_id in old_ids:
+        if _REACTION_ID_RE.fullmatch(old_id):
+            new_ids.append(None)
+            continue
+        new_id = f"ord-{uuid.uuid4().hex}"
+        new_ids.append(new_id)
+        if old_id:
+            id_substitutions[old_id] = new_id
+    return new_ids, id_substitutions
+
+
+def apply_reaction_updates(reaction: reaction_pb2.Reaction, *, new_id: str | None) -> bool:
+    """Applies per-reaction updates in place using a pre-computed reaction ID.
+
+    Splitting ID generation out of this function lets a streaming caller
+    allocate IDs in a cheap pre-pass (e.g. from a Parquet ``reaction_id``
+    column) and inject them here without re-deriving them.
+
+    Args:
+        reaction: Reaction message to mutate.
+        new_id: Pre-computed reaction_id to assign, or ``None`` to leave the
+            existing ID untouched.
+
+    Returns:
+        True if the reaction was modified.
+    """
+    modified = False
+    if new_id is not None:
+        reaction.reaction_id = new_id
+        modified = True
+    for func in _UPDATES:
+        # NOTE(kearnes): Order matters; ``func(reaction) or modified`` would
+        # short-circuit when ``modified`` is True and skip the side effect.
+        modified = func(reaction) or modified
+    if modified:
+        event = reaction.provenance.record_modified.add()
+        event.time.value = datetime.datetime.now(datetime.timezone.utc).ctime()
+        event.person.username = _USERNAME
+        event.person.email = _EMAIL
+        event.details = "Automatic updates from the submission pipeline."
+    return modified
+
+
+def apply_cross_reference_substitutions(reaction: reaction_pb2.Reaction, id_substitutions: dict[str, str]) -> None:
+    """Rewrites cross-referenced reaction_ids inside ``reaction`` using the substitution map."""
+    if not id_substitutions:
+        return
+    for reaction_input in reaction.inputs.values():
+        for component in reaction_input.components:
+            for preparation in component.preparations:
+                if preparation.reaction_id in id_substitutions:
+                    preparation.reaction_id = id_substitutions[preparation.reaction_id]
+        for crude_component in reaction_input.crude_components:
+            if crude_component.reaction_id in id_substitutions:
+                crude_component.reaction_id = id_substitutions[crude_component.reaction_id]
 
 
 def update_reaction(reaction: reaction_pb2.Reaction) -> dict[str, str]:
@@ -37,29 +133,8 @@ def update_reaction(reaction: reaction_pb2.Reaction) -> dict[str, str]:
         A dictionary mapping placeholder reaction_ids to newly-assigned
             reaction_ids.
     """
-    modified = False
-    id_substitutions = {}
-    if not re.fullmatch("^ord-[0-9a-f]{32}$", reaction.reaction_id):
-        # NOTE(kearnes): This does not check for the case where a Dataset is
-        # edited and reaction_id values are changed inappropriately. This will
-        # need to be either (1) caught in review or (2) found by a complex
-        # check of the diff.
-        reaction_id = f"ord-{uuid.uuid4().hex}"
-        if reaction.reaction_id:
-            id_substitutions[reaction.reaction_id] = reaction_id
-        reaction.reaction_id = reaction_id
-        modified = True
-    for func in _UPDATES:
-        # NOTE(kearnes): Order is important here; if you write
-        # `modified or func(reaction)` and modified is True, the interpreter
-        # will skip the evaluation of func(reaction).
-        modified = func(reaction) or modified
-    if modified:
-        event = reaction.provenance.record_modified.add()
-        event.time.value = datetime.datetime.now(datetime.timezone.utc).ctime()
-        event.person.username = _USERNAME
-        event.person.email = _EMAIL
-        event.details = "Automatic updates from the submission pipeline."
+    new_ids, id_substitutions = assign_id_substitutions([reaction.reaction_id])
+    apply_reaction_updates(reaction, new_id=new_ids[0])
     return id_substitutions
 
 
@@ -78,22 +153,48 @@ def update_dataset(dataset: dataset_pb2.Dataset):
             cross-referenced reaction_id in any Reaction that is not defined
             elsewhere in the Dataset.
     """
-    if not re.fullmatch("^ord_dataset-[0-9a-f]{32}$", dataset.dataset_id):
-        dataset.dataset_id = f"ord_dataset-{uuid.uuid4().hex}"
-    # Reaction-level updates
-    id_substitutions = {}
+    assign_dataset_id(dataset)
+    new_ids, id_substitutions = assign_id_substitutions(r.reaction_id for r in dataset.reactions)
+    for reaction, new_id in zip(dataset.reactions, new_ids, strict=True):
+        apply_reaction_updates(reaction, new_id=new_id)
     for reaction in dataset.reactions:
-        id_substitutions.update(update_reaction(reaction))
-    # Dataset-level updates of cross-references
-    for reaction in dataset.reactions:
-        for reaction_input in reaction.inputs.values():
-            for component in reaction_input.components:
-                for preparation in component.preparations:
-                    if preparation.reaction_id and preparation.reaction_id in id_substitutions:
-                        preparation.reaction_id = id_substitutions[preparation.reaction_id]
-            for crude_component in reaction_input.crude_components:
-                if crude_component.reaction_id in id_substitutions:
-                    crude_component.reaction_id = id_substitutions[crude_component.reaction_id]
+        apply_cross_reference_substitutions(reaction, id_substitutions)
+
+
+def update_dataset_parquet(input_path: str, output_path: str, *, dataset_id: str) -> None:
+    """Stream-applies ``update_dataset`` to a Parquet input, writing the result to ``output_path``.
+
+    Two passes over ``input_path``:
+
+    * Pass 1 reads only the ``reaction_id`` column (no Reaction decode) to
+      pre-allocate canonical reaction IDs and build the cross-reference map.
+    * Pass 2 streams full Reactions, applies per-reaction updates and
+      cross-reference rewrites, and writes them via ``DatasetWriter``.
+
+    Peak memory is bounded by one row group plus the ID maps. The caller is
+    responsible for choosing ``output_path`` based on the resolved ``dataset_id``
+    (call ``assign_dataset_id`` on the input header first to learn it) and for
+    any atomic-rename / validation dance — keeping the rename outside lets the
+    caller validate the written file before publishing it.
+
+    Args:
+        input_path: Path to the input Parquet dataset.
+        output_path: Path to write the updated Parquet dataset to.
+        dataset_id: Resolved dataset_id to write into the output footer.
+    """
+    header = parquet_dataset.read_metadata(input_path)
+    new_ids, id_substitutions = assign_id_substitutions(parquet_dataset.iter_reaction_ids(input_path))
+    with parquet_dataset.DatasetWriter(
+        output_path,
+        name=header.name,
+        description=header.description,
+        dataset_id=dataset_id,
+    ) as writer:
+        reactions = (reaction for _, reaction in parquet_dataset.iter_reactions(input_path))
+        for reaction, new_id in zip(reactions, new_ids, strict=True):
+            apply_reaction_updates(reaction, new_id=new_id)
+            apply_cross_reference_substitutions(reaction, id_substitutions)
+            writer.write(reaction)
 
 
 # Standard updates.

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -93,8 +93,9 @@ def apply_reaction_updates(reaction: reaction_pb2.Reaction, *, new_id: str | Non
         reaction.reaction_id = new_id
         modified = True
     for func in _UPDATES:
-        # NOTE(kearnes): Order matters; ``func(reaction) or modified`` would
-        # short-circuit when ``modified`` is True and skip the side effect.
+        # NOTE(kearnes): Order is important here; if you write
+        # `modified or func(reaction)` and modified is True, the interpreter
+        # will skip the evaluation of func(reaction).
         modified = func(reaction) or modified
     if modified:
         event = reaction.provenance.record_modified.add()

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -18,8 +18,6 @@ import re
 import uuid
 from collections.abc import Iterable
 
-import pyarrow.parquet as pq
-
 from ord_schema import parquet_dataset
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
@@ -172,22 +170,19 @@ def update_parquet_dataset(input_path: str, output_path: str, *, dataset_id: str
         output_path: Path to write the updated Parquet dataset to.
         dataset_id: Resolved dataset_id to write into the output footer.
     """
-    # Share a single ParquetFile handle across the header read, the pass-1
-    # column scan, and the pass-2 streaming read so we open the file once.
-    with pq.ParquetFile(input_path) as input_file:
-        header = parquet_dataset._dataset_from_metadata(input_file.schema_arrow.metadata)
-        new_ids, id_substitutions = assign_id_substitutions(parquet_dataset._iter_reaction_ids(input_file))
-        with parquet_dataset.DatasetWriter(
-            output_path,
-            name=header.name,
-            description=header.description,
-            dataset_id=dataset_id,
-        ) as writer:
-            reactions = (reaction for _, reaction in parquet_dataset._iter_reactions(input_file, filter_set=None))
-            for reaction, new_id in zip(reactions, new_ids, strict=True):
-                apply_reaction_updates(reaction, new_id=new_id)
-                apply_cross_reference_substitutions(reaction, id_substitutions)
-                writer.write(reaction)
+    header = parquet_dataset.read_metadata(input_path)
+    new_ids, id_substitutions = assign_id_substitutions(parquet_dataset.iter_reaction_ids(input_path))
+    with parquet_dataset.DatasetWriter(
+        output_path,
+        name=header.name,
+        description=header.description,
+        dataset_id=dataset_id,
+    ) as writer:
+        reactions = (reaction for _, reaction in parquet_dataset.iter_reactions(input_path))
+        for reaction, new_id in zip(reactions, new_ids, strict=True):
+            apply_reaction_updates(reaction, new_id=new_id)
+            apply_cross_reference_substitutions(reaction, id_substitutions)
+            writer.write(reaction)
 
 
 # Standard updates.

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -18,6 +18,8 @@ import re
 import uuid
 from collections.abc import Iterable
 
+import pyarrow.parquet as pq
+
 from ord_schema import parquet_dataset
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
@@ -50,6 +52,10 @@ def assign_id_substitutions(old_ids: Iterable[str]) -> tuple[list[str | None], d
     only applies to old IDs that were non-empty (i.e., user-supplied
     placeholders); reactions whose old ID was empty get a new ID but no
     substitution entry, since nothing else could have referenced them.
+
+    NOTE(kearnes): This does not check for the case where a Dataset is edited
+    and reaction_id values are changed inappropriately. This will need to be
+    either (1) caught in review or (2) found by a complex check of the diff.
 
     Args:
         old_ids: Reaction IDs in the order they appear in the dataset.
@@ -166,19 +172,22 @@ def update_parquet_dataset(input_path: str, output_path: str, *, dataset_id: str
         output_path: Path to write the updated Parquet dataset to.
         dataset_id: Resolved dataset_id to write into the output footer.
     """
-    header = parquet_dataset.read_metadata(input_path)
-    new_ids, id_substitutions = assign_id_substitutions(parquet_dataset.iter_reaction_ids(input_path))
-    with parquet_dataset.DatasetWriter(
-        output_path,
-        name=header.name,
-        description=header.description,
-        dataset_id=dataset_id,
-    ) as writer:
-        reactions = (reaction for _, reaction in parquet_dataset.iter_reactions(input_path))
-        for reaction, new_id in zip(reactions, new_ids, strict=True):
-            apply_reaction_updates(reaction, new_id=new_id)
-            apply_cross_reference_substitutions(reaction, id_substitutions)
-            writer.write(reaction)
+    # Share a single ParquetFile handle across the header read, the pass-1
+    # column scan, and the pass-2 streaming read so we open the file once.
+    with pq.ParquetFile(input_path) as input_file:
+        header = parquet_dataset._dataset_from_metadata(input_file.schema_arrow.metadata)
+        new_ids, id_substitutions = assign_id_substitutions(parquet_dataset._iter_reaction_ids(input_file))
+        with parquet_dataset.DatasetWriter(
+            output_path,
+            name=header.name,
+            description=header.description,
+            dataset_id=dataset_id,
+        ) as writer:
+            reactions = (reaction for _, reaction in parquet_dataset._iter_reactions(input_file, filter_set=None))
+            for reaction, new_id in zip(reactions, new_ids, strict=True):
+                apply_reaction_updates(reaction, new_id=new_id)
+                apply_cross_reference_substitutions(reaction, id_substitutions)
+                writer.write(reaction)
 
 
 # Standard updates.

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 """Tests for ord_schema.updates."""
 
+import os
 from collections.abc import Iterator
 
 import pytest
 
-from ord_schema import updates
+from ord_schema import parquet_dataset, updates
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 
@@ -100,3 +101,153 @@ class TestUpdateDataset:
         assert dummy_input.crude_components[0].reaction_id == "ord-c0bbd41f095a44a78b6221135961d809"
         assert dummy_input.components[0].preparations[0].reaction_id == dataset.reactions[2].reaction_id
         assert dummy_input.components[0].preparations[0].reaction_id == "ord-d0bbd41f095a44a78b6221135961d809"
+
+
+class TestAssignDatasetId:
+    def test_assigns_when_missing(self):
+        dataset = dataset_pb2.Dataset()
+        result = updates.assign_dataset_id(dataset)
+        assert dataset.dataset_id == result
+        assert dataset.dataset_id.startswith("ord_dataset-")
+
+    def test_assigns_when_non_canonical(self):
+        dataset = dataset_pb2.Dataset(dataset_id="placeholder")
+        updates.assign_dataset_id(dataset)
+        assert dataset.dataset_id != "placeholder"
+        assert dataset.dataset_id.startswith("ord_dataset-")
+
+    def test_keeps_canonical(self):
+        dataset = dataset_pb2.Dataset(dataset_id="ord_dataset-c0bbd41f095a44a78b6221135961d809")
+        updates.assign_dataset_id(dataset)
+        assert dataset.dataset_id == "ord_dataset-c0bbd41f095a44a78b6221135961d809"
+
+
+class TestAssignIdSubstitutions:
+    def test_canonical_ids_get_none(self):
+        new_ids, subs = updates.assign_id_substitutions(["ord-c0bbd41f095a44a78b6221135961d809"])
+        assert new_ids == [None]
+        assert subs == {}
+
+    def test_placeholder_ids_get_substitutions(self):
+        new_ids, subs = updates.assign_id_substitutions(["placeholder"])
+        assert new_ids[0] is not None and new_ids[0].startswith("ord-")
+        assert subs == {"placeholder": new_ids[0]}
+
+    def test_empty_id_gets_new_id_but_no_substitution(self):
+        # Empty old_id: nothing else could have referenced it, so no entry
+        # in id_substitutions; the reaction still receives a fresh canonical ID.
+        new_ids, subs = updates.assign_id_substitutions([""])
+        assert new_ids[0] is not None and new_ids[0].startswith("ord-")
+        assert subs == {}
+
+    def test_parallel_to_input(self):
+        old = ["ord-c0bbd41f095a44a78b6221135961d809", "p1", "", "p2"]
+        new_ids, subs = updates.assign_id_substitutions(old)
+        assert len(new_ids) == 4
+        assert new_ids[0] is None
+        assert subs == {"p1": new_ids[1], "p2": new_ids[3]}
+
+
+class TestApplyReactionUpdates:
+    def test_with_new_id(self):
+        reaction = reaction_pb2.Reaction()
+        modified = updates.apply_reaction_updates(reaction, new_id="ord-c0bbd41f095a44a78b6221135961d809")
+        assert modified
+        assert reaction.reaction_id == "ord-c0bbd41f095a44a78b6221135961d809"
+        assert len(reaction.provenance.record_modified) == 1
+
+    def test_no_new_id_no_other_changes_means_no_modification(self):
+        reaction = reaction_pb2.Reaction(reaction_id="ord-c0bbd41f095a44a78b6221135961d809")
+        modified = updates.apply_reaction_updates(reaction, new_id=None)
+        assert not modified
+        assert len(reaction.provenance.record_modified) == 0
+
+
+class TestApplyCrossReferenceSubstitutions:
+    def test_no_substitutions_is_noop(self):
+        reaction = reaction_pb2.Reaction()
+        reaction.inputs["x"].components.add().preparations.add(type="SYNTHESIZED", reaction_id="orig")
+        updates.apply_cross_reference_substitutions(reaction, {})
+        assert reaction.inputs["x"].components[0].preparations[0].reaction_id == "orig"
+
+    def test_rewrites_preparations_and_crude_components(self):
+        reaction = reaction_pb2.Reaction()
+        reaction.inputs["x"].components.add().preparations.add(type="SYNTHESIZED", reaction_id="prep")
+        reaction.inputs["x"].crude_components.add(reaction_id="crude", has_derived_amount=True)
+        updates.apply_cross_reference_substitutions(reaction, {"prep": "ord-new1", "crude": "ord-new2"})
+        assert reaction.inputs["x"].components[0].preparations[0].reaction_id == "ord-new1"
+        assert reaction.inputs["x"].crude_components[0].reaction_id == "ord-new2"
+
+
+class TestUpdateDatasetParquet:
+    def _make_dataset(self) -> dataset_pb2.Dataset:
+        # Three reactions; r2 and r3 are referenced by r1 via placeholder IDs
+        # that should be rewritten by the streaming update.
+        r1 = reaction_pb2.Reaction(reaction_id="r1")
+        comp = r1.inputs["x"].components.add()
+        comp.identifiers.add(type="SMILES", value="CC")
+        comp.preparations.add(type="SYNTHESIZED", reaction_id="r2")
+        r1.inputs["x"].crude_components.add(reaction_id="r3", has_derived_amount=True)
+        r2 = reaction_pb2.Reaction(reaction_id="r2")
+        r3 = reaction_pb2.Reaction(reaction_id="r3")
+        return dataset_pb2.Dataset(name="streaming", description="streaming test", reactions=[r1, r2, r3])
+
+    def test_round_trip_assigns_ids_and_rewrites_cross_refs(self, tmp_path):
+        original = self._make_dataset()
+        input_path = os.path.join(tmp_path, "in.parquet")
+        output_path = os.path.join(tmp_path, "out.parquet")
+        parquet_dataset.write_dataset(original, input_path)
+        updates.update_dataset_parquet(
+            input_path, output_path, dataset_id="ord_dataset-c0bbd41f095a44a78b6221135961d809"
+        )
+        result = parquet_dataset.read_dataset(output_path)
+        assert result.dataset_id == "ord_dataset-c0bbd41f095a44a78b6221135961d809"
+        # Each reaction got a canonical ord- ID (the placeholders r1/r2/r3 were
+        # all non-canonical, so all three should have been rewritten).
+        new_ids = [r.reaction_id for r in result.reactions]
+        assert all(rid.startswith("ord-") and len(rid) == 36 for rid in new_ids)
+        # Cross-references on r1 should now point at the new IDs of r2 and r3.
+        prep = result.reactions[0].inputs["x"].components[0].preparations[0]
+        crude = result.reactions[0].inputs["x"].crude_components[0]
+        assert prep.reaction_id == new_ids[1]
+        assert crude.reaction_id == new_ids[2]
+        # Each modified reaction got a record_modified event.
+        assert all(len(r.provenance.record_modified) == 1 for r in result.reactions)
+
+    def test_canonical_ids_are_preserved(self, tmp_path):
+        canonical = "ord-c0bbd41f095a44a78b6221135961d809"
+        reaction = reaction_pb2.Reaction(reaction_id=canonical)
+        # An already-canonical reaction with a record_created date so it doesn't
+        # trip any other update. Should round-trip unchanged.
+        reaction.provenance.record_created.time.value = "2020-01-01"
+        original = dataset_pb2.Dataset(name="x", description="x", reactions=[reaction])
+        input_path = os.path.join(tmp_path, "in.parquet")
+        output_path = os.path.join(tmp_path, "out.parquet")
+        parquet_dataset.write_dataset(original, input_path)
+        updates.update_dataset_parquet(
+            input_path, output_path, dataset_id="ord_dataset-c0bbd41f095a44a78b6221135961d809"
+        )
+        result = parquet_dataset.read_dataset(output_path)
+        assert result.reactions[0].reaction_id == canonical
+        assert len(result.reactions[0].provenance.record_modified) == 0
+
+    def test_streaming_matches_in_memory(self, tmp_path):
+        # update_dataset_parquet (streaming) and update_dataset (in-memory)
+        # should produce the same per-reaction shape modulo the random IDs.
+        original = self._make_dataset()
+        input_path = os.path.join(tmp_path, "in.parquet")
+        output_path = os.path.join(tmp_path, "out.parquet")
+        parquet_dataset.write_dataset(original, input_path)
+        dataset_id = "ord_dataset-c0bbd41f095a44a78b6221135961d809"
+        updates.update_dataset_parquet(input_path, output_path, dataset_id=dataset_id)
+        streamed = parquet_dataset.read_dataset(output_path)
+        in_memory = self._make_dataset()
+        in_memory.dataset_id = dataset_id
+        updates.update_dataset(in_memory)
+        # Same number of reactions; cross-refs preserved by index.
+        assert len(streamed.reactions) == len(in_memory.reactions)
+        for s, m in zip(streamed.reactions, in_memory.reactions, strict=True):
+            assert (len(s.inputs["x"].components) if "x" in s.inputs else 0) == (
+                len(m.inputs["x"].components) if "x" in m.inputs else 0
+            )
+            assert len(s.provenance.record_modified) == len(m.provenance.record_modified)

--- a/ord_schema/updates_test.py
+++ b/ord_schema/updates_test.py
@@ -22,37 +22,6 @@ from ord_schema import parquet_dataset, updates
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 
-class TestUpdateReaction:
-    def test_with_updates_simple(self):
-        message = reaction_pb2.Reaction()
-        updates.update_reaction(message)
-        assert message != reaction_pb2.Reaction()
-        assert len(message.provenance.record_modified) == 1
-
-    def test_with_no_updates(self):
-        message = reaction_pb2.Reaction()
-        message.provenance.record_created.time.value = "2020-05-08"
-        message.reaction_id = "ord-c0bbd41f095a44a78b6221135961d809"
-        copied = reaction_pb2.Reaction()
-        copied.CopyFrom(message)
-        updates.update_reaction(copied)
-        assert copied == message
-
-    def test_add_reaction_id(self):
-        message = reaction_pb2.Reaction()
-        updates.update_reaction(message)
-        assert message.reaction_id
-        assert len(message.provenance.record_modified) == 1
-
-    def test_keep_existing_reaction_id(self):
-        message = reaction_pb2.Reaction()
-        message.reaction_id = "ord-c0bbd41f095a44a78b6221135961d809"
-        message.provenance.record_created.time.value = "2020-01-01"
-        updates.update_reaction(message)
-        assert message.reaction_id == "ord-c0bbd41f095a44a78b6221135961d809"
-        assert len(message.provenance.record_modified) == 0
-
-
 class TestUpdateDataset:
     @pytest.fixture
     def dataset(self) -> Iterator[dataset_pb2.Dataset]:
@@ -179,7 +148,7 @@ class TestApplyCrossReferenceSubstitutions:
         assert reaction.inputs["x"].crude_components[0].reaction_id == "ord-new2"
 
 
-class TestUpdateDatasetParquet:
+class TestUpdateParquetDataset:
     def _make_dataset(self) -> dataset_pb2.Dataset:
         # Three reactions; r2 and r3 are referenced by r1 via placeholder IDs
         # that should be rewritten by the streaming update.
@@ -197,7 +166,7 @@ class TestUpdateDatasetParquet:
         input_path = os.path.join(tmp_path, "in.parquet")
         output_path = os.path.join(tmp_path, "out.parquet")
         parquet_dataset.write_dataset(original, input_path)
-        updates.update_dataset_parquet(
+        updates.update_parquet_dataset(
             input_path, output_path, dataset_id="ord_dataset-c0bbd41f095a44a78b6221135961d809"
         )
         result = parquet_dataset.read_dataset(output_path)
@@ -224,7 +193,7 @@ class TestUpdateDatasetParquet:
         input_path = os.path.join(tmp_path, "in.parquet")
         output_path = os.path.join(tmp_path, "out.parquet")
         parquet_dataset.write_dataset(original, input_path)
-        updates.update_dataset_parquet(
+        updates.update_parquet_dataset(
             input_path, output_path, dataset_id="ord_dataset-c0bbd41f095a44a78b6221135961d809"
         )
         result = parquet_dataset.read_dataset(output_path)
@@ -232,14 +201,14 @@ class TestUpdateDatasetParquet:
         assert len(result.reactions[0].provenance.record_modified) == 0
 
     def test_streaming_matches_in_memory(self, tmp_path):
-        # update_dataset_parquet (streaming) and update_dataset (in-memory)
+        # update_parquet_dataset (streaming) and update_dataset (in-memory)
         # should produce the same per-reaction shape modulo the random IDs.
         original = self._make_dataset()
         input_path = os.path.join(tmp_path, "in.parquet")
         output_path = os.path.join(tmp_path, "out.parquet")
         parquet_dataset.write_dataset(original, input_path)
         dataset_id = "ord_dataset-c0bbd41f095a44a78b6221135961d809"
-        updates.update_dataset_parquet(input_path, output_path, dataset_id=dataset_id)
+        updates.update_parquet_dataset(input_path, output_path, dataset_id=dataset_id)
         streamed = parquet_dataset.read_dataset(output_path)
         in_memory = self._make_dataset()
         in_memory.dataset_id = dataset_id


### PR DESCRIPTION
## Summary

Closes follow-up #2 from #790: `process_dataset.py` now streams `.parquet` inputs end-to-end, including the `--update` path. Builds on #794, which delivered the read-side `DatasetView` wrapper.

### What's in here

- **`updates` refactor** — `update_dataset` is split into composable helpers so the streaming caller can drive the same logic over a Parquet file:
  - `assign_dataset_id(dataset)` — works on `Dataset` and `DatasetView`.
  - `assign_id_substitutions(old_ids)` — pre-allocates canonical reaction IDs from a sequence; returns a parallel `new_ids` list plus the cross-reference substitution map. Lifting ID generation out of the per-reaction update is what makes the two-pass streaming flow possible: pass 1 cheaply scans the `reaction_id` column once, pass 2 injects the resulting IDs without re-deriving them.
  - `apply_reaction_updates(reaction, *, new_id)` — per-reaction work given a pre-computed ID. Drives `_UPDATES` and the `record_modified` bump.
  - `apply_cross_reference_substitutions(reaction, id_substitutions)` — the cross-ref pass, runnable inline during streaming pass 2 instead of as a separate dataset-wide loop.
  - `update_dataset` is now a thin orchestrator over these. The previous `update_reaction` is **dropped** — after the refactor nothing called it from production code, and standalone it was a footgun (generated a fresh `ord-{uuid}` without coordinating with the rest of the dataset). Its tests are subsumed by direct coverage of the new helpers.

- **`updates.update_parquet_dataset(input_path, output_path, *, dataset_id)`** — the streaming entry point. Two passes over `input_path`:
  - Pass 1 reads only the `reaction_id` column to build the ID maps.
  - Pass 2 streams full Reactions through the per-reaction helpers and writes them via `DatasetWriter`.

  Peak memory is bounded by one row group plus the ID maps. The caller owns the rename / validation dance, so the function composes cleanly with an atomic temp-then-rename publish flow.

- **`parquet_dataset` additions** — `iter_reaction_ids(path)` (streams the `reaction_id` column row-group at a time, no Reaction decode) and a `DatasetView.path` property so callers can reach the underlying file without touching `_path`.

- **`process_dataset.py` migration** — loads `.parquet` inputs as `DatasetView` (matching `validate_dataset.py`) and dispatches `--update`:
  - **Parquet input + `--output_format .parquet`** runs the streaming two-pass via `updates.update_parquet_dataset`. The `dataset_id` is resolved up-front so the output filename is known before the writer opens. The streaming write goes to `<output>.tmp`; if validation against the temp passes, `os.replace` atomically publishes it to the final path; cleanup then runs against the published file. If anything before the publish fails, the temp is removed and the input is untouched. Aligns the script with the broader atomic-writes follow-up from #791.
  - **Other format combinations** materialize the dataset via `parquet_dataset.read_dataset` (for Parquet input) and fall through to the in-memory `update_dataset` + `message_helpers.write_dataset` path.

  `_get_reaction_ids` and `_load_base_dataset` use `iter_reaction_ids` for the Parquet branch, so the diff path also avoids decoding Reaction blobs. `_load_base_dataset` spills `git show` bytes to a temp file whose lifetime extends past the call (process-lifetime leak; fine for a CLI script).

- **Order-aware `cleanup`** — `cleanup(input, output)` now branches on whether `output` already exists. The streaming path publishes via `os.replace` first, then calls cleanup, which sees the destination exists and does `git rm -f input` (relying on `git diff -M` for rename detection). The in-memory path still calls cleanup before its write, so the destination doesn't exist yet and cleanup does the original `git mv input → output`. Both write paths can call cleanup regardless of order.

### Not in this PR

- **`add_datasets.py` streaming** (follow-up #3 from #790). `database.add_dataset` expects a real proto and the MD5 is computed from `SerializeToString()`, so a minimal `DatasetView` swap doesn't help much. Will land separately and may want a different shape (streaming ORM upserts).

## Test plan

- [x] `uv run pytest -n auto ord_schema/` — 327/327 pass (Postgres on PATH for ORM tests).
- [x] `TestUpdateParquetDataset` — round-trip assigns IDs and rewrites cross-refs; canonical IDs survive untouched; streaming output matches in-memory `update_dataset` shape modulo random IDs.
- [x] `TestAssignDatasetId`, `TestAssignIdSubstitutions`, `TestApplyReactionUpdates`, `TestApplyCrossReferenceSubstitutions` — direct helper coverage including edge cases (canonical preserved, empty old_id gets new ID but no substitution, no-substitutions is a no-op).
- [x] `TestProcessParquetDataset::test_main_with_streaming_update` — streaming path writes the final output, leaves no `.tmp` sibling, and stamps `record_modified`.
- [x] `TestProcessParquetDataset::test_streaming_update_cleans_up_temp_on_validation_failure` — validation failure removes the `.tmp` and does not publish the final output.
- [x] `TestProcessParquetDataset::test_main_with_parquet_input_pbgz_output` — Parquet input + non-Parquet output falls back through the in-memory path.
- [x] `TestSubmissionWorkflow::test_add_parquet_dataset_with_cleanup` — end-to-end git workflow with `--cleanup --output_format .parquet`: streaming pass reads input before cleanup runs, atomic publish completes, input is removed via the order-aware cleanup branch.
- [x] `ruff check` + `ruff format --check` clean; `ty` clean via pre-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
