### PR TITLE
Codebase cleanup: dedup, dead code, consistency; standardize --input_pattern

### DIFF
--- a/docs/submissions.rst
+++ b/docs/submissions.rst
@@ -33,7 +33,7 @@ interactively with the ORD web editor.
 
         .. code-block:: shell
 
-            $ python validate_dataset.py --input="example_dataset.pbtxt"
+            $ python validate_dataset.py --input_pattern="example_dataset.pbtxt"
 
         When defining reactions and datasets programatically, it is good
         practice to use the `validation methods

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -29,6 +29,7 @@ from google.protobuf import (
     json_format,
     text_format,
 )
+from google.protobuf.descriptor import Descriptor
 from google.protobuf.message import DecodeError
 from huggingface_hub import hf_hub_download
 from huggingface_hub.errors import EntryNotFoundError
@@ -48,6 +49,18 @@ MessageType = TypeVar("MessageType")  # Generic for setting return types
 # Hugging Face dataset that mirrors the ord-data repository; see
 # https://huggingface.co/datasets/open-reaction-database/ord-data.
 ORD_DATA_HF_REPO = "open-reaction-database/ord-data"
+
+
+def _resolve_enum_value(descriptor: Descriptor, field_name: str, key: str) -> int:
+    """Returns the numeric value for ``key`` in the named enum field of ``descriptor``."""
+    assert descriptor is not None  # Type hint.
+    field = descriptor.fields_by_name[field_name]
+    assert field.enum_type is not None  # Type hint.
+    values = field.enum_type.values_by_name
+    try:
+        return values[key.upper()].number
+    except KeyError as error:
+        raise KeyError(f"{key} is not a supported type: {values.keys()}") from error
 
 
 def build_compound(
@@ -106,15 +119,9 @@ def build_compound(
     if role:
         compound_desc = reaction_pb2.Compound.DESCRIPTOR
         assert compound_desc is not None  # Type hint.
-        field = compound_desc.fields_by_name["reaction_role"]
-        assert field.enum_type is not None  # Type hint.
-        values_dict = field.enum_type.values_by_name
-        try:
-            compound.reaction_role = values_dict[role.upper()].number
-        except KeyError as error:
-            raise KeyError(
-                f"{role} is not a supported type: {values_dict.keys()}"
-            ) from error
+        compound.reaction_role = _resolve_enum_value(
+            compound_desc, "reaction_role", role
+        )
     if is_limiting is not None:
         if not (is_limiting is True or is_limiting is False):
             raise TypeError(f"is_limiting must be a boolean value: {is_limiting}")
@@ -122,15 +129,7 @@ def build_compound(
     if prep:
         prep_desc = reaction_pb2.CompoundPreparation.DESCRIPTOR
         assert prep_desc is not None  # Type hint.
-        field = prep_desc.fields_by_name["type"]
-        assert field.enum_type is not None  # Type hint.
-        values_dict = field.enum_type.values_by_name
-        try:
-            compound.preparations.add().type = values_dict[prep.upper()].number
-        except KeyError as error:
-            raise KeyError(
-                f"{prep} is not a supported type: {values_dict.keys()}"
-            ) from error
+        compound.preparations.add().type = _resolve_enum_value(prep_desc, "type", prep)
         if (
             compound.preparations[0].type == reaction_pb2.CompoundPreparation.CUSTOM
             and not prep_details
@@ -176,7 +175,7 @@ def set_solute_moles(
         raise ValueError("solute has defined amount and overwrite is False")
 
     # Get total solvent volume in liters.
-    volume_liter = 0
+    volume_liter = 0.0
     for solvent in solvents:
         amount = solvent.amount
         if not amount.HasField("volume") or not amount.volume.value:

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -17,6 +17,7 @@ import re
 import urllib.error
 import urllib.parse
 import urllib.request
+import warnings
 
 from rdkit import Chem
 from tenacity import (
@@ -41,9 +42,6 @@ _COMPOUND_STRUCTURAL_IDENTIFIERS = [
     reaction_pb2.CompoundIdentifier.XYZ,
 ]
 
-_USERNAME = "github-actions"
-_EMAIL = "github-actions@github.com"
-
 
 def canonicalize_smiles(smiles: str) -> str:
     """Canonicalizes a SMILES string.
@@ -63,7 +61,7 @@ def canonicalize_smiles(smiles: str) -> str:
     return Chem.MolToSmiles(mol)
 
 
-def name_resolve(value_type: str, value: str) -> tuple[str, str]:
+def resolve_name(value_type: str, value: str) -> tuple[str, str]:
     """Resolves compound identifiers to SMILES via multiple APIs."""
     for resolver, resolver_func in _NAME_RESOLVERS.items():
         try:
@@ -99,7 +97,7 @@ def resolve_names(message: ord_schema.Message) -> bool:
         for identifier in compound.identifiers:
             if identifier.type == identifier.NAME:
                 try:
-                    smiles, resolver = name_resolve("name", identifier.value)
+                    smiles, resolver = resolve_name("name", identifier.value)
                     new_identifier = compound.identifiers.add()
                     new_identifier.type = new_identifier.SMILES
                     new_identifier.value = smiles
@@ -148,7 +146,7 @@ def _opsin_resolve(value_type: str, value: str) -> str:
 
 
 def resolve_input(input_string: str) -> reaction_pb2.ReactionInput:
-    """Resolve a text-based description of an input.
+    """Resolves a text-based description of an input.
 
     Supported formats:
         (1) [AMOUNT] of [NAME]
@@ -180,7 +178,7 @@ def resolve_input(input_string: str) -> reaction_pb2.ReactionInput:
     pattern = re.compile(r"(\d+.?\d*)\s?(\w+)\s(.+)\sin\s(.+)")
     match = pattern.fullmatch(description.strip())
     if not match:
-        raise ValueError("String did not match template!")
+        raise ValueError("String does not match template!")
     conc_value, conc_units, solute_name, solvent_name = match.groups()
     assert solute_name is not None  # Type hint.
     assert solvent_name is not None  # Type hint.
@@ -212,3 +210,13 @@ _NAME_RESOLVERS = {
     "PubChem API": _pubchem_resolve,
     "OPSIN": _opsin_resolve,
 }
+
+
+def name_resolve(*args: str, **kwargs: str) -> tuple[str, str]:
+    """Deprecated alias for :func:`resolve_name`."""
+    warnings.warn(
+        "resolvers.name_resolve is deprecated; use resolve_name instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return resolve_name(*args, **kwargs)

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -80,7 +80,7 @@ class TestNameResolvers:
         # plumbing (adds a SMILES identifier with details) without the live call,
         # so the logic stays covered if the live smoke test is ever removed.
         monkeypatch.setattr(
-            "ord_schema.resolvers.name_resolve",
+            "ord_schema.resolvers.resolve_name",
             mock.MagicMock(return_value=("CC(=O)Oc1ccccc1C(=O)O", "PubChem API")),
         )
         message = reaction_pb2.Reaction()
@@ -162,7 +162,7 @@ class TestInputResolvers:
             "water": "O",
         }
         monkeypatch.setattr(
-            "ord_schema.resolvers.name_resolve",
+            "ord_schema.resolvers.resolve_name",
             lambda _value_type, value: (smiles_by_name[value], "PubChem API"),
         )
 
@@ -207,7 +207,7 @@ class TestInputResolvers:
                 "100 g of 5.0uM sodium hydroxide in water",
                 "amount of solution must be a volume",
             ),
-            ("100 L of 5 grapes in water", "String did not match template"),
+            ("100 L of 5 grapes in water", "String does not match template"),
         ],
     )
     def test_input_resolve_should_fail(self, string, expected):
@@ -290,7 +290,7 @@ class TestNameResolveFallback:
         monkeypatch.setattr(
             "ord_schema.resolvers._NAME_RESOLVERS", {"first": first, "second": second}
         )
-        smiles, resolver_name = resolvers.name_resolve("name", "ethylene glycol")
+        smiles, resolver_name = resolvers.resolve_name("name", "ethylene glycol")
         assert smiles == "OCCO"
         assert resolver_name == "second"
         first.assert_called_once_with("name", "ethylene glycol")
@@ -300,7 +300,7 @@ class TestNameResolveFallback:
         only = mock.MagicMock(side_effect=_http_error(404, "Not Found"))
         monkeypatch.setattr("ord_schema.resolvers._NAME_RESOLVERS", {"only": only})
         with pytest.raises(ValueError, match="Could not resolve"):
-            resolvers.name_resolve("name", "definitely-not-a-compound")
+            resolvers.resolve_name("name", "definitely-not-a-compound")
 
 
 class TestResolveNamesSkipsStructuralIdentifiers:
@@ -308,7 +308,7 @@ class TestResolveNamesSkipsStructuralIdentifiers:
         # If a Compound already has a structural identifier, name resolution
         # must not be attempted.
         called = mock.MagicMock()
-        monkeypatch.setattr("ord_schema.resolvers.name_resolve", called)
+        monkeypatch.setattr("ord_schema.resolvers.resolve_name", called)
         message = reaction_pb2.Reaction()
         compound = message.inputs["test"].components.add()
         compound.identifiers.add(type="NAME", value="aspirin")
@@ -317,10 +317,10 @@ class TestResolveNamesSkipsStructuralIdentifiers:
         called.assert_not_called()
 
     def test_swallows_value_error(self, monkeypatch):
-        # When name_resolve raises ValueError, resolve_names skips that NAME and
+        # When resolve_name raises ValueError, resolve_names skips that NAME and
         # reports no modification.
         monkeypatch.setattr(
-            "ord_schema.resolvers.name_resolve",
+            "ord_schema.resolvers.resolve_name",
             mock.MagicMock(side_effect=ValueError("not found")),
         )
         message = reaction_pb2.Reaction()

--- a/ord_schema/scripts/build_dataset.py
+++ b/ord_schema/scripts/build_dataset.py
@@ -30,7 +30,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parses command-line arguments."""
     parser = argparse.ArgumentParser(description="Build a Dataset from Reaction protos")
     parser.add_argument(
-        "--input", required=True, help="Input pattern for Reaction protos"
+        "--input_pattern",
+        "--input",
+        required=True,
+        help="Input pattern for Reaction protos (--input is a deprecated alias)",
     )
     parser.add_argument(
         "--output", required=True, help="Output Dataset filename (*.pbtxt)"
@@ -49,7 +52,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(args: argparse.Namespace) -> None:
     """Loads matching Reaction protos into a Dataset, validates it, and writes it out."""
-    filenames = sorted(glob.glob(args.input, recursive=True))
+    filenames = sorted(glob.glob(args.input_pattern, recursive=True))
     logger.info("Found %d Reaction protos", len(filenames))
     reactions = [
         message_helpers.load_message(filename, reaction_pb2.Reaction)

--- a/ord_schema/scripts/build_dataset.py
+++ b/ord_schema/scripts/build_dataset.py
@@ -49,7 +49,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(args: argparse.Namespace) -> None:
     """Loads matching Reaction protos into a Dataset, validates it, and writes it out."""
-    filenames = glob.glob(args.input, recursive=True)
+    filenames = sorted(glob.glob(args.input, recursive=True))
     logger.info("Found %d Reaction protos", len(filenames))
     reactions = [
         message_helpers.load_message(filename, reaction_pb2.Reaction)

--- a/ord_schema/scripts/build_dataset_test.py
+++ b/ord_schema/scripts/build_dataset_test.py
@@ -49,7 +49,7 @@ def test_simple(dirname):
     input_pattern = str(pathlib.Path(dirname) / "reaction-1.pbtxt")
     output_filename = str(pathlib.Path(dirname) / "dataset.pbtxt")
     argv = [
-        "--input",
+        "--input_pattern",
         input_pattern,
         "--name",
         "test dataset",
@@ -70,7 +70,7 @@ def test_validation(dirname):
     input_pattern = str(pathlib.Path(dirname) / "reaction-?.pbtxt")
     output_filename = str(pathlib.Path(dirname) / "dataset.pbtxt")
     argv = [
-        "--input",
+        "--input_pattern",
         input_pattern,
         "--name",
         "test dataset",
@@ -86,7 +86,7 @@ def test_validation(dirname):
         build_dataset.main(build_dataset.parse_args(argv))
     # Make sure disabling validation works.
     argv = [
-        "--input",
+        "--input_pattern",
         input_pattern,
         "--name",
         "test dataset",

--- a/ord_schema/scripts/parse_uspto.py
+++ b/ord_schema/scripts/parse_uspto.py
@@ -350,9 +350,8 @@ def parse_conditions(root: ET.Element, reaction: reaction_pb2.Reaction) -> None:
     del reaction  # Unused.
     if not root.findall("cml:chemical", namespaces=NAMESPACES):
         return  # Refers to an added component; is a workup.
-    action = root.attrib["action"]
-    del action  # Unused.
-    return  # TODO(kearnes): Implement this?
+    # TODO(kearnes): Non-workup conditions are not parsed yet.
+    return
 
 
 def parse_workup(root: ET.Element, reaction: reaction_pb2.Reaction) -> None:

--- a/ord_schema/scripts/process_dataset.py
+++ b/ord_schema/scripts/process_dataset.py
@@ -93,7 +93,7 @@ def _get_inputs(args: argparse.Namespace) -> list[FileStatus]:
                 else:
                     status, filename = fields
                     if not status.startswith(("A", "D", "M")):
-                        raise ValueError(f"unsupported git-diff statue: {status}")
+                        raise ValueError(f"unsupported git-diff status: {status}")
                     original_filename = ""
                 inputs.append(FileStatus(filename, status, original_filename))
         return inputs

--- a/ord_schema/scripts/validate_dataset.py
+++ b/ord_schema/scripts/validate_dataset.py
@@ -102,7 +102,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parses command-line arguments."""
     parser = argparse.ArgumentParser(description="Validate Dataset protocol buffers")
     parser.add_argument(
-        "--input", required=True, help="Input pattern for Dataset protos"
+        "--input_pattern",
+        "--input",
+        required=True,
+        help="Input pattern for Dataset protos (--input is a deprecated alias)",
     )
     parser.add_argument("--filter", default=None, help="Regex filename filter")
     parser.add_argument(
@@ -113,7 +116,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(args: argparse.Namespace) -> None:
     """Validates matching Dataset protos in parallel and reports any failures."""
-    filenames = sorted(glob.glob(args.input, recursive=True))
+    filenames = sorted(glob.glob(args.input_pattern, recursive=True))
     logger.info("Found %d datasets", len(filenames))
     if args.filter:
         filenames = filter_filenames(filenames, args.filter)

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -62,14 +62,17 @@ def setup(request, tmp_path) -> tuple[str, str]:
 
 def test_simple(setup):
     test_subdirectory, suffix = setup
-    argv = ["--input", str(pathlib.Path(test_subdirectory) / f"dataset1{suffix}")]
+    argv = [
+        "--input_pattern",
+        str(pathlib.Path(test_subdirectory) / f"dataset1{suffix}"),
+    ]
     validate_dataset.main(validate_dataset.parse_args(argv))
 
 
 def test_filter(setup):
     test_subdirectory, suffix = setup
     argv = [
-        "--input",
+        "--input_pattern",
         str(pathlib.Path(test_subdirectory) / f"dataset1{suffix}"),
         "--filter",
         "dataset",
@@ -79,7 +82,10 @@ def test_filter(setup):
 
 def test_validation_errors(setup):
     test_subdirectory, suffix = setup
-    argv = ["--input", str(pathlib.Path(test_subdirectory) / f"dataset*{suffix}")]
+    argv = [
+        "--input_pattern",
+        str(pathlib.Path(test_subdirectory) / f"dataset*{suffix}"),
+    ]
     with pytest.raises(
         validations.ValidationError,
         match="Reactions should have at least 1 reaction input",
@@ -133,7 +139,9 @@ def test_parquet_cross_row_group_duplicate_id(tmp_path):
         validations.ValidationError,
         match="Multiple Reactions should never have the same IDs",
     ):
-        validate_dataset.main(validate_dataset.parse_args(["--input", str(path)]))
+        validate_dataset.main(
+            validate_dataset.parse_args(["--input_pattern", str(path)])
+        )
 
 
 def test_parquet_empty_file(tmp_path):
@@ -151,7 +159,9 @@ def test_parquet_empty_file(tmp_path):
         validations.ValidationError,
         match="Dataset requires reactions or reaction_ids",
     ):
-        validate_dataset.main(validate_dataset.parse_args(["--input", str(path)]))
+        validate_dataset.main(
+            validate_dataset.parse_args(["--input_pattern", str(path)])
+        )
 
 
 def test_parquet_per_reaction_error_in_late_row_group(tmp_path):
@@ -171,7 +181,9 @@ def test_parquet_per_reaction_error_in_late_row_group(tmp_path):
         validations.ValidationError,
         match="Reactions should have at least 1 reaction input",
     ):
-        validate_dataset.main(validate_dataset.parse_args(["--input", str(path)]))
+        validate_dataset.main(
+            validate_dataset.parse_args(["--input_pattern", str(path)])
+        )
 
 
 @pytest.mark.parametrize(

--- a/ord_schema/templating.py
+++ b/ord_schema/templating.py
@@ -137,7 +137,7 @@ def generate_dataset(
         description: Dataset description.
         template_string: The contents of a Reaction pbtxt where placeholder
             values to be replaced are defined between dollar signs. For example,
-            a SMILES identifier value could be "$product_smiles$". PLaceholders
+            a SMILES identifier value could be "$product_smiles$". Placeholders
             may only use letters, numbers, and underscores.
         df: Pandas Dataframe where each row corresponds to one reaction and
             column names match placeholders in the template_string.

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -142,6 +142,22 @@ _FORBIDDEN_UNITS = {
     "m": "ambiguous between meter and minute",
 }
 
+# Temperature conversions to and from Celsius, used as an intermediate when
+# converting between temperature units.
+_TO_CELSIUS = {
+    reaction_pb2.Temperature.CELSIUS: lambda T: T,
+    reaction_pb2.Temperature.FAHRENHEIT: lambda T: (T - 32) * 5 / 9,
+    reaction_pb2.Temperature.KELVIN: lambda T: T - 273.15,
+}
+_FROM_CELSIUS = {
+    reaction_pb2.Temperature.CELSIUS: lambda T: T,
+    reaction_pb2.Temperature.FAHRENHEIT: lambda T: T * 9 / 5 + 32,
+    reaction_pb2.Temperature.KELVIN: lambda T: T + 273.15,
+}
+
+# Conversion factor between wavenumber (cm⁻¹) and wavelength (nm): nm·cm⁻¹.
+_WAVENUMBER_NM_CM = 1e7
+
 _UNIT_CONVERSIONS: dict[
     type[ord_schema.UnitMessage], dict[ProtoEnumMember, int | float]
 ] = {
@@ -249,8 +265,6 @@ class UnitResolver:
             unit_synonyms = _UNIT_SYNONYMS
         if forbidden_units is None:
             forbidden_units = _FORBIDDEN_UNITS
-        assert unit_synonyms is not None  # Type hint.
-        assert forbidden_units is not None  # Type hint.
         self._forbidden_units = forbidden_units
         self._resolver = {}
         for message in unit_synonyms:
@@ -362,16 +376,8 @@ class UnitResolver:
         new_message = message_type(units=new_units)
 
         if message_type == reaction_pb2.Temperature:
-            temperature_celsius = {
-                reaction_pb2.Temperature.CELSIUS: lambda T: T,
-                reaction_pb2.Temperature.FAHRENHEIT: lambda T: (T - 32) * 5 / 9,
-                reaction_pb2.Temperature.KELVIN: lambda T: T - 273.15,
-            }[message.units](message.value)
-            new_message.value = {
-                reaction_pb2.Temperature.CELSIUS: lambda T: T,
-                reaction_pb2.Temperature.FAHRENHEIT: lambda T: T * 9 / 5 + 32,
-                reaction_pb2.Temperature.KELVIN: lambda T: T + 273.15,
-            }[new_units](temperature_celsius)
+            temperature_celsius = _TO_CELSIUS[message.units](message.value)
+            new_message.value = _FROM_CELSIUS[new_units](temperature_celsius)
             if message.precision:
                 if (
                     message.units == reaction_pb2.Temperature.FAHRENHEIT
@@ -396,11 +402,11 @@ class UnitResolver:
 
         elif message_type == reaction_pb2.Wavelength:
             if message.units != new_units:
-                new_message.value = 10000000 / message.value
+                new_message.value = _WAVENUMBER_NM_CM / message.value
                 # Approximate precision as stdev of previous value \pm precision
                 if message.precision:
                     new_message.precision = (
-                        10000000
+                        _WAVENUMBER_NM_CM
                         / 2
                         * (
                             1 / (message.value - message.precision)
@@ -435,7 +441,7 @@ def format_message(message: ord_schema.UnitMessage) -> str | None:
         message: a message with units, e.g., Mass, Length.
 
     Returns:
-        A string describing the value, e.g., "5.0 (p/m 0.1) mL" using the
+        A string describing the value, e.g., "5.0 (± 0.1) mL" using the
             first unit synonym listed in _UNIT_SYNONYMS.
     """
     if message.units == type(message)().UNSPECIFIED:

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -103,11 +103,6 @@ def apply_reaction_updates(
     if new_id is not None:
         reaction.reaction_id = new_id
         modified = True
-    for func in _UPDATES:
-        # NOTE(kearnes): Order is important here; if you write
-        # `modified or func(reaction)` and modified is True, the interpreter
-        # will skip the evaluation of func(reaction).
-        modified = func(reaction) or modified
     if modified:
         event = reaction.provenance.record_modified.add()
         event.time.value = datetime.datetime.now(datetime.UTC).ctime()
@@ -203,7 +198,3 @@ def update_parquet_dataset(
             apply_reaction_updates(reaction, new_id=new_id)
             apply_cross_reference_substitutions(reaction, id_substitutions)
             writer.write(reaction)
-
-
-# Standard updates.
-_UPDATES = []

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -633,19 +633,19 @@ def validate_reaction(
     """Validates a Reaction's inputs, outcomes, identifiers, and provenance."""
     if options is None:
         options = ValidationOptions()
-    if (
+    # A reaction-SMILES-only record is allowed to omit inputs and outcomes.
+    smiles_only = (
         options.allow_reaction_smiles_only
         and message_helpers.get_reaction_smiles(message)
-        and len(message.inputs) == 0
-        and len(message.outcomes) == 0
-    ):
-        pass
-    else:
-        if len(message.inputs) == 0:
+        and not message.inputs
+        and not message.outcomes
+    )
+    if not smiles_only:
+        if not message.inputs:
             warnings.warn(
                 "Reactions should have at least 1 reaction input", ValidationError
             )
-        if len(message.outcomes) == 0:
+        if not message.outcomes:
             warnings.warn(
                 "Reactions should have at least 1 reaction outcome", ValidationError
             )

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -197,9 +197,10 @@ def validate_message(
     if not isinstance(message, tuple(_VALIDATOR_SWITCH.keys())):
         # NOTE(ccoley): I made the conscious decision to raise an error here,
         # rather than assume that the message is valid. If a message does not
-        # require any message-level checks (not uncommon), then it should still
-        # be listed in the dictionary switch above withpass. This will force
-        # us to think about what is necessary if/when new messages are added.
+        # require any message-level checks (not uncommon), it should still be
+        # registered in ``_VALIDATOR_SWITCH`` (mapped to ``skip_validation``).
+        # This forces us to think about what is necessary if/when new messages
+        # are added.
         raise NotImplementedError(f"Don't know how to validate {type(message)}")
 
     with warnings.catch_warnings(record=True) as tape:
@@ -671,8 +672,7 @@ def validate_reaction(
             ValidationError,
         )
     if options.validate_ids:
-        # The reaction_id suffix is a 32-character uuid4 hex string.
-        if not re.fullmatch("^ord-[0-9a-f]{32}$", message.reaction_id):
+        if not is_valid_reaction_id(message.reaction_id):
             warnings.warn("Reaction ID is malformed", ValidationError)
     if options.require_provenance:
         if not message.HasField("provenance"):
@@ -706,6 +706,30 @@ def validate_reaction_identifier(message: reaction_pb2.ReactionIdentifier) -> No
         warnings.warn("value must be set", ValidationError)
 
 
+class _StateOfMatter(IntEnum):
+    GAS = 1
+    LIQUID = 2
+    SOLID = 3
+
+
+# Coarse state of matter implied by each Texture type, for input/component
+# consistency checks; UNSPECIFIED/CUSTOM map to None (unknown).
+_TEXTURE_TO_STATE = {
+    reaction_pb2.Texture.UNSPECIFIED: None,
+    reaction_pb2.Texture.CUSTOM: None,
+    reaction_pb2.Texture.GAS: _StateOfMatter.GAS,
+    reaction_pb2.Texture.OIL: _StateOfMatter.LIQUID,
+    reaction_pb2.Texture.FOAM: _StateOfMatter.LIQUID,
+    reaction_pb2.Texture.LIQUID: _StateOfMatter.LIQUID,
+    reaction_pb2.Texture.POWDER: _StateOfMatter.SOLID,
+    reaction_pb2.Texture.CRYSTAL: _StateOfMatter.SOLID,
+    reaction_pb2.Texture.WAX: _StateOfMatter.SOLID,
+    reaction_pb2.Texture.AMORPHOUS_SOLID: _StateOfMatter.SOLID,
+    reaction_pb2.Texture.SEMI_SOLID: _StateOfMatter.SOLID,
+    reaction_pb2.Texture.SOLID: _StateOfMatter.SOLID,
+}
+
+
 def validate_reaction_input(message: reaction_pb2.ReactionInput) -> None:
     """Validates ReactionInput component counts and texture consistency."""
     if len(message.components) + len(message.crude_components) == 0:
@@ -725,40 +749,20 @@ def validate_reaction_input(message: reaction_pb2.ReactionInput) -> None:
                     ValidationWarning,
                 )
 
-    class StateOfMatter(IntEnum):
-        GAS = 1
-        LIQUID = 2
-        SOLID = 3
-
-    texture_type_to_state_of_matter = {
-        reaction_pb2.Texture.UNSPECIFIED: None,
-        reaction_pb2.Texture.CUSTOM: None,
-        reaction_pb2.Texture.GAS: StateOfMatter.GAS,
-        reaction_pb2.Texture.OIL: StateOfMatter.LIQUID,
-        reaction_pb2.Texture.FOAM: StateOfMatter.LIQUID,
-        reaction_pb2.Texture.LIQUID: StateOfMatter.LIQUID,
-        reaction_pb2.Texture.POWDER: StateOfMatter.SOLID,
-        reaction_pb2.Texture.CRYSTAL: StateOfMatter.SOLID,
-        reaction_pb2.Texture.WAX: StateOfMatter.SOLID,
-        reaction_pb2.Texture.AMORPHOUS_SOLID: StateOfMatter.SOLID,
-        reaction_pb2.Texture.SEMI_SOLID: StateOfMatter.SOLID,
-        reaction_pb2.Texture.SOLID: StateOfMatter.SOLID,
-    }
-    input_state_code = texture_type_to_state_of_matter[message.texture.type]
+    input_state_code = _TEXTURE_TO_STATE[message.texture.type]
     if input_state_code is not None:
         components = [*message.components, *message.crude_components]
-        component_state_codes = [
-            texture_type_to_state_of_matter[c.texture.type] for c in components
-        ]
+        component_state_codes = [_TEXTURE_TO_STATE[c.texture.type] for c in components]
         if (
             component_state_codes
             and None not in component_state_codes
             and max(component_state_codes) < input_state_code
         ):
             warnings.warn(
-                f"the ReactionInput has texture type of: {message.texture.type},"
-                f"but its components are: {[c.texture.type for c in components]},"
-                f"this seems unlikely"
+                f"the ReactionInput has texture type of: {message.texture.type}, "
+                f"but its components are: {[c.texture.type for c in components]}; "
+                "this seems unlikely",
+                ValidationWarning,
             )
 
 
@@ -802,8 +806,10 @@ def validate_crude_component(message: reaction_pb2.CrudeComponent) -> None:
         )
 
 
-def validate_compound(message: reaction_pb2.Compound) -> None:
-    """Validates that a Compound has usable identifiers."""
+def _validate_compound_identifiers(
+    message: reaction_pb2.Compound | reaction_pb2.ProductCompound,
+) -> None:
+    """Warns if a compound lacks identifiers, has only NAME, or has inconsistent ones."""
     if len(message.identifiers) == 0:
         warnings.warn("Compounds must have at least one identifier", ValidationError)
     if all(identifier.type == identifier.NAME for identifier in message.identifiers):
@@ -815,6 +821,11 @@ def validate_compound(message: reaction_pb2.Compound) -> None:
         message_helpers.check_compound_identifiers(message)
     except ValueError as error:
         warnings.warn(str(error), ValidationWarning)
+
+
+def validate_compound(message: reaction_pb2.Compound) -> None:
+    """Validates that a Compound has usable identifiers."""
+    _validate_compound_identifiers(message)
 
 
 def validate_compound_preparation(message: reaction_pb2.CompoundPreparation) -> None:
@@ -1064,18 +1075,7 @@ def validate_reaction_outcome(message: reaction_pb2.ReactionOutcome) -> None:
 
 def validate_product_compound(message: reaction_pb2.ProductCompound) -> None:
     """Validates a ProductCompound's identifiers and desired-product role."""
-    if len(message.identifiers) == 0:
-        warnings.warn("Compounds must have at least one identifier", ValidationError)
-    if all(identifier.type == identifier.NAME for identifier in message.identifiers):
-        warnings.warn(
-            "Compounds should have more specific identifiers than NAME whenever possible",
-            ValidationWarning,
-        )
-    try:
-        message_helpers.check_compound_identifiers(message)
-    except ValueError as error:
-        warnings.warn(str(error), ValidationWarning)
-
+    _validate_compound_identifiers(message)
     if message.is_desired_product:
         if (
             message.reaction_role
@@ -1207,7 +1207,7 @@ def validate_reaction_provenance(message: reaction_pb2.ReactionProvenance) -> No
             # Use the last record as the most recent modification time.
             record_modified = parser.parse(record.time.value)
     except parser.ParserError:
-        warnings.warn("Failed to parse DateTime string(s)")
+        warnings.warn("Failed to parse DateTime string(s)", ValidationWarning)
     # Check signs of time differences
     if experiment_start and record_created:
         if (record_created - experiment_start).total_seconds() < 0:
@@ -1300,7 +1300,7 @@ def validate_percentage(message: reaction_pb2.Percentage) -> None:
     ensure_float_nonnegative(message, "precision")
 
 
-def validate_float_value(message: ord_schema.Message) -> None:
+def validate_float_value(message: reaction_pb2.FloatValue) -> None:
     """Validates that a FloatValue's precision is non-negative."""
     ensure_float_nonnegative(message, "precision")
 


### PR DESCRIPTION
## What

A consistency / readability sweep after the recent I/O module reorg. All changes are behavior-preserving except the two noted renames and the `--input_pattern` flag standardization (all of which keep deprecated aliases). ruff + ty clean, full suite green.

### `validations.py`
- **Dedup**: `validate_compound` and `validate_product_compound` had a byte-identical compound-identifier validation block → extracted `_validate_compound_identifiers`.
- Reuse `is_valid_reaction_id` instead of re-inlining its `re.fullmatch(...)`.
- **Hoist** the `StateOfMatter` enum + `Texture`→state map (rebuilt on every `validate_reaction_input` call) to module level.
- Give the two **category-less `warnings.warn`** calls an explicit `ValidationWarning` (consistency — they already routed to `output.warnings` via the `else` branch, so no behavior change), and fix the texture message's missing spaces.
- Type `validate_float_value` as `reaction_pb2.FloatValue` (not the generic base), matching its peers.
- Fix a stale comment that referenced a non-existent "switch above with `pass`" instead of `_VALIDATOR_SWITCH`/`skip_validation`.
- **Invert the SMILES-only guard** in `validate_reaction`: the old `if (smiles-only): pass / else: <warn>` carried an empty `pass` branch with the real work in the `else`; replaced with a named `smiles_only` guard (`if not smiles_only: <warn>`). Behavior identical.

### `resolvers.py`
- Delete unused `_USERNAME`/`_EMAIL`; unify a duplicated error message; **rename `name_resolve` → `resolve_name`** (verb-first, matching `resolve_names`/`resolve_input`/`resolve_unit`) **with a deprecated `name_resolve` alias**; third-person `resolve_input` docstring.

### `units.py`
- Hoist per-call temperature-conversion tables to module constants; name the `1e7` wavenumber↔wavelength factor; drop two no-op narrowing asserts; fix a stale `p/m` → `±` docstring.

### `message_helpers.py`
- Factor `build_compound`'s duplicated enum-resolution dance into `_resolve_enum_value`; init a float accumulator as `0.0`.

### `updates.py`
- Remove the permanently-empty `_UPDATES` registry + its dead loop/comment.

### scripts / `templating.py`
- **Standardize the dataset CLIs on `--input_pattern`**: `build_dataset.py`/`validate_dataset.py` previously used `--input` for the same glob-pattern concept that `parse_uspto.py`/`process_dataset.py` spell `--input_pattern`. Added `--input_pattern` as the canonical name with `--input` retained as a backward-compatible argparse alias; migrated all call sites (tests, `docs/submissions.rst`) to the new name.
- Sort `build_dataset`'s glob (deterministic output ordering); drop a no-op tail in `parse_uspto.parse_conditions`; fix `"statue"` → `"status"` and `"PLaceholders"` → `"Placeholders"` typos.

## Deferred (from the sweep, intentionally not here)
- `ParquetFooter.num_rows` → considered, **kept** for consistency with `num_row_groups` (parquet-native footer terms).
- Extracting the `messages_to_dataframe` cluster into a `dataframes.py` module — left alone for now.
- `parse_uspto`'s hardcoded personal provenance — needs a product decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a broad consistency and readability sweep across the `ord_schema` codebase following a recent I/O module reorganisation. All changes are behaviour-preserving except two renames (`name_resolve` → `resolve_name`, `--input` → `--input_pattern`) which retain deprecated backward-compatible aliases.

- **Deduplication & hoisting**: byte-identical compound-identifier validation blocks extracted into `_validate_compound_identifiers`; the `StateOfMatter` enum, texture→state map, and temperature-conversion lambda dicts moved from per-call locals to module constants; `build_compound`'s repeated enum-lookup pattern factored into `_resolve_enum_value`.
- **Dead-code removal**: unused `_USERNAME`/`_EMAIL` in `resolvers.py`, the permanently-empty `_UPDATES` loop in `updates.py`, and a no-op attribute read in `parse_uspto.parse_conditions` are all deleted.
- **Correctness/polish**: `validate_float_value` now typed as `reaction_pb2.FloatValue`; `volume_liter` accumulator initialised as `0.0`; two `warnings.warn` calls gain an explicit `ValidationWarning` category; several stale comments, two typos (`statue`/`PLaceholders`), and the `p/m` → `±` docstring are fixed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — every change is either a mechanical refactor with an identical call-graph or a dead-code deletion of a permanently-empty registry, and the two public renames both carry deprecated aliases.

The refactors (helper extraction, constant hoisting, flag rename) are all verified to preserve the original logic. The _UPDATES loop deletion is provably inert since the list was always empty. Deprecated aliases are correctly wired with stacklevel=2 and argparse stores the value under the right attribute name. No new code paths or side-effects are introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/validations.py | Refactors compound-identifier validation into a shared helper, hoists the StateOfMatter enum and texture-to-state map to module level, inverts the SMILES-only guard, reuses is_valid_reaction_id, and adds explicit ValidationWarning categories — all behavior-preserving. |
| ord_schema/resolvers.py | Renames name_resolve to resolve_name (verb-first convention), adds a deprecated stacklevel=2 alias, removes unused _USERNAME/_EMAIL constants, and unifies error message tense. |
| ord_schema/units.py | Hoists per-call temperature-conversion lambdas to module-level dicts, names the 1e7 wavenumber-nm factor, drops two no-op narrowing asserts, and fixes the format_message docstring (p/m → ±). |
| ord_schema/message_helpers.py | Extracts _resolve_enum_value to deduplicate the enum-field lookup in build_compound, and initializes the float volume accumulator as 0.0 instead of 0. |
| ord_schema/updates.py | Removes the permanently-empty _UPDATES list and its dead iteration loop; no behavior change since the list was always empty. |
| ord_schema/scripts/build_dataset.py | Renames --input to --input_pattern (keeping --input as a backward-compatible alias) and adds sorted() for deterministic glob output ordering. |
| ord_schema/scripts/validate_dataset.py | Renames --input to --input_pattern with backward-compatible alias, matching build_dataset.py; updates args.input → args.input_pattern in main(). |
| ord_schema/scripts/process_dataset.py | Fixes the 'statue' → 'status' typo in an error message string. |
| ord_schema/scripts/parse_uspto.py | Removes a no-op action attribute read in parse_conditions and replaces the dead-code comment with a cleaner TODO. |
| ord_schema/resolvers_test.py | Updates all monkeypatches and direct calls from name_resolve to resolve_name, and updates the error message assertion to match the unified tense fix. |
| ord_schema/scripts/build_dataset_test.py | Updates all test argv arrays from --input to --input_pattern to match the renamed canonical flag. |
| ord_schema/scripts/validate_dataset_test.py | Updates all test argv arrays from --input to --input_pattern to match the renamed canonical flag. |
| ord_schema/templating.py | Fixes the 'PLaceholders' → 'Placeholders' capitalization typo in the generate_dataset docstring. |
| docs/submissions.rst | Updates the documentation example to use --input_pattern instead of --input, consistent with the CLI rename. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Invert SMILES-only validation guard; sta..."](https://github.com/open-reaction-database/ord-schema/commit/962c8658b720cf6d44c21d876c116b27c189a0f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38863811)</sub>

<!-- /greptile_comment -->