### PR TITLE
Bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           python-version: '3.11'

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '>=1.16'
       - name: Install dependencies

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -24,7 +24,7 @@ jobs:
   check_licenses:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-go@v5
         with:
           go-version: '>=1.16'
@@ -38,11 +38,11 @@ jobs:
   check_python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           python-version: '3.11'
@@ -65,7 +65,7 @@ jobs:
   check_proto:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: clang-format
         run: |
           sudo apt update && sudo apt install clang-format --yes

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -50,7 +50,7 @@ jobs:
         run: uv sync --extra examples --extra tests --locked
       - name: Verify bump2version config (dry-run)
         run: |
-          uv pip install bump2version
+          uv pip install --system bump2version
           bump2version patch --dry-run --verbose
       - name: Run ruff
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,16 +42,16 @@ jobs:
       contents: write
       id-token: write  # PyPI + npm trusted publishing (OIDC).
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.ACTIONS_PUSH }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           python-version: '3.11'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           # Trusted publishing requires Node >= 22.14 and npm >= 11.5.1 (https://docs.npmjs.com/trusted-publishers)
           node-version: '24'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.11'
       - uses: actions/setup-node@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,13 +61,13 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
-          uv pip install bump2version
+          uv pip install --system bump2version
           bump2version "${{ inputs.level }}" --verbose
       # PyPI Trusted Publishing (OIDC); configure at https://docs.pypi.org/trusted-publishers/
       # for this repo + workflow file publish.yml (no PYPI_API_TOKEN / legacy upload).
       - name: Build Python distributions
         run: |
