### PR TITLE
Add additional validation checks

### DIFF
--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -788,7 +788,7 @@ def validate_compound_identifier(message: reaction_pb2.CompoundIdentifier):
             )
     elif message.type in (message.PUBCHEM_CID, message.CHEMSPIDER_ID):
         identifier_type = "PubChem CID" if message.type == message.PUBCHEM_CID else "ChemSpider ID"
-        if not message.value.isdigit():
+        if not message.value.isdecimal():
             warnings.warn(
                 f"{identifier_type} {message.value} should be an integer",
                 ValidationWarning,
@@ -973,7 +973,7 @@ def validate_reaction_workup(message: reaction_pb2.ReactionWorkup):
         and not message.input.components
     ):
         warnings.warn("Workup step missing recommended inputs definition", ValidationWarning)
-    if message.type == reaction_pb2.ReactionWorkup.STIRRING and not message.stirring:
+    if message.type == reaction_pb2.ReactionWorkup.STIRRING and not message.HasField("stirring"):
         warnings.warn("Stirring workup step missing stirring definition", ValidationWarning)
     if message.type == reaction_pb2.ReactionWorkup.PH_ADJUST and not message.HasField("target_ph"):
         warnings.warn("pH adjustment workup missing target pH", ValidationWarning)

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -384,6 +384,40 @@ def is_valid_dataset_id(dataset_id: str) -> bool:
     return bool(match)
 
 
