### PR TITLE
Dispatch PressureConditions.Atmosphere to validate_atmosphere

### DIFF
--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -1150,7 +1150,7 @@ _VALIDATOR_SWITCH: dict[type, Callable[..., None]] = {
     reaction_pb2.TemperatureConditions.TemperatureMeasurement: validate_temperature_measurement,
     reaction_pb2.PressureConditions: validate_pressure_conditions,
     reaction_pb2.PressureConditions.PressureControl: validate_pressure_control,
-    reaction_pb2.PressureConditions.Atmosphere: validate_pressure_control,
+    reaction_pb2.PressureConditions.Atmosphere: validate_atmosphere,
     reaction_pb2.PressureConditions.PressureMeasurement: validate_pressure_measurement,
     reaction_pb2.StirringConditions: validate_stirring_conditions,
     reaction_pb2.StirringConditions.StirringRate: validate_stirring_rate,


### PR DESCRIPTION
## Summary

The `_VALIDATOR_SWITCH` entry for `PressureConditions.Atmosphere` pointed at `validate_pressure_control` instead of `validate_atmosphere` ([validations.py:1153](https://github.com/open-reaction-database/ord-schema/blob/main/ord_schema/validations.py#L1153)). Looks like a copy-paste from the row above.

Both validators currently just call `check_type_and_details(message)`, so the misdispatch has no observable effect today — but it's still wrong: any future change to either function would silently apply to the wrong message type. `validate_atmosphere` is otherwise unreachable through `validate_message`.

Spotted while reviewing #806; filed standalone to keep the coverage PR focused.

## Test plan
- [x] `pytest ord_schema/validations_test.py` — 64 passed
- [x] pre-commit (ruff, ty, addlicense) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)