### PR TITLE
Tighten ruff ignores now that the rollout has settled

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -655,10 +655,7 @@ def has_transition_metal(mol: Chem.Mol) -> bool:
     Returns:
         Boolean for whether the molecule has a transition metal.
     """
-    for atom in mol.GetAtoms():
-        if is_transition_metal(atom):
-            return True
-    return False
+    return any(is_transition_metal(atom) for atom in mol.GetAtoms())
 
 
 def set_dative_bonds(

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -28,6 +28,7 @@ Notes:
       the database.
 """
 
+import contextlib
 from collections import defaultdict
 from collections.abc import Mapping
 from hashlib import md5
@@ -378,10 +379,8 @@ def from_proto(
         if reaction_smiles is not None:
             kwargs["reaction_smiles"] = reaction_smiles.split()[0]  # Handle CXSMILES.
     elif isinstance(message, reaction_pb2.Compound | reaction_pb2.ProductCompound):
-        try:
+        with contextlib.suppress(ValueError):
             kwargs["smiles"] = message_helpers.smiles_from_compound(message)
-        except ValueError:
-            pass
     return mapper(**kwargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,9 +160,9 @@ ignore = [
     "T201",                  # print() is intentional in CLI scripts and notebooks
     "G004",                  # f-strings in logging calls are fine
     "FBT001", "FBT002",      # boolean positional args exist in public APIs already
-    "C901", "PLR0911", "PLR0912", "PLR0913", "PLR0915",  # complexity caps -> churn
+    "C901", "PLR0912", "PLR0913", "PLR0915",  # complexity caps -> churn
     "PLR2004",               # "magic value" flags ordinary numeric literals
-    "N803", "N806",          # domain names (SMILES, fromAtoms) are deliberate
+    "N803",                  # domain argument names (SMILES, fromAtoms) are deliberate
     "INP001",                # docs/conf.py is config, not a package
     "TD003",                 # don't force issue links on informal TODOs
     # S101 (assert): used for test assertions and production type-narrowing
@@ -170,18 +170,15 @@ ignore = [
     "S101",
     "FIX002",                # TODO comments are allowed
     "E501",    # Line length is enforced by the formatter, not the linter.
-    "SIM108",  # Ternary expressions are not always clearer than if/else.
-    "B008",    # Function calls in argument defaults are fine for our use cases.
-    # B028 (missing stacklevel= on warnings.warn) flags ~88 pre-existing call
-    # sites in ord_schema/validations.py. Tackle as a focused follow-up PR
-    # rather than mixing it in with tooling migration.
+    # B028 (missing stacklevel= on warnings.warn): the ~103 sites in
+    # validations.py are data-validation messages collected into ValidationOutput,
+    # not deprecation/misuse warnings -- there is no caller location worth pointing
+    # at, so stacklevel= would add noise without value.
     "B028",
-    # SIM102/SIM105/SIM110 are stylistic rewrites (nested-if flattening,
-    # contextlib.suppress, any()). Flagged sites here are pre-existing and
-    # out of scope for the tooling migration.
+    # SIM102 (collapsible nested-if): most flagged sites carry an explanatory
+    # comment between the outer and inner `if`; collapsing to `if x and y` would
+    # orphan that comment and read worse. Left nested on purpose.
     "SIM102",
-    "SIM105",
-    "SIM110",
     # PTH207 (glob.glob -> Path.glob) flags CLI scripts that glob arbitrary
     # user-supplied patterns (e.g. --input_pattern, possibly absolute or with
     # recursive **). pathlib.Path.glob requires a base dir + relative pattern


### PR DESCRIPTION
## What

A pass over the ignore list accumulated during the ruff rollout, removing entries that no longer earn their place.

**Removed (rules now enforced):**
- **SIM105** (1 site) and **SIM110** (2 sites, incl. one notebook): genuine readability wins — `try/except: pass` → `contextlib.suppress`, and a `for`-loop-returns-bool → `any(...)`. Fixed in place and dropped from the ignore list.
- **PLR0911, N806, SIM108, B008**: zero violations in the codebase today, so dropping them is pure regression-prevention — no churn now, enforced going forward.

**Kept, with sharpened rationale:**
- **SIM102** (collapsible nested-if): of the 9 sites, the ones ruff won't auto-collapse all carry an explanatory comment *between* the outer and inner `if` (e.g. "# The dataset_id is a 32-character uuid4 hex string."). Collapsing to `if x and y` would orphan the comment and read worse. Stays nested.
- **B028** (missing `stacklevel=`): the ~103 `warnings.warn` calls in `validations.py` are data-validation messages collected into `ValidationOutput`, not deprecation/misuse warnings — there's no caller location worth pointing at, so `stacklevel=` would be cargo-culted noise. (Reverses the earlier "follow-up PR" note.)

The remaining ignores are all deliberate design choices (formatter conflicts, domain naming, intentional readability calls) and are left as-is.

## Verification

- `ruff check .` clean, `ty check ord_schema` clean, affected tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the ruff ignore list after the initial rollout has stabilized, removing entries that are either zero-violation (PLR0911, N806, SIM108, B008) or have been fixed in place (SIM105, SIM110), while updating comments on the remaining deliberate ignores.

- **`pyproject.toml`**: Drops six entries from the `ignore` list and sharpens comments on the two retained stylistic exceptions (`B028`, `SIM102`).
- **`ord_schema/orm/mappers.py`**: Replaces a bare `try/except ValueError: pass` block with `contextlib.suppress(ValueError)` (SIM105 fix), adding the required import.
- **`ord_schema/message_helpers.py` + notebook**: Rewrites the `has_transition_metal` for-loop-with-early-return to `any(...)` in both the library and the corresponding example notebook (SIM110 fix).

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are mechanical readability improvements with no behavioral impact.

Every code change is a semantically equivalent rewrite: `contextlib.suppress` instead of a bare `try/except: pass`, and `any(...)` instead of a for-loop with an early return. The pyproject.toml changes only tighten the linter config, enforcing rules that already have zero violations in the codebase. There is no new logic, no changed data flow, and no risk of regression.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Tightens ruff ignore list: removes PLR0911, N806, SIM108, B008 (zero violations), removes SIM105 and SIM110 (fixed at source), and updates comments for B028 and SIM102 with clearer rationale. |
| ord_schema/orm/mappers.py | Adds `contextlib` import and replaces bare `try/except ValueError: pass` with `contextlib.suppress(ValueError)` — the SIM105 fix enabling removal of that ignore rule. |
| ord_schema/message_helpers.py | Rewrites `has_transition_metal` from an explicit for-loop with early return to `any(...)` generator expression — the SIM110 fix enabling removal of that ignore rule. |
| examples/submissions/1_Santanilla_Nanomole_HTE/example_Santanilla.ipynb | Applies the same for-loop → `any(...)` refactor to the corresponding notebook cell, keeping it consistent with the library code. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Tighten ruff ignores now that the rollou..."](https://github.com/open-reaction-database/ord-schema/commit/96096e5887317cc1bdddca4503ed5c343f9dd075) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38854813)</sub>

<!-- /greptile_comment -->