### PR TITLE
Enable flake8-commas (COM) and flake8-implicit-str-concat (ISC)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,12 +107,16 @@ select = [
     "SIM",  # flake8-simplify
     "ANN",  # flake8-annotations (argument, return, and Any-return types)
     "C4",   # flake8-comprehensions
+    "COM",  # flake8-commas
 ]
 ignore = [
     # ANN401 (disallow typing.Any) fires only on genuinely dynamic call sites:
     # proxy __getattr__/__getitem__ on message wrappers, a metaclass proxy, an
     # enum __call__, and the recursive field-value validator. Any is correct there.
     "ANN401",
+    # COM812 (missing trailing comma) conflicts with the ruff formatter, which
+    # ruff itself recommends disabling when running `ruff format`.
+    "COM812",
     "E501",    # Line length is enforced by the formatter, not the linter.
     "SIM108",  # Ternary expressions are not always clearer than if/else.
     "B008",    # Function calls in argument defaults are fine for our use cases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,15 +108,18 @@ select = [
     "ANN",  # flake8-annotations (argument, return, and Any-return types)
     "C4",   # flake8-comprehensions
     "COM",  # flake8-commas
+    "ISC",  # flake8-implicit-str-concat
 ]
 ignore = [
     # ANN401 (disallow typing.Any) fires only on genuinely dynamic call sites:
     # proxy __getattr__/__getitem__ on message wrappers, a metaclass proxy, an
     # enum __call__, and the recursive field-value validator. Any is correct there.
     "ANN401",
-    # COM812 (missing trailing comma) conflicts with the ruff formatter, which
-    # ruff itself recommends disabling when running `ruff format`.
+    # COM812 (missing trailing comma) and ISC001 (single-line implicit string
+    # concat) conflict with the ruff formatter, which ruff itself recommends
+    # disabling when running `ruff format`.
     "COM812",
+    "ISC001",
     "E501",    # Line length is enforced by the formatter, not the linter.
     "SIM108",  # Ternary expressions are not always clearer than if/else.
     "B008",    # Function calls in argument defaults are fine for our use cases.


### PR DESCRIPTION
Part of the staged ruff rollout. Batches the two **formatter-conflict guard-rail** families (config-only, no code changes):

- **`COM`** (flake8-commas): keeps `COM818`/`COM819` (trailing-comma bug catches); ignores **`COM812`** (missing trailing comma) — conflicts with the ruff formatter.
- **`ISC`** (flake8-implicit-str-concat): keeps `ISC002`/`ISC003`; ignores **`ISC001`** (single-line implicit concat) — also conflicts with the formatter.

Both `COM812`/`ISC001` are the exact rules [ruff's docs](https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules) say to disable when using `ruff format`. No current `COM818/819`/`ISC002/003` violations, so no code changes. `ruff check` / `ruff format --check` / `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Config-only ruff rollout step enabling two linting families in `pyproject.toml` with no code changes required.

- Adds `COM` (flake8-commas) and `ISC` (flake8-implicit-str-concat) to `select`, activating `COM818`/`COM819` and `ISC002`/`ISC003` as guard-rails.
- Adds `COM812` and `ISC001` to `ignore` to prevent conflicts with the ruff formatter, exactly as prescribed by [ruff's documentation on conflicting lint rules](https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules).

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure configuration change with no effect on production code.

The change is a two-rule-family opt-in with the formatter-conflicting rules explicitly suppressed, consistent with ruff's own recommendations. No code is modified and the PR description confirms ruff check, ruff format --check, and ty all pass clean.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Adds COM and ISC rule families to ruff's select list while ignoring the two formatter-conflicting rules (COM812, ISC001), exactly matching ruff's documented guidance. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Also enable flake8-implicit-str-concat (..."](https://github.com/open-reaction-database/ord-schema/commit/66589b48b2cec55277e328767d032b550a650395) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38838338)</sub>

<!-- /greptile_comment -->