### PR TITLE
Add NCI/CADD CIR resolver; drop PubChem retry/tenacity

### DIFF
--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -20,12 +20,6 @@ import urllib.request
 import warnings
 
 from rdkit import Chem
-from tenacity import (
-    retry,
-    retry_if_exception,
-    stop_after_attempt,
-    wait_random_exponential,
-)
 
 import ord_schema
 from ord_schema import message_helpers
@@ -109,26 +103,34 @@ def resolve_names(message: ord_schema.Message) -> bool:
     return modified
 
 
-def _is_pubchem_busy(exception: BaseException) -> bool:
-    # PubChem returns 503 PUGREST.ServerBusy when its service-wide concurrent
-    # request load is shedding (independent of any per-IP quota). Retry only
-    # that case; 404 (unknown name) and other 4xx codes should fall through.
-    return isinstance(exception, urllib.error.HTTPError) and exception.code == 503
-
-
-@retry(
-    retry=retry_if_exception(_is_pubchem_busy),
-    stop=stop_after_attempt(5),
-    wait=wait_random_exponential(multiplier=1, max=8),
-    reraise=True,
-)
 def _pubchem_resolve(value_type: str, value: str) -> str:
-    """Resolves compound identifiers to SMILES via the PubChem REST API."""
+    """Resolves compound identifiers to SMILES via the PubChem REST API.
+
+    A 503 (genuine service load or an IP-level block) propagates to
+    ``resolve_name``, which falls through to the next resolver instead of
+    retrying.
+    """
     with urllib.request.urlopen(
         f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/{value_type}/"
         f"{urllib.parse.quote(value)}/property/IsomericSMILES/txt"
     ) as response:
         return response.read().decode().strip()
+
+
+def _cactus_resolve(value_type: str, value: str) -> str:
+    """Resolves compound identifiers to SMILES via the NCI/CADD CIR web service.
+
+    CIR resolves trade names, trivial names, abbreviations, and CAS numbers, so
+    it serves as a fast fallback when PubChem is unavailable. Unknown names come
+    back as HTTP 500 (not 404), which ``resolve_name`` treats like any other
+    HTTPError and falls through.
+    """
+    del value_type  # CIR infers the identifier type from the string.
+    with urllib.request.urlopen(
+        f"https://cactus.nci.nih.gov/chemical/structure/{urllib.parse.quote(value)}/smiles"
+    ) as response:
+        # CIR can return several representations newline-separated; take the first.
+        return response.read().decode().strip().split("\n", 1)[0]
 
 
 def _opsin_resolve(value_type: str, value: str) -> str:
@@ -196,18 +198,19 @@ def resolve_input(input_string: str) -> reaction_pb2.ReactionInput:
     return reaction_input
 
 
-# Standard name resolvers.
+# Standard name resolvers, tried in order until one returns a SMILES.
 #
 # PubChem handles the bulk of inputs (trade names, trivial names, abbreviations,
-# CAS numbers), and OPSIN is a reliable fallback for systematic IUPAC names when
-# PubChem is unavailable or rate-limited.
+# CAS numbers). NCI/CADD CIR (cactus) covers the same broad space and is a fast
+# fallback when PubChem is rate-limited. OPSIN handles systematic IUPAC names
+# that lookup services may not index.
 #
-# Previously also included NCI/CADD (cactus.nci.nih.gov) and eMolecules, which
-# are both effectively dead: cactus has been returning uniform 503s with a silent
-# blog since 2013, and eMolecules' public /lookup?q= endpoint now always replies
-# "__END__" (their current API requires authentication).
+# eMolecules' public /lookup?q= endpoint is unusable (it always replies "__END__";
+# their current API requires authentication), and ChemSpider now requires a
+# registered RSC API key, so neither is included.
 _NAME_RESOLVERS = {
     "PubChem API": _pubchem_resolve,
+    "NCI/CADD CIR": _cactus_resolve,
     "OPSIN": _opsin_resolve,
 }
 

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -287,7 +287,10 @@ class TestCactusResolve:
 
     @_live_resolvers
     def test_cactus_resolve_live(self):
