### PR TITLE
Enable pydocstyle (D) with Google convention

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+"""Configuration file for the Sphinx documentation builder."""
+
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,5 @@
 """Configuration file for the Sphinx documentation builder."""
 
-# Configuration file for the Sphinx documentation builder.
-#
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html

--- a/ord_schema/frozen_message.py
+++ b/ord_schema/frozen_message.py
@@ -97,9 +97,11 @@ class FrozenMessage(collections.abc.Mapping):
         return value
 
     def __iter__(self) -> collections.abc.Iterator:
+        """Returns an iterator over the underlying message."""
         return iter(self._message)
 
     def __len__(self) -> int:
+        """Returns the length of the underlying message."""
         return len(self._message)
 
     def __getitem__(self, key: str) -> Any:

--- a/ord_schema/macros/__init__.py
+++ b/ord_schema/macros/__init__.py
@@ -11,3 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Macros for programmatically constructing reaction messages (solutions, workups)."""

--- a/ord_schema/macros/solutions.py
+++ b/ord_schema/macros/solutions.py
@@ -91,6 +91,14 @@ def simple_solution(
 def brine(
     volume: str | reaction_pb2.Volume | None = None,
 ) -> list[reaction_pb2.Compound]:
+    """Creates a saturated aqueous sodium chloride (brine) solution.
+
+    Args:
+        volume: Volume of the brine solution.
+
+    Returns:
+        A list of solvent/solute Compounds.
+    """
     return simple_solution(
         solute_smiles="[Na+].[Cl-]", solvent_smiles="O", volume=volume, saturated=True
     )

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -151,8 +151,9 @@ def set_solute_moles(
     concentration: str,
     overwrite: bool = False,
 ) -> list[reaction_pb2.Compound]:
-    """Helps define components for stock solution inputs with a single solute
-    and a one or more solvent compounds.
+    """Helps define components for stock solution inputs.
+
+    Handles a single solute and one or more solvent compounds.
 
     Args:
         solute: Compound with identifiers, roles, etc.; this argument is
@@ -286,7 +287,7 @@ def smiles_from_compound(
 
     Args:
         compound: reaction_pb2.Compound or reaction_pb2.ProductCompound message.
-        validate: If True, returns a canonicalized SMILES.
+        canonical: If True, returns a canonicalized SMILES.
 
     Returns:
         Text SMILES.
@@ -539,8 +540,9 @@ def reaction_from_smiles(reaction_smiles: str) -> reaction_pb2.Reaction:
 def get_product_yield(
     product: reaction_pb2.ProductCompound, as_measurement: bool = False
 ) -> reaction_pb2.ProductMeasurement | float | None:
-    """Returns the value of a product's yield if it is defined. If multiple
-    measurements of type YIELD exist, only the first is returned.
+    """Returns the value of a product's yield if it is defined.
+
+    If multiple measurements of type YIELD exist, only the first is returned.
 
     Args:
         product: ProductCompound message.
@@ -562,8 +564,9 @@ def get_compound_identifier(
     compound: reaction_pb2.Compound | reaction_pb2.ProductCompound,
     identifier_type: reaction_pb2.CompoundIdentifier.CompoundIdentifierType,
 ) -> str | None:
-    """Returns the value of a compound identifier if it exists. If multiple
-    identifiers of that type exist, only the first is returned.
+    """Returns the value of a compound identifier if it exists.
+
+    If multiple identifiers of that type exist, only the first is returned.
 
     Args:
         compound: Compound message.
@@ -583,8 +586,9 @@ def set_compound_identifier(
     identifier_type: reaction_pb2.CompoundIdentifier.CompoundIdentifierType,
     value: str,
 ) -> reaction_pb2.CompoundIdentifier:
-    """Sets the value of a compound identifier if it exists or creates one. If
-    multiple identifiers of that type exist, only the first is overwritten.
+    """Sets the value of a compound identifier if it exists or creates one.
+
+    If multiple identifiers of that type exist, only the first is overwritten.
 
     Args:
         compound: Compound message.
@@ -618,8 +622,7 @@ def get_compound_smiles(
 def set_compound_smiles(
     compound: reaction_pb2.Compound, value: str
 ) -> reaction_pb2.CompoundIdentifier:
-    """Sets the value of the compound's SMILES identifier if it exists or
-    creates one.
+    """Sets the value of the compound's SMILES identifier if it exists or creates one.
 
     Args:
         compound: Compound message.
@@ -744,8 +747,7 @@ def get_compound_name(compound: reaction_pb2.Compound) -> str | None:
 def set_compound_name(
     compound: reaction_pb2.Compound, value: str
 ) -> reaction_pb2.CompoundIdentifier:
-    """Sets the value of the compound's NAME identifier if it exists or
-    creates one.
+    """Sets the value of the compound's NAME identifier if it exists or creates one.
 
     Args:
         compound: Compound message.
@@ -776,8 +778,7 @@ def get_compound_molblock(
 def set_compound_molblock(
     compound: reaction_pb2.Compound, value: str
 ) -> reaction_pb2.CompoundIdentifier:
-    """Sets the value of the compound's MOLBLOCK identifier if it exists or
-    creates one.
+    """Sets the value of the compound's MOLBLOCK identifier if it exists or creates one.
 
     Args:
         compound: Compound message.
@@ -1006,8 +1007,9 @@ def id_filename(filename: str) -> str:
 
 
 def create_message(message_name: str) -> ord_schema.Message:
-    """Converts a message name into an instantiation of that class, where
-    the message belongs to the reaction_pb2 module.
+    """Converts a message name into an instantiation of that class.
+
+    The message belongs to the reaction_pb2 module.
 
     Args:
         message_name: Text name of a message field. For example, "Reaction" or

--- a/ord_schema/orm/rdkit_mappers.py
+++ b/ord_schema/orm/rdkit_mappers.py
@@ -55,6 +55,7 @@ class RDKitMol(UserDefinedType):
 
     @property
     def python_type(self) -> type:
+        """Raises NotImplementedError; this type has no Python equivalent."""
         raise NotImplementedError
 
     def get_col_spec(self, **kwargs: Any) -> str:
@@ -70,6 +71,7 @@ class RDKitReaction(UserDefinedType):
 
     @property
     def python_type(self) -> type:
+        """Raises NotImplementedError; this type has no Python equivalent."""
         raise NotImplementedError
 
     def get_col_spec(self, **kwargs: Any) -> str:
@@ -85,6 +87,7 @@ class RDKitBfp(UserDefinedType):
 
     @property
     def python_type(self) -> type:
+        """Raises NotImplementedError; this type has no Python equivalent."""
         raise NotImplementedError
 
     def get_col_spec(self, **kwargs: Any) -> str:
@@ -100,6 +103,7 @@ class RDKitSfp(UserDefinedType):
 
     @property
     def python_type(self) -> type:
+        """Raises NotImplementedError; this type has no Python equivalent."""
         raise NotImplementedError
 
     def get_col_spec(self, **kwargs: Any) -> str:
@@ -115,6 +119,7 @@ class CString(UserDefinedType):
 
     @property
     def python_type(self) -> type:
+        """Raises NotImplementedError; this type has no Python equivalent."""
         raise NotImplementedError
 
     def get_col_spec(self, **kwargs: Any) -> str:
@@ -131,6 +136,7 @@ class FingerprintType(Enum):
     MORGAN_SFP = func.morgan_fp
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Invokes the wrapped RDKit fingerprint function."""
         return self.value(*args, **kwargs)
 
 