+def is_valid_orcid(orcid: str) -> bool:
+    """Returns whether an ORCID is well-formed, including its checksum.
+
+    The final character is an ISO 7064 MOD 11-2 check digit over the preceding
+    15 digits; see https://support.orcid.org/hc/en-us/articles/360006897674.
+
+    Args:
+        orcid: ORCID string, expected as 0000-0000-0000-0000.
+
+    Returns:
+        True if ``orcid`` is well-formed and the checksum is correct.
+    """
+    if not re.fullmatch(r"[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]", orcid):
+        return False
+    digits = orcid.replace("-", "")
+    total = 0
+    for digit in digits[:-1]:
+        total = (total + int(digit)) * 2
+    expected = (12 - total % 11) % 11
+    check = "X" if expected == 10 else str(expected)
+    return check == digits[-1]
+
+
+def is_url(value: str) -> bool:
+    """Returns whether a string looks like an http(s) URL with a host."""
+    return bool(re.fullmatch(r"https?://[^\s/]+(?:/.*)?", value, flags=re.IGNORECASE))
+
+
+def has_atom_mapping(smiles: str) -> bool:
+    """Returns whether a SMILES string contains atom-map numbers."""
+    # Atom maps in SMILES are always written inside brackets as e.g. [CH3:1].
+    return bool(re.search(r"\[[^][]*:[0-9]+]", smiles))
+
+
 @dataclasses.dataclass
 class DatasetCrossRefState:
     """Aggregated cross-reference observations for a Dataset.
@@ -578,6 +612,17 @@ def validate_reaction_identifier(message: reaction_pb2.ReactionIdentifier):
             message_helpers.validate_reaction_smiles(smiles)
         except ValueError as error:
             warnings.warn(str(error), ValidationError)
+        has_mapping = has_atom_mapping(smiles)
+        if message.is_mapped and not has_mapping:
+            warnings.warn(
+                "ReactionIdentifier is marked is_mapped but the SMILES contains no atom maps",
+                ValidationWarning,
+            )
+        elif has_mapping and not message.is_mapped:
+            warnings.warn(
+                "ReactionIdentifier SMILES contains atom maps but is_mapped is not set to True",
+                ValidationWarning,
+            )
     if not message.value:
         warnings.warn("value must be set", ValidationError)
 
@@ -727,6 +772,27 @@ def validate_compound_identifier(message: reaction_pb2.CompoundIdentifier):
                     f"RDKit {RDKIT_VERSION} could not sanitize {identifier_type} identifier {message.value}",
                     ValidationWarning,
                 )
+    elif message.type == message.CAS_NUMBER:
+        # CAS numbers are 2-7 digits, 2 digits, and a single check digit,
+        # separated by hyphens (e.g., 64-17-5 for ethanol).
+        if not re.fullmatch(r"\d{2,7}-\d{2}-\d", message.value):
+            warnings.warn(
+                f"CAS number {message.value} is malformed (expected e.g. 64-17-5)",
+                ValidationWarning,
+            )
+    elif message.type == message.INCHI_KEY:
+        if not re.fullmatch(r"[A-Z]{14}-[A-Z]{10}-[A-Z]", message.value):
+            warnings.warn(
+                f"InChIKey {message.value} is malformed",
+                ValidationWarning,
+            )
+    elif message.type in (message.PUBCHEM_CID, message.CHEMSPIDER_ID):
+        identifier_type = "PubChem CID" if message.type == message.PUBCHEM_CID else "ChemSpider ID"
+        if not message.value.isdigit():
+            warnings.warn(
+                f"{identifier_type} {message.value} should be an integer",
+                ValidationWarning,
+            )
 
 
 def validate_vessel(message: reaction_pb2.Vessel):
@@ -768,6 +834,11 @@ def validate_reaction_conditions(message: reaction_pb2.ReactionConditions):
             "Reaction condition details provided but field "
             "conditions_are_dynamic is False. If the conditions "
             "cannot be fully captured by the schema, set to True.",
+            ValidationWarning,
+        )
+    if message.HasField("ph") and not 0 <= message.ph <= 14:
+        warnings.warn(
+            f"Reaction pH ({message.ph}) is outside the expected range (0-14)",
             ValidationWarning,
         )
 
@@ -814,12 +885,30 @@ def validate_stirring_rate(message: reaction_pb2.StirringConditions.StirringRate
 
 def validate_illumination_conditions(message: reaction_pb2.IlluminationConditions):
     check_type_and_details(message)
+    if message.type in (
+        reaction_pb2.IlluminationConditions.DARK,
+        reaction_pb2.IlluminationConditions.AMBIENT,
+    ) and message.HasField("peak_wavelength"):
+        warnings.warn(
+            "peak_wavelength should not be specified for DARK or AMBIENT illumination",
+            ValidationWarning,
+        )
 
 
 def validate_electrochemistry_conditions(
     message: reaction_pb2.ElectrochemistryConditions,
 ):
     check_type_and_details(message)
+    if message.type == reaction_pb2.ElectrochemistryConditions.CONSTANT_CURRENT and not message.HasField("current"):
+        warnings.warn(
+            "CONSTANT_CURRENT electrochemistry conditions should specify the current",
+            ValidationWarning,
+        )
+    if message.type == reaction_pb2.ElectrochemistryConditions.CONSTANT_VOLTAGE and not message.HasField("voltage"):
+        warnings.warn(
+            "CONSTANT_VOLTAGE electrochemistry conditions should specify the voltage",
+            ValidationWarning,
+        )
 
 
 def validate_electrochemistry_cell(
@@ -888,6 +977,11 @@ def validate_reaction_workup(message: reaction_pb2.ReactionWorkup):
         warnings.warn("Stirring workup step missing stirring definition", ValidationWarning)
     if message.type == reaction_pb2.ReactionWorkup.PH_ADJUST and not message.HasField("target_ph"):
         warnings.warn("pH adjustment workup missing target pH", ValidationWarning)
+    if message.HasField("target_ph") and not 0 <= message.target_ph <= 14:
+        warnings.warn(
+            f"Workup target pH ({message.target_ph}) is outside the expected range (0-14)",
+            ValidationWarning,
+        )
     if message.type == reaction_pb2.ReactionWorkup.ALIQUOT:
         if message.amount.WhichOneof("kind") is None:
             warnings.warn("Aliquot workup step missing volume/mass amount", ValidationWarning)
@@ -1019,6 +1113,31 @@ def validate_mass_spec_measurement_type(
     message: reaction_pb2.ProductMeasurement.MassSpecMeasurementDetails,
 ):
     check_type_and_details(message)
+    ensure_float_nonnegative(message, "tic_minimum_mz")
+    ensure_float_nonnegative(message, "tic_maximum_mz")
+    if (
+        message.HasField("tic_minimum_mz")
+        and message.HasField("tic_maximum_mz")
+        and message.tic_minimum_mz > message.tic_maximum_mz
+    ):
+        warnings.warn(
+            f"tic_minimum_mz ({message.tic_minimum_mz}) must not exceed tic_maximum_mz ({message.tic_maximum_mz})",
+            ValidationError,
+        )
+    if any(mass < 0 for mass in message.eic_masses):
+        warnings.warn("eic_masses must be non-negative", ValidationError)
+    if message.type == reaction_pb2.ProductMeasurement.MassSpecMeasurementDetails.EIC and not message.eic_masses:
+        warnings.warn("EIC mass spec measurements should specify eic_masses", ValidationWarning)
+    if (
+        message.type
+        in (
+            reaction_pb2.ProductMeasurement.MassSpecMeasurementDetails.TIC,
+            reaction_pb2.ProductMeasurement.MassSpecMeasurementDetails.TIC_POSITIVE,
+            reaction_pb2.ProductMeasurement.MassSpecMeasurementDetails.TIC_NEGATIVE,
+        )
+        and message.eic_masses
+    ):
+        warnings.warn("eic_masses should only be specified for EIC mass spec measurements", ValidationWarning)
 
 
 def validate_date_time(message: reaction_pb2.DateTime):
@@ -1073,7 +1192,11 @@ def validate_reaction_provenance(message: reaction_pb2.ReactionProvenance):
                 )
         except ValueError as error:
             warnings.warn(str(error), ValidationError)
-    # TODO(ccoley) could check if publication_url is valid, etc.
+    if message.publication_url and not is_url(message.publication_url):
+        warnings.warn(
+            f"publication_url does not look like a valid URL: {message.publication_url}",
+            ValidationWarning,
+        )
 
 
 def validate_record_event(message: reaction_pb2.RecordEvent):
@@ -1090,9 +1213,8 @@ def validate_record_event(message: reaction_pb2.RecordEvent):
 
 
 def validate_person(message: reaction_pb2.Person):
-    # NOTE(ccoley): final character is checksum, but ignoring that for now
     if message.orcid:
-        if not re.match("[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]", message.orcid):
+        if not is_valid_orcid(message.orcid):
             warnings.warn("Invalid ORCID: Enter as 0000-0000-0000-0000", ValidationError)
     if message.email:
         # Based on https://www.regular-expressions.info/email.html.
@@ -1199,11 +1321,12 @@ def validate_float_value(message: ord_schema.Message):
 
 
 def validate_data(message: reaction_pb2.Data):
-    # TODO(kearnes): Validate/ping URLs?
     if not message.WhichOneof("kind"):
         warnings.warn("Data requires one of {value, bytes_value, url}", ValidationError)
     if message.bytes_value and not message.format:
         warnings.warn("Data format is required for bytes_data", ValidationError)
+    if message.WhichOneof("kind") == "url" and not is_url(message.url):
+        warnings.warn(f"Data URL does not look like a valid URL: {message.url}", ValidationWarning)
 
 
 _VALIDATOR_SWITCH: dict[type, Callable[..., None]] = {

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -106,14 +106,21 @@ def test_units_should_fail(message, expected):
 
 
 def test_orcid():
-    message = reaction_pb2.Person(orcid="0000-0001-2345-678X")
+    message = reaction_pb2.Person(orcid="0000-0002-1825-0097")
     output = _run_validation(message)
     assert len(output.errors) == 0
     assert len(output.warnings) == 0
 
 
-def test_orcid_should_fail():
-    message = reaction_pb2.Person(orcid="abcd-0001-2345-678X")
+@pytest.mark.parametrize(
+    "orcid",
+    (
+        "abcd-0001-2345-678X",  # Non-numeric.
+        "0000-0001-2345-678X",  # Well-formed but incorrect checksum.
+    ),
+)
+def test_orcid_should_fail(orcid):
+    message = reaction_pb2.Person(orcid=orcid)
     with pytest.raises(validations.ValidationError, match="Invalid"):
         _run_validation(message)
 
@@ -297,6 +304,125 @@ def test_invalid_compound_identifier(identifier_type, value):
     message = reaction_pb2.CompoundIdentifier(type=identifier_type, value=value)
     with pytest.raises(validations.ValidationError, match="could not validate"):
         _run_validation(message)
+
+
+@pytest.mark.parametrize(
+    "identifier_type, value",
+    (
+        ("CAS_NUMBER", "64-17-5"),
+        ("INCHI_KEY", "LFQSCWFLJHTTHZ-UHFFFAOYSA-N"),
+        ("PUBCHEM_CID", "702"),
+        ("CHEMSPIDER_ID", "682"),
+    ),
+)
+def test_compound_identifier_format(identifier_type, value):
+    message = reaction_pb2.CompoundIdentifier(type=identifier_type, value=value)
+    output = _run_validation(message)
+    assert len(output.errors) == 0
+    assert len(output.warnings) == 0
+
+
+@pytest.mark.parametrize(
+    "identifier_type, value, expected",
+    (
+        ("CAS_NUMBER", "64175", "CAS number"),
+        ("INCHI_KEY", "not-a-key", "InChIKey"),
+        ("PUBCHEM_CID", "abc", "PubChem CID"),
+        ("CHEMSPIDER_ID", "12x", "ChemSpider ID"),
+    ),
+)
+def test_bad_compound_identifier_format(identifier_type, value, expected):
+    message = reaction_pb2.CompoundIdentifier(type=identifier_type, value=value)
+    output = _run_validation(message)
+    assert len(output.errors) == 0
+    assert len(output.warnings) == 1
+    assert expected in output.warnings[0]
+
+
+@pytest.mark.parametrize(
+    "ph_text",
+    (
+        "ph: 7.0",
+        "ph: 0.0",
+        "ph: 14.0",
+    ),
+)
+def test_reaction_conditions_ph(ph_text):
+    message = text_format.Parse(ph_text, reaction_pb2.ReactionConditions())
+    output = _run_validation(message)
+    assert len(output.errors) == 0
+    assert len(output.warnings) == 0
+
+
+@pytest.mark.parametrize("ph_value", (-1.0, 15.0))
+def test_reaction_conditions_bad_ph(ph_value):
+    message = reaction_pb2.ReactionConditions(ph=ph_value)
+    output = _run_validation(message)
+    assert len(output.warnings) == 1
+    assert "outside the expected range" in output.warnings[0]
+
+
+def test_electrochemistry_missing_current():
+    message = reaction_pb2.ElectrochemistryConditions(type="CONSTANT_CURRENT")
+    output = _run_validation(message)
+    assert len(output.warnings) == 1
+    assert "should specify the current" in output.warnings[0]
+
+
+def test_electrochemistry_missing_voltage():
+    message = reaction_pb2.ElectrochemistryConditions(type="CONSTANT_VOLTAGE")
+    output = _run_validation(message)
+    assert len(output.warnings) == 1
+    assert "should specify the voltage" in output.warnings[0]
+
+
+def test_mass_spec_mz_range():
+    message = text_format.Parse(
+        "type: TIC tic_minimum_mz: 100.0 tic_maximum_mz: 50.0",
+        reaction_pb2.ProductMeasurement.MassSpecMeasurementDetails(),
+    )
+    with pytest.raises(validations.ValidationError, match="tic_minimum_mz"):
+        _run_validation(message)
+
+
+def test_mass_spec_eic_requires_masses():
+    message = reaction_pb2.ProductMeasurement.MassSpecMeasurementDetails(type="EIC")
+    output = _run_validation(message)
+    assert len(output.warnings) == 1
+    assert "should specify eic_masses" in output.warnings[0]
+
+
+def test_illumination_dark_with_wavelength():
+    message = text_format.Parse(
+        "type: DARK peak_wavelength {value: 450.0 units: NANOMETER}",
+        reaction_pb2.IlluminationConditions(),
+    )
+    output = _run_validation(message)
+    assert len(output.warnings) == 1
+    assert "DARK or AMBIENT" in output.warnings[0]
+
+
+@pytest.mark.parametrize(
+    "value, is_mapped, expected",
+    (
+        # Atom maps present but the flag is not set.
+        ("[CH4:1]>>[CH4:1]", False, "is_mapped is not set"),
+        # Flag is set but the SMILES contains no atom maps.
+        ("CO>>CO", True, "no atom maps"),
+    ),
+)
+def test_reaction_identifier_atom_mapping(value, is_mapped, expected):
+    message = reaction_pb2.ReactionIdentifier(type="REACTION_SMILES", value=value, is_mapped=is_mapped)
+    output = _run_validation(message)
+    assert len(output.warnings) == 1
+    assert expected in output.warnings[0]
+
+
+def test_data_bad_url():
+    message = reaction_pb2.Data(url="not a url")
+    output = _run_validation(message)
+    assert len(output.warnings) == 1
+    assert "valid URL" in output.warnings[0]
 
 
 @pytest.mark.parametrize(

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -17,7 +17,6 @@ import sys
 import warnings
 
 import pytest
-from google.protobuf import text_format
 
 from ord_schema import validations
 from ord_schema.proto import dataset_pb2, reaction_pb2
@@ -81,6 +80,7 @@ def test_is_not_empty(message):
         reaction_pb2.Volume(value=15.0, units=reaction_pb2.Volume.MILLILITER),
         reaction_pb2.Time(value=24, units=reaction_pb2.Time.HOUR),
         reaction_pb2.Mass(value=32.1, units=reaction_pb2.Mass.GRAM),
+        reaction_pb2.Temperature(value=25.0, units=reaction_pb2.Temperature.CELSIUS),
     ),
 )
 def test_units(message):
@@ -339,16 +339,9 @@ def test_bad_compound_identifier_format(identifier_type, value, expected):
     assert expected in output.warnings[0]
 
 
-@pytest.mark.parametrize(
-    "ph_text",
-    (
-        "ph: 7.0",
-        "ph: 0.0",
-        "ph: 14.0",
-    ),
-)
-def test_reaction_conditions_ph(ph_text):
-    message = text_format.Parse(ph_text, reaction_pb2.ReactionConditions())
+@pytest.mark.parametrize("ph_value", (7.0, 0.0, 14.0))
+def test_reaction_conditions_ph(ph_value):
+    message = reaction_pb2.ReactionConditions(ph=ph_value)
     output = _run_validation(message)
     assert len(output.errors) == 0
     assert len(output.warnings) == 0
@@ -377,9 +370,8 @@ def test_electrochemistry_missing_voltage():
 
 
 def test_mass_spec_mz_range():
-    message = text_format.Parse(
-        "type: TIC tic_minimum_mz: 100.0 tic_maximum_mz: 50.0",
-        reaction_pb2.ProductMeasurement.MassSpecMeasurementDetails(),
+    message = reaction_pb2.ProductMeasurement.MassSpecMeasurementDetails(
+        type="TIC", tic_minimum_mz=100.0, tic_maximum_mz=50.0
     )
     with pytest.raises(validations.ValidationError, match="tic_minimum_mz"):
         _run_validation(message)
@@ -392,11 +384,31 @@ def test_mass_spec_eic_requires_masses():
     assert "should specify eic_masses" in output.warnings[0]
 
 
-def test_illumination_dark_with_wavelength():
-    message = text_format.Parse(
-        "type: DARK peak_wavelength {value: 450.0 units: NANOMETER}",
-        reaction_pb2.IlluminationConditions(),
+def test_mass_spec_negative_eic_mass():
+    message = reaction_pb2.ProductMeasurement.MassSpecMeasurementDetails(type="EIC", eic_masses=[-1.0])
+    with pytest.raises(validations.ValidationError, match="eic_masses must be non-negative"):
+        _run_validation(message)
+
+
+def test_mass_spec_tic_with_eic_masses():
+    message = reaction_pb2.ProductMeasurement.MassSpecMeasurementDetails(type="TIC", eic_masses=[100.0])
+    output = _run_validation(message)
+    assert len(output.warnings) == 1
+    assert "should only be specified for EIC" in output.warnings[0]
+
+
+def test_provenance_bad_url():
+    message = reaction_pb2.ReactionProvenance(
+        record_created=dict(time=dict(value="2021-01-01"), person=dict(username="test", email="a@b.com")),
+        publication_url="not a url",
     )
+    output = _run_validation(message)
+    assert len(output.warnings) == 1
+    assert "valid URL" in output.warnings[0]
+
+
+def test_illumination_dark_with_wavelength():
+    message = reaction_pb2.IlluminationConditions(type="DARK", peak_wavelength=dict(value=450.0, units="NANOMETER"))
     output = _run_validation(message)
     assert len(output.warnings) == 1
     assert "DARK or AMBIENT" in output.warnings[0]
@@ -425,36 +437,37 @@ def test_data_bad_url():
     assert "valid URL" in output.warnings[0]
 
 
+_ADDITION_INPUT = dict(
+    components=[dict(identifiers=[dict(value="CCO", type="SMILES")], amount=dict(mass=dict(value=10.0, units="GRAM")))]
+)
+
+
 @pytest.mark.parametrize(
-    "workup_text",
+    "message",
     (
-        "type: ALIQUOT amount {mass {value: 1.0 units: GRAM}}",
-        "type: ADDITION input {components {"
-        'identifiers {value: "CCO" type: SMILES} '
-        "amount {mass {value: 10.0 units: GRAM}}}}",
+        reaction_pb2.ReactionWorkup(type="ALIQUOT", amount=dict(mass=dict(value=1.0, units="GRAM"))),
+        reaction_pb2.ReactionWorkup(type="ADDITION", input=_ADDITION_INPUT),
     ),
 )
-def test_reaction_workup(workup_text):
-    message = text_format.Parse(workup_text, reaction_pb2.ReactionWorkup())
+def test_reaction_workup(message):
     output = _run_validation(message)
     assert len(output.errors) == 0
     assert len(output.warnings) == 0
 
 
 @pytest.mark.parametrize(
-    "workup_text,error_msg",
+    "message,error_msg",
     (
-        ("type: ALIQUOT", "missing volume/mass"),
+        (reaction_pb2.ReactionWorkup(type="ALIQUOT"), "missing volume/mass"),
         (
-            "type: ADDITION amount {mass {value: 1.0 units: GRAM}} "
-            'input {components {identifiers {value: "CCO" type: SMILES} '
-            "amount {mass {value: 10.0 units: GRAM}}}}",
+            reaction_pb2.ReactionWorkup(
+                type="ADDITION", amount=dict(mass=dict(value=1.0, units="GRAM")), input=_ADDITION_INPUT
+            ),
             "should only be specified",
         ),
     ),
 )
-def test_bad_reaction_workup(workup_text, error_msg):
-    message = text_format.Parse(workup_text, reaction_pb2.ReactionWorkup())
+def test_bad_reaction_workup(message, error_msg):
     output = _run_validation(message)
     assert len(output.warnings) == 1
     assert error_msg in output.warnings[0]
@@ -743,3 +756,373 @@ def test_validator_switch_dispatches(message_cls):
         options=validations.ValidationOptions(require_provenance=False),
     )
     assert isinstance(output, validations.ValidationOutput)
+
+
+def _capture_warnings(func, *args, **kwargs):
+    """Calls a validator directly and returns the recorded warnings.
+
+    Used for branches that are shadowed by recursion in ``validate_message``
+    (e.g. provenance-level DateTime parsing, which the DateTime validator would
+    otherwise flag first).
+    """
+    with warnings.catch_warnings(record=True) as tape:
+        warnings.simplefilter("always")
+        func(*args, **kwargs)
+    return tape
+
+
+def test_type_and_details_missing_type():
+    # Non-empty TypeDetailsMessage with an unset type.
+    message = reaction_pb2.Texture(details="fine needles")
+    with pytest.raises(validations.ValidationError, match="requires `type`"):
+        _run_validation(message)
+
+
+def test_type_and_details_custom_without_details():
+    message = reaction_pb2.Texture(type="CUSTOM")
+    with pytest.raises(validations.ValidationError, match="CUSTOM but details"):
+        _run_validation(message)
+
+
+def test_reaction_cxsmiles():
+    message = reaction_pb2.ReactionIdentifier(type="REACTION_CXSMILES", value="CO>>CO |f:0|")
+    output = _run_validation(message)
+    assert len(output.errors) == 0
+    assert len(output.warnings) == 0
+
+
+def test_amount_volume_includes_solutes_non_volume():
+    message = reaction_pb2.Amount(
+        mass=reaction_pb2.Mass(value=1.0, units="GRAM"),
+        volume_includes_solutes=True,
+    )
+    with pytest.raises(validations.ValidationError, match="only be set for volume"):
+        _run_validation(message)
+
+
+@pytest.mark.parametrize(
+    "message, expected",
+    (
+        (
+            reaction_pb2.CrudeComponent(
+                reaction_id="r", has_derived_amount=True, amount=dict(mass=dict(value=1.0, units="GRAM"))
+            ),
+            "cannot have their mass",
+        ),
+        (
+            reaction_pb2.CrudeComponent(reaction_id="r", amount=dict(moles=dict(value=1.0, units="MOLE"))),
+            "must be specified by mass or volume",
+        ),
+        (
+            reaction_pb2.CrudeComponent(
+                reaction_id="r", amount=dict(volume=dict(value=1.0, units="LITER"), volume_includes_solutes=True)
+            ),
+            "only be used for input Compounds",
+        ),
+    ),
+)
+def test_crude_component_amounts(message, expected):
+    with pytest.raises(validations.ValidationError, match=expected):
+        _run_validation(message)
+
+
+def test_compound_inconsistent_identifiers():
+    message = reaction_pb2.Compound(
+        identifiers=[
+            dict(type="SMILES", value="CO"),  # methanol
+            dict(type="INCHI", value="InChI=1S/CH4/h1H4"),  # methane
+        ]
+    )
+    output = _run_validation(message)
+    assert len(output.errors) == 0
+    assert any(
+        "could not validate that" in warning.lower() or "consistent" in warning.lower() for warning in output.warnings
+    )
+
+
+@pytest.mark.parametrize(
+    "message, raises, expected",
+    (
+        (reaction_pb2.ReactionConditions(conditions_are_dynamic=True), True, "dynamic"),
+        (reaction_pb2.ReactionConditions(details="ramped"), False, "details provided"),
+    ),
+)
+def test_reaction_conditions_dynamic(message, raises, expected):
+    if raises:
+        with pytest.raises(validations.ValidationError, match=expected):
+            _run_validation(message)
+    else:
+        output = _run_validation(message)
+        assert len(output.warnings) == 1
+        assert expected in output.warnings[0]
+
+
+@pytest.mark.parametrize(
+    "message, expected",
+    (
+        (reaction_pb2.ReactionWorkup(type="WAIT"), "WAIT workup"),
+        (reaction_pb2.ReactionWorkup(type="TEMPERATURE"), "temperature conditions"),
+        (reaction_pb2.ReactionWorkup(type="EXTRACTION"), "keep_phase"),
+        (reaction_pb2.ReactionWorkup(type="WASH"), "missing recommended inputs"),
+        (reaction_pb2.ReactionWorkup(type="STIRRING"), "Stirring workup"),
+        (
+            reaction_pb2.ReactionWorkup(
+                type="PH_ADJUST",
+                input=dict(
+                    components=[
+                        dict(
+                            identifiers=[dict(value="O", type="SMILES")],
+                            amount=dict(volume=dict(value=1.0, units="LITER")),
+                        )
+                    ]
+                ),
+            ),
+            "missing target pH",
+        ),
+        (
+            reaction_pb2.ReactionWorkup(type="ALIQUOT", amount=dict(moles=dict(value=1.0, units="MOLE"))),
+            "specified by mass or volume",
+        ),
+        (
+            reaction_pb2.ReactionWorkup(
+                type="ALIQUOT", amount=dict(volume=dict(value=1.0, units="LITER"), volume_includes_solutes=True)
+            ),
+            "only be used for input Compounds",
+        ),
+        (
+            reaction_pb2.ReactionWorkup(type="CONCENTRATION", amount=dict(mass=dict(value=1.0, units="GRAM"))),
+            "only be specified if workup type",
+        ),
+    ),
+)
+def test_reaction_workup_recommendations(message, expected):
+    output = _run_validation(message)
+    assert any(expected in warning for warning in output.warnings)
+
+
+def test_reaction_outcome_bad_analysis_key():
+    message = reaction_pb2.ReactionOutcome(
+        products=[
+            dict(
+                identifiers=[dict(value="CO", type="SMILES")],
+                measurements=[dict(type="IDENTITY", analysis_key="missing")],
+            )
+        ]
+    )
+    with pytest.raises(validations.ValidationError, match="does not match any known analysis"):
+        _run_validation(message)
+
+
+def test_product_compound_side_product_desired():
+    message = reaction_pb2.ProductCompound(
+        identifiers=[dict(value="CO", type="SMILES")], is_desired_product=True, reaction_role="SIDE_PRODUCT"
+    )
+    with pytest.raises(validations.ValidationError, match="SIDE_PRODUCT"):
+        _run_validation(message)
+
+
+def test_product_compound_inconsistent_identifiers():
+    message = reaction_pb2.ProductCompound(
+        identifiers=[
+            dict(type="SMILES", value="CO"),  # methanol
+            dict(type="INCHI", value="InChI=1S/CH4/h1H4"),  # methane
+        ],
+        is_desired_product=True,  # Also exercises the desired/not-SIDE_PRODUCT branch.
+    )
+    output = _run_validation(message)
+    assert len(output.errors) == 0
+    assert any(
+        "could not validate that" in warning.lower() or "consistent" in warning.lower() for warning in output.warnings
+    )
+
+
+@pytest.mark.parametrize(
+    "message, raises, expected",
+    (
+        (
+            reaction_pb2.ProductMeasurement(type="IDENTITY", analysis_key="x", percentage=dict(value=50.0)),
+            True,
+            "IDENTITY should not have",
+        ),
+        (
+            reaction_pb2.ProductMeasurement(type="YIELD", analysis_key="x", float_value=dict(value=5.0)),
+            False,
+            "YIELD measurements",
+        ),
+        (
+            reaction_pb2.ProductMeasurement(type="AREA", analysis_key="x", string_value="big"),
+            True,
+            "must use numeric values",
+        ),
+    ),
+)
+def test_product_measurement_values(message, raises, expected):
+    if raises:
+        with pytest.raises(validations.ValidationError, match=expected):
+            _run_validation(message)
+    else:
+        output = _run_validation(message)
+        assert any(expected in warning for warning in output.warnings)
+
+
+def test_bad_datetime():
+    message = reaction_pb2.DateTime(value="definitely not a date")
+    with pytest.raises(validations.ValidationError, match="Could not parse DateTime"):
+        _run_validation(message)
+
+
+def test_provenance_record_modified_before_created():
+    message = reaction_pb2.ReactionProvenance(
+        record_created=dict(time=dict(value="2021-06-01"), person=dict(username="u", email="a@b.com")),
+        record_modified=[dict(time=dict(value="2021-01-01"), person=dict(username="u", email="a@b.com"))],
+    )
+    with pytest.raises(validations.ValidationError, match="after creation"):
+        _run_validation(message)
+
+
+def test_provenance_doi_should_be_trimmed():
+    message = reaction_pb2.ReactionProvenance(
+        record_created=dict(time=dict(value="2021-01-01"), person=dict(username="u", email="a@b.com")),
+        doi="https://doi.org/10.1234/foo",
+    )
+    with pytest.raises(validations.ValidationError, match="trimmed"):
+        _run_validation(message)
+
+
+def test_provenance_unparseable_datetime_direct():
+    # Shadowed by the DateTime validator under recursion, so call directly.
+    message = reaction_pb2.ReactionProvenance()
+    message.record_created.time.value = "garbage"
+    message.record_created.person.username = "u"
+    message.record_created.person.email = "a@b.com"
+    tape = _capture_warnings(validations.validate_reaction_provenance, message)
+    assert any("Failed to parse" in str(warning.message) for warning in tape)
+
+
+def test_temperature_fahrenheit_below_absolute_zero():
+    message = reaction_pb2.Temperature(value=-500.0, units="FAHRENHEIT")
+    with pytest.raises(validations.ValidationError, match="between"):
+        _run_validation(message)
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    (
+        (0.5, "not fractions"),
+        (150.0, "outside the expected range"),
+    ),
+)
+def test_percentage_ranges(value, expected):
+    message = reaction_pb2.Percentage(value=value)
+    output = _run_validation(message)
+    assert any(expected in warning for warning in output.warnings)
+
+
+def test_cross_ref_state_merge():
+    state_a = validations.DatasetCrossRefState(defined_ids={"a", "shared"})
+    state_b = validations.DatasetCrossRefState(
+        defined_ids={"b", "shared"}, referenced_ids={"a"}, self_reference_count=1
+    )
+    state_a.merge(state_b)
+    assert state_a.defined_ids == {"a", "b", "shared"}
+    assert state_a.referenced_ids == {"a"}
+    assert state_a.duplicate_count == 1  # "shared" defined in both.
+    assert state_a.self_reference_count == 1
+
+
+def test_validators_default_options():
+    # Exercise the ``options is None`` default branches.
+    validations.validate_reaction(reaction_pb2.Reaction(), options=None)
+    validations.validate_dataset(dataset_pb2.Dataset(), options=None)
+    validations.validate_dataset_streaming(
+        name="n",
+        description="d",
+        dataset_id="",
+        reaction_ids=[],
+        has_reactions=True,
+        state=validations.DatasetCrossRefState(),
+        options=None,
+    )
+
+
+def test_workup_target_ph_out_of_range():
+    message = reaction_pb2.ReactionWorkup(
+        type="PH_ADJUST",
+        target_ph=20.0,
+        input=dict(
+            components=[
+                dict(identifiers=[dict(value="O", type="SMILES")], amount=dict(mass=dict(value=1.0, units="GRAM")))
+            ]
+        ),
+    )
+    output = _run_validation(message)
+    assert any("outside the expected range" in warning for warning in output.warnings)
+
+
+def test_reaction_outcome_multiple_desired_products():
+    product = dict(identifiers=[dict(value="CO", type="SMILES")], is_desired_product=True, reaction_role="PRODUCT")
+    message = reaction_pb2.ReactionOutcome(products=[product, product])
+    output = _run_validation(message)
+    assert any("at most one" in warning for warning in output.warnings)
+
+
+@pytest.mark.parametrize(
+    "measurement, expects_warning",
+    (
+        (reaction_pb2.ProductMeasurement(type="PURITY", analysis_key="x", float_value=dict(value=5.0)), True),
+        (reaction_pb2.ProductMeasurement(type="AREA", analysis_key="x", float_value=dict(value=5.0)), False),
+    ),
+)
+def test_product_measurement_purity_and_area(measurement, expects_warning):
+    output = _run_validation(measurement)
+    has_purity_warning = any("PURITY measurements" in warning for warning in output.warnings)
+    assert has_purity_warning == expects_warning
+
+
+def test_provenance_clean():
+    # A fully valid provenance: record_modified after record_created and a DOI
+    # that needs no trimming (exercises the "no warning" branches).
+    message = reaction_pb2.ReactionProvenance(
+        record_created=dict(time=dict(value="2021-01-01"), person=dict(username="u", email="a@b.com")),
+        record_modified=[dict(time=dict(value="2021-06-01"), person=dict(username="u", email="a@b.com"))],
+        doi="10.1234/foo",
+    )
+    output = _run_validation(message)
+    assert len(output.errors) == 0
+    assert len(output.warnings) == 0
+
+
+def test_provenance_record_modified_missing_email_direct():
+    # Shadowed by validate_record_event under recursion, so call directly.
+    message = reaction_pb2.ReactionProvenance()
+    message.record_created.time.value = "2021-01-01"
+    message.record_created.person.email = "a@b.com"
+    record = message.record_modified.add()
+    record.time.value = "2021-06-01"
+    record.person.username = "u"
+    tape = _capture_warnings(validations.validate_reaction_provenance, message)
+    assert any("email is required for record_modified" in str(warning.message) for warning in tape)
+
+
+def test_validate_datasets(tmp_path):
+    options = validations.ValidationOptions(require_provenance=False)
+    good = dataset_pb2.Dataset(
+        name="test",
+        description="test",
+        reactions=[reaction_pb2.Reaction(identifiers=[dict(type="REACTION_SMILES", value="CO>>CC")])],
+    )
+    # A clean dataset does not raise.
+    validations.validate_datasets({"good.pbtxt": good}, options=options)
+    # This dataset has both a reaction-level error (an empty Reaction) and a
+    # dataset-level error (reactions and reaction_ids are mutually exclusive);
+    # with write_errors it also writes a sidecar file.
+    bad = dataset_pb2.Dataset(
+        name="test",
+        description="test",
+        reactions=[reaction_pb2.Reaction()],
+        reaction_ids=["ord-c0bbd41f095a44a78b6221135961d809"],
+    )
+    bad_path = tmp_path / "bad.pbtxt"
+    with pytest.raises(validations.ValidationError, match="validation encountered errors"):
+        validations.validate_datasets({str(bad_path): bad}, write_errors=True, options=options)
+    assert bad_path.with_suffix(".pbtxt.error").exists()


### PR DESCRIPTION
## Summary

Bolsters message validation in `ord_schema/validations.py` with additional reasonable checks. New checks default to `ValidationWarning` (advisory) unless the constraint is a true invariant, in which case they are `ValidationError`.

### Tier 1 — constraints stated in the proto, low false-positive risk
- **pH range 0–14** for `ReactionConditions.ph` and `ReactionWorkup.target_ph` (warning).
- **MassSpec m/z sanity** in `MassSpecMeasurementDetails`: `tic_minimum_mz <= tic_maximum_mz` (error); non-negative `tic_minimum_mz`/`tic_maximum_mz`/`eic_masses`; EIC should specify `eic_masses` and TIC variants should not (warnings).
- **Electrochemistry type↔field consistency**: `CONSTANT_CURRENT` should set `current`; `CONSTANT_VOLTAGE` should set `voltage` (warnings). Previously a no-op validator.
- **CompoundIdentifier format checks** (warnings): `CAS_NUMBER` (`\d{2,7}-\d{2}-\d`), `INCHI_KEY` (`[A-Z]{14}-[A-Z]{10}-[A-Z]`), and integer-valued `PUBCHEM_CID`/`CHEMSPIDER_ID`.

### Tier 2 — reasonable, slightly more opinionated
- **Atom-mapping consistency**: warn if `ReactionIdentifier.is_mapped` is set but the SMILES has no atom maps, or maps are present but the flag is unset.
- **Illumination**: `peak_wavelength` should not be set for `DARK`/`AMBIENT` (warning).
- **URL format**: basic scheme/host check for `ReactionProvenance.publication_url` and `Data.url` (resolves the longstanding `TODO`); warnings only.
- **Tightened ORCID**: anchor the regex (`fullmatch`) and verify the ISO 7064 mod-11-2 check digit. This is a tightening of the existing check, so the format-placeholder ORCID in the tests was replaced with a real, valid ORCID.

### Skipped (out of scope)
Setpoint-vs-control-method "sanity", RPM upper bounds, measurement time-ordering, future-date checks (needs a non-deterministic `now`), and duplicate-product detection — all opinionated or false-positive prone.

### Drive-by fix
While adding tests, found that the existing `validate_reaction_workup` check `not message.stirring` is **always False** for a singular proto message field (proto messages are always truthy), so the "Stirring workup missing stirring definition" warning never fired. Switched it to `not message.HasField("stirring")`.

### Review follow-ups
- Greptile: `PUBCHEM_CID`/`CHEMSPIDER_ID` now use `str.isdecimal()` (rejects non-ASCII digits) instead of `str.isdigit()`.
- Greptile: added the requested tests for the `target_ph` range and `publication_url` checks.
- Backfilled tests across many previously-untested validator branches, raising `validations.py` line coverage from ~86% to ~98%. Remaining gaps are defensive guards and trivial branch directions.

## Test plan
- Added parametrized good/bad cases to `validations_test.py` for every new check, plus broad coverage of pre-existing branches.
- `pytest -n auto ord_schema/validations_test.py ord_schema/message_helpers_test.py ord_schema/scripts/validate_dataset_test.py` → 312 passed.
- `ruff format` / `ruff check` / `ty check` clean (pre-commit hooks pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bolsters `validate_*` functions in `validations.py` with a set of advisory (`ValidationWarning`) and invariant (`ValidationError`) checks that were previously missing or stubbed out. The existing ORCID validator is also tightened to anchor the regex and verify the ISO 7064 MOD 11-2 check digit.

- **New advisory checks:** pH range (0–14), mass-spec EIC/TIC field coherence, electrochemistry type↔field consistency, compound-identifier format (CAS, InChIKey, PubChem CID, ChemSpider ID), atom-mapping flag vs. SMILES consistency, illumination wavelength for DARK/AMBIENT, and basic http(s) URL validation for `publication_url` and `Data.url`.
- **New invariant checks (ValidationError):** `tic_minimum_mz ≤ tic_maximum_mz` and non-negative `eic_masses`.
- **Test hygiene:** text-format proto parsing replaced with proto constructors, `text_format` import removed, and parametrized good/bad cases added for every new check.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all new checks are advisory warnings or well-justified invariant errors, with no changes to existing passing behaviour.

The new validators are narrowly scoped: advisory warnings gate on HasField before touching optional-scalar values, the tic_minimum_mz ≤ tic_maximum_mz error is a true data invariant, and the ORCID checksum algorithm was verified against a known-good ORCID. Every new code path has a matching parametrized test.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/validations.py | Adds ~70 lines of new validation logic across seven validators: pH range, mass-spec m/z invariants, electrochemistry type/field consistency, compound-identifier format checks (CAS, InChIKey, PubChem CID, ChemSpider ID), atom-mapping consistency for REACTION_SMILES/CXSMILES, illumination/wavelength coherence, URL sanity checks, and a tightened ORCID validator with ISO 7064 check-digit verification. No logic bugs found in new code. |
| ord_schema/validations_test.py | Adds parametrized good/bad tests for every new check. Also replaces text_format.Parse-based workup tests with proto constructor style, removes unused text_format import, and adds Temperature to the units parametrize list. Coverage appears complete for the new validators. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ord_schema/validations_test.py`, line 428-461 ([link](https://github.com/open-reaction-database/ord-schema/blob/d15f38e88883be664e4e80a6557a2de14d968edc/ord_schema/validations_test.py#L428-L461)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing test coverage for two new validators**

   Two validators added in this PR have no corresponding tests:

   1. `validate_reaction_workup` now warns when `target_ph` is outside 0–14 (`validations.py` line 980), but no test verifies that, e.g., `target_ph: -1.0` or `target_ph: 15.0` triggers the warning.
   2. `validate_reaction_provenance` now warns when `publication_url` doesn't look like a valid URL (`validations.py` line 1195), yet no test covers this path — analogous to the existing `test_data_bad_url` test added for `Data.url`.

   Without tests, a future refactor could silently break these checks. Adding parametrized good/bad cases (mirroring `test_reaction_conditions_bad_ph` and `test_data_bad_url`) would close the gap.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Address review: isdecimal, dead-code fix..."](https://github.com/open-reaction-database/ord-schema/commit/065e716a18d2a5cd192ff74747a48c45db87a503) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35540072)</sub>

<!-- /greptile_comment -->