-        smiles = resolvers._cactus_resolve("name", "aspirin")
+        try:
+            smiles = resolvers._cactus_resolve("name", "aspirin")
+        except (urllib.error.HTTPError, urllib.error.URLError) as error:
+            pytest.skip(f"CIR unavailable ({error}); skipping live resolver smoke test")
         assert Chem.MolToSmiles(Chem.MolFromSmiles(smiles)) == Chem.MolToSmiles(
             Chem.MolFromSmiles("CC(=O)Oc1ccccc1C(O)=O")
         )

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -35,17 +35,16 @@ _live_resolvers = pytest.mark.skipif(
 )
 
 
-def _skip_if_pubchem_unavailable(caplog):
-    """Skip the calling test when PubChem signalled it was overloaded.
+def _skip_if_resolver_unavailable(caplog):
+    """Skip the calling test when a resolver signalled an upstream outage.
 
-    A 503 PUGREST.ServerBusy (or other 5xx) means PubChem is rate-limiting or
-    down, not that resolution logic is broken; the resolver logs it at INFO. A
-    wrong-but-resolved answer still fails via the test's own assertions.
+    A 5xx from any resolver (PubChem 503 PUGREST.ServerBusy, CIR 500) means the
+    service is rate-limiting or down, not that resolution logic is broken;
+    resolvers log it at INFO. A wrong-but-resolved answer still fails via the
+    test's own assertions.
     """
     if "ServerBusy" in caplog.text or "HTTP Error 5" in caplog.text:
-        pytest.skip(
-            "PubChem unavailable (503 ServerBusy); skipping live resolver smoke test"
-        )
+        pytest.skip("resolver unavailable (5xx); skipping live resolver smoke test")
 
 
 class TestNameResolvers:
@@ -60,7 +59,7 @@ class TestNameResolvers:
         )
         with caplog.at_level(logging.INFO, logger="ord_schema.resolvers"):
             modified = resolvers.resolve_names(message)
-        _skip_if_pubchem_unavailable(caplog)
+        _skip_if_resolver_unavailable(caplog)
         assert modified
         resolved_smi = roundtrip_smi(
             message.inputs["test"].components[0].identifiers[1].value
@@ -103,7 +102,7 @@ class TestInputResolvers:
         string = "10 g of THF"
         with caplog.at_level(logging.INFO, logger="ord_schema.resolvers"):
             reaction_input = resolvers.resolve_input(string)
-        _skip_if_pubchem_unavailable(caplog)
+        _skip_if_resolver_unavailable(caplog)
         assert len(reaction_input.components) == 1
         assert reaction_input.components[0].amount.mass == reaction_pb2.Mass(
             value=10, units="GRAM"
@@ -122,7 +121,7 @@ class TestInputResolvers:
         string = "100 mL of 5.0uM sodium hydroxide in water"
         with caplog.at_level(logging.INFO, logger="ord_schema.resolvers"):
             reaction_input = resolvers.resolve_input(string)
-        _skip_if_pubchem_unavailable(caplog)
+        _skip_if_resolver_unavailable(caplog)
         assert len(reaction_input.components) == 2
         assert reaction_input.components[0].amount.moles == reaction_pb2.Moles(
             value=500, units="NANOMOLE"

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -24,11 +24,11 @@ from rdkit import Chem
 from ord_schema import resolvers
 from ord_schema.proto import reaction_pb2
 
-# The live PubChem/OPSIN smoke tests below run on a single CI matrix entry (set by
-# the workflow) to avoid tripping PubChem's per-IP throttling; locally they always
-# run. They already retry 503 ServerBusy via tenacity in resolvers.py -- we do not
-# stack additional reruns on top of that. If PubChem is still busy after those
-# retries, skip rather than fail so a third-party outage never reddens the build.
+# The live resolver smoke tests below run on a single CI matrix entry (set by the
+# workflow) to avoid tripping PubChem's per-IP throttling; locally they always run.
+# A PubChem 503 falls through to CIR/OPSIN rather than failing, but if every
+# resolver is unreachable we skip rather than fail so a third-party outage never
+# reddens the build.
 _live_resolvers = pytest.mark.skipif(
     os.environ.get("ORD_LIVE_RESOLVERS", "true") != "true",
     reason="live resolver smoke tests run on a single CI matrix entry",
@@ -221,40 +221,23 @@ def _http_error(code: int, msg: str) -> urllib.error.HTTPError:
     return urllib.error.HTTPError("", code, msg, hdrs=None, fp=None)  # ty: ignore[invalid-argument-type]
 
 
-class TestPubChemRetry:
-    """Tests for the tenacity-driven retry on PubChem 503 ServerBusy."""
-
-    @staticmethod
-    def _ok_response() -> mock.MagicMock:
+class TestPubChemResolve:
+    def test_pubchem_resolve(self, monkeypatch):
         response = mock.MagicMock()
         response.read.return_value = b"CC(=O)Oc1ccccc1C(=O)O\n"
         response.__enter__.return_value = response
-        return response
-
-    def test_retries_then_succeeds(self, monkeypatch):
-        # Two 503s then a successful response — the decorator should swallow both
-        # 503s without surfacing them and return the eventual SMILES.
-        responses = [
-            _http_error(503, "PUGREST.ServerBusy"),
-            _http_error(503, "PUGREST.ServerBusy"),
-            self._ok_response(),
-        ]
-        urlopen = mock.MagicMock(side_effect=responses)
+        urlopen = mock.MagicMock(return_value=response)
         monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
-        # Drop tenacity's wait so the test runs in milliseconds, not seconds.
-        # tenacity attaches a Retrying object to the wrapped function as .retry;
-        # ty's stubs don't model this, hence the ignore.
-        retrying = resolvers._pubchem_resolve.retry  # ty: ignore[unresolved-attribute]
-        monkeypatch.setattr(retrying, "wait", lambda *_, **__: 0)
         assert resolvers._pubchem_resolve("name", "aspirin") == "CC(=O)Oc1ccccc1C(=O)O"
-        assert urlopen.call_count == 3
+        assert urlopen.call_count == 1
 
-    def test_does_not_retry_404(self, monkeypatch):
-        # 404 means "no such compound" — must not be retried.
-        urlopen = mock.MagicMock(side_effect=_http_error(404, "Not Found"))
+    def test_does_not_retry_503(self, monkeypatch):
+        # A 503 is raised on the first attempt without retrying; resolve_name then
+        # falls through to the next resolver (see TestNameResolveFallback).
+        urlopen = mock.MagicMock(side_effect=_http_error(503, "PUGREST.ServerBusy"))
         monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
         with pytest.raises(urllib.error.HTTPError):
-            resolvers._pubchem_resolve("name", "definitely-not-a-compound")
+            resolvers._pubchem_resolve("name", "aspirin")
         assert urlopen.call_count == 1
 
 
@@ -280,6 +263,34 @@ class TestOpsinResolve:
         # value_type is ignored by OPSIN.
         assert resolvers._opsin_resolve("name", "ethane-1,2-diol") == "OCCO"
         assert urlopen.call_count == 1
+
+
+class TestCactusResolve:
+    def test_cactus_resolve(self, monkeypatch):
+        response = mock.MagicMock()
+        response.read.return_value = b"OCCO\n"
+        response.__enter__.return_value = response
+        urlopen = mock.MagicMock(return_value=response)
+        monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
+        # value_type is ignored by CIR.
+        assert resolvers._cactus_resolve("name", "ethylene glycol") == "OCCO"
+        assert urlopen.call_count == 1
+
+    def test_cactus_resolve_takes_first_line(self, monkeypatch):
+        # CIR can return multiple newline-separated representations.
+        response = mock.MagicMock()
+        response.read.return_value = b"OCCO\nC(CO)O\n"
+        response.__enter__.return_value = response
+        urlopen = mock.MagicMock(return_value=response)
+        monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
+        assert resolvers._cactus_resolve("name", "ethylene glycol") == "OCCO"
+
+    @_live_resolvers
+    def test_cactus_resolve_live(self):
+        smiles = resolvers._cactus_resolve("name", "aspirin")
+        assert Chem.MolToSmiles(Chem.MolFromSmiles(smiles)) == Chem.MolToSmiles(
+            Chem.MolFromSmiles("CC(=O)Oc1ccccc1C(O)=O")
+        )
 
 
 class TestNameResolveFallback:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,6 @@ dependencies = [
     "pyarrow>=14",
     "python-dateutil>=1.10.0",
     "rdkit>=2021.9.5",
-    # Pinned <10 because we read _pubchem_resolve.retry to monkeypatch the wait
-    # in tests; tenacity 10 may rework that introspection surface.
-    "tenacity>=8.0.0,<10",
     "tqdm>=4.61.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2187,7 +2187,6 @@ dependencies = [
     { name = "pyarrow" },
     { name = "python-dateutil" },
     { name = "rdkit" },
-    { name = "tenacity" },
     { name = "tqdm" },
 ]
 
@@ -2262,7 +2261,6 @@ requires-dist = [
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=1.1.1" },
     { name = "sphinx-tabs", marker = "extra == 'docs'", specifier = ">=3.4.0" },
     { name = "sqlalchemy", marker = "extra == 'orm'", specifier = ">=2" },
-    { name = "tenacity", specifier = ">=8.0.0,<10" },
     { name = "tensorflow", marker = "extra == 'examples'", specifier = ">=2.4.1" },
     { name = "testing-postgresql", marker = "extra == 'tests'", specifier = ">=1.3.0" },
     { name = "tqdm", specifier = ">=4.61.2" },
@@ -3662,15 +3660,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
-]
-
-[[package]]
-name = "tenacity"
-version = "9.1.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add the **NCI/CADD Chemical Identifier Resolver** (cactus) as a name resolver, between PubChem and OPSIN. It resolves trade names, trivial names, abbreviations, and CAS numbers — the same broad space as PubChem — so it absorbs PubChem outages instead of leaving us with OPSIN's systematic-names-only fallback.
- **Drop the tenacity retry on PubChem** (and the `tenacity` dependency). PubChem returns `503 PUGREST.ServerBusy` both for genuine service load and for edge-level IP blocks. On a blocked IP every 503 is persistent, so the 5-attempt exponential-backoff retry just burned **~8s per name** before falling through. With CIR as a fast fallback the retry no longer earns its keep — a single 503 now falls straight through to CIR/OPSIN in **~0.3s per name**.

## Why this ordering

PubChem stays first: diagnosis via its `X-Throttling-Control` header showed all three gauges (per-IP request count, per-IP request time, and global `Service status`) reporting **Green (0%)** while still returning 503 — i.e. the flakiness is an IP/edge block specific to our egress network, not a global PubChem problem or a rate-limit we're tripping. Other environments (CI, clean IPs) should see PubChem work normally, so it keeps priority and yields canonical isomeric SMILES; CIR covers the gap where PubChem is blocked.

## Alternatives evaluated, not added

- **ChemSpider** — both the legacy `.asmx` endpoint and `api.rsc.org` now return 403; requires a registered RSC API key + secret management.
- **OpenMolecules name2structure** — `n2s.openmolecules.org` only returns a rendered PNG, with no SMILES/text output mode.

## Testing

- `pytest ord_schema/resolvers_test.py` — 17 passed, 2 skipped (the PubChem-dependent live smoke tests). Suite runtime dropped from ~9s to ~2s with the backoff gone.
- Added hermetic tests for `_cactus_resolve` (basic + multi-line first-line handling) and a live smoke test; replaced `TestPubChemRetry` with `TestPubChemResolve` asserting a 503 raises on the first attempt without retrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the NCI/CADD Chemical Identifier Resolver (CIR/cactus) as a middle-tier fallback between PubChem and OPSIN, and removes the `tenacity`-based exponential-backoff retry on PubChem 503s. The rationale is that on egress-blocked IPs every PubChem 503 is persistent, so the old 5-attempt retry was burning ~8s per name with no benefit; CIR provides fast coverage of the same name space (trade names, CAS numbers, abbreviations) in ~0.3s instead.

- **`resolvers.py`**: Removes `tenacity` import/decorator from `_pubchem_resolve`; adds `_cactus_resolve` using `https://cactus.nci.nih.gov/chemical/structure/{name}/smiles`; inserts it between PubChem and OPSIN in `_NAME_RESOLVERS`.
- **`resolvers_test.py`**: Replaces `TestPubChemRetry` with `TestPubChemResolve` (single-attempt assertion), adds hermetic and live `TestCactusResolve` tests, renames `_skip_if_pubchem_unavailable` → `_skip_if_resolver_unavailable` to reflect broader scope, and wraps the live CIR smoke test in try/except to skip on outage.
- **`pyproject.toml` / `uv.lock`**: Drops the `tenacity>=8.0.0,<10` dependency entirely.
</details>


<h3>Confidence Score: 5/5</h3>

The change is safe to merge: it adds a well-tested fallback resolver, removes a retry that was counterproductive on blocked IPs, and cleanly drops one dependency.

The resolver chain logic is straightforward, the CIR URL and first-line parsing are correct, the new tests cover both the hermetic and live paths, and the live smoke test properly skips on outage. No behavioural contracts are broken for callers.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/resolvers.py | Adds _cactus_resolve (CIR) as a middle fallback and drops tenacity retry from _pubchem_resolve; logic and URL construction are correct. |
| ord_schema/resolvers_test.py | New hermetic and live CIR tests added; live smoke test correctly skips on outage; helper renamed to reflect broader resolver scope. |
| pyproject.toml | Removes the tenacity dependency now that the retry decorator is gone. |
| uv.lock | Lock file updated to remove the tenacity package entry; consistent with pyproject.toml change. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolve_name called] --> B[Try PubChem REST API]
    B -- SMILES returned --> Z[Return SMILES + resolver name]
    B -- HTTPError 503 blocked IP --> C[Log at INFO, fall through]
    B -- HTTPError 404 unknown --> C
    C --> D[Try NCI/CADD CIR]
    D -- SMILES returned first line --> Z
    D -- HTTPError 500 unknown name --> E[Log at INFO, fall through]
    D -- HTTPError other --> E
    E --> F[Try OPSIN]
    F -- SMILES returned --> Z
    F -- HTTPError 404 not IUPAC --> G[Log at INFO, fall through]
    G --> H[Raise ValueError: Could not resolve]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[resolve_name called] --> B[Try PubChem REST API]
    B -- SMILES returned --> Z[Return SMILES + resolver name]
    B -- HTTPError 503 blocked IP --> C[Log at INFO, fall through]
    B -- HTTPError 404 unknown --> C
    C --> D[Try NCI/CADD CIR]
    D -- SMILES returned first line --> Z
    D -- HTTPError 500 unknown name --> E[Log at INFO, fall through]
    D -- HTTPError other --> E
    E --> F[Try OPSIN]
    F -- SMILES returned --> Z
    F -- HTTPError 404 not IUPAC --> G[Log at INFO, fall through]
    G --> H[Raise ValueError: Could not resolve]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `ord_schema/resolvers_test.py`, line 38-48 ([link](https://github.com/open-reaction-database/ord-schema/blob/7942cd5bb33f68623c97fc8c20552984d0d5c76b/ord_schema/resolvers_test.py#L38-L48)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Helper name and docstring now describe only part of what it detects**

   `_skip_if_pubchem_unavailable` triggers on `"HTTP Error 5"` in the log, which now also matches CIR 500 responses (CIR returns 500, not 404, for unknown names). With CIR in the resolver chain, this helper can skip a test because CIR had a hiccup — not because PubChem was busy — and the name, docstring, and skip message all say "PubChem unavailable." The behaviour is defensively correct (any 5xx from any resolver is a good skip reason), but a future reader will find the mismatch confusing. Renaming to `_skip_if_resolver_unavailable` and updating the docstring and skip reason would reflect the broader scope.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Rename \_skip\_if\_pubchem\_unavailable to r..."](https://github.com/open-reaction-database/ord-schema/commit/b7970fd87240d7474747891cc74d5a5deaf4cb7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40239359)</sub>

<!-- /greptile_comment -->