### PR TITLE
Parallelize parquet dataset validation over row groups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: ty-check
         name: ty check (ord_schema)
-        entry: uv run ty check ord_schema
+        entry: uv run --extra tests ty check ord_schema
         language: system
         pass_filenames: false
 

--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -27,6 +27,7 @@ without loading the full dataset into memory.
 """
 
 import contextlib
+import dataclasses
 import hashlib
 import os
 import tempfile
@@ -288,6 +289,30 @@ def read_metadata(path: str) -> dataset_pb2.Dataset:
         return _dataset_from_metadata(parquet_file.schema_arrow.metadata)
 
 
+@dataclasses.dataclass(frozen=True)
+class ParquetFooter:
+    """Footer info for a Parquet dataset: scalars + row-group/row counts."""
+
+    dataset: dataset_pb2.Dataset
+    num_row_groups: int
+    num_rows: int
+
+
+def read_footer(path: str) -> ParquetFooter:
+    """Returns scalar Dataset fields and row-group/row counts in one open.
+
+    Equivalent to ``read_metadata`` plus ``num_row_groups`` plus a row count,
+    but reads the footer once. Use when the caller needs more than one of
+    those values.
+    """
+    with pq.ParquetFile(path) as parquet_file:
+        return ParquetFooter(
+            dataset=_dataset_from_metadata(parquet_file.schema_arrow.metadata),
+            num_row_groups=parquet_file.num_row_groups,
+            num_rows=parquet_file.metadata.num_rows,
+        )
+
+
 def iter_reactions(
     path: str,
     reaction_ids: Iterable[str] | None = None,
@@ -345,7 +370,7 @@ def _iter_reactions(
 
 
 def _iter_table(
-    table: "pa.Table | pa.RecordBatch",
+    table: pa.Table | pa.RecordBatch,
     *,
     filter_set: set[str] | None,
 ) -> Iterator[tuple[str, reaction_pb2.Reaction]]:

--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -291,6 +291,8 @@ def read_metadata(path: str) -> dataset_pb2.Dataset:
 def iter_reactions(
     path: str,
     reaction_ids: Iterable[str] | None = None,
+    *,
+    row_group: int | None = None,
 ) -> Iterator[tuple[str, reaction_pb2.Reaction]]:
     """Yields ``(reaction_id, Reaction)`` pairs from a Parquet dataset.
 
@@ -302,6 +304,10 @@ def iter_reactions(
             ``None`` (the default) to iterate all reactions; an explicitly
             empty iterable raises ``ValueError`` since it is almost always a
             bug.
+        row_group: Optional row-group index. When set, only that row group is
+            read; this is the unit of parallelism for callers that fan out
+            across row groups (see ``num_row_groups``). Out-of-range indices
+            raise ``IndexError``.
     """
     if reaction_ids is None:
         filter_set = None
@@ -310,7 +316,23 @@ def iter_reactions(
         if not filter_set:
             raise ValueError("reaction_ids must be non-empty when provided; pass None to iterate all")
     with pq.ParquetFile(path) as parquet_file:
-        yield from _iter_reactions(parquet_file, filter_set=filter_set)
+        if row_group is not None:
+            if not 0 <= row_group < parquet_file.num_row_groups:
+                raise IndexError(f"row_group {row_group} out of range [0, {parquet_file.num_row_groups})")
+            table = parquet_file.read_row_group(row_group, columns=["reaction_id", "reaction"])
+            yield from _iter_table(table, filter_set=filter_set)
+        else:
+            yield from _iter_reactions(parquet_file, filter_set=filter_set)
+
+
+def num_row_groups(path: str) -> int:
+    """Returns the number of row groups in a Parquet dataset.
+
+    Used by callers that parallelize over row groups via ``iter_reactions(...,
+    row_group=i)``. Cheap: only reads the file footer.
+    """
+    with pq.ParquetFile(path) as parquet_file:
+        return parquet_file.num_row_groups
 
 
 def _iter_reactions(
@@ -319,12 +341,20 @@ def _iter_reactions(
     filter_set: set[str] | None,
 ) -> Iterator[tuple[str, reaction_pb2.Reaction]]:
     for batch in parquet_file.iter_batches(columns=["reaction_id", "reaction"]):
-        ids = batch.column("reaction_id").to_pylist()
-        blobs = batch.column("reaction").to_pylist()
-        for reaction_id, blob in zip(ids, blobs, strict=True):
-            if filter_set is not None and reaction_id not in filter_set:
-                continue
-            yield reaction_id, reaction_pb2.Reaction.FromString(blob)
+        yield from _iter_table(batch, filter_set=filter_set)
+
+
+def _iter_table(
+    table: "pa.Table | pa.RecordBatch",
+    *,
+    filter_set: set[str] | None,
+) -> Iterator[tuple[str, reaction_pb2.Reaction]]:
+    ids = table.column("reaction_id").to_pylist()
+    blobs = table.column("reaction").to_pylist()
+    for reaction_id, blob in zip(ids, blobs, strict=True):
+        if filter_set is not None and reaction_id not in filter_set:
+            continue
+        yield reaction_id, reaction_pb2.Reaction.FromString(blob)
 
 
 def streaming_md5(path: str) -> tuple[str, int]:

--- a/ord_schema/parquet_dataset_test.py
+++ b/ord_schema/parquet_dataset_test.py
@@ -96,6 +96,20 @@ def test_iter_reactions_filtered(tmp_path):
     assert [rid for rid, _ in pairs] == ["ord-0001", "ord-0003"]
 
 
+def test_iter_reactions_row_group(tmp_path):
+    original = _make_dataset(n=5)
+    path = os.path.join(tmp_path, "ds.parquet")
+    # row_group_size=2 -> row groups of [0,1], [2,3], [4]
+    with dataset.DatasetWriter(path, name=original.name, description=original.description, row_group_size=2) as writer:
+        writer.write_all(original.reactions)
+    assert dataset.num_row_groups(path) == 3
+    assert [rid for rid, _ in dataset.iter_reactions(path, row_group=0)] == ["ord-0000", "ord-0001"]
+    assert [rid for rid, _ in dataset.iter_reactions(path, row_group=1)] == ["ord-0002", "ord-0003"]
+    assert [rid for rid, _ in dataset.iter_reactions(path, row_group=2)] == ["ord-0004"]
+    with pytest.raises(IndexError, match="out of range"):
+        list(dataset.iter_reactions(path, row_group=3))
+
+
 def test_iter_reactions_empty_filter_raises(tmp_path):
     original = _make_dataset(n=3)
     path = os.path.join(tmp_path, "ds.parquet")

--- a/ord_schema/scripts/validate_dataset.py
+++ b/ord_schema/scripts/validate_dataset.py
@@ -27,7 +27,6 @@ import warnings
 from collections.abc import Iterable
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
-import pyarrow.parquet as pq
 from tqdm import tqdm
 
 from ord_schema import message_helpers, parquet_dataset, validations
@@ -70,17 +69,16 @@ def _validate_row_group(filename: str, row_group: int) -> tuple[list[str], valid
     return errors, state
 
 
-def _finalize_parquet(filename: str, has_reactions: bool, state: validations.DatasetCrossRefState) -> list[str]:
+def _finalize_parquet(footer: parquet_dataset.ParquetFooter, state: validations.DatasetCrossRefState) -> list[str]:
     """Runs dataset-level checks on aggregated parquet state; returns errors."""
-    metadata = parquet_dataset.read_metadata(filename)
     with warnings.catch_warnings(record=True) as tape:
         warnings.simplefilter("always", validations.ValidationError)
         validations.validate_dataset_streaming(
-            name=metadata.name,
-            description=metadata.description,
-            dataset_id=metadata.dataset_id,
+            name=footer.dataset.name,
+            description=footer.dataset.description,
+            dataset_id=footer.dataset.dataset_id,
             reaction_ids=[],
-            has_reactions=has_reactions,
+            has_reactions=footer.num_rows > 0,
             state=state,
         )
     return [f"Dataset: {w.message}" for w in tape if issubclass(w.category, validations.ValidationError)]
@@ -89,7 +87,7 @@ def _finalize_parquet(filename: str, has_reactions: bool, state: validations.Dat
 @dataclasses.dataclass
 class _ParquetEntry:
     remaining: int
-    has_reactions: bool
+    footer: parquet_dataset.ParquetFooter
     state: validations.DatasetCrossRefState
 
 
@@ -115,21 +113,17 @@ def main(args):
         futures: dict = {}
         for filename in filenames:
             if filename.endswith(".parquet"):
-                with pq.ParquetFile(filename) as parquet_file:
-                    num_row_groups = parquet_file.num_row_groups
-                    num_rows = parquet_file.metadata.num_rows
+                footer = parquet_dataset.read_footer(filename)
                 entry = _ParquetEntry(
-                    remaining=num_row_groups,
-                    has_reactions=num_rows > 0,
+                    remaining=footer.num_row_groups,
+                    footer=footer,
                     state=validations.DatasetCrossRefState(),
                 )
                 parquet_entries[filename] = entry
-                if num_row_groups == 0:
-                    failures.extend(
-                        f"{filename}: {e}" for e in _finalize_parquet(filename, entry.has_reactions, entry.state)
-                    )
+                if footer.num_row_groups == 0:
+                    failures.extend(f"{filename}: {e}" for e in _finalize_parquet(footer, entry.state))
                     continue
-                for row_group in range(num_row_groups):
+                for row_group in range(footer.num_row_groups):
                     future = executor.submit(_validate_row_group, filename, row_group)
                     futures[future] = ("parquet", filename, row_group)
             else:
@@ -150,7 +144,7 @@ def main(args):
                 entry.state.merge(state)
                 entry.remaining -= 1
                 if entry.remaining == 0:
-                    for error in _finalize_parquet(filename, entry.has_reactions, entry.state):
+                    for error in _finalize_parquet(entry.footer, entry.state):
                         failures.append(f"{filename}: {error}")
 
     if failures:

--- a/ord_schema/scripts/validate_dataset.py
+++ b/ord_schema/scripts/validate_dataset.py
@@ -11,14 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Validates a set of Dataset protocol buffers."""
+"""Validates a set of Dataset protocol buffers.
+
+pb inputs are validated as a single per-file task. Parquet inputs are fanned
+out one task per row group so ``--n_jobs`` actually saturates on a single
+large dataset; per-file dataset-level checks (cross-references, scalar
+fields) are then run once after the per-row-group results merge.
+"""
 
 import argparse
+import dataclasses
 import glob
 import re
+import warnings
 from collections.abc import Iterable
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
+import pyarrow.parquet as pq
 from tqdm import tqdm
 
 from ord_schema import message_helpers, parquet_dataset, validations
@@ -37,19 +46,51 @@ def filter_filenames(filenames: Iterable[str], pattern: str) -> list[str]:
     return filtered_filenames
 
 
-def run(filename: str) -> None:
-    """Validates a single dataset.
-
-    Parquet inputs are wrapped in a ``DatasetView`` that streams Reactions
-    one at a time, so peak memory stays bounded for large datasets. Other
-    formats are loaded fully.
-    """
+def _validate_pb(filename: str) -> list[str]:
+    """Validates a single pb dataset; returns formatted error lines."""
     silence_rdkit_logs()
-    if filename.endswith(".parquet"):
-        dataset = parquet_dataset.DatasetView(filename)
-    else:
-        dataset = message_helpers.load_message(filename, dataset_pb2.Dataset)
-    validations.validate_datasets({filename: dataset})
+    dataset = message_helpers.load_message(filename, dataset_pb2.Dataset)
+    try:
+        validations.validate_datasets({filename: dataset})
+    except validations.ValidationError as error:
+        return [str(error)]
+    return []
+
+
+def _validate_row_group(filename: str, row_group: int) -> tuple[list[str], validations.DatasetCrossRefState]:
+    """Validates one row group: per-reaction checks + cross-ref observations."""
+    silence_rdkit_logs()
+    errors: list[str] = []
+    state = validations.DatasetCrossRefState()
+    for i, (_, reaction) in enumerate(parquet_dataset.iter_reactions(filename, row_group=row_group)):
+        output = validations.validate_message(reaction, raise_on_error=False)
+        for error in output.errors:
+            errors.append(f"row_group {row_group}, reaction {i}: {error}")
+        state.observe(reaction)
+    return errors, state
+
+
+def _finalize_parquet(filename: str, has_reactions: bool, state: validations.DatasetCrossRefState) -> list[str]:
+    """Runs dataset-level checks on aggregated parquet state; returns errors."""
+    metadata = parquet_dataset.read_metadata(filename)
+    with warnings.catch_warnings(record=True) as tape:
+        warnings.simplefilter("always", validations.ValidationError)
+        validations.validate_dataset_streaming(
+            name=metadata.name,
+            description=metadata.description,
+            dataset_id=metadata.dataset_id,
+            reaction_ids=[],
+            has_reactions=has_reactions,
+            state=state,
+        )
+    return [f"Dataset: {w.message}" for w in tape if issubclass(w.category, validations.ValidationError)]
+
+
+@dataclasses.dataclass
+class _ParquetEntry:
+    remaining: int
+    has_reactions: bool
+    state: validations.DatasetCrossRefState
 
 
 def parse_args(argv=None):
@@ -66,17 +107,52 @@ def main(args):
     if args.filter:
         filenames = filter_filenames(filenames, args.filter)
         logger.info("Filtered to %d datasets", len(filenames))
-    futures = {}
-    failures = []
+
+    parquet_entries: dict[str, _ParquetEntry] = {}
+    failures: list[str] = []
+
     with ProcessPoolExecutor(args.n_jobs) as executor:
+        futures: dict = {}
         for filename in filenames:
-            future = executor.submit(run, filename=filename)
-            futures[future] = filename
-        for future in tqdm(as_completed(futures), total=len(futures)):
-            try:
-                future.result()
-            except validations.ValidationError as error:
-                failures.append(f"{futures[future]}: {error}")
+            if filename.endswith(".parquet"):
+                with pq.ParquetFile(filename) as parquet_file:
+                    num_row_groups = parquet_file.num_row_groups
+                    num_rows = parquet_file.metadata.num_rows
+                entry = _ParquetEntry(
+                    remaining=num_row_groups,
+                    has_reactions=num_rows > 0,
+                    state=validations.DatasetCrossRefState(),
+                )
+                parquet_entries[filename] = entry
+                if num_row_groups == 0:
+                    failures.extend(
+                        f"{filename}: {e}" for e in _finalize_parquet(filename, entry.has_reactions, entry.state)
+                    )
+                    continue
+                for row_group in range(num_row_groups):
+                    future = executor.submit(_validate_row_group, filename, row_group)
+                    futures[future] = ("parquet", filename, row_group)
+            else:
+                future = executor.submit(_validate_pb, filename)
+                futures[future] = ("pb", filename, None)
+
+        total_tasks = len(futures)
+        for future in tqdm(as_completed(futures), total=total_tasks):
+            kind, filename, _ = futures[future]
+            if kind == "pb":
+                for error in future.result():
+                    failures.append(f"{filename}: {error}")
+            else:
+                errors, state = future.result()
+                for error in errors:
+                    failures.append(f"{filename}: {error}")
+                entry = parquet_entries[filename]
+                entry.state.merge(state)
+                entry.remaining -= 1
+                if entry.remaining == 0:
+                    for error in _finalize_parquet(filename, entry.has_reactions, entry.state):
+                        failures.append(f"{filename}: {error}")
+
     if failures:
         text = "\n".join(failures)
         raise validations.ValidationError(f"Dataset(s) failed validation:\n{text}")

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -123,8 +123,12 @@ def test_parquet_cross_row_group_duplicate_id(tmp_path):
 
 
 def test_parquet_empty_file(tmp_path):
-    """A parquet with zero row groups must hit the synchronous finalize path
-    and raise the standard 'requires reactions or reaction_ids' error."""
+    """A zero-row-group parquet still hits the dataset-level finalize path.
+
+    Exercises the synchronous fallthrough in ``main`` (no row-group tasks
+    submitted) and asserts the standard 'requires reactions or reaction_ids'
+    error surfaces.
+    """
     path = tmp_path / "empty.parquet"
     with parquet_dataset.DatasetWriter(str(path), name="test", description="test") as writer:
         writer.write_all([])

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -122,6 +122,20 @@ def test_parquet_cross_row_group_duplicate_id(tmp_path):
         validate_dataset.main(validate_dataset.parse_args(["--input", str(path)]))
 
 
+def test_parquet_empty_file(tmp_path):
+    """A parquet with zero row groups must hit the synchronous finalize path
+    and raise the standard 'requires reactions or reaction_ids' error."""
+    path = tmp_path / "empty.parquet"
+    with parquet_dataset.DatasetWriter(str(path), name="test", description="test") as writer:
+        writer.write_all([])
+    assert parquet_dataset.num_row_groups(str(path)) == 0
+    with pytest.raises(
+        validations.ValidationError,
+        match="Dataset requires reactions or reaction_ids",
+    ):
+        validate_dataset.main(validate_dataset.parse_args(["--input", str(path)]))
+
+
 def test_parquet_per_reaction_error_in_late_row_group(tmp_path):
     """Per-reaction errors must surface from any row group, not just the first."""
     reactions = [

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -18,7 +18,7 @@ from collections.abc import Iterator
 
 import pytest
 
-from ord_schema import message_helpers, validations
+from ord_schema import message_helpers, parquet_dataset, validations
 from ord_schema.proto import dataset_pb2, reaction_pb2
 from ord_schema.scripts import validate_dataset
 
@@ -73,6 +73,71 @@ def test_validation_errors(setup):
         match="Reactions should have at least 1 reaction input",
     ):
         validate_dataset.main(validate_dataset.parse_args(argv))
+
+
+def _valid_reaction(reaction_id: str = "") -> reaction_pb2.Reaction:
+    """Builds a Reaction that passes per-reaction validation."""
+    reaction = reaction_pb2.Reaction()
+    if reaction_id:
+        reaction.reaction_id = reaction_id
+    dummy_input = reaction.inputs["dummy_input"]
+    dummy_component = dummy_input.components.add()
+    dummy_component.identifiers.add(type="CUSTOM")
+    dummy_component.identifiers[0].details = "custom_identifier"
+    dummy_component.identifiers[0].value = "custom_value"
+    dummy_component.is_limiting = True
+    dummy_component.amount.mass.value = 1
+    dummy_component.amount.mass.units = reaction_pb2.Mass.GRAM
+    reaction.outcomes.add().conversion.value = 75
+    reaction.provenance.record_created.time.value = "2023-07-01"
+    reaction.provenance.record_created.person.name = "test"
+    reaction.provenance.record_created.person.email = "test@example.com"
+    return reaction
+
+
+def test_parquet_cross_row_group_duplicate_id(tmp_path):
+    """A duplicate reaction_id split across row groups must still be caught.
+
+    Exercises the row-group parallelism path: row_group_size=2 places the
+    repeated id in row groups 0 and 2, so cross-reference detection only
+    succeeds if per-row-group state is correctly merged.
+    """
+    repeated_id = "ord-deadbeef00000000000000000000a1"
+    reactions = [
+        _valid_reaction(reaction_id=repeated_id),
+        _valid_reaction(reaction_id="ord-deadbeef00000000000000000000a2"),
+        _valid_reaction(reaction_id="ord-deadbeef00000000000000000000a3"),
+        _valid_reaction(reaction_id="ord-deadbeef00000000000000000000a4"),
+        _valid_reaction(reaction_id=repeated_id),
+    ]
+    path = tmp_path / "cross_group_dup.parquet"
+    with parquet_dataset.DatasetWriter(str(path), name="test", description="test", row_group_size=2) as writer:
+        writer.write_all(reactions)
+    # Sanity-check the layout the test is asserting against.
+    assert parquet_dataset.num_row_groups(str(path)) == 3
+    with pytest.raises(
+        validations.ValidationError,
+        match="Multiple Reactions should never have the same IDs",
+    ):
+        validate_dataset.main(validate_dataset.parse_args(["--input", str(path)]))
+
+
+def test_parquet_per_reaction_error_in_late_row_group(tmp_path):
+    """Per-reaction errors must surface from any row group, not just the first."""
+    reactions = [
+        _valid_reaction(),
+        _valid_reaction(),
+        reaction_pb2.Reaction(),  # invalid: no inputs / no outcomes
+    ]
+    path = tmp_path / "late_invalid.parquet"
+    with parquet_dataset.DatasetWriter(str(path), name="test", description="test", row_group_size=2) as writer:
+        writer.write_all(reactions)
+    assert parquet_dataset.num_row_groups(str(path)) == 2
+    with pytest.raises(
+        validations.ValidationError,
+        match="Reactions should have at least 1 reaction input",
+    ):
+        validate_dataset.main(validate_dataset.parse_args(["--input", str(path)]))
 
 
 @pytest.mark.parametrize(

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -384,48 +384,136 @@ def is_valid_dataset_id(dataset_id: str) -> bool:
     return bool(match)
 
 
+@dataclasses.dataclass
+class DatasetCrossRefState:
+    """Aggregated cross-reference observations for a Dataset.
+
+    A worker validating a slice of reactions feeds each one into ``observe``
+    and returns the resulting state. The master process merges the per-slice
+    states with ``merge`` and then ``emit_warnings`` raises a warning per
+    duplicate occurrence, per self-reference, and one summary warning if any
+    referenced reaction_ids are undefined. This keeps the streaming path
+    behaviorally equivalent to the in-memory path.
+    """
+
+    defined_ids: set[str] = dataclasses.field(default_factory=set)
+    referenced_ids: set[str] = dataclasses.field(default_factory=set)
+    duplicate_count: int = 0
+    self_reference_count: int = 0
+
+    def observe(self, reaction: reaction_pb2.Reaction) -> None:
+        if reaction.reaction_id:
+            if reaction.reaction_id in self.defined_ids:
+                self.duplicate_count += 1
+            self.defined_ids.add(reaction.reaction_id)
+        referenced = get_referenced_reaction_ids(reaction)
+        if any(_id == reaction.reaction_id for _id in referenced):
+            self.self_reference_count += 1
+        self.referenced_ids |= referenced
+
+    def merge(self, other: "DatasetCrossRefState") -> None:
+        self.duplicate_count += other.duplicate_count + len(self.defined_ids & other.defined_ids)
+        self.defined_ids |= other.defined_ids
+        self.referenced_ids |= other.referenced_ids
+        self.self_reference_count += other.self_reference_count
+
+    def emit_warnings(self) -> None:
+        for _ in range(self.duplicate_count):
+            warnings.warn("Multiple Reactions should never have the same IDs", ValidationError)
+        for _ in range(self.self_reference_count):
+            warnings.warn("A Reaction should not reference its own ID", ValidationError)
+        undefined = self.referenced_ids - self.defined_ids
+        if undefined:
+            warnings.warn(
+                f"Reactions in the Dataset refer to undefined reaction_ids {undefined}",
+                ValidationError,
+            )
+
+
+def _validate_dataset_scalars(
+    *,
+    name: str,
+    description: str,
+    dataset_id: str,
+    reaction_ids: list[str],
+    has_reactions: bool,
+    options: ValidationOptions,
+) -> None:
+    """Issues the dataset-level scalar/structural warnings.
+
+    Pure function over the scalar fields so the streaming path can reuse it
+    without re-iterating reactions.
+    """
+    if not name:
+        warnings.warn("Dataset name is required", ValidationError)
+    if not description:
+        warnings.warn("Dataset description is required", ValidationError)
+    if not has_reactions and not reaction_ids:
+        warnings.warn("Dataset requires reactions or reaction_ids", ValidationError)
+    elif has_reactions and reaction_ids:
+        warnings.warn("Dataset requires reactions or reaction_ids, not both", ValidationError)
+    if reaction_ids:
+        for reaction_id in reaction_ids:
+            if not is_valid_reaction_id(reaction_id):
+                warnings.warn("Reaction ID is malformed", ValidationError)
+    if options.validate_ids:
+        # The dataset_id is a 32-character uuid4 hex string.
+        if not is_valid_dataset_id(dataset_id):
+            warnings.warn("Dataset ID is malformed", ValidationError)
+
+
 def validate_dataset(
     message: dataset_pb2.Dataset | parquet_dataset.DatasetView,
     options: ValidationOptions | None = None,
 ):
     if options is None:
         options = ValidationOptions()
-    if not message.name:
-        warnings.warn("Dataset name is required", ValidationError)
-    if not message.description:
-        warnings.warn("Dataset description is required", ValidationError)
-    if not message.reactions and not message.reaction_ids:
-        warnings.warn("Dataset requires reactions or reaction_ids", ValidationError)
-    elif message.reactions and message.reaction_ids:
-        warnings.warn("Dataset requires reactions or reaction_ids, not both", ValidationError)
-    if message.reaction_ids:
-        for reaction_id in message.reaction_ids:
-            if not is_valid_reaction_id(reaction_id):
-                warnings.warn("Reaction ID is malformed", ValidationError)
-    if options.validate_ids:
-        # The dataset_id is a 32-character uuid4 hex string.
-        if not is_valid_dataset_id(message.dataset_id):
-            warnings.warn("Dataset ID is malformed", ValidationError)
-    # Check cross-references
-    dataset_referenced_ids = set()
-    dataset_defined_ids = set()
+    _validate_dataset_scalars(
+        name=message.name,
+        description=message.description,
+        dataset_id=message.dataset_id,
+        reaction_ids=list(message.reaction_ids),
+        has_reactions=bool(message.reactions),
+        options=options,
+    )
+    state = DatasetCrossRefState()
     for reaction in message.reactions:
-        if reaction.reaction_id:
-            if reaction.reaction_id in dataset_defined_ids:
-                warnings.warn(
-                    "Multiple Reactions should never have the same IDs",
-                    ValidationError,
-                )
-            dataset_defined_ids.add(reaction.reaction_id)
-        referenced_ids = get_referenced_reaction_ids(reaction)
-        if any(_id == reaction.reaction_id for _id in referenced_ids):
-            warnings.warn("A Reaction should not reference its own ID", ValidationError)
-        dataset_referenced_ids |= referenced_ids
-    if len(dataset_referenced_ids - dataset_defined_ids) > 0:
-        warnings.warn(
-            f"Reactions in the Dataset refer to undefined reaction_ids {dataset_referenced_ids - dataset_defined_ids}",
-            ValidationError,
-        )
+        state.observe(reaction)
+    state.emit_warnings()
+
+
+def validate_dataset_streaming(
+    *,
+    name: str,
+    description: str,
+    dataset_id: str,
+    reaction_ids: list[str],
+    has_reactions: bool,
+    state: DatasetCrossRefState,
+    options: ValidationOptions | None = None,
+) -> None:
+    """Dataset-level validation for callers that have already streamed reactions.
+
+    Equivalent to ``validate_dataset`` for a Dataset whose reactions have been
+    iterated in slices (e.g., per Parquet row group) by upstream workers, with
+    each worker contributing a ``DatasetCrossRefState`` that the caller has
+    merged. ``has_reactions`` should reflect the source's row count (e.g.,
+    ``parquet_dataset.read_metadata`` plus ``num_row_groups`` for parquet);
+    inferring it from ``state`` would misclassify reactions without
+    reaction_ids or references as empty. Pass ``reaction_ids=[]`` for the
+    typical streaming case (parquet does not persist Dataset.reaction_ids).
+    """
+    if options is None:
+        options = ValidationOptions()
+    _validate_dataset_scalars(
+        name=name,
+        description=description,
+        dataset_id=dataset_id,
+        reaction_ids=reaction_ids,
+        has_reactions=has_reactions,
+        options=options,
+    )
+    state.emit_warnings()
 
 
 def validate_dataset_example(message: dataset_pb2.DatasetExample):


### PR DESCRIPTION
## Summary

`validate_dataset.py` used to submit one `ProcessPoolExecutor` task per file. A single un-sharded parquet dataset (e.g. 1.7M reactions in 1771 row groups) collapsed `--n_jobs` to one busy worker. Fan out per row group instead.

- `parquet_dataset.iter_reactions` gains an optional `row_group=` kwarg, plus a `num_row_groups(path)` helper, so callers can address a single row group.
- `validations.validate_dataset` is refactored: scalar checks moved to `_validate_dataset_scalars`; cross-reference checks moved to a new `DatasetCrossRefState` (observe / merge / emit_warnings). The merged state preserves "one warning per duplicate occurrence" semantics across slices.
- `validations.validate_dataset_streaming` runs scalar + cross-reference checks once after a caller has aggregated `DatasetCrossRefState` across parallel workers.
- `validate_dataset.py` now submits one task per row group for `.parquet` inputs; the pb path is unchanged.

Motivation: ord-data is converting per-month USPTO datasets into a single un-sharded parquet (~1.77M reactions). Without this change, the CI matrix shard that lands on that file would single-thread for ~30+ minutes.

Also fixes the `ty-check` pre-commit hook to install the `tests` extra (`uv run --extra tests ty check ord_schema`) — without it, the hook reports 25 `unresolved-import` diagnostics on plain `main` because pytest et al. are not in the default uv environment.

## Test plan
- [x] `pytest ord_schema/parquet_dataset_test.py ord_schema/scripts/validate_dataset_test.py ord_schema/validations_test.py` passes (177 tests, including new row-group cases).
- [x] New tests cover: `iter_reactions(row_group=N)`, cross-row-group duplicate detection, per-reaction errors surfacing from row groups other than the first.
- [x] `pre-commit run --all-files` passes (ty included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)