### PR TITLE
Enable flake8-bandit (S) with security-aware exemptions

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -298,7 +298,7 @@ def _link_mol_ids(session: Session, *, target_table: str, link_table: str, link_
               AND ord.reaction.dataset_id = ord.dataset.id
               AND ord.dataset.dataset_id = :dataset_id
               AND {target_table}.rdkit_mol_id IS NULL
-            """),
+            """),  # noqa: S608  (table/column names are internal constants, not user input)
         {"dataset_id": dataset_id},
     )
     return cast(Any, result).rowcount

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -308,7 +308,7 @@ def from_proto(message: Message, mapper: type[Base] | None = None, key: str | No
         else:
             kwargs[field.name] = value
     if isinstance(message, dataset_pb2.Dataset):
-        kwargs["md5"] = md5(message.SerializeToString(deterministic=True)).hexdigest()
+        kwargs["md5"] = md5(message.SerializeToString(deterministic=True), usedforsecurity=False).hexdigest()
         assert hasattr(message, "reactions")
         assert hasattr(message, "reaction_ids")
         kwargs["num_reactions"] = len(message.reactions) or len(message.reaction_ids)

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -72,7 +72,7 @@ def add_dataset(dsn: str, filename: str, overwrite: bool) -> str:
         dataset_id = dataset.dataset_id
 
         def compute_md5() -> str:
-            return md5(dataset.SerializeToString(deterministic=True)).hexdigest()
+            return md5(dataset.SerializeToString(deterministic=True), usedforsecurity=False).hexdigest()
 
         def insert(session: Session) -> None:
             database.add_dataset(dataset, session, rdkit_cartridge=False)  # Done separately in add_rdkit().

--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -407,7 +407,7 @@ def streaming_md5(path: str) -> tuple[str, int]:
     file layout (row group sizes, compression) so the same logical content
     rewritten with different writer settings still hashes the same.
     """
-    hasher = hashlib.md5()
+    hasher = hashlib.md5(usedforsecurity=False)
     metadata = read_metadata(path)
     if metadata.name:
         hasher.update(f"name={metadata.name}\n".encode())

--- a/ord_schema/scripts/parse_uspto.py
+++ b/ord_schema/scripts/parse_uspto.py
@@ -493,7 +493,7 @@ def clean_reaction(reaction: reaction_pb2.Reaction) -> None:
 
 def run(filename: str) -> tuple[list[reaction_pb2.Reaction], list[reaction_pb2.Reaction]]:
     """Parses reactions from a single CML file."""
-    tree = ET.parse(filename)
+    tree = ET.parse(filename)  # noqa: S314  (parses trusted USPTO XML downloads)
     root = tree.getroot()
     reactions = []
     failures = []

--- a/ord_schema/scripts/process_dataset.py
+++ b/ord_schema/scripts/process_dataset.py
@@ -113,7 +113,7 @@ def cleanup(filename: str, output_filename: str) -> None:
     else:
         args = ["git", "mv", filename, output_filename]
     logger.info("Running command: %s", " ".join(args))
-    subprocess.run(args, check=True)
+    subprocess.run(args, check=True)  # noqa: S603  (internal command, no untrusted input)
 
 
 def _get_reaction_ids(dataset: dataset_pb2.Dataset | parquet_dataset.DatasetView) -> set[str]:
@@ -144,11 +144,11 @@ def _load_base_dataset(file_status: FileStatus, base: str) -> dataset_pb2.Datase
     else:
         git_args.append(f"{base}:{file_status.filename}")
     logger.info("Running command: %s", " ".join(git_args))
-    serialized = subprocess.run(git_args, capture_output=True, check=True, text=False)
+    serialized = subprocess.run(git_args, capture_output=True, check=True, text=False)  # noqa: S603  (internal git command)
     if serialized.stdout.startswith(b"version"):
         # Convert Git LFS pointers to real data.
         serialized = subprocess.run(
-            ["git", "lfs", "smudge"],
+            ["git", "lfs", "smudge"],  # noqa: S607  (git resolved from PATH)
             input=serialized.stdout,
             capture_output=True,
             check=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,7 @@ select = [
     "ERA",  # eradicate (commented-out code)
     "TD",   # flake8-todos
     "FIX",  # flake8-fixme
+    "S",    # flake8-bandit
 ]
 ignore = [
     # ANN401 (disallow typing.Any) fires only on genuinely dynamic call sites:
@@ -163,6 +164,9 @@ ignore = [
     "N803", "N806",          # domain names (SMILES, fromAtoms) are deliberate
     "INP001",                # docs/conf.py is config, not a package
     "TD003",                 # don't force issue links on informal TODOs
+    # S101 (assert): used for test assertions and production type-narrowing
+    # (assert x is not None  # Type hint); not a security concern here.
+    "S101",
     "FIX002",                # TODO comments are allowed
     "E501",    # Line length is enforced by the formatter, not the linter.
     "SIM108",  # Ternary expressions are not always clearer than if/else.
@@ -184,9 +188,9 @@ ignore = [
 # and B017 (overly broad `pytest.raises(Exception)`); type annotations (ANN) also add
 # little value on test functions/fixtures, and SLF001 (private-member access)
 # is fine in tests. Skip these in tests.
-"**/*_test.py" = ["B011", "B017", "ANN", "SLF001"]
+"**/*_test.py" = ["B011", "B017", "ANN", "SLF001", "S603", "S607"]
 # Tutorial notebooks legitimately show commented-out alternative code.
-"**/*.ipynb" = ["ERA001"]
+"**/*.ipynb" = ["ERA001", "S310"]  # tutorials download from known URLs
 
 [tool.ty.src]
 exclude = ["**/*_pb2.py*"]


### PR DESCRIPTION
Part of the staged ruff rollout. Adds the **`S`** (flake8-bandit) family. Most flags are false positives for this codebase, handled deliberately:

| Rule | Handling |
|------|----------|
| `S101` (assert) | **Ignored globally** — used for test assertions and production type-narrowing (`assert x is not None  # Type hint`), not runtime security checks. |
| `S324` (md5) | **Fixed**: `usedforsecurity=False` — md5 is content-addressing (dataset/file hashes), not crypto. |
| `S603`/`S607` (subprocess) | Per-line `noqa` in production (fixed internal `git` commands); per-file-ignore in tests (controlled setup commands). |
| `S314` (xml) | `noqa` — `parse_uspto` reads trusted USPTO XML downloads. |
| `S608` (SQL f-string) | `noqa` — interpolated names are internal constants, not user input. |
| `S310` (urlopen) | Per-file-ignore for notebooks (tutorials fetch known URLs). |

All other bandit checks stay enforced. `ruff check` / `ruff format --check` / `ty` clean; touched-module tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables the `S` (flake8-bandit) rule family in ruff as part of a staged linter rollout. Exemptions are applied carefully and consistently — md5 usages are fixed with `usedforsecurity=False`, and `noqa` comments are added only where the flagged pattern is genuinely a false positive (trusted XML, internal SQL constants, controlled git subprocesses).

- Three `hashlib.md5` / `md5()` call sites across `mappers.py`, `add_datasets.py`, and `parquet_dataset.py` gain `usedforsecurity=False`, which is the correct fix for FIPS-compatible environments; all sites use MD5 for content-addressing, not cryptography.
- `S101` (assert) is globally suppressed with justification (type-narrowing and test assertions), and `S603`/`S607` are excluded for test files and notebooks via `per-file-ignores` rather than scattered inline comments.
- One minor asymmetry: the second `subprocess.run` in `_load_base_dataset` carries `# noqa: S607` on line 151 but no explicit `S603` suppression on its own call line (150), unlike the other git subprocess calls in the same file.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are linter configuration and noqa/usedforsecurity annotations with no behaviour changes to production logic.

The md5 fixes are additive and correct for Python 3.11+ (the minimum required version). Every noqa exemption is documented and scoped tightly. The only observation is a noqa placement asymmetry on a multi-line subprocess call that currently passes ruff check; it carries no runtime risk.

ord_schema/scripts/process_dataset.py — the second subprocess.run noqa comment placement warrants a quick check if ruff is ever upgraded to a version that changes multi-line noqa scoping.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pyproject.toml | Enables the S (flake8-bandit) rule family; globally ignores S101 (assert) with clear justification; adds per-file ignores for tests (S603, S607) and notebooks (S310). |
| ord_schema/orm/mappers.py | Adds usedforsecurity=False to md5() call; correct fix for S324 — hash is used for content-addressing, not cryptographic security. |
| ord_schema/orm/scripts/add_datasets.py | Adds usedforsecurity=False to md5() call for dataset content-hash computation; same correct fix as mappers.py. |
| ord_schema/parquet_dataset.py | Adds usedforsecurity=False to hashlib.md5() in streaming_md5(); used for change-detection hashing, not cryptography. |
| ord_schema/scripts/process_dataset.py | Adds noqa: S603 on the git subprocess calls in cleanup() and _load_base_dataset(), and noqa: S607 on the ["git", "lfs", "smudge"] literal. The second subprocess.run (spanning lines 150–156) only has S607 suppressed on line 151; S603 for that call is not explicitly suppressed on line 150. |
| ord_schema/orm/database.py | Adds noqa: S608 for SQL f-string interpolation; table/column names are internal constants and dataset_id is properly parameterized. |
| ord_schema/scripts/parse_uspto.py | Adds noqa: S314 for ET.parse(); input is trusted USPTO XML downloaded from an official source, not user-supplied data. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ord_schema/scripts/process_dataset.py`, line 150-156 ([link](https://github.com/open-reaction-database/ord-schema/blob/3ed41670bf0f7f2e54838adee3a7198d4b411487/ord_schema/scripts/process_dataset.py#L150-L156)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Asymmetric noqa suppression on multi-line subprocess call**

   The `# noqa: S607` comment is placed on line 151 (the list literal), while `S603` — which ruff attributes to the `subprocess.run` call site on line 150 — has no suppression here. The first `subprocess.run` in this function has an explicit `# noqa: S603` on its own line (147); this second call does not. If ruff's multi-line noqa scoping doesn't propagate line-151 suppressions back to line 150, a future ruff version could start failing on S603 here. Consider adding `# noqa: S603, S607` to be consistent with the pattern used on line 147.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/open-reaction-database/ord-schema/commit/3ed41670bf0f7f2e54838adee3a7198d4b411487) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38845463)</sub>

<!-- /greptile_comment -->