### PR TITLE
Document transaction-scoped GUC for is_similar in ORM README

### DIFF
--- a/ord_schema/orm/README.md
+++ b/ord_schema/orm/README.md
@@ -248,8 +248,25 @@ with Session(engine) as session:
 assert len(reactions) == 20
   ```
 
-`is_similar` uses the GiST fingerprint index; the cutoff is read from the
-`rdkit.tanimoto_threshold` session setting (default 0.5). Set a different cutoff
-with `session.execute(select(func.set_config("rdkit.tanimoto_threshold", "0.7", False)))`
-before running the query. Use `RDKitMols.tanimoto(...)` instead when you need the
-similarity *value* (e.g. to select or order by it).
+`is_similar` uses the GiST fingerprint index; the cutoff is read from a session
+setting (default 0.5) rather than passed to the method. `MORGAN_BFP` uses Tanimoto
+similarity (`rdkit.tanimoto_threshold`); `MORGAN_SFP` uses Dice similarity
+(`rdkit.dice_threshold`). Set a different cutoff for the rest of the session with:
+
+```python
+session.execute(select(func.set_config("rdkit.tanimoto_threshold", "0.7", False)))
+```
+
+The third argument to `set_config` is `is_local`. Passing `True` instead scopes the
+change to the current transaction only (equivalent to `SET LOCAL`), so it reverts
+automatically afterward — useful for a one-off query without disturbing the rest of
+the session:
+
+```python
+with session.begin():
+    session.execute(select(func.set_config("rdkit.tanimoto_threshold", "0.7", True)))
+    results = session.execute(query)
+```
+
+Use `RDKitMols.tanimoto(...)` instead when you need the similarity *value* (e.g. to
+select or order by it).


### PR DESCRIPTION
## Summary

Follow-up to #848. Documents how to scope the RDKit similarity threshold to a single query rather than the whole session.

PostgreSQL's `set_config(setting, value, is_local)` takes a third `is_local` argument. The README only showed the session-wide form (`False`); passing `True` gives `SET LOCAL` semantics — the change applies only to the current transaction and reverts automatically afterward. Paired with `Session.begin()`, that's the idiomatic way to set the threshold for a one-off query without disturbing the rest of the session.

Also clarifies that `MORGAN_SFP` reads `rdkit.dice_threshold` (Dice similarity) rather than `rdkit.tanimoto_threshold`, consistent with the `is_similar` docstring.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a docs-only follow-up to #848 that expands the `is_similar` GUC documentation in the ORM README with two clarifications: the `is_local` argument to `set_config` and how to use `session.begin()` to scope the threshold change to a single transaction, plus a correction noting that `MORGAN_SFP` reads `rdkit.dice_threshold` (Dice) rather than `rdkit.tanimoto_threshold` (Tanimoto).

- Adds a `SET LOCAL`-style example using `set_config(..., True)` inside `with session.begin():`, correctly explaining that the GUC reverts automatically at transaction end.
- Correctly distinguishes the two fingerprint types' GUCs (`rdkit.tanimoto_threshold` for `MORGAN_BFP`, `rdkit.dice_threshold` for `MORGAN_SFP`), consistent with the docstring in `rdkit_mappers.py` lines 181–183 and the test comments in `rdkit_mappers_test.py` lines 68–70.

<h3>Confidence Score: 5/5</h3>

Docs-only change with no code modifications; all factual claims are verified against the implementation.

Every claim in the added text was cross-checked against rdkit_mappers.py and rdkit_mappers_test.py: the MORGAN_BFP/tanimoto_threshold and MORGAN_SFP/dice_threshold distinction is accurate, and the session.begin() pattern for SET LOCAL semantics is the standard SQLAlchemy idiom. No code paths are changed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/README.md | Expands the `is_similar` GUC docs to cover transaction-scoped SET LOCAL semantics and correctly distinguishes rdkit.tanimoto_threshold (MORGAN_BFP) from rdkit.dice_threshold (MORGAN_SFP); both claims are verified against the implementation in rdkit_mappers.py. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Document transaction-scoped GUC for is\_s..."](https://github.com/open-reaction-database/ord-schema/commit/685dd0aba87946702f575eed2bd04a8cc7f4d555) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39445065)</sub>

<!-- /greptile_comment -->