-          uv pip install build twine wheel
+          uv pip install --system build twine wheel
           python -m build
           python -m twine check dist/*
       # Use release/v1 (not a bare v1.x.x tag): each tag must have a matching GHCR image

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -157,7 +157,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Bump patch without commit (for publish dry-runs)
         run: |
-          uv pip install bump2version
+          uv pip install --system bump2version
           # Dry-run first: assert .bumpversion.cfg and every configured file still contain the
           # expected current_version / search patterns before we mutate the tree (misconfig or
           # version drift fails here without leaving a half-updated checkout).
@@ -166,7 +166,7 @@ jobs:
       - name: Test python
         run: |
           # Same pre-upload steps as publish.yml; PyPI upload runs only on main with secrets.
-          uv pip install build twine wheel
+          uv pip install --system build twine wheel
           python -m build
           python -m twine check dist/*
       - name: Test javascript

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,7 +31,7 @@ jobs:
       PGDATA: $GITHUB_WORKSPACE/rdkit-postgres
     steps:
       - uses: actions/checkout@v7
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           miniconda-version: 'latest'
       - name: Setup PostgreSQL
@@ -114,7 +114,7 @@ jobs:
           unzip protobuf-javascript-3.21.2-linux-x86_64.zip
           npm i -g ts-protoc-gen@0.15.0 protobufjs@7.4.0 protobufjs-cli@1.1.3
           PATH=$GITHUB_WORKSPACE/protoc/bin:$PATH protoc --version
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '>=1.16'
       - name: Install addlicense

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,7 +30,7 @@ jobs:
     env:
       PGDATA: $GITHUB_WORKSPACE/rdkit-postgres
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniconda-version: 'latest'
@@ -40,10 +40,10 @@ jobs:
           # NOTE(skearnes): conda is only used for postgres (not python).
           conda install -c conda-forge rdkit-postgresql
           initdb
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -78,11 +78,11 @@ jobs:
       CUDA_VISIBLE_DEVICES: "-1"
       TF_CPP_MIN_LOG_LEVEL: "2"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -95,11 +95,11 @@ jobs:
   test_proto_wrappers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
       - name: Install protoc
@@ -131,8 +131,8 @@ jobs:
   test_js:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
       - name: Test NPM package
@@ -143,14 +143,14 @@ jobs:
   test_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8
         with:
           python-version: '3.11'
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           # Trusted publishing requires Node >= 22.14 and npm >= 11.5.1 (https://docs.npmjs.com/trusted-publishers)
           node-version: '24'

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -147,7 +147,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.11'
       - uses: actions/setup-node@v6


### PR DESCRIPTION
Bumps the pinned action majors that GitHub flagged as targeting the deprecated Node.js 20 runtime (annotation seen on the [latest publish run](https://github.com/open-reaction-database/ord-schema/actions/runs/28135985321)):

| Action | Old | New |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-node | v4 | v6 |
| actions/setup-python | v5 | v6 |
| astral-sh/setup-uv | v5 | v7 |
| actions/setup-go | v5 | v6 |
| conda-incubator/setup-miniconda | v3 | v4 |

Applied across `publish.yml`, `cleanup.yml`, and `run_tests.yml`. All existing `with:` inputs (`token`, `python-version`, `node-version`, `enable-cache`) remain valid in the new majors, so no config changes were needed. This clears the "Node.js 20 is deprecated … forced to run on Node.js 24" warning.

Note on `setup-uv`: v7 is the highest floating major tag and already runs on Node 24 (v6 was the last Node 20 release); there is no `v8` floating tag, so pinning `@v8` fails to resolve. v7 is the correct target.

Companion change: `setup-uv` v7 sets `UV_PYTHON` and no longer lets a bare `uv pip install` target the runner Python, so the build/publish helper installs (`bump2version`, `build`, `twine`, `wheel`) now pass `--system` to install into the setup-python interpreter on PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps all GitHub Actions action versions to their current Node 24-compatible majors across three workflow files, clearing the "Node.js 20 is deprecated" runner annotation. The PR also adds `--system` to every bare `uv pip install` call, which is required by newer uv releases when no virtual environment is active.

- `actions/checkout` v4→v7, `actions/setup-python` v5→v6, `actions/setup-node` v4→v6, `actions/setup-go` v5→v6, `astral-sh/setup-uv` v5→v7, and `conda-incubator/setup-miniconda` v3→v4 — all confirmed to target the Node 24 runtime.
- `uv pip install --system` additions are a necessary companion fix: without `--system`, newer uv versions refuse to install into a non-venv Python, which would break `bump2version`, `build`, `twine`, and `wheel` installs in CI.

<h3>Confidence Score: 5/5</h3>

All three workflow files receive straightforward action version bumps with no logic changes; safe to merge.

The changes are mechanical version pin updates verified against official action repositories, all confirmed to run on Node 24. The uv pip install --system additions correctly address a requirement introduced in newer uv releases when no virtual environment is active. No inputs were removed or renamed, and no workflow logic was altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/cleanup.yml | Bumps actions/checkout v4→v7, actions/setup-python v5→v6, actions/setup-go v5→v6, astral-sh/setup-uv v5→v7; adds --system flag to uv pip install for compatibility with newer uv versions that require an active venv otherwise. |
| .github/workflows/publish.yml | Bumps actions/checkout v4→v7, actions/setup-python v5→v6, astral-sh/setup-uv v5→v7, actions/setup-node v4→v6; adds --system to two uv pip install invocations. |
| .github/workflows/run_tests.yml | Bumps actions/checkout v4→v7, actions/setup-python v5→v6, actions/setup-node v4→v6, actions/setup-go v5→v6, astral-sh/setup-uv v5→v7, conda-incubator/setup-miniconda v3→v4; adds --system to three uv pip install calls. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/run_tests.yml`, line 46-51 ([link](https://github.com/open-reaction-database/ord-schema/blob/8fcd8e0d486d1ca78af63df8c5ca5dba99030eb1/.github/workflows/run_tests.yml#L46-L51)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> `astral-sh/setup-uv@v7` still runs on Node.js 20. All four occurrences of `setup-uv` in this file should be `v8` to actually eliminate the deprecation warning. The same fix applies to the other `setup-uv@v7` references at lines 85 and 150.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["Bump setup-go v5→v6 and setup-miniconda ..."](https://github.com/open-reaction-database/ord-schema/commit/9526acf664e90a34b71ca0f9ae27b76cd0f8770e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39696639)</sub>

<!-- /greptile_comment -->