@@ -155,16 +161,19 @@ class RDKitMols(Base):
     def tanimoto(
         cls, other: str, fp_type: FingerprintType = FingerprintType.MORGAN_BFP
     ) -> ColumnElement[float]:
+        """Returns a Tanimoto similarity expression between the stored fingerprint and ``other``."""
         return func.tanimoto_sml(
             getattr(cls, fp_type.name.lower()), fp_type(cast(other, RDKitMol))
         )
 
     @classmethod
     def contains_substructure(cls, pattern: str) -> ColumnElement[bool]:
+        """Returns an expression testing whether the stored mol contains the ``pattern`` substructure."""
         return func.substruct(cls.mol, cast(pattern, RDKitMol))
 
     @classmethod
     def matches_smarts(cls, pattern: str) -> ColumnElement[bool]:
+        """Returns an expression testing whether the stored mol matches the SMARTS ``pattern``."""
         return func.substruct(cls.mol, func.qmol_from_smarts(cast(pattern, CString)))
 
 
@@ -183,6 +192,7 @@ class RDKitReactions(Base):
 
     @classmethod
     def matches_smarts(cls, pattern: str) -> ColumnElement[bool]:
+        """Returns an expression testing whether the stored reaction matches the reaction SMARTS ``pattern``."""
         return func.substruct(
             cls.reaction, func.reaction_from_smarts(cast(pattern, CString))
         )

