### PR TITLE
ci: set explicit Codecov slug for org-wide token

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -61,6 +61,8 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          # CODECOV_TOKEN is an org-wide token, so the repo slug must be explicit.
+          slug: open-reaction-database/ord-schema
           fail_ci_if_error: ${{ github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && !startsWith(github.head_ref, 'dependabot/')) }}
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary

`CODECOV_TOKEN` was changed to an **org-wide** upload token. Unlike a per-repo upload token, an org token does not identify the target Codecov project, so uploads depend on git-context slug detection. Set the slug explicitly to attribute coverage to this repo deterministically.

```diff
       - uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          # CODECOV_TOKEN is an org-wide token, so the repo slug must be explicit.
+          slug: open-reaction-database/ord-schema
           fail_ci_if_error: ${{ ... }}
           token: ${{ secrets.CODECOV_TOKEN }}
```

Part of a 3-repo set (ord-app, ord-schema, ord-interface) aligning Codecov uploads to the org-wide token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an explicit `slug: open-reaction-database/ord-schema` field to the `codecov/codecov-action@v5` step in the CI workflow, along with a comment explaining why it is needed. The change is required because `CODECOV_TOKEN` was switched from a per-repo token (which implicitly identifies the target project) to an org-wide token (which relies on git-context slug detection that can be ambiguous across repos).

- Adds `slug: open-reaction-database/ord-schema` so Codecov deterministically attributes coverage to this repository when an org-wide upload token is used.
- No logic, dependencies, or test behaviour is changed; the impact is limited to CI coverage reporting.

<h3>Confidence Score: 5/5</h3>

This is a safe, minimal CI-only change with no impact on application code or test logic.

The only change is adding a two-line block (a comment and a slug field) to a single Codecov upload step. The slug value matches the repository name exactly, the surrounding fail_ci_if_error and token fields are untouched, and nothing else in the workflow is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/run_tests.yml | Adds `slug: open-reaction-database/ord-schema` and an explanatory comment to the Codecov upload step; no other logic changes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant Codecov as Codecov API

    GHA->>GHA: "Run tests & generate coverage.xml"
    GHA->>Codecov: "Upload coverage.xml<br/>token=CODECOV_TOKEN (org-wide)<br/>slug=open-reaction-database/ord-schema"
    Codecov-->>Codecov: Resolve target repo via explicit slug
    Codecov-->>GHA: Upload acknowledged for ord-schema
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: set explicit Codecov slug for org-wi..."](https://github.com/open-reaction-database/ord-schema/commit/6a121e1a3b97864a0e01ea1d431bf24e39569ceb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35037016)</sub>

<!-- /greptile_comment -->