### PR TITLE
Make core file I/O accept path-like objects

### DIFF
--- a/ord_schema/atomic_io.py
+++ b/ord_schema/atomic_io.py
@@ -25,7 +25,7 @@ from collections.abc import Iterator
 
 
 @contextlib.contextmanager
-def atomic_path(path: str) -> Iterator[str]:
+def atomic_path(path: str | os.PathLike[str]) -> Iterator[str]:
     """Yields a sibling temp path; renames it onto ``path`` on clean exit.
 
     Usage:

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -17,6 +17,7 @@ import contextlib
 import enum
 import gzip
 import os
+import pathlib
 import posixpath
 import re
 import warnings
@@ -799,11 +800,19 @@ def fetch_dataset(
     raise RuntimeError(f"Dataset {dataset_id} not found in {ORD_DATA_HF_REPO}@{revision}")
 
 
-def load_message(filename: str, message_type: type[MessageType]) -> MessageType:
+def _message_format(path: pathlib.Path) -> MessageFormat:
+    """Returns the MessageFormat implied by a filename's suffix, ignoring ``.gz``."""
+    suffixes = path.suffixes
+    if suffixes and suffixes[-1] == ".gz":
+        suffixes = suffixes[:-1]
+    return MessageFormat(suffixes[-1] if suffixes else "")
+
+
+def load_message(filename: str | os.PathLike[str], message_type: type[MessageType]) -> MessageType:
     """Loads a protocol buffer message from a file.
 
     Args:
-        filename: Text filename containing a serialized protocol buffer message.
+        filename: Filename (``str`` or path-like) containing a serialized message.
         message_type: Message subclass.
 
     Returns:
@@ -813,18 +822,11 @@ def load_message(filename: str, message_type: type[MessageType]) -> MessageType:
         ValueError: if the message cannot be parsed, or if `input_format` is not
             supported.
     """
-    if filename.endswith(".gz"):
-        this_open = gzip.open
-        _, extension = os.path.splitext(".".join(filename.split(".")[:-1]))
-    else:
-        this_open = open
-        _, extension = os.path.splitext(filename)
-    input_format = MessageFormat(extension)
-    if input_format in _BINARY_FORMATS:
-        mode = "rb"
-    else:
-        mode = "rt"
-    with this_open(filename, mode) as f:
+    path = pathlib.Path(filename)
+    this_open = gzip.open if path.suffix == ".gz" else open
+    input_format = _message_format(path)
+    mode = "rb" if input_format in _BINARY_FORMATS else "rt"
+    with this_open(path, mode) as f:
         try:
             if input_format == MessageFormat.JSON:
                 return json_format.Parse(f.read(), message_type())
@@ -838,25 +840,22 @@ def load_message(filename: str, message_type: type[MessageType]) -> MessageType:
             DecodeError,
             text_format.ParseError,
         ) as error:
-            raise ValueError(f"error parsing {filename}: {error}") from error
+            raise ValueError(f"error parsing {path}: {error}") from error
 
 
-def write_message(message: ord_schema.Message, filename: str) -> None:
+def write_message(message: ord_schema.Message, filename: str | os.PathLike[str]) -> None:
     """Writes a protocol buffer message to disk.
 
     Args:
         message: Protocol buffer message.
-        filename: Text output filename.
+        filename: Output filename (``str`` or path-like).
 
     Raises:
         ValueError: if `filename` does not have the expected suffix.
     """
-    if filename.endswith(".gz"):
-        _, extension = os.path.splitext(".".join(filename.split(".")[:-1]))
-    else:
-        _, extension = os.path.splitext(filename)
-    output_format = MessageFormat(extension)
-    with atomic_io.atomic_path(filename) as tmp_filename, _open_for_write(tmp_filename, dest=filename) as f:
+    path = pathlib.Path(filename)
+    output_format = _message_format(path)
+    with atomic_io.atomic_path(path) as tmp_filename, _open_for_write(tmp_filename, dest=path) as f:
         if output_format == MessageFormat.JSON:
             f.write(json_format.MessageToJson(message).encode())
         elif output_format in _TEXT_FORMATS:
@@ -869,29 +868,30 @@ def write_message(message: ord_schema.Message, filename: str) -> None:
 
 
 @contextlib.contextmanager
-def _open_for_write(tmp_path: str, *, dest: str) -> Iterator[Any]:
+def _open_for_write(tmp_path: str | os.PathLike[str], *, dest: str | os.PathLike[str]) -> Iterator[Any]:
     """Opens ``tmp_path`` for binary writing.
 
     For ``.gz`` destinations, wraps the file in a ``GzipFile`` with a fixed
-    mtime and pins the gzip header's filename to ``os.path.basename(dest)``
+    mtime and pins the gzip header's filename to the destination's basename
     so the encoded bytes are deterministic regardless of the random temp
     name used during writing.
     """
+    dest = pathlib.Path(dest)
     with open(tmp_path, "wb") as raw:
-        if dest.endswith(".gz"):
-            with gzip.GzipFile(filename=os.path.basename(dest), mode="wb", mtime=1, fileobj=raw) as f:
+        if dest.suffix == ".gz":
+            with gzip.GzipFile(filename=dest.name, mode="wb", mtime=1, fileobj=raw) as f:
                 yield f
         else:
             yield raw
 
 
-def write_dataset(dataset: dataset_pb2.Dataset, filename: str) -> None:
+def write_dataset(dataset: dataset_pb2.Dataset, filename: str | os.PathLike[str]) -> None:
     """Writes a Dataset to disk, dispatching on filename suffix.
 
     ``.parquet`` routes to ``parquet_dataset.write_dataset``; other suffixes
     go through ``write_message``.
     """
-    if filename.endswith(".parquet"):
+    if pathlib.Path(filename).suffix == ".parquet":
         parquet_dataset.write_dataset(dataset, filename)
         return
     write_message(dataset, filename)

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -480,6 +480,20 @@ class TestSetDativeBonds:
         assert bond_types[frozenset(["P", "Pd"])] == Chem.BondType.DATIVE
 
 
+_ROUND_TRIP_SUFFIXES = [
+    ".pbtxt",
+    ".pb",
+    ".json",
+    ".pbtxt.gz",
+    ".pb.gz",
+    ".json.gz",
+    ".txtpb",
+    ".binpb",
+    ".txtpb.gz",
+    ".binpb.gz",
+]
+
+
 class TestLoadAndWriteMessage:
     @pytest.fixture
     def messages(self) -> list:
@@ -491,21 +505,7 @@ class TestLoadAndWriteMessage:
             test_pb2.Nested(child=test_pb2.Nested.Child(value=1.2)),
         ]
 
-    @pytest.mark.parametrize(
-        "suffix",
-        [
-            ".pbtxt",
-            ".pb",
-            ".json",
-            ".pbtxt.gz",
-            ".pb.gz",
-            ".json.gz",
-            ".txtpb",
-            ".binpb",
-            ".txtpb.gz",
-            ".binpb.gz",
-        ],
-    )
+    @pytest.mark.parametrize("suffix", _ROUND_TRIP_SUFFIXES)
     def test_round_trip(self, suffix, messages):
         for message in messages:
             with tempfile.NamedTemporaryFile(suffix=suffix) as f:
@@ -513,7 +513,7 @@ class TestLoadAndWriteMessage:
                 f.flush()
                 assert message == message_helpers.load_message(f.name, type(message))
 
-    @pytest.mark.parametrize("suffix", [".pbtxt", ".pb", ".json", ".pb.gz", ".binpb.gz"])
+    @pytest.mark.parametrize("suffix", _ROUND_TRIP_SUFFIXES)
     def test_round_trip_path_input(self, suffix, messages, tmp_path):
         """write_message/load_message accept pathlib.Path, not just str."""
         for i, message in enumerate(messages):

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -513,6 +513,14 @@ class TestLoadAndWriteMessage:
                 f.flush()
                 assert message == message_helpers.load_message(f.name, type(message))
 
+    @pytest.mark.parametrize("suffix", [".pbtxt", ".pb", ".json", ".pb.gz", ".binpb.gz"])
+    def test_round_trip_path_input(self, suffix, messages, tmp_path):
+        """write_message/load_message accept pathlib.Path, not just str."""
+        for i, message in enumerate(messages):
+            path = tmp_path / f"message_{i}{suffix}"
+            message_helpers.write_message(message, path)
+            assert message == message_helpers.load_message(path, type(message))
+
     def test_gzip_reproducibility(self, messages, tmp_path):
         # write_message pins the gzip header mtime, so repeated writes of the same
         # message are byte-identical regardless of wall-clock time between them.

--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -74,7 +74,7 @@ class DatasetWriter:
 
     def __init__(
         self,
-        path: str,
+        path: str | os.PathLike[str],
         *,
         name: str,
         description: str,
@@ -93,9 +93,9 @@ class DatasetWriter:
         # on successful close, remove on exception. Same semantics as
         # ``atomic_io.atomic_path``, inlined because the open/close lifecycle
         # is split across __init__/close().
-        self._path = path
-        parent = os.path.dirname(path) or "."
-        basename = os.path.basename(path)
+        self._path = os.fspath(path)
+        parent = os.path.dirname(self._path) or "."
+        basename = os.path.basename(self._path)
         fd, self._tmp_path = tempfile.mkstemp(dir=parent, prefix=basename + ".", suffix=".tmp")
         os.close(fd)
         try:
@@ -179,7 +179,7 @@ class DatasetWriter:
 
 def write_dataset(
     dataset: dataset_pb2.Dataset,
-    path: str,
+    path: str | os.PathLike[str],
     *,
     compression: str = "zstd",
     row_group_size: int = 1000,
@@ -223,7 +223,7 @@ class _ReactionStream:
     always being truthy the way a bare generator would be.
     """
 
-    def __init__(self, path: str, num_reactions: int) -> None:
+    def __init__(self, path: str | os.PathLike[str], num_reactions: int) -> None:
         self._path = path
         self._num_reactions = num_reactions
 
@@ -250,8 +250,8 @@ class DatasetView:
     is exposed as a read-only property so accidental rebinding raises.
     """
 
-    def __init__(self, path: str) -> None:
-        self._path = path
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self._path = os.fspath(path)
         with pq.ParquetFile(path) as parquet_file:
             scalars = _dataset_from_metadata(parquet_file.schema_arrow.metadata)
             num_rows = parquet_file.metadata.num_rows
@@ -271,7 +271,7 @@ class DatasetView:
         return self._reactions
 
 
-def read_dataset(path: str) -> dataset_pb2.Dataset:
+def read_dataset(path: str | os.PathLike[str]) -> dataset_pb2.Dataset:
     """Reads a full Dataset from a Parquet file.
 
     All reactions are deserialized into memory; prefer ``iter_reactions`` or
@@ -284,7 +284,7 @@ def read_dataset(path: str) -> dataset_pb2.Dataset:
     return dataset
 
 
-def read_metadata(path: str) -> dataset_pb2.Dataset:
+def read_metadata(path: str | os.PathLike[str]) -> dataset_pb2.Dataset:
     """Reads Dataset scalar fields (``name``, ``description``, ``dataset_id``)
     from the Parquet footer. No column data is read. The returned ``Dataset``
     has no ``reactions`` or ``reaction_ids`` populated.
@@ -302,7 +302,7 @@ class ParquetFooter:
     num_rows: int
 
 
-def read_footer(path: str) -> ParquetFooter:
+def read_footer(path: str | os.PathLike[str]) -> ParquetFooter:
     """Returns scalar Dataset fields and row-group/row counts in one open.
 
     Equivalent to ``read_metadata`` plus ``num_row_groups`` plus a row count,
@@ -318,7 +318,7 @@ def read_footer(path: str) -> ParquetFooter:
 
 
 def iter_reactions(
-    path: str,
+    path: str | os.PathLike[str],
     reaction_ids: Iterable[str] | None = None,
     *,
     row_group: int | None = None,
@@ -354,7 +354,7 @@ def iter_reactions(
             yield from _iter_reactions(parquet_file, filter_set=filter_set)
 
 
-def num_row_groups(path: str) -> int:
+def num_row_groups(path: str | os.PathLike[str]) -> int:
     """Returns the number of row groups in a Parquet dataset.
 
     Used by callers that parallelize over row groups via ``iter_reactions(...,
@@ -386,7 +386,7 @@ def _iter_table(
         yield reaction_id, reaction_pb2.Reaction.FromString(blob)
 
 
-def streaming_md5(path: str) -> tuple[str, int]:
+def streaming_md5(path: str | os.PathLike[str]) -> tuple[str, int]:
     """Returns ``(md5_hexdigest, num_reactions)`` for a Parquet dataset.
 
     Streams the file row-group at a time so peak memory stays bounded. The
@@ -425,7 +425,7 @@ def streaming_md5(path: str) -> tuple[str, int]:
     return hasher.hexdigest(), num_reactions
 
 
-def iter_reaction_ids(path: str) -> Iterator[str]:
+def iter_reaction_ids(path: str | os.PathLike[str]) -> Iterator[str]:
     """Yields ``reaction_id`` values from a Parquet dataset without decoding Reaction blobs.
 
     Reads only the ``reaction_id`` column row-group at a time, so this is
@@ -436,7 +436,7 @@ def iter_reaction_ids(path: str) -> Iterator[str]:
             yield from batch.column("reaction_id").to_pylist()
 
 
-def read_reaction(path: str, reaction_id: str) -> reaction_pb2.Reaction:
+def read_reaction(path: str | os.PathLike[str], reaction_id: str) -> reaction_pb2.Reaction:
     """Reads a single Reaction by ID.
 
     Passes ``reaction_id`` as a Parquet predicate, which lets row groups be

--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -259,7 +259,7 @@ class DatasetView:
         self.description = scalars.description
         self.dataset_id = scalars.dataset_id
         self.reaction_ids: list[str] = []
-        self._reactions = _ReactionStream(path, num_rows)
+        self._reactions = _ReactionStream(self._path, num_rows)
 
     @property
     def path(self) -> str:


### PR DESCRIPTION
## What

The save/load entry points in `message_helpers` (and friends) did format detection with **string operations** on the filename — `filename.endswith(".gz")`, `os.path.splitext(...)`. That forced every caller to pass a `str`, and broke when handed a `pathlib.Path`:

```
AttributeError: 'PosixPath' object has no attribute 'endswith'
```

This makes the core I/O **path-aware** so it accepts `str | os.PathLike[str]`:

- **`message_helpers`**: `load_message`, `write_message`, `write_dataset`, `_open_for_write` now normalize to `pathlib.Path` and dispatch on `.suffix` / `.suffixes` via a new `_message_format` helper (replacing the `.endswith`/`splitext` slicing).
- **`parquet_dataset`**: widened all `path: str` params to `str | os.PathLike[str]` (no internal string ops; `self._path` is normalized via `os.fspath` so the public `.path` property stays `str`).
- **`atomic_io.atomic_path`**: widened the hint (its `os.path.*` calls already accept path-like).

## Why

Prerequisite for the upcoming **pathlib migration (ruff PTH)**: tests build paths as `tmp_path / "x"` (a `Path`) and feed them directly into these functions. Without this, the PTH sweep breaks ~24 tests. Doing the core refactor on its own keeps that change reviewable and behavior-preserving.

## Tests

- New `test_round_trip_path_input` exercises `Path` inputs across formats (incl. `.pb.gz`, `.binpb.gz`) alongside the existing `str` round-trip.
- Full suite green (515 non-ORM + 24 ORM), `ruff` + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the core I/O entry points (`load_message`, `write_message`, `write_dataset`, and the Parquet helpers) accept `str | os.PathLike[str]` instead of `str` only, resolving `AttributeError` failures when callers pass `pathlib.Path` objects.

- **`message_helpers`**: A new `_message_format` helper replaces ad-hoc string-splitting with `pathlib.Path.suffixes`, stripping `.gz` before dispatching on the inner suffix; `load_message`, `write_message`, `_open_for_write`, and `write_dataset` all normalize inputs to `pathlib.Path` internally.
- **`parquet_dataset`**: All public `path: str` parameters widened to `str | os.PathLike[str]`; `DatasetWriter._path` and `DatasetView._path` normalized to `str` via `os.fspath`, with `_ReactionStream` receiving the already-normalized string.
- **Tests**: A shared `_ROUND_TRIP_SUFFIXES` list ensures the new `test_round_trip_path_input` (exercising `pathlib.Path` inputs) covers the same 10 formats as the existing string round-trip test.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely additive type widening with no behavior change on existing str callers.

Every changed function normalizes inputs with pathlib.Path or os.fspath before any path operations, so existing str callers are unaffected. The _message_format helper correctly strips .gz using Path.suffixes and covers all 10 supported format suffixes, matching the logic it replaces. The previously flagged inconsistency in DatasetView was fixed in a follow-up commit included in this PR head.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/message_helpers.py | Introduces _message_format helper using pathlib.Path.suffixes to replace string-splitting format detection; load_message, write_message, write_dataset, and _open_for_write now accept and normalize path-like inputs — logic is correct and behavior-preserving |
| ord_schema/parquet_dataset.py | All public path: str parameters widened to str | os.PathLike[str]; DatasetWriter._path and DatasetView._path normalized via os.fspath; _ReactionStream now receives the already-normalized self._path from DatasetView |
| ord_schema/atomic_io.py | Trivial type-hint widening of atomic_path; internal os.path.* calls already accept path-like objects, no behavior change |
| ord_schema/message_helpers_test.py | Extracts shared _ROUND_TRIP_SUFFIXES list so both the existing str test and new test_round_trip_path_input exercise all 10 format suffixes; coverage cannot drift between the two |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ord_schema/parquet_dataset.py`, line 262 ([link](https://github.com/open-reaction-database/ord-schema/blob/7eb7f58f5345599b3b035db6216cb918948dd0c6/ord_schema/parquet_dataset.py#L262)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `DatasetView` normalizes its own `_path` via `os.fspath`, but then passes the original (possibly `pathlib.Path`) argument to `_ReactionStream`. Passing the already-normalized `self._path` keeps the two private fields consistent in type and avoids holding a second reference to the caller's original object.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Pass normalized self.\_path to \_ReactionS..."](https://github.com/open-reaction-database/ord-schema/commit/1b01eae5a5adb34f56539b525b520a670dc9ff79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38848442)</sub>

<!-- /greptile_comment -->