--- a/ord_schema/orm/scripts/__init__.py
+++ b/ord_schema/orm/scripts/__init__.py
@@ -11,3 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Command-line scripts for populating the ORD relational (ORM) database."""

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -115,6 +115,7 @@ def add_rdkit(engine: Engine, dataset_id: str) -> None:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parses command-line arguments."""
     parser = argparse.ArgumentParser(description="Add datasets to the ORM database")
     parser.add_argument(
         "--pattern", required=True, help="Pattern for dataset filenames"
@@ -136,6 +137,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> None:
+    """Loads matching datasets into the ORM database and adds RDKit functionality."""
     silence_rdkit_logs()
     if args.debug:
         get_logger(database.__name__, level=logging.DEBUG)

--- a/ord_schema/parquet_dataset.py
+++ b/ord_schema/parquet_dataset.py
@@ -83,6 +83,19 @@ class DatasetWriter:
         compression: str = "zstd",
         row_group_size: int = 1000,
     ) -> None:
+        """Opens a Parquet writer that publishes atomically to ``path`` on close.
+
+        Args:
+            path: Destination path for the published Parquet file.
+            name: Dataset name; must be non-empty.
+            description: Dataset description; must be non-empty.
+            dataset_id: Optional dataset ID, assigned during submission.
+            compression: Parquet compression codec.
+            row_group_size: Number of reactions buffered per row group.
+
+        Raises:
+            ValueError: If ``name`` or ``description`` is empty.
+        """
         if not name:
             raise ValueError("DatasetWriter requires a non-empty name")
         if not description:
@@ -170,6 +183,7 @@ class DatasetWriter:
         self._buffer_blobs.clear()
 
     def __enter__(self) -> Self:
+        """Enters the context manager, returning this writer."""
         return self
 
     def __exit__(
@@ -178,6 +192,7 @@ class DatasetWriter:
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
+        """Closes the writer on success or aborts the write on exception."""
         # On exception in the with body, abort the write so the destination
         # path is never created; let the original exception propagate.
         if exc_type is None:
@@ -263,6 +278,11 @@ class DatasetView:
     """
 
     def __init__(self, path: str | os.PathLike[str]) -> None:
+        """Opens a read-only view backed by the Parquet file at ``path``.
+
+        Args:
+            path: Path to the Parquet-serialized Dataset.
+        """
         self._path = os.fspath(path)
         with pq.ParquetFile(path) as parquet_file:
             scalars = _dataset_from_metadata(parquet_file.schema_arrow.metadata)
@@ -280,6 +300,7 @@ class DatasetView:
 
     @property
     def reactions(self) -> _ReactionStream:
+        """Re-iterable stream of Reactions read from the backing file."""
         return self._reactions
 
 
@@ -297,9 +318,10 @@ def read_dataset(path: str | os.PathLike[str]) -> dataset_pb2.Dataset:
 
 
 def read_metadata(path: str | os.PathLike[str]) -> dataset_pb2.Dataset:
-    """Reads Dataset scalar fields (``name``, ``description``, ``dataset_id``)
-    from the Parquet footer. No column data is read. The returned ``Dataset``
-    has no ``reactions`` or ``reaction_ids`` populated.
+    """Reads Dataset scalar fields (``name``, ``description``, ``dataset_id``).
+
+    The values are read from the Parquet footer. No column data is read. The
+    returned ``Dataset`` has no ``reactions`` or ``reaction_ids`` populated.
     """
     with pq.ParquetFile(path) as parquet_file:
         return _dataset_from_metadata(parquet_file.schema_arrow.metadata)
@@ -405,7 +427,7 @@ def _iter_table(
 
 
 def streaming_md5(path: str | os.PathLike[str]) -> tuple[str, int]:
-    """Returns ``(md5_hexdigest, num_reactions)`` for a Parquet dataset.
+    r"""Returns ``(md5_hexdigest, num_reactions)`` for a Parquet dataset.
 
     Streams the file row-group at a time so peak memory stays bounded. The
     hash is fed in this order:

--- a/ord_schema/proto/__init__.py
+++ b/ord_schema/proto/__init__.py
@@ -11,3 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Generated protocol buffer bindings for the Open Reaction Database schema."""

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -148,8 +148,9 @@ def _opsin_resolve(value_type: str, value: str) -> str:
 
 
 def resolve_input(input_string: str) -> reaction_pb2.ReactionInput:
-    """Resolve a text-based description of an input in one of the following
-    formats:
+    """Resolve a text-based description of an input.
+
+    Supported formats:
         (1) [AMOUNT] of [NAME]
         (2) [AMOUNT] of [CONCENTRATION] [SOLUTE] in [SOLVENT]
 

--- a/ord_schema/scripts/__init__.py
+++ b/ord_schema/scripts/__init__.py
@@ -11,3 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Command-line scripts for building, processing, and validating ORD datasets."""

--- a/ord_schema/scripts/build_dataset.py
+++ b/ord_schema/scripts/build_dataset.py
@@ -27,6 +27,7 @@ logger = get_logger(__name__)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parses command-line arguments."""
     parser = argparse.ArgumentParser(description="Build a Dataset from Reaction protos")
     parser.add_argument(
         "--input", required=True, help="Input pattern for Reaction protos"
@@ -47,6 +48,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> None:
+    """Loads matching Reaction protos into a Dataset, validates it, and writes it out."""
     filenames = glob.glob(args.input, recursive=True)
     logger.info("Found %d Reaction protos", len(filenames))
     reactions = [

--- a/ord_schema/scripts/check_pb.py
+++ b/ord_schema/scripts/check_pb.py
@@ -30,6 +30,7 @@ from ord_schema.proto import dataset_pb2
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parses command-line arguments."""
     parser = argparse.ArgumentParser(description="Compare pbtxt and pb Datasets")
     parser.add_argument("--pb", required=True, help="Path to *.pb Dataset")
     parser.add_argument("--pbtxt", required=True, help="Path to *.pbtxt Dataset")
@@ -37,6 +38,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> None:
+    """Verifies that the pb and pbtxt Datasets are identical, raising on any difference."""
     dataset = message_helpers.load_message(args.pb, dataset_pb2.Dataset)
     pb_data = text_format.MessageToString(dataset)
     with pathlib.Path(args.pbtxt).open() as f:

--- a/ord_schema/scripts/enumerate_dataset.py
+++ b/ord_schema/scripts/enumerate_dataset.py
@@ -23,6 +23,7 @@ logger = get_logger(__name__)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parses command-line arguments."""
     parser = argparse.ArgumentParser(
         description="Enumerate a template with a spreadsheet"
     )
@@ -48,6 +49,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> None:
+    """Enumerates a Dataset from a Reaction template and spreadsheet, then writes it out."""
     with pathlib.Path(args.template).open() as f:
         template_string = f.read()
     df = templating.read_spreadsheet(args.spreadsheet)

--- a/ord_schema/scripts/parse_uspto.py
+++ b/ord_schema/scripts/parse_uspto.py
@@ -16,7 +16,7 @@
 Data is at:
 https://figshare.com/articles/dataset/Chemical_reactions_from_US_patents_1976-Sep2016_/5104873
 
-See also:
+See Also:
 https://depth-first.com/articles/2019/01/28/the-nextmove-patent-reaction-dataset/
 """
 
@@ -565,6 +565,7 @@ def run(
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parses command-line arguments."""
     parser = argparse.ArgumentParser(description="Parse CML from the NRD")
     parser.add_argument(
         "--input_pattern", required=True, help="Input pattern for CML files"
@@ -578,6 +579,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> None:
+    """Parses CML reaction files in parallel and writes a combined Dataset."""
     filenames = sorted(glob.glob(args.input_pattern))
     all_reactions = joblib.Parallel(n_jobs=args.n_jobs, verbose=True)(
         joblib.delayed(run)(filename) for filename in filenames

--- a/ord_schema/scripts/pb_to_parquet_dataset.py
+++ b/ord_schema/scripts/pb_to_parquet_dataset.py
@@ -42,6 +42,7 @@ class _Resolved:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parses command-line arguments."""
     parser = argparse.ArgumentParser(
         description="Convert serialized Dataset files to a single Parquet file."
     )
@@ -68,6 +69,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> None:
+    """Streams reactions from the input Dataset files into a single Parquet file."""
     if not args.inputs:
         raise ValueError("at least one input file is required")
 

--- a/ord_schema/scripts/process_dataset.py
+++ b/ord_schema/scripts/process_dataset.py
@@ -56,6 +56,7 @@ class FileStatus:
     original_filename: str
 
     def __post_init__(self) -> None:
+        """Validates that the Git status is one of {'A', 'D', 'M', 'R'}."""
         if self.status[0] not in ["A", "D", "M", "R"]:
             raise ValueError(f"unsupported file status: {self.status}")
 
@@ -379,6 +380,7 @@ def run(
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parses command-line arguments."""
     parser = argparse.ArgumentParser(
         description="Process datasets for database submissions"
     )
@@ -422,6 +424,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> None:
+    """Silences RDKit logs and runs dataset processing for a database submission."""
     silence_rdkit_logs()
     run(args)
 

--- a/ord_schema/scripts/validate_dataset.py
+++ b/ord_schema/scripts/validate_dataset.py
@@ -99,6 +99,7 @@ class _ParquetEntry:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parses command-line arguments."""
     parser = argparse.ArgumentParser(description="Validate Dataset protocol buffers")
     parser.add_argument(
         "--input", required=True, help="Input pattern for Dataset protos"
@@ -111,6 +112,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> None:
+    """Validates matching Dataset protos in parallel and reports any failures."""
     filenames = sorted(glob.glob(args.input, recursive=True))
     logger.info("Found %d datasets", len(filenames))
     if args.filter:

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -340,8 +340,7 @@ class UnitResolver:
     def convert(
         self, message: ord_schema.UnitMessage, new_units: str | int
     ) -> ord_schema.UnitMessage:
-        """Converts a united message into another united message of the same
-        type, but with different units.
+        """Converts a united message into another of the same type with different units.
 
         Args:
             message: a message with units, e.g., Mass, Length.

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -56,6 +56,7 @@ class ValidationOutput:
     warnings: list[str] = dataclasses.field(default_factory=list)
 
     def extend(self, other: "ValidationOutput") -> None:
+        """Appends the errors and warnings from another output to this one."""
         self.errors.extend(other.errors)
         self.warnings.extend(other.warnings)
 
@@ -273,10 +274,14 @@ def _validate_message(
 
 
 class ValidationError(Warning):
+    """Warning category for validation failures that indicate invalid data."""
+
     pass
 
 
 class ValidationWarning(Warning):
+    """Warning category for non-fatal validation concerns."""
+
     pass
 
 
@@ -287,6 +292,12 @@ def is_empty(message: ord_schema.Message) -> bool:
 
 
 def ensure_float_nonnegative(message: ord_schema.Message, field: str) -> None:
+    """Warns if the given numeric field of the message is negative.
+
+    Args:
+        message: The message whose field is checked.
+        field: Name of the numeric field to check.
+    """
     if getattr(message, field) < 0:
         desc = type(message).DESCRIPTOR
         assert desc is not None  # Type hint.
@@ -302,6 +313,14 @@ def ensure_float_range(
     min_value: float = -math.inf,
     max_value: float = math.inf,
 ) -> None:
+    """Warns if the given numeric field of the message is outside [min_value, max_value].
+
+    Args:
+        message: The message whose field is checked.
+        field: Name of the numeric field to check.
+        min_value: Inclusive lower bound for the field value.
+        max_value: Inclusive upper bound for the field value.
+    """
     if getattr(message, field) < min_value or getattr(message, field) > max_value:
         desc = type(message).DESCRIPTOR
         assert desc is not None  # Type hint.
@@ -410,11 +429,13 @@ def get_referenced_reaction_ids(message: reaction_pb2.Reaction) -> set[str]:
 
 
 def is_valid_reaction_id(reaction_id: str) -> bool:
+    """Returns whether a reaction ID matches the ord-<32 hex digits> format."""
     match = re.fullmatch("^ord-[0-9a-f]{32}$", reaction_id)
     return bool(match)
 
 
 def is_valid_dataset_id(dataset_id: str) -> bool:
+    """Returns whether a dataset ID matches the ord_dataset-<32 hex digits> format."""
     match = re.fullmatch("^ord_dataset-[0-9a-f]{32}$", dataset_id)
     return bool(match)
 
@@ -471,6 +492,7 @@ class DatasetCrossRefState:
     self_reference_count: int = 0
 
     def observe(self, reaction: reaction_pb2.Reaction) -> None:
+        """Records one reaction's defined ID, referenced IDs, and self-references."""
         if reaction.reaction_id:
             if reaction.reaction_id in self.defined_ids:
                 self.duplicate_count += 1
@@ -481,6 +503,7 @@ class DatasetCrossRefState:
         self.referenced_ids |= referenced
 
     def merge(self, other: "DatasetCrossRefState") -> None:
+        """Merges another state into this one, counting cross-slice duplicate IDs."""
         self.duplicate_count += other.duplicate_count + len(
             self.defined_ids & other.defined_ids
         )
@@ -489,6 +512,7 @@ class DatasetCrossRefState:
         self.self_reference_count += other.self_reference_count
 
     def emit_warnings(self) -> None:
+        """Emits warnings for duplicate IDs, self-references, and undefined references."""
         for _ in range(self.duplicate_count):
             warnings.warn(
                 "Multiple Reactions should never have the same IDs", ValidationError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ select = [
     "FIX",  # flake8-fixme
     "S",    # flake8-bandit
     "PTH",  # flake8-use-pathlib
+    "D",    # pydocstyle (docstrings)
 ]
 ignore = [
     # ANN401 (disallow typing.Any) fires only on genuinely dynamic call sites:
@@ -189,14 +190,19 @@ ignore = [
     "PTH207",
 ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.ruff.lint.per-file-ignores]
 # Tests trip a couple of flake8-bugbear (the "B" rules) checks -- B011 (`assert False`)
 # and B017 (overly broad `pytest.raises(Exception)`); type annotations (ANN) also add
 # little value on test functions/fixtures, and SLF001 (private-member access)
 # is fine in tests. Skip these in tests.
-"**/*_test.py" = ["B011", "B017", "ANN", "SLF001", "S603", "S607"]
+"**/*_test.py" = ["B011", "B017", "ANN", "SLF001", "S603", "S607", "D"]
+# conftest.py holds pytest fixtures/hooks; docstrings add little there.
+"**/conftest.py" = ["D"]
 # Tutorial notebooks legitimately show commented-out alternative code.
-"**/*.ipynb" = ["ERA001", "S310"]  # tutorials download from known URLs
+"**/*.ipynb" = ["ERA001", "S310", "D"]  # tutorials download from known URLs; D: cells are narrative, not modules
 
 [tool.ty.src]
 exclude = ["**/*_pb2.py*"]


### PR DESCRIPTION
## What

Final PR of the ruff rollout: adds **D** (`pydocstyle`) with `convention = "google"` (the repo's docstring style) and documents the previously-undocumented public API.

## Scope decision

Of 405 raw D violations, **~340 were in test files and notebooks**. Docstrings on `test_*` functions and narrative notebook cells add noise rather than clarity — the test name is the documentation — so D is excluded there via `per-file-ignores` (consistent with the existing test-only `ANN` exclusion). `conftest.py` (fixtures/hooks) is excluded for the same reason.

That leaves the **65 production violations, all fixed properly**:
- Wrote accurate Google-style docstrings for public modules, packages (`__init__.py`), classes, methods, functions, and `__init__`/magic methods. Summaries were written from the actual implementation (e.g. `is_valid_reaction_id` → "Returns whether a reaction ID matches the ord-<32 hex digits> format.").
- Repaired docstring formatting: D205 (blank line after summary), D415 (terminal punctuation), D405 (section capitalization), D301 (raw string for backslashes), and D417 — documented the `canonical` arg of `smiles_from_compound`, replacing a **stale `validate:` entry** that referred to a removed parameter.

## Verification

- `ruff check .` clean, `ty check ord_schema` clean.
- Full suite **544 tests (incl. ORM)** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the ruff rollout by enabling `pydocstyle` (rule group `D`) with the Google convention, fixing 65 production docstring violations while excluding test files, `conftest.py`, and notebooks via `per-file-ignores`.

- All new and repaired docstrings are accurate to their implementations: the stale `validate:` argument entry in `smiles_from_compound` is correctly updated to `canonical:`, multi-sentence summaries are split per D205, and the `streaming_md5` docstring is promoted to a raw string (D301) to protect its `\\n` sequences.
- The `pyproject.toml` changes are self-consistent: `convention = "google"` is set, and `"D"` is added to each relevant `per-file-ignores` list alongside the existing test-only exclusions.

<h3>Confidence Score: 5/5</h3>

Pure documentation change with no logic modifications; safe to merge.

Every change is a docstring addition or reformatting with no alterations to runtime behaviour. The one substantive correction — renaming the stale `validate:` arg to `canonical:` in `smiles_from_compound` — matches the actual function signature. Config changes in `pyproject.toml` are limited to enabling and scoping a linting rule.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Adds "D" (pydocstyle) to ruff's select list with Google convention; correctly excludes test files, conftest.py, and notebooks via per-file-ignores. |
| ord_schema/message_helpers.py | Fixes D205 wrapping on several multi-sentence summaries and corrects a stale "validate:" arg entry to "canonical:" in smiles_from_compound, matching the actual parameter name. |
| ord_schema/parquet_dataset.py | Adds __init__ and dunder docstrings to DatasetWriter/DatasetView; converts streaming_md5 to r-string (D301) to protect the \\n escape sequences already in the docstring body. |
| ord_schema/validations.py | Adds class-level docstrings for ValidationError/ValidationWarning, one-liner docstrings for ensure_float_nonnegative/ensure_float_range/is_valid_reaction_id/is_valid_dataset_id, and method docstrings for DatasetCrossRefState. |
| ord_schema/orm/rdkit_mappers.py | Adds docstrings to five python_type properties (all correctly noting NotImplementedError), FingerprintType.__call__, and the three RDKitMols/RDKitReactions classmethods. |
| ord_schema/resolvers.py | Reformats resolve_input docstring to comply with D205 (blank line between summary and extended description); content is unchanged and accurate. |
| ord_schema/frozen_message.py | Adds minimal one-liner docstrings to __iter__ and __len__ to satisfy D105; descriptions are accurate. |
| ord_schema/macros/solutions.py | Adds a complete Google-style docstring (Args, Returns) to the previously undocumented brine() function. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Drop docs/conf.py comment that duplicate..."](https://github.com/open-reaction-database/ord-schema/commit/f8611917b74cbb11697b80004bd6ca61e251452d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38854374)</sub>

<!-- /greptile_comment -->