### PR TITLE
Reorganize ORM schemas: ord=index, public=payload, derived=computed

### DIFF
--- a/ord_schema/orm/README.md
+++ b/ord_schema/orm/README.md
@@ -77,14 +77,15 @@ table.
   fields of `Dataset` and `Reaction`, respectively. Notably, the `CompoundPreparation` and `CrudeComponent` messages
   refer to ORD reaction IDs (`reaction.reaction_id`, _not_ `reaction.id`); these are explicit ORD-level relationships
   that are not part of the database-specific relationship structure.
-* The ORM uses four schemas. `ord` holds the decomposed message tables — the search index. `public` holds the served
-  payload: `public.reactions` is the serialized `Reaction` proto keyed by `reaction_id`. `derived` holds best-effort
-  data computed from the search index — generated SMILES and RDKit links in
-  `derived.{reaction,compound,product_compound}_smiles`, reaction classes, and per-dataset `num_reactions` /
-  `submitted_at` in `derived.dataset_summary`. `rdkit` holds RDKit cartridge data (deduplicated mols/reactions and
-  fingerprints). `from_proto` writes only `ord.*` and `public.reactions`; `update_derived_tables` then computes the
-  `derived` SMILES by reconstructing each message from the search index, and the RDKit pass populates/links the
-  cartridge from those SMILES.
+* The ORM uses four schemas. `ord` holds the decomposed message tables — the search index, i.e. only the proto fields
+  plus the structural columns (`id`, the `ord_schema_context` discriminator, map `key`, and parent foreign keys).
+  `public` holds API-facing data: `public.reactions` is the serialized `Reaction` proto keyed by `reaction_id`, and
+  `public.datasets` holds per-dataset metadata (`md5` for change detection, `num_reactions` and `submitted_at` for
+  browsing) keyed by `dataset_id`. `derived` holds search helpers computed from the index — generated SMILES and RDKit
+  links in `derived.{reaction,compound,product_compound}_smiles`, plus reaction classes. `rdkit` holds RDKit cartridge
+  data (deduplicated mols/reactions and fingerprints). `from_proto` writes only `ord.*` and the `public` rows;
+  `update_derived_tables` then computes the `derived` SMILES by reconstructing each message from the search index, and
+  the RDKit pass populates/links the cartridge from those SMILES.
 * Partial indexes over not-yet-linked rows (`reaction_smiles_unlinked_index`, `compound_smiles_unlinked_index`, and
   `product_compound_smiles_unlinked_index`, on the `derived` SMILES tables) keep incremental RDKit linking fast. They
   index only the rows whose `rdkit_*_id` is still `NULL`, so the repeated "which of this dataset's rows still need

--- a/ord_schema/orm/README.md
+++ b/ord_schema/orm/README.md
@@ -77,13 +77,19 @@ table.
   fields of `Dataset` and `Reaction`, respectively. Notably, the `CompoundPreparation` and `CrudeComponent` messages
   refer to ORD reaction IDs (`reaction.reaction_id`, _not_ `reaction.id`); these are explicit ORD-level relationships
   that are not part of the database-specific relationship structure.
-* Data specific to the RDKit PostgreSQL cartridge, such as molecular fingerprints, is stored in a separate `rdkit`
-  schema to avoid conflicts with message-specific tables in the `public` (default) schema.
-* Partial indexes over not-yet-linked rows (`reaction_unlinked_index`, `compound_unlinked_index`, and
-  `product_compound_unlinked_index`, defined in `mappers.py`) keep incremental RDKit linking fast. They index only
-  the rows whose `rdkit_*_id` is still `NULL`, so the repeated "which of this dataset's rows still need linking?"
-  queries stay proportional to the in-flight backlog rather than the full table. `prepare_database` creates them on
-  new databases; see [Adding the partial indexes to an existing database](#adding-the-partial-indexes-to-an-existing-database)
+* The ORM uses four schemas. `ord` holds the decomposed message tables — the search index. `public` holds the served
+  payload: `public.reactions` is the serialized `Reaction` proto keyed by `reaction_id`. `derived` holds best-effort
+  data computed from the search index — generated SMILES and RDKit links in
+  `derived.{reaction,compound,product_compound}_smiles`, reaction classes, and per-dataset `num_reactions` /
+  `submitted_at` in `derived.dataset_summary`. `rdkit` holds RDKit cartridge data (deduplicated mols/reactions and
+  fingerprints). `from_proto` writes only `ord.*` and `public.reactions`; `update_derived_tables` then computes the
+  `derived` SMILES by reconstructing each message from the search index, and the RDKit pass populates/links the
+  cartridge from those SMILES.
+* Partial indexes over not-yet-linked rows (`reaction_smiles_unlinked_index`, `compound_smiles_unlinked_index`, and
+  `product_compound_smiles_unlinked_index`, on the `derived` SMILES tables) keep incremental RDKit linking fast. They
+  index only the rows whose `rdkit_*_id` is still `NULL`, so the repeated "which of this dataset's rows still need
+  linking?" queries stay proportional to the in-flight backlog rather than the full table. `prepare_database` creates
+  them on new databases; see [Adding the partial indexes to an existing database](#adding-the-partial-indexes-to-an-existing-database)
   to backfill them on an older one.
 
 ## Usage
@@ -139,12 +145,12 @@ already have them. A database created before these indexes were introduced shoul
 transaction block; `IF NOT EXISTS` makes the migration idempotent):
 
 ```sql
-CREATE INDEX CONCURRENTLY IF NOT EXISTS reaction_unlinked_index
-    ON ord.reaction (dataset_id) WHERE rdkit_reaction_id IS NULL;
-CREATE INDEX CONCURRENTLY IF NOT EXISTS compound_unlinked_index
-    ON ord.compound (reaction_input_id) WHERE rdkit_mol_id IS NULL;
-CREATE INDEX CONCURRENTLY IF NOT EXISTS product_compound_unlinked_index
-    ON ord.product_compound (reaction_outcome_id) WHERE rdkit_mol_id IS NULL;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS reaction_smiles_unlinked_index
+    ON derived.reaction_smiles (reaction_id) WHERE rdkit_reaction_id IS NULL;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS compound_smiles_unlinked_index
+    ON derived.compound_smiles (compound_id) WHERE rdkit_mol_id IS NULL;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS product_compound_smiles_unlinked_index
+    ON derived.product_compound_smiles (product_compound_id) WHERE rdkit_mol_id IS NULL;
 ```
 
 These definitions must stay in sync with the `Index(...)` declarations in `mappers.py`.

--- a/ord_schema/orm/README.md
+++ b/ord_schema/orm/README.md
@@ -147,14 +147,14 @@ transaction block; `IF NOT EXISTS` makes the migration idempotent):
 
 ```sql
 CREATE INDEX CONCURRENTLY IF NOT EXISTS reaction_smiles_unlinked_index
-    ON derived.reaction_smiles (reaction_id) WHERE rdkit_reaction_id IS NULL;
+    ON derived.reaction_smiles (reaction_smiles) WHERE rdkit_reaction_id IS NULL;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS compound_smiles_unlinked_index
-    ON derived.compound_smiles (compound_id) WHERE rdkit_mol_id IS NULL;
+    ON derived.compound_smiles (smiles) WHERE rdkit_mol_id IS NULL;
 CREATE INDEX CONCURRENTLY IF NOT EXISTS product_compound_smiles_unlinked_index
-    ON derived.product_compound_smiles (product_compound_id) WHERE rdkit_mol_id IS NULL;
+    ON derived.product_compound_smiles (smiles) WHERE rdkit_mol_id IS NULL;
 ```
 
-These definitions must stay in sync with the `Index(...)` declarations in `mappers.py`.
+These definitions must stay in sync with the `Index(...)` declarations in `derived_mappers.py`.
 
 ### Add data
 

--- a/ord_schema/orm/README.md
+++ b/ord_schema/orm/README.md
@@ -85,7 +85,11 @@ table.
   links in `derived.{reaction,compound,product_compound}_smiles`, plus reaction classes. `rdkit` holds RDKit cartridge
   data (deduplicated mols/reactions and fingerprints). `from_proto` writes only `ord.*` and the `public` rows;
   `update_derived_tables` then computes the `derived` SMILES by reconstructing each message from the search index, and
-  the RDKit pass populates/links the cartridge from those SMILES.
+  the RDKit pass populates/links the cartridge from those SMILES. The two layers store at different granularities on
+  purpose: `derived.*_smiles` is one row per reaction/compound (the SMILES string is cheap, and the per-id row is the
+  direct lookup into its RDKit object), while `rdkit.*` is deduplicated by SMILES because the parsed structures and
+  fingerprints are expensive to recompute and store — i.e. deduplicate where the payload is expensive, store per-entity
+  where it is cheap.
 * Partial indexes over not-yet-linked rows (`reaction_smiles_unlinked_index`, `compound_smiles_unlinked_index`, and
   `product_compound_smiles_unlinked_index`, on the `derived` SMILES tables) keep incremental RDKit linking fast. They
   index only the rows whose `rdkit_*_id` is still `NULL`, so the repeated "which of this dataset's rows still need

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -30,11 +30,11 @@ from ord_schema import message_helpers, parquet
 from ord_schema.logging import get_logger
 from ord_schema.orm.derived_mappers import (
     CompoundSmiles,
-    DatasetSummary,
     ProductCompoundSmiles,
     ReactionSmiles,
 )
 from ord_schema.orm.mappers import Base, Mappers, from_proto, to_proto
+from ord_schema.orm.public_mappers import DatasetMetadata
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 try:
@@ -208,10 +208,8 @@ def set_submitted_at(dataset_id: str, session: Session) -> None:
     ).scalar_one_or_none()
     session.execute(
         text(
-            "UPDATE derived.dataset_summary SET submitted_at = :submitted_at "
-            "FROM ord.dataset "
-            "WHERE derived.dataset_summary.dataset_id = ord.dataset.id "
-            "AND ord.dataset.dataset_id = :dataset_id"
+            "UPDATE public.datasets SET submitted_at = :submitted_at "
+            "WHERE dataset_id = :dataset_id"
         ),
         {
             "submitted_at": _parse_date(value) if value is not None else None,
@@ -228,9 +226,9 @@ def backfill_submission_times(session: Session) -> None:
     """
     dataset_ids = (
         session.execute(
-            select(Mappers.Dataset.dataset_id)
-            .join(DatasetSummary, DatasetSummary.dataset_id == Mappers.Dataset.id)
-            .where(DatasetSummary.submitted_at.is_(None))
+            select(DatasetMetadata.dataset_id).where(
+                DatasetMetadata.submitted_at.is_(None)
+            )
         )
         .scalars()
         .all()
@@ -280,7 +278,7 @@ def add_parquet_dataset(
         name=metadata.name,
         description=metadata.description,
         dataset_id=metadata.dataset_id,
-        md5=md5_hex,
+        metadata_row=DatasetMetadata(md5=md5_hex, num_reactions=num_reactions),
     )
     session.add(mapped_dataset)
     session.flush()
@@ -319,7 +317,7 @@ def add_parquet_dataset(
 def get_dataset_md5(dataset_id: str, session: Session) -> str | None:
     """Returns the MD5 hash of the current version of a dataset, if it exists in the database."""
     result = session.execute(
-        select(Mappers.Dataset.md5).where(Mappers.Dataset.dataset_id == dataset_id)
+        select(DatasetMetadata.md5).where(DatasetMetadata.dataset_id == dataset_id)
     )
     row = result.first()
     return row[0] if row else None
@@ -328,9 +326,9 @@ def get_dataset_md5(dataset_id: str, session: Session) -> str | None:
 def get_dataset_size(dataset_id: str, session: Session) -> int:
     """Returns the number of reactions in a dataset."""
     result = session.execute(
-        select(DatasetSummary.num_reactions)
-        .join(Mappers.Dataset, Mappers.Dataset.id == DatasetSummary.dataset_id)
-        .where(Mappers.Dataset.dataset_id == dataset_id)
+        select(DatasetMetadata.num_reactions).where(
+            DatasetMetadata.dataset_id == dataset_id
+        )
     )
     row = result.first()
     if row is None:
@@ -370,24 +368,8 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
         text("SELECT id FROM ord.dataset WHERE dataset_id = :dataset_id"),
         {"dataset_id": dataset_id},
     ).scalar_one()
-    # Dataset summary; submitted_at is filled separately by set_submitted_at().
-    if session.get(DatasetSummary, dataset_pk) is None:
-        # Mirror the original len(reactions) or len(reaction_ids): id-only datasets have
-        # no reaction rows but carry reaction_ids.
-        num_reactions = (
-            session.execute(
-                text("SELECT count(*) FROM ord.reaction WHERE dataset_id = :id"),
-                {"id": dataset_pk},
-            ).scalar_one()
-            or session.execute(
-                text(
-                    "SELECT coalesce(array_length(reaction_ids, 1), 0) "
-                    "FROM ord.dataset WHERE id = :id"
-                ),
-                {"id": dataset_pk},
-            ).scalar_one()
-        )
-        session.add(DatasetSummary(dataset_id=dataset_pk, num_reactions=num_reactions))
+    # public.datasets (md5) and derived.dataset_summary (num_reactions) are populated at
+    # ingest; this pass only fills the per-reaction/compound SMILES.
     # Reaction SMILES (generated from the whole reaction; CXSMILES handled by split()).
     reaction_ids = session.execute(
         text("""

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -28,11 +28,6 @@ from sqlalchemy.orm import Session
 
 from ord_schema import message_helpers, parquet
 from ord_schema.logging import get_logger
-from ord_schema.orm.derived_mappers import (
-    CompoundSmiles,
-    ProductCompoundSmiles,
-    ReactionSmiles,
-)
 from ord_schema.orm.mappers import Base, Mappers, from_proto, to_proto
 from ord_schema.orm.public_mappers import DatasetMetadata
 from ord_schema.proto import dataset_pb2, reaction_pb2
@@ -349,25 +344,26 @@ def delete_dataset(dataset_id: str, session: Session) -> None:
 def update_derived_tables(dataset_id: str, session: Session) -> None:
     """Populates the derived SMILES tables from the search index.
 
-    Reconstructs each reaction/compound from ord.* via to_proto and reuses the proto SMILES
-    helpers, so derived data stays decoupled from ingest. Idempotent (skips rows that
-    already have a derived entry); runs before the RDKit pass, which reads the SMILES.
-    Rebuilding every message is the cost of that decoupling -- batch or read identifiers via
-    SQL if it becomes a bottleneck.
+    Reaction SMILES come from the ground-truth proto in public.reactions; compound SMILES
+    from each ord.compound row's reconstructed message. Idempotent (skips rows that already
+    have a derived entry); runs before the RDKit pass, which reads the SMILES. Rows are
+    streamed and inserted in bulk so the session does not grow with the dataset.
     """
     logger.debug(f"Updating derived tables for {dataset_id=}")
     start = time.time()
     # dataset_id and the compound link columns live on the polymorphic child mappers, so
-    # rows are selected by id via raw SQL and loaded with session.get (like the RDKit pass).
+    # rows are scoped to the dataset via raw SQL (like the RDKit pass).
     dataset_pk = session.execute(
         text("SELECT id FROM ord.dataset WHERE dataset_id = :dataset_id"),
         {"dataset_id": dataset_id},
     ).scalar_one()
-    # Reaction SMILES (generated from the whole reaction; CXSMILES handled by split()).
-    reaction_ids = session.execute(
+    # Reaction SMILES from the served proto (no ORM objects loaded); keyed by ord.reaction.id.
+    rows = session.execute(
         text("""
-            SELECT ord.reaction.id
+            SELECT ord.reaction.id, public.reactions.proto
             FROM ord.reaction
+            JOIN public.reactions
+                ON public.reactions.reaction_id = ord.reaction.reaction_id
             WHERE ord.reaction.dataset_id = :id
               AND NOT EXISTS (
                   SELECT 1 FROM derived.reaction_smiles
@@ -375,13 +371,12 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
               )
             """),
         {"id": dataset_pk},
-    ).scalars()
-    for reaction_id in reaction_ids:
-        reaction = session.get(Mappers.Reaction, reaction_id)
-        assert reaction is not None  # Selected by id above.
+    )
+    inserts = []
+    for reaction_id, proto in rows:
         try:
             reaction_smiles = message_helpers.get_reaction_smiles(
-                cast(reaction_pb2.Reaction, to_proto(reaction)),
+                reaction_pb2.Reaction.FromString(proto),
                 generate_if_missing=True,
                 allow_incomplete=False,
                 validate=True,
@@ -389,14 +384,17 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
         except ValueError as error:
             logger.debug(f"No reaction SMILES for reaction id={reaction_id}: {error}")
             continue
-        if reaction_smiles is None:
-            continue
-        session.add(
-            ReactionSmiles(
-                reaction_id=reaction_id, reaction_smiles=reaction_smiles.split()[0]
-            )
+        tokens = reaction_smiles.split() if reaction_smiles else []  # Handle CXSMILES.
+        if tokens:
+            inserts.append({"reaction_id": reaction_id, "reaction_smiles": tokens[0]})
+    if inserts:
+        session.execute(
+            text(
+                "INSERT INTO derived.reaction_smiles (reaction_id, reaction_smiles) "
+                "VALUES (:reaction_id, :reaction_smiles)"
+            ),
+            inserts,
         )
-    # Compound / ProductCompound SMILES, keyed per decomposed compound row.
     _update_compound_smiles(
         session,
         dataset_pk=dataset_pk,
@@ -406,7 +404,6 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
         compound_class=Mappers.Compound,
         derived_table="derived.compound_smiles",
         derived_id="compound_id",
-        derived_class=CompoundSmiles,
     )
     _update_compound_smiles(
         session,
@@ -417,7 +414,6 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
         compound_class=Mappers.ProductCompound,
         derived_table="derived.product_compound_smiles",
         derived_id="product_compound_id",
-        derived_class=ProductCompoundSmiles,
     )
     logger.debug(f"Updating derived tables took {time.time() - start:g}s")
 
@@ -432,9 +428,13 @@ def _update_compound_smiles(
     compound_class: Any,
     derived_table: str,
     derived_id: str,
-    derived_class: Any,
 ) -> None:
-    """Derives SMILES for one (product) compound table's not-yet-derived rows."""
+    """Derives SMILES for one (product) compound table's not-yet-derived rows.
+
+    Compounds aren't stored as protos, so each is reconstructed from its identifiers via
+    to_proto; rows load one at a time (SQLAlchemy's weak identity map releases each after
+    use) and SMILES are inserted in bulk.
+    """
     compound_ids = session.execute(
         text(f"""
             SELECT {compound_table}.id
@@ -449,16 +449,29 @@ def _update_compound_smiles(
             """),  # noqa: S608  (table/column names are internal constants, not user input)
         {"id": dataset_pk},
     ).scalars()
+    inserts = []
     for compound_id in compound_ids:
         compound = session.get(compound_class, compound_id)
         assert compound is not None  # Selected by id above.
         try:
             smiles = message_helpers.smiles_from_compound(
-                cast(reaction_pb2.Compound, to_proto(compound))
+                cast(
+                    "reaction_pb2.Compound | reaction_pb2.ProductCompound",
+                    to_proto(compound),
+                )
             )
         except ValueError:
             continue
-        session.add(derived_class(**{derived_id: compound_id, "smiles": smiles}))
+        inserts.append({derived_id: compound_id, "smiles": smiles})
+    if inserts:
+        # The interpolated names are internal constants (not user input); see S608 below.
+        session.execute(
+            text(
+                f"INSERT INTO {derived_table} ({derived_id}, smiles) "  # noqa: S608
+                f"VALUES (:{derived_id}, :smiles)"
+            ),
+            inserts,
+        )
 
 
 def update_rdkit_tables(dataset_id: str, session: Session) -> None:

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -26,10 +26,16 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NotSupportedError, OperationalError
 from sqlalchemy.orm import Session
 
-from ord_schema import parquet
+from ord_schema import message_helpers, parquet
 from ord_schema.logging import get_logger
-from ord_schema.orm.mappers import Base, Mappers, from_proto
-from ord_schema.proto import dataset_pb2
+from ord_schema.orm.derived_mappers import (
+    CompoundSmiles,
+    DatasetSummary,
+    ProductCompoundSmiles,
+    ReactionSmiles,
+)
+from ord_schema.orm.mappers import Base, Mappers, from_proto, to_proto
+from ord_schema.proto import dataset_pb2, reaction_pb2
 
 try:
     from ord_schema.orm.reaction_class import update_reaction_classes
@@ -129,6 +135,8 @@ def add_dataset(
     mapped_dataset = from_proto(dataset)
     logger.debug(f"from_proto() took {time.time() - start:g}s")
     session.add(mapped_dataset)
+    session.flush()
+    update_derived_tables(dataset.dataset_id, session)
     if rdkit_cartridge:
         session.flush()
         update_rdkit_tables(dataset.dataset_id, session)
@@ -200,8 +208,10 @@ def set_submitted_at(dataset_id: str, session: Session) -> None:
     ).scalar_one_or_none()
     session.execute(
         text(
-            "UPDATE ord.dataset SET submitted_at = :submitted_at "
-            "WHERE dataset_id = :dataset_id"
+            "UPDATE derived.dataset_summary SET submitted_at = :submitted_at "
+            "FROM ord.dataset "
+            "WHERE derived.dataset_summary.dataset_id = ord.dataset.id "
+            "AND ord.dataset.dataset_id = :dataset_id"
         ),
         {
             "submitted_at": _parse_date(value) if value is not None else None,
@@ -218,9 +228,9 @@ def backfill_submission_times(session: Session) -> None:
     """
     dataset_ids = (
         session.execute(
-            select(Mappers.Dataset.dataset_id).where(
-                Mappers.Dataset.submitted_at.is_(None)
-            )
+            select(Mappers.Dataset.dataset_id)
+            .join(DatasetSummary, DatasetSummary.dataset_id == Mappers.Dataset.id)
+            .where(DatasetSummary.submitted_at.is_(None))
         )
         .scalars()
         .all()
@@ -271,7 +281,6 @@ def add_parquet_dataset(
         description=metadata.description,
         dataset_id=metadata.dataset_id,
         md5=md5_hex,
-        num_reactions=num_reactions,
     )
     session.add(mapped_dataset)
     session.flush()
@@ -296,6 +305,7 @@ def add_parquet_dataset(
     logger.debug(
         f"add_parquet_dataset() took {time.time() - start:g}s ({num_reactions} reactions)"
     )
+    update_derived_tables(metadata.dataset_id, session)
     if rdkit_cartridge:
         update_rdkit_tables(metadata.dataset_id, session)
         session.flush()
@@ -318,9 +328,9 @@ def get_dataset_md5(dataset_id: str, session: Session) -> str | None:
 def get_dataset_size(dataset_id: str, session: Session) -> int:
     """Returns the number of reactions in a dataset."""
     result = session.execute(
-        select(Mappers.Dataset.num_reactions).where(
-            Mappers.Dataset.dataset_id == dataset_id
-        )
+        select(DatasetSummary.num_reactions)
+        .join(Mappers.Dataset, Mappers.Dataset.id == DatasetSummary.dataset_id)
+        .where(Mappers.Dataset.dataset_id == dataset_id)
     )
     row = result.first()
     if row is None:
@@ -336,6 +346,144 @@ def delete_dataset(dataset_id: str, session: Session) -> None:
         delete(Mappers.Dataset).where(Mappers.Dataset.dataset_id == dataset_id)
     )
     logger.debug(f"delete took {time.time() - start}s")
+
+
+def update_derived_tables(dataset_id: str, session: Session) -> None:
+    """Populates the derived SMILES and summary tables from the search index.
+
+    Reconstructs each reaction/compound from ord.* via to_proto and reuses the proto
+    SMILES helpers, keeping derived values decoupled from ingest (from_proto only writes
+    ord.* and public.reactions). Idempotent: only rows without a derived entry are
+    processed. Must run before the RDKit pass, which reads derived.reaction_smiles and
+    derived.*_smiles.
+
+    Note: this rebuilds each message (reaction and compound) from the relational tables,
+    so it trades ingest-time coupling for reconstruction cost; batching/SQL identifier
+    reads could speed it up if it becomes a bottleneck.
+    """
+    logger.debug(f"Updating derived tables for {dataset_id=}")
+    start = time.time()
+    # ord.reaction.dataset_id and the compound link columns live on the polymorphic child
+    # mappers (single-table inheritance), so rows are selected by id via raw SQL and loaded
+    # with session.get for to_proto, mirroring the RDKit pass's raw-SQL scoping.
+    dataset_pk = session.execute(
+        text("SELECT id FROM ord.dataset WHERE dataset_id = :dataset_id"),
+        {"dataset_id": dataset_id},
+    ).scalar_one()
+    # Dataset summary; submitted_at is filled separately by set_submitted_at().
+    if session.get(DatasetSummary, dataset_pk) is None:
+        # Mirror the original len(reactions) or len(reaction_ids): id-only datasets have
+        # no reaction rows but carry reaction_ids.
+        num_reactions = (
+            session.execute(
+                text("SELECT count(*) FROM ord.reaction WHERE dataset_id = :id"),
+                {"id": dataset_pk},
+            ).scalar_one()
+            or session.execute(
+                text(
+                    "SELECT coalesce(array_length(reaction_ids, 1), 0) "
+                    "FROM ord.dataset WHERE id = :id"
+                ),
+                {"id": dataset_pk},
+            ).scalar_one()
+        )
+        session.add(DatasetSummary(dataset_id=dataset_pk, num_reactions=num_reactions))
+    # Reaction SMILES (generated from the whole reaction; CXSMILES handled by split()).
+    reaction_ids = session.execute(
+        text("""
+            SELECT ord.reaction.id
+            FROM ord.reaction
+            WHERE ord.reaction.dataset_id = :id
+              AND NOT EXISTS (
+                  SELECT 1 FROM derived.reaction_smiles
+                  WHERE derived.reaction_smiles.reaction_id = ord.reaction.id
+              )
+            """),
+        {"id": dataset_pk},
+    ).scalars()
+    for reaction_id in reaction_ids:
+        reaction = session.get(Mappers.Reaction, reaction_id)
+        assert reaction is not None  # Selected by id above.
+        try:
+            reaction_smiles = message_helpers.get_reaction_smiles(
+                cast(reaction_pb2.Reaction, to_proto(reaction)),
+                generate_if_missing=True,
+                allow_incomplete=False,
+                validate=True,
+            )
+        except ValueError as error:
+            logger.debug(f"No reaction SMILES for reaction id={reaction_id}: {error}")
+            continue
+        if reaction_smiles is None:
+            continue
+        session.add(
+            ReactionSmiles(
+                reaction_id=reaction_id, reaction_smiles=reaction_smiles.split()[0]
+            )
+        )
+    # Compound / ProductCompound SMILES, keyed per decomposed compound row.
+    _update_compound_smiles(
+        session,
+        dataset_pk=dataset_pk,
+        compound_table="ord.compound",
+        link_table="ord.reaction_input",
+        link_column="reaction_input_id",
+        compound_class=Mappers.Compound,
+        derived_table="derived.compound_smiles",
+        derived_id="compound_id",
+        derived_class=CompoundSmiles,
+    )
+    _update_compound_smiles(
+        session,
+        dataset_pk=dataset_pk,
+        compound_table="ord.product_compound",
+        link_table="ord.reaction_outcome",
+        link_column="reaction_outcome_id",
+        compound_class=Mappers.ProductCompound,
+        derived_table="derived.product_compound_smiles",
+        derived_id="product_compound_id",
+        derived_class=ProductCompoundSmiles,
+    )
+    logger.debug(f"Updating derived tables took {time.time() - start:g}s")
+
+
+def _update_compound_smiles(
+    session: Session,
+    *,
+    dataset_pk: int,
+    compound_table: str,
+    link_table: str,
+    link_column: str,
+    compound_class: Any,
+    derived_table: str,
+    derived_id: str,
+    derived_class: Any,
+) -> None:
+    """Derives SMILES for one (product) compound table's not-yet-derived rows."""
+    compound_ids = session.execute(
+        text(f"""
+            SELECT {compound_table}.id
+            FROM {compound_table}
+            JOIN {link_table} ON {compound_table}.{link_column} = {link_table}.id
+            JOIN ord.reaction ON {link_table}.reaction_id = ord.reaction.id
+            WHERE ord.reaction.dataset_id = :id
+              AND NOT EXISTS (
+                  SELECT 1 FROM {derived_table}
+                  WHERE {derived_table}.{derived_id} = {compound_table}.id
+              )
+            """),  # noqa: S608  (table/column names are internal constants, not user input)
+        {"id": dataset_pk},
+    ).scalars()
+    for compound_id in compound_ids:
+        compound = session.get(compound_class, compound_id)
+        assert compound is not None  # Selected by id above.
+        try:
+            smiles = message_helpers.smiles_from_compound(
+                cast(reaction_pb2.Compound, to_proto(compound))
+            )
+        except ValueError:
+            continue
+        session.add(derived_class(**{derived_id: compound_id, "smiles": smiles}))
 
 
 def update_rdkit_tables(dataset_id: str, session: Session) -> None:
@@ -363,15 +511,16 @@ def _update_rdkit_reactions(dataset_id: str, session: Session) -> None:
                     -- reaction_smiles IS NOT NULL is required: unlike EXCEPT (which treats NULLs as equal),
                     -- NOT EXISTS never matches a NULL, so without it a no-SMILES reaction would re-insert a junk
                     -- (NULL, NULL) row on every run.
-                    SELECT DISTINCT reaction_smiles
-                        FROM ord.reaction
+                    SELECT DISTINCT derived.reaction_smiles.reaction_smiles
+                        FROM derived.reaction_smiles
+                        JOIN ord.reaction ON ord.reaction.id = derived.reaction_smiles.reaction_id
                         JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
                         WHERE ord.dataset.dataset_id = :dataset_id
-                          AND ord.reaction.rdkit_reaction_id IS NULL
-                          AND ord.reaction.reaction_smiles IS NOT NULL
+                          AND derived.reaction_smiles.rdkit_reaction_id IS NULL
+                          AND derived.reaction_smiles.reaction_smiles IS NOT NULL
                           AND NOT EXISTS (
                               SELECT 1 FROM rdkit.reactions
-                              WHERE rdkit.reactions.reaction_smiles = ord.reaction.reaction_smiles
+                              WHERE rdkit.reactions.reaction_smiles = derived.reaction_smiles.reaction_smiles
                           )
                 ) candidates
             ) computed
@@ -402,24 +551,27 @@ def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
                 -- to materialize for this same reason.
                 SELECT smiles
                 FROM (
-                    SELECT smiles
+                    SELECT derived.compound_smiles.smiles
                         -- NOTE(skearnes): This join path does not include non-input compounds like workups,
                         -- internal standards, etc.
-                        FROM ord.compound
+                        FROM derived.compound_smiles
+                        JOIN ord.compound ON ord.compound.id = derived.compound_smiles.compound_id
                         JOIN ord.reaction_input ON ord.compound.reaction_input_id = ord.reaction_input.id
                         JOIN ord.reaction ON ord.reaction_input.reaction_id = ord.reaction.id
                         JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
                         WHERE ord.dataset.dataset_id = :dataset_id
-                          AND ord.compound.rdkit_mol_id IS NULL
+                          AND derived.compound_smiles.rdkit_mol_id IS NULL
                     UNION
-                    SELECT smiles
-                        FROM ord.product_compound
+                    SELECT derived.product_compound_smiles.smiles
+                        FROM derived.product_compound_smiles
+                        JOIN ord.product_compound
+                            ON ord.product_compound.id = derived.product_compound_smiles.product_compound_id
                         JOIN ord.reaction_outcome
                             ON ord.product_compound.reaction_outcome_id = ord.reaction_outcome.id
                         JOIN ord.reaction ON ord.reaction_outcome.reaction_id = ord.reaction.id
                         JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
                         WHERE ord.dataset.dataset_id = :dataset_id
-                          AND ord.product_compound.rdkit_mol_id IS NULL
+                          AND derived.product_compound_smiles.rdkit_mol_id IS NULL
                 ) candidates
                 WHERE smiles NOT LIKE '%[Ti+5]%'  -- See https://github.com/open-reaction-database/ord-schema/issues/672.
                   AND NOT EXISTS (SELECT 1 FROM rdkit.mols WHERE rdkit.mols.smiles = candidates.smiles)
@@ -444,24 +596,30 @@ def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
 def _link_mol_ids(
     session: Session,
     *,
-    target_table: str,
+    derived_table: str,
+    derived_id_column: str,
+    compound_table: str,
     link_table: str,
     link_column: str,
     dataset_id: str,
 ) -> int:
-    """Links rdkit.mols ids into a compound table for one dataset's unlinked rows.
+    """Links rdkit.mols ids into a derived compound-SMILES table for one dataset.
 
-    The Compound and ProductCompound updates are identical apart from the table
+    The Compound and ProductCompound updates are identical apart from the tables
     and join path, so they share this helper. Identifier arguments are trusted
     literals supplied by ``update_rdkit_ids`` (never user input) and are
     interpolated into the statement; ``dataset_id`` is passed as a bind param.
 
     Args:
         session: Active SQLAlchemy session.
-        target_table: Compound table to update (e.g. ``"ord.compound"``).
-        link_table: Join table connecting ``target_table`` to ``ord.reaction``
+        derived_table: Derived table to update (e.g. ``"derived.compound_smiles"``).
+        derived_id_column: ``derived_table`` foreign key to ``compound_table.id``
+            (e.g. ``"compound_id"``).
+        compound_table: ORD compound table (e.g. ``"ord.compound"``), joined to
+            reach the dataset via ``link_table``.
+        link_table: Join table connecting ``compound_table`` to ``ord.reaction``
             (e.g. ``"ord.reaction_input"``).
-        link_column: Foreign-key column on ``target_table`` that references
+        link_column: Foreign-key column on ``compound_table`` that references
             ``link_table`` (e.g. ``"reaction_input_id"``).
         dataset_id: Dataset to scope the update to.
 
@@ -470,15 +628,16 @@ def _link_mol_ids(
     """
     result = session.execute(
         text(f"""
-            UPDATE {target_table}
+            UPDATE {derived_table}
             SET rdkit_mol_id = rdkit.mols.id
-            FROM rdkit.mols, {link_table}, ord.reaction, ord.dataset
-            WHERE rdkit.mols.smiles = {target_table}.smiles
-              AND {target_table}.{link_column} = {link_table}.id
+            FROM rdkit.mols, {compound_table}, {link_table}, ord.reaction, ord.dataset
+            WHERE rdkit.mols.smiles = {derived_table}.smiles
+              AND {derived_table}.{derived_id_column} = {compound_table}.id
+              AND {compound_table}.{link_column} = {link_table}.id
               AND {link_table}.reaction_id = ord.reaction.id
               AND ord.reaction.dataset_id = ord.dataset.id
               AND ord.dataset.dataset_id = :dataset_id
-              AND {target_table}.rdkit_mol_id IS NULL
+              AND {derived_table}.rdkit_mol_id IS NULL
             """),  # noqa: S608  (table/column names are internal constants, not user input)
         {"dataset_id": dataset_id},
     )
@@ -493,30 +652,35 @@ def update_rdkit_ids(dataset_id: str, session: Session) -> None:
     # ``FROM (SELECT id, rdkit_id ...) WHERE target.id = subquery.id``, which materialized the pairs and then
     # re-joined the target by id. The rdkit join keys (reaction_smiles/smiles) are unique-indexed, and the
     # dataset scope is reached via the indexed foreign keys.
-    # Update Reaction.
+    # Update derived.reaction_smiles (reaction_smiles and rdkit_reaction_id live there).
     reaction_result = session.execute(
         text("""
-            UPDATE ord.reaction
+            UPDATE derived.reaction_smiles
             SET rdkit_reaction_id = rdkit.reactions.id
-            FROM rdkit.reactions, ord.dataset
-            WHERE rdkit.reactions.reaction_smiles = ord.reaction.reaction_smiles
+            FROM rdkit.reactions, ord.reaction, ord.dataset
+            WHERE rdkit.reactions.reaction_smiles = derived.reaction_smiles.reaction_smiles
+              AND derived.reaction_smiles.reaction_id = ord.reaction.id
               AND ord.reaction.dataset_id = ord.dataset.id
               AND ord.dataset.dataset_id = :dataset_id
-              AND ord.reaction.rdkit_reaction_id IS NULL
+              AND derived.reaction_smiles.rdkit_reaction_id IS NULL
             """),
         {"dataset_id": dataset_id},
     )
     reaction_rows = cast(Any, reaction_result).rowcount
     compound_rows = _link_mol_ids(
         session,
-        target_table="ord.compound",
+        derived_table="derived.compound_smiles",
+        derived_id_column="compound_id",
+        compound_table="ord.compound",
         link_table="ord.reaction_input",
         link_column="reaction_input_id",
         dataset_id=dataset_id,
     )
     product_compound_rows = _link_mol_ids(
         session,
-        target_table="ord.product_compound",
+        derived_table="derived.product_compound_smiles",
+        derived_id_column="product_compound_id",
+        compound_table="ord.product_compound",
         link_table="ord.reaction_outcome",
         link_column="reaction_outcome_id",
         dataset_id=dataset_id,

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -347,29 +347,22 @@ def delete_dataset(dataset_id: str, session: Session) -> None:
 
 
 def update_derived_tables(dataset_id: str, session: Session) -> None:
-    """Populates the derived SMILES and summary tables from the search index.
+    """Populates the derived SMILES tables from the search index.
 
-    Reconstructs each reaction/compound from ord.* via to_proto and reuses the proto
-    SMILES helpers, keeping derived values decoupled from ingest (from_proto only writes
-    ord.* and public.reactions). Idempotent: only rows without a derived entry are
-    processed. Must run before the RDKit pass, which reads derived.reaction_smiles and
-    derived.*_smiles.
-
-    Note: this rebuilds each message (reaction and compound) from the relational tables,
-    so it trades ingest-time coupling for reconstruction cost; batching/SQL identifier
-    reads could speed it up if it becomes a bottleneck.
+    Reconstructs each reaction/compound from ord.* via to_proto and reuses the proto SMILES
+    helpers, so derived data stays decoupled from ingest. Idempotent (skips rows that
+    already have a derived entry); runs before the RDKit pass, which reads the SMILES.
+    Rebuilding every message is the cost of that decoupling -- batch or read identifiers via
+    SQL if it becomes a bottleneck.
     """
     logger.debug(f"Updating derived tables for {dataset_id=}")
     start = time.time()
-    # ord.reaction.dataset_id and the compound link columns live on the polymorphic child
-    # mappers (single-table inheritance), so rows are selected by id via raw SQL and loaded
-    # with session.get for to_proto, mirroring the RDKit pass's raw-SQL scoping.
+    # dataset_id and the compound link columns live on the polymorphic child mappers, so
+    # rows are selected by id via raw SQL and loaded with session.get (like the RDKit pass).
     dataset_pk = session.execute(
         text("SELECT id FROM ord.dataset WHERE dataset_id = :dataset_id"),
         {"dataset_id": dataset_id},
     ).scalar_one()
-    # public.datasets (md5) and derived.dataset_summary (num_reactions) are populated at
-    # ingest; this pass only fills the per-reaction/compound SMILES.
     # Reaction SMILES (generated from the whole reaction; CXSMILES handled by split()).
     reaction_ids = session.execute(
         text("""

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -26,8 +26,8 @@ from ord_schema.orm.database import (
     get_dataset_size,
     update_rdkit_tables,
 )
-from ord_schema.orm.derived_mappers import DatasetSummary
 from ord_schema.orm.mappers import Mappers
+from ord_schema.orm.public_mappers import DatasetMetadata
 from ord_schema.proto import reaction_pb2
 
 
@@ -133,15 +133,15 @@ def test_submitted_at(test_session):
     # entry; the fixture's reactions were modified on 2021-02-25 and created on
     # 2020-11-28, so record_modified must win.
     submitted_at = test_session.execute(
-        select(DatasetSummary.submitted_at)
+        select(DatasetMetadata.submitted_at)
     ).scalar_one()
     assert submitted_at == datetime.date(2021, 2, 25)
 
 
 def test_backfill_submission_times(test_session):
-    test_session.execute(text("UPDATE derived.dataset_summary SET submitted_at = NULL"))
+    test_session.execute(text("UPDATE public.datasets SET submitted_at = NULL"))
     backfill_submission_times(test_session)
     submitted_at = test_session.execute(
-        select(DatasetSummary.submitted_at)
+        select(DatasetMetadata.submitted_at)
     ).scalar_one()
     assert submitted_at is not None

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -26,6 +26,7 @@ from ord_schema.orm.database import (
     get_dataset_size,
     update_rdkit_tables,
 )
+from ord_schema.orm.derived_mappers import DatasetSummary
 from ord_schema.orm.mappers import Mappers
 from ord_schema.proto import reaction_pb2
 
@@ -43,7 +44,8 @@ def test_orm(test_session):
     )
     results = test_session.execute(query)
     reactions = [
-        reaction_pb2.Reaction.FromString(result[0].proto) for result in results
+        reaction_pb2.Reaction.FromString(result[0].proto_row.proto)
+        for result in results
     ]
     assert len(reactions) == 12
 
@@ -95,13 +97,16 @@ def test_unlinked_partial_indexes(test_session):
     """prepare_database creates partial indexes over unlinked rows to keep incremental linking cheap."""
     indexes = dict(
         test_session.execute(
-            text("SELECT indexname, indexdef FROM pg_indexes WHERE schemaname = 'ord'")
+            text(
+                "SELECT indexname, indexdef FROM pg_indexes "
+                "WHERE schemaname IN ('ord', 'derived')"
+            )
         ).all()
     )
     for name, predicate in (
-        ("reaction_unlinked_index", "rdkit_reaction_id IS NULL"),
-        ("compound_unlinked_index", "rdkit_mol_id IS NULL"),
-        ("product_compound_unlinked_index", "rdkit_mol_id IS NULL"),
+        ("reaction_smiles_unlinked_index", "rdkit_reaction_id IS NULL"),
+        ("compound_smiles_unlinked_index", "rdkit_mol_id IS NULL"),
+        ("product_compound_smiles_unlinked_index", "rdkit_mol_id IS NULL"),
     ):
         assert name in indexes, f"missing index {name}"
         assert predicate in indexes[name], (
@@ -128,15 +133,15 @@ def test_submitted_at(test_session):
     # entry; the fixture's reactions were modified on 2021-02-25 and created on
     # 2020-11-28, so record_modified must win.
     submitted_at = test_session.execute(
-        select(Mappers.Dataset.submitted_at)
+        select(DatasetSummary.submitted_at)
     ).scalar_one()
     assert submitted_at == datetime.date(2021, 2, 25)
 
 
 def test_backfill_submission_times(test_session):
-    test_session.execute(text("UPDATE ord.dataset SET submitted_at = NULL"))
+    test_session.execute(text("UPDATE derived.dataset_summary SET submitted_at = NULL"))
     backfill_submission_times(test_session)
     submitted_at = test_session.execute(
-        select(Mappers.Dataset.submitted_at)
+        select(DatasetSummary.submitted_at)
     ).scalar_one()
     assert submitted_at is not None

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -24,6 +24,7 @@ from ord_schema.orm.database import (
     delete_dataset,
     get_dataset_md5,
     get_dataset_size,
+    update_derived_tables,
     update_rdkit_tables,
 )
 from ord_schema.orm.mappers import Mappers
@@ -91,6 +92,26 @@ def test_update_rdkit_tables_idempotent(test_session):
         ).scalar()
         == 0
     )
+
+
+def test_update_derived_tables_idempotent(test_session):
+    """Re-running update_derived_tables inserts no duplicate derived rows (NOT EXISTS guard)."""
+    tables = ("reaction_smiles", "compound_smiles", "product_compound_smiles")
+    before = {
+        table: test_session.execute(
+            text(f"SELECT count(*) FROM derived.{table}")  # noqa: S608  (constant)
+        ).scalar()
+        for table in tables
+    }
+    assert before["reaction_smiles"] > 0
+    update_derived_tables("test_dataset", test_session)
+    for table, count in before.items():
+        assert (
+            test_session.execute(
+                text(f"SELECT count(*) FROM derived.{table}")  # noqa: S608  (constant)
+            ).scalar()
+            == count
+        )
 
 
 def test_unlinked_partial_indexes(test_session):

--- a/ord_schema/orm/derived_mappers.py
+++ b/ord_schema/orm/derived_mappers.py
@@ -18,9 +18,114 @@ These live in a separate "derived" schema to keep the proto-mirroring "ord" sche
 canonical. Populated by post-passes (not from_proto); the ORM works without them.
 """
 
-from sqlalchemy import Column, ForeignKey, Integer, Text
+from sqlalchemy import Column, Date, ForeignKey, Index, Integer, Text, text
+from sqlalchemy.orm import relationship
 
 from ord_schema.orm import Base
+
+
+class DatasetSummary(Base):
+    """Denormalized, cheap-to-browse dataset fields derived from its reactions.
+
+    One row per ord.dataset. num_reactions is the reaction count; submitted_at is an
+    arbitrary reaction's latest record-event date (set by database.set_submitted_at),
+    used to browse datasets by recency without scanning reaction provenance.
+    """
+
+    __tablename__ = "dataset_summary"
+    dataset_id = Column(
+        Integer, ForeignKey("ord.dataset.id", ondelete="CASCADE"), primary_key=True
+    )
+    num_reactions = Column(Integer, nullable=False)
+    submitted_at = Column(Date, index=True)
+
+    __table_args__ = ({"schema": "derived"},)
+
+
+class ReactionSmiles(Base):
+    """Generated reaction SMILES and its link to the deduplicated RDKit reaction.
+
+    One row per reaction: reaction_smiles is generated from the proto at import,
+    rdkit_reaction_id is set during the RDKit linking pass. rdkit.reactions stays
+    deduplicated by SMILES, so this is the per-reaction pointer into it.
+    """
+
+    __tablename__ = "reaction_smiles"
+    # Integer FK to ord.reaction.id, per the ORM's reaction FK convention (see mappers).
+    reaction_id = Column(
+        Integer, ForeignKey("ord.reaction.id", ondelete="CASCADE"), primary_key=True
+    )
+    reaction_smiles = Column(Text, index=True)
+    rdkit_reaction_id = Column(
+        Integer, ForeignKey("rdkit.reactions.id", ondelete="CASCADE"), index=True
+    )
+    rdkit_reaction = relationship("RDKitReactions")
+
+    __table_args__ = (
+        # Partial index over not-yet-linked rows keeps the RDKit linking pass O(unlinked);
+        # moved here with rdkit_reaction_id (see ord_schema/orm/README.md).
+        Index(
+            "reaction_smiles_unlinked_index",
+            "reaction_id",
+            postgresql_where=text("rdkit_reaction_id IS NULL"),
+        ),
+        {"schema": "derived"},
+    )
+
+
+class CompoundSmiles(Base):
+    """Generated compound SMILES and its link to the deduplicated RDKit mol.
+
+    One row per ord.compound: smiles is generated from the proto at import,
+    rdkit_mol_id is set during the RDKit linking pass.
+    """
+
+    __tablename__ = "compound_smiles"
+    compound_id = Column(
+        Integer, ForeignKey("ord.compound.id", ondelete="CASCADE"), primary_key=True
+    )
+    smiles = Column(Text, index=True)
+    rdkit_mol_id = Column(
+        Integer, ForeignKey("rdkit.mols.id", ondelete="CASCADE"), index=True
+    )
+    rdkit_mol = relationship("RDKitMols")
+
+    __table_args__ = (
+        Index(
+            "compound_smiles_unlinked_index",
+            "compound_id",
+            postgresql_where=text("rdkit_mol_id IS NULL"),
+        ),
+        {"schema": "derived"},
+    )
+
+
+class ProductCompoundSmiles(Base):
+    """Generated product-compound SMILES and its link to the deduplicated RDKit mol.
+
+    One row per ord.product_compound; see CompoundSmiles.
+    """
+
+    __tablename__ = "product_compound_smiles"
+    product_compound_id = Column(
+        Integer,
+        ForeignKey("ord.product_compound.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    smiles = Column(Text, index=True)
+    rdkit_mol_id = Column(
+        Integer, ForeignKey("rdkit.mols.id", ondelete="CASCADE"), index=True
+    )
+    rdkit_mol = relationship("RDKitMols")
+
+    __table_args__ = (
+        Index(
+            "product_compound_smiles_unlinked_index",
+            "product_compound_id",
+            postgresql_where=text("rdkit_mol_id IS NULL"),
+        ),
+        {"schema": "derived"},
+    )
 
 
 class ReactionClasses(Base):

--- a/ord_schema/orm/derived_mappers.py
+++ b/ord_schema/orm/derived_mappers.py
@@ -43,10 +43,12 @@ class ReactionSmiles(Base):
     rdkit_reaction = relationship("RDKitReactions")
 
     __table_args__ = (
-        # Partial index over not-yet-linked rows keeps RDKit linking O(unlinked); see README.
+        # Partial index on the RDKit join key over not-yet-linked rows; the RDKit linking
+        # pass joins these to rdkit.reactions by reaction_smiles and filters unlinked, so
+        # this stays tiny once most rows are linked. See ord_schema/orm/README.md.
         Index(
             "reaction_smiles_unlinked_index",
-            "reaction_id",
+            "reaction_smiles",
             postgresql_where=text("rdkit_reaction_id IS NULL"),
         ),
         {"schema": "derived"},
@@ -71,9 +73,10 @@ class CompoundSmiles(Base):
     rdkit_mol = relationship("RDKitMols")
 
     __table_args__ = (
+        # Partial index on the RDKit join key (smiles) over not-yet-linked rows; see README.
         Index(
             "compound_smiles_unlinked_index",
-            "compound_id",
+            "smiles",
             postgresql_where=text("rdkit_mol_id IS NULL"),
         ),
         {"schema": "derived"},
@@ -99,9 +102,10 @@ class ProductCompoundSmiles(Base):
     rdkit_mol = relationship("RDKitMols")
 
     __table_args__ = (
+        # Partial index on the RDKit join key (smiles) over not-yet-linked rows; see README.
         Index(
             "product_compound_smiles_unlinked_index",
-            "product_compound_id",
+            "smiles",
             postgresql_where=text("rdkit_mol_id IS NULL"),
         ),
         {"schema": "derived"},

--- a/ord_schema/orm/derived_mappers.py
+++ b/ord_schema/orm/derived_mappers.py
@@ -27,9 +27,8 @@ from ord_schema.orm import Base
 class ReactionSmiles(Base):
     """Generated reaction SMILES and its link to the deduplicated RDKit reaction.
 
-    One row per reaction: reaction_smiles is generated from the proto at import,
-    rdkit_reaction_id is set during the RDKit linking pass. rdkit.reactions stays
-    deduplicated by SMILES, so this is the per-reaction pointer into it.
+    One row per reaction: reaction_smiles is filled by update_derived_tables, rdkit_reaction_id
+    by the RDKit linking pass (rdkit.reactions is deduplicated by SMILES).
     """
 
     __tablename__ = "reaction_smiles"
@@ -44,8 +43,7 @@ class ReactionSmiles(Base):
     rdkit_reaction = relationship("RDKitReactions")
 
     __table_args__ = (
-        # Partial index over not-yet-linked rows keeps the RDKit linking pass O(unlinked);
-        # moved here with rdkit_reaction_id (see ord_schema/orm/README.md).
+        # Partial index over not-yet-linked rows keeps RDKit linking O(unlinked); see README.
         Index(
             "reaction_smiles_unlinked_index",
             "reaction_id",
@@ -58,8 +56,8 @@ class ReactionSmiles(Base):
 class CompoundSmiles(Base):
     """Generated compound SMILES and its link to the deduplicated RDKit mol.
 
-    One row per ord.compound: smiles is generated from the proto at import,
-    rdkit_mol_id is set during the RDKit linking pass.
+    One row per ord.compound: smiles is filled by update_derived_tables, rdkit_mol_id by
+    the RDKit linking pass.
     """
 
     __tablename__ = "compound_smiles"

--- a/ord_schema/orm/derived_mappers.py
+++ b/ord_schema/orm/derived_mappers.py
@@ -18,28 +18,10 @@ These live in a separate "derived" schema to keep the proto-mirroring "ord" sche
 canonical. Populated by post-passes (not from_proto); the ORM works without them.
 """
 
-from sqlalchemy import Column, Date, ForeignKey, Index, Integer, Text, text
+from sqlalchemy import Column, ForeignKey, Index, Integer, Text, text
 from sqlalchemy.orm import relationship
 
 from ord_schema.orm import Base
-
-
-class DatasetSummary(Base):
-    """Denormalized, cheap-to-browse dataset fields derived from its reactions.
-
-    One row per ord.dataset. num_reactions is the reaction count; submitted_at is an
-    arbitrary reaction's latest record-event date (set by database.set_submitted_at),
-    used to browse datasets by recency without scanning reaction provenance.
-    """
-
-    __tablename__ = "dataset_summary"
-    dataset_id = Column(
-        Integer, ForeignKey("ord.dataset.id", ondelete="CASCADE"), primary_key=True
-    )
-    num_reactions = Column(Integer, nullable=False)
-    submitted_at = Column(Date, index=True)
-
-    __table_args__ = ({"schema": "derived"},)
 
 
 class ReactionSmiles(Base):

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -28,7 +28,6 @@ Notes:
       the database.
 """
 
-import contextlib
 from collections import defaultdict
 from collections.abc import Mapping
 from hashlib import md5
@@ -41,11 +40,9 @@ from inflection import underscore
 from sqlalchemy import (
     Boolean,
     Column,
-    Date,
     Enum,
     Float,
     ForeignKey,
-    Index,
     Integer,
     LargeBinary,
     String,
@@ -54,14 +51,12 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import relationship
 
-# Registers derived-schema tables (e.g. ReactionClasses) on Base.metadata.
+# Registers the rdkit and derived tables on Base for string relationship() targets.
 import ord_schema.orm.derived_mappers
-
-# Registers RDKitMols/RDKitReactions on Base for string relationship() targets.
 import ord_schema.orm.rdkit_mappers  # noqa: F401
-from ord_schema import message_helpers
 from ord_schema.logging import get_logger
 from ord_schema.orm import Base
+from ord_schema.orm.public_mappers import ReactionProto
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 logger = get_logger(__name__)
@@ -215,31 +210,16 @@ def build_mapper(
         attrs["dataset_id"] = Column(Text, nullable=False, unique=True)
         # Track the MD5 hash so we can quickly identify changes.
         attrs["md5"] = Column(String(32), nullable=False)
-        # Track the number of reactions for quicker browsing.
-        attrs["num_reactions"] = Column(Integer, nullable=False)
-        # Denormalized submission date (an arbitrary reaction's last record_modified
-        # timestamp, or record_created when there is none) so datasets can be browsed
-        # by recency without an expensive join into reaction provenance. Date rather
-        # than timestamp: recency browsing only needs day granularity, which also
-        # sidesteps the timezones in free-text provenance times. Populated by
-        # set_submitted_at(); NULL for datasets whose reactions carry no timestamps.
-        attrs["submitted_at"] = Column(Date, index=True)
+        # num_reactions / submitted_at are derived; see derived_mappers.DatasetSummary.
     elif message_type == reaction_pb2.Reaction:
         # Make reaction IDs globally unique.
         attrs["reaction_id"] = Column(Text, nullable=False, unique=True)
-        # Serialize and store the entire Reaction proto.
-        attrs["proto"] = Column(LargeBinary, nullable=False)
-        attrs["reaction_smiles"] = Column(Text)
-        attrs["rdkit_reaction_id"] = Column(
-            Integer, ForeignKey("rdkit.reactions.id", ondelete="CASCADE"), index=True
+        # The serialized proto (the served payload) lives in the public schema, and
+        # generated SMILES / RDKit links in the derived schema; ord.* is the search
+        # index. See public_mappers.ReactionProto and derived_mappers.ReactionSmiles.
+        attrs["proto_row"] = relationship(
+            "ReactionProto", uselist=False, cascade="all, delete-orphan"
         )
-        attrs["rdkit_reaction"] = relationship("RDKitReactions")
-    elif message_type in {reaction_pb2.Compound, reaction_pb2.ProductCompound}:
-        attrs["smiles"] = Column(Text)
-        attrs["rdkit_mol_id"] = Column(
-            Integer, ForeignKey("rdkit.mols.id", ondelete="CASCADE"), index=True
-        )
-        attrs["rdkit_mol"] = relationship("RDKitMols")
     elif message_type == reaction_pb2.ReactionProvenance:
         # Index the DOI so reactions can be looked up by publication.
         attrs["doi"] = Column(Text, index=True)
@@ -294,31 +274,9 @@ _MAPPER_TO_MESSAGE: dict[type, type[Message]] = {
     value: key for key, value in _MESSAGE_TO_MAPPER.items()
 }
 
-# Partial indexes over not-yet-linked rows, keyed by the foreign key used to reach a dataset. The incremental
-# RDKit-linking queries (ord_schema.orm.database.update_rdkit_tables / update_rdkit_ids) repeatedly ask "which of
-# this dataset's rows still have rdkit_*_id IS NULL?" -- zero for an already-loaded dataset. Indexing only the
-# unlinked rows keeps these tiny (just the in-flight datasets), so the planner answers in ~O(unlinked) instead of
-# scanning every reaction/compound in the dataset. create_all builds these on new databases; backfill them on an
-# existing database with CREATE INDEX CONCURRENTLY (see "Adding the partial indexes to an existing database" in
-# ord_schema/orm/README.md). Keep the SQL in that section in sync with the Index() declarations below.
-_REACTION_TABLE = Base.metadata.tables["ord.reaction"]
-Index(
-    "reaction_unlinked_index",
-    _REACTION_TABLE.c.dataset_id,
-    postgresql_where=_REACTION_TABLE.c.rdkit_reaction_id.is_(None),
-)
-_COMPOUND_TABLE = Base.metadata.tables["ord.compound"]
-Index(
-    "compound_unlinked_index",
-    _COMPOUND_TABLE.c.reaction_input_id,
-    postgresql_where=_COMPOUND_TABLE.c.rdkit_mol_id.is_(None),
-)
-_PRODUCT_COMPOUND_TABLE = Base.metadata.tables["ord.product_compound"]
-Index(
-    "product_compound_unlinked_index",
-    _PRODUCT_COMPOUND_TABLE.c.reaction_outcome_id,
-    postgresql_where=_PRODUCT_COMPOUND_TABLE.c.rdkit_mol_id.is_(None),
-)
+# The generated SMILES and rdkit_*_id links, and the partial "unlinked" indexes that keep
+# incremental RDKit linking O(unlinked), now live on the derived tables; see
+# ord_schema.orm.derived_mappers and ord_schema/orm/README.md.
 
 
 class _MappersMeta(type):
@@ -375,26 +333,13 @@ def from_proto(
         kwargs["md5"] = md5(
             message.SerializeToString(deterministic=True), usedforsecurity=False
         ).hexdigest()
-        assert hasattr(message, "reactions")
-        assert hasattr(message, "reaction_ids")
-        kwargs["num_reactions"] = len(message.reactions) or len(message.reaction_ids)
     elif isinstance(message, reaction_pb2.Reaction):
-        kwargs["proto"] = message.SerializeToString(deterministic=True)
-        try:
-            reaction_smiles = message_helpers.get_reaction_smiles(
-                message, generate_if_missing=True, allow_incomplete=False, validate=True
-            )
-        except ValueError as error:
-            assert hasattr(message, "reaction_id")  # Type hint.
-            logger.debug(
-                f"Error generating reaction SMILES for {message.reaction_id}: {error}"
-            )
-            reaction_smiles = None
-        if reaction_smiles is not None:
-            kwargs["reaction_smiles"] = reaction_smiles.split()[0]  # Handle CXSMILES.
-    elif isinstance(message, reaction_pb2.Compound | reaction_pb2.ProductCompound):
-        with contextlib.suppress(ValueError):
-            kwargs["smiles"] = message_helpers.smiles_from_compound(message)
+        # Store the serialized proto (the served payload) in the public schema. Derived
+        # values (SMILES, dataset summary) are computed from the search index afterward
+        # by ord_schema.orm.database.update_derived_tables.
+        kwargs["proto_row"] = ReactionProto(
+            proto=message.SerializeToString(deterministic=True)
+        )
     return mapper(**kwargs)
 
 

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -215,9 +215,8 @@ def build_mapper(
     elif message_type == reaction_pb2.Reaction:
         # Make reaction IDs globally unique.
         attrs["reaction_id"] = Column(Text, nullable=False, unique=True)
-        # The serialized proto (the served payload) lives in the public schema, and
-        # generated SMILES / RDKit links in the derived schema; ord.* is the search
-        # index. See public_mappers.ReactionProto and derived_mappers.ReactionSmiles.
+        # The served proto lives in public.reactions; generated SMILES / RDKit links in the
+        # derived schema. See public_mappers.ReactionProto, derived_mappers.ReactionSmiles.
         attrs["proto_row"] = relationship(
             "ReactionProto", uselist=False, cascade="all, delete-orphan"
         )

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -275,7 +275,7 @@ _MAPPER_TO_MESSAGE: dict[type, type[Message]] = {
 }
 
 # The generated SMILES and rdkit_*_id links, and the partial "unlinked" indexes that keep
-# incremental RDKit linking O(unlinked), now live on the derived tables; see
+# incremental RDKit linking O(unlinked), live on the derived tables; see
 # ord_schema.orm.derived_mappers and ord_schema/orm/README.md.
 
 

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -45,18 +45,17 @@ from sqlalchemy import (
     ForeignKey,
     Integer,
     LargeBinary,
-    String,
     Text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import relationship
 
-# Registers the rdkit and derived tables on Base for string relationship() targets.
+# Register the rdkit and derived tables on Base for string relationship() targets.
 import ord_schema.orm.derived_mappers
 import ord_schema.orm.rdkit_mappers  # noqa: F401
 from ord_schema.logging import get_logger
 from ord_schema.orm import Base
-from ord_schema.orm.public_mappers import ReactionProto
+from ord_schema.orm.public_mappers import DatasetMetadata, ReactionProto
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 logger = get_logger(__name__)
@@ -208,9 +207,11 @@ def build_mapper(
     if message_type == dataset_pb2.Dataset:
         # Make dataset IDs globally unique.
         attrs["dataset_id"] = Column(Text, nullable=False, unique=True)
-        # Track the MD5 hash so we can quickly identify changes.
-        attrs["md5"] = Column(String(32), nullable=False)
-        # num_reactions / submitted_at are derived; see derived_mappers.DatasetSummary.
+        # Per-dataset metadata (md5, num_reactions, submitted_at) lives in public.datasets,
+        # populated at ingest so every dataset has its metadata row.
+        attrs["metadata_row"] = relationship(
+            "DatasetMetadata", uselist=False, cascade="all, delete-orphan"
+        )
     elif message_type == reaction_pb2.Reaction:
         # Make reaction IDs globally unique.
         attrs["reaction_id"] = Column(Text, nullable=False, unique=True)
@@ -330,13 +331,15 @@ def from_proto(
         else:
             kwargs[field.name] = value
     if isinstance(message, dataset_pb2.Dataset):
-        kwargs["md5"] = md5(
-            message.SerializeToString(deterministic=True), usedforsecurity=False
-        ).hexdigest()
+        kwargs["metadata_row"] = DatasetMetadata(
+            md5=md5(
+                message.SerializeToString(deterministic=True), usedforsecurity=False
+            ).hexdigest(),
+            num_reactions=len(message.reactions) or len(message.reaction_ids),
+        )
     elif isinstance(message, reaction_pb2.Reaction):
-        # Store the serialized proto (the served payload) in the public schema. Derived
-        # values (SMILES, dataset summary) are computed from the search index afterward
-        # by ord_schema.orm.database.update_derived_tables.
+        # Store the serialized proto (the served payload) in the public schema. The SMILES
+        # are computed from the search index afterward by database.update_derived_tables.
         kwargs["proto_row"] = ReactionProto(
             proto=message.SerializeToString(deterministic=True)
         )

--- a/ord_schema/orm/public_mappers.py
+++ b/ord_schema/orm/public_mappers.py
@@ -18,7 +18,7 @@ The ord.* schema is the search index over reactions; the canonical serialized Re
 proto that the API serves lives here, keyed by the public reaction_id.
 """
 
-from sqlalchemy import Column, ForeignKey, LargeBinary, Text
+from sqlalchemy import Column, Date, ForeignKey, Integer, LargeBinary, String, Text
 
 from ord_schema.orm import Base
 
@@ -33,5 +33,26 @@ class ReactionProto(Base):
         primary_key=True,
     )
     proto = Column(LargeBinary, nullable=False)
+
+    __table_args__ = ({"schema": "public"},)
+
+
+class DatasetMetadata(Base):
+    """Per-dataset metadata for the API, keyed by dataset_id.
+
+    md5 hashes the original Dataset proto (computed at ingest, not reconstructed) and is
+    used to skip re-importing unchanged datasets. num_reactions and submitted_at support
+    dataset browsing; submitted_at is filled by database.set_submitted_at.
+    """
+
+    __tablename__ = "datasets"
+    dataset_id = Column(
+        Text,
+        ForeignKey("ord.dataset.dataset_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    md5 = Column(String(32), nullable=False)
+    num_reactions = Column(Integer, nullable=False)
+    submitted_at = Column(Date, index=True)
 
     __table_args__ = ({"schema": "public"},)

--- a/ord_schema/orm/public_mappers.py
+++ b/ord_schema/orm/public_mappers.py
@@ -1,0 +1,37 @@
+# Copyright 2022 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ORM table for the served Reaction proto payload, in the public schema.
+
+The ord.* schema is the search index over reactions; the canonical serialized Reaction
+proto that the API serves lives here, keyed by the public reaction_id.
+"""
+
+from sqlalchemy import Column, ForeignKey, LargeBinary, Text
+
+from ord_schema.orm import Base
+
+
+class ReactionProto(Base):
+    """Serialized Reaction proto (the served payload), keyed by reaction_id."""
+
+    __tablename__ = "reactions"
+    reaction_id = Column(
+        Text,
+        ForeignKey("ord.reaction.reaction_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    proto = Column(LargeBinary, nullable=False)
+
+    __table_args__ = ({"schema": "public"},)

--- a/ord_schema/orm/rdkit_mappers_test.py
+++ b/ord_schema/orm/rdkit_mappers_test.py
@@ -17,6 +17,11 @@
 import pytest
 from sqlalchemy import cast, func, select, text
 
+from ord_schema.orm.derived_mappers import (
+    CompoundSmiles,
+    ProductCompoundSmiles,
+    ReactionSmiles,
+)
 from ord_schema.orm.mappers import Mappers
 from ord_schema.orm.rdkit_mappers import (
     CString,
@@ -32,6 +37,7 @@ def test_tanimoto_operator(test_session):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
+        .join(CompoundSmiles)
         .join(RDKitMols)
         .where(
             RDKitMols.morgan_bfp
@@ -48,6 +54,7 @@ def test_tanimoto(test_session, fp_type):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
+        .join(CompoundSmiles)
         .join(RDKitMols)
         .where(RDKitMols.tanimoto("c1ccccc1CCC(O)C", fp_type=fp_type) > 0.5)
     )
@@ -61,6 +68,7 @@ def test_is_similar(test_session, fp_type):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
+        .join(CompoundSmiles)
         .join(RDKitMols)
         .where(RDKitMols.is_similar("c1ccccc1CCC(O)C", fp_type=fp_type))
     )
@@ -76,6 +84,7 @@ def test_substructure_operator(test_session):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
+        .join(CompoundSmiles)
         .join(RDKitMols)
         .where(RDKitMols.mol.op("@>")("c1ccccc1CCC(O)C"))
     )
@@ -88,6 +97,7 @@ def test_contains_substructure(test_session):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
+        .join(CompoundSmiles)
         .join(RDKitMols)
         .where(RDKitMols.contains_substructure("c1ccccc1CCC(O)C"))
     )
@@ -100,6 +110,7 @@ def test_smarts_operator(test_session):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
+        .join(CompoundSmiles)
         .join(RDKitMols)
         .where(
             RDKitMols.mol.op("@>")(
@@ -116,6 +127,7 @@ def test_matches_smarts(test_session):
         select(Mappers.Reaction)
         .join(Mappers.ReactionInput)
         .join(Mappers.Compound)
+        .join(CompoundSmiles)
         .join(RDKitMols)
         .where(RDKitMols.matches_smarts("c1ccccc1CCC(O)[#6]"))
     )
@@ -126,6 +138,7 @@ def test_matches_smarts(test_session):
 def test_reaction_smarts_operator(test_session):
     query = (
         select(Mappers.Reaction)
+        .join(ReactionSmiles)
         .join(RDKitReactions)
         .where(
             RDKitReactions.reaction.op("@>")(
@@ -142,6 +155,7 @@ def test_reaction_smarts_operator(test_session):
 def test_reaction_matches_smarts(test_session):
     query = (
         select(Mappers.Reaction)
+        .join(ReactionSmiles)
         .join(RDKitReactions)
         .where(RDKitReactions.matches_smarts("[#6:1].[#9:2]>>[#6:1][#9:2]"))
     )
@@ -157,15 +171,15 @@ def test_product_compound_rdkit_link(test_session):
     The mol/reaction operator tests cover the input-Compound and Reaction link paths; product_compound has none.
     """
     linked = test_session.execute(
-        select(Mappers.ProductCompound).join(RDKitMols)
+        select(Mappers.ProductCompound).join(ProductCompoundSmiles).join(RDKitMols)
     ).fetchall()
     assert len(linked) > 0  # The fixture has linkable product compounds.
     # Completeness: no product_compound with a resolvable SMILES is left unlinked.
     unlinked = test_session.execute(
         text(
-            "SELECT count(*) FROM ord.product_compound pc "
-            "JOIN rdkit.mols m ON m.smiles = pc.smiles "
-            "WHERE pc.rdkit_mol_id IS NULL"
+            "SELECT count(*) FROM derived.product_compound_smiles d "
+            "JOIN rdkit.mols m ON m.smiles = d.smiles "
+            "WHERE d.rdkit_mol_id IS NULL"
         )
     ).scalar()
     assert unlinked == 0

--- a/ord_schema/orm/reaction_class.py
+++ b/ord_schema/orm/reaction_class.py
@@ -74,11 +74,13 @@ def update_reaction_classes(dataset_id: str, session: Session) -> None:
     start = time.time()
     result = session.execute(
         text("""
-            SELECT ord.reaction.id, ord.reaction.reaction_smiles
+            SELECT ord.reaction.id, derived.reaction_smiles.reaction_smiles
             FROM ord.reaction
             JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
+            JOIN derived.reaction_smiles
+                ON derived.reaction_smiles.reaction_id = ord.reaction.id
             WHERE ord.dataset.dataset_id = :dataset_id
-              AND ord.reaction.reaction_smiles IS NOT NULL
+              AND derived.reaction_smiles.reaction_smiles IS NOT NULL
               AND NOT EXISTS (
                   SELECT 1 FROM derived.reaction_classes
                   WHERE derived.reaction_classes.reaction_id = ord.reaction.id

--- a/ord_schema/orm/scripts/add_datasets_test.py
+++ b/ord_schema/orm/scripts/add_datasets_test.py
@@ -70,12 +70,12 @@ def test_main_parquet(prepared_engine, tmp_path):
         )
         assert mapped_dataset is not None
         assert len(mapped_dataset.reactions) == expected_count
-        # Spot-check that one reaction round-trips byte-identical through the proto column.
+        # Spot-check that one reaction round-trips byte-identical through public.reactions.
         original = dataset.reactions[0]
         stored = next(
             r for r in mapped_dataset.reactions if r.reaction_id == original.reaction_id
         )
-        assert reaction_pb2.Reaction.FromString(stored.proto) == original
+        assert reaction_pb2.Reaction.FromString(stored.proto_row.proto) == original
 
 
 def test_main_parquet_skip_unchanged(prepared_engine, tmp_path):


### PR DESCRIPTION
## Summary

Reorganizes the ORM into role-based schemas so `ord.*` is a pure search index, and **decouples ingest from derived data**. Implements #856 (and the related design discussion).

**Schemas**
- **`ord`** — the decomposed message tables (the search index). Now holds *only* proto fields plus structural columns (`id`, the `ord_schema_context` discriminator, map `key`, and parent foreign keys).
- **`public`** — API-facing data: `public.reactions` is the serialized `Reaction` proto keyed by `reaction_id`; `public.datasets` is per-dataset metadata (`md5` for change detection, `num_reactions`/`submitted_at` for browsing) keyed by `dataset_id`.
- **`derived`** — search helpers computed from the index: generated SMILES + RDKit links in `derived.{reaction,compound,product_compound}_smiles`, and reaction classes.
- **`rdkit`** — unchanged (deduplicated cartridge objects + fingerprints).

**Population is decoupled.** `from_proto` writes only `ord.*` + the `public` rows — no knowledge of the `derived` SMILES tables. A new `update_derived_tables` post-pass reconstructs each message from the search index via `to_proto` and reuses `get_reaction_smiles` / `smiles_from_compound` to populate the derived SMILES; it runs before the RDKit pass, which reads them. Ingest order: **populate `public` + `ord`, then `derived`, then `rdkit`.**

## What moved off `ord.*`

| From | To |
|---|---|
| `ord.reaction.proto` | `public.reactions` (keyed by `reaction_id`) |
| `ord.dataset.md5` / `num_reactions` / `submitted_at` | `public.datasets` (keyed by `dataset_id`) |
| `ord.reaction.reaction_smiles` / `rdkit_reaction_id` | `derived.reaction_smiles` |
| `ord.compound.smiles` / `rdkit_mol_id` | `derived.compound_smiles` |
| `ord.product_compound.smiles` / `rdkit_mol_id` | `derived.product_compound_smiles` |

`reaction_id` / `dataset_id` stay on `ord.*` (they're proto fields). After this, an audit confirms **no non-proto data columns remain on `ord.*`** — only proto fields + the structural columns above.

`md5` / `num_reactions` are computed at ingest (md5 must hash the original proto, not a `to_proto` round-trip), so `public.datasets` is populated by a relationship during `from_proto`; `submitted_at` is filled by the existing `set_submitted_at` pass. The partial "unlinked" indexes move to the derived SMILES tables; the RDKit population/linking SQL and the reaction-class selector read SMILES from `derived`. Structure-search queries hop through the derived/public tables (joins resolve via FK).

## Cross-repo: `ord-interface`

`ord-interface` reads several moved columns and **needs matching query updates** (it pins `ord-schema`, so it's updated separately, at cutover):
- `reaction.proto` → `public.reactions` (`fetch_reactions`) — becomes a direct keyed lookup, no join.
- `reaction.rdkit_reaction_id`, `compound.rdkit_mol_id`, `product_compound.rdkit_mol_id` (structure search) → join the derived SMILES tables.
- `dataset.num_reactions` / `submitted_at` (browse) → read from `public.datasets` (direct keyed lookup).

## Notes / follow-ups

- **No in-place migration**: intended to land with a full Parquet re-import, so there are no `ALTER`/backfill scripts.
- **Perf**: `update_derived_tables` reconstructs each reaction *and* compound message from the relational tables (`to_proto`), trading ingest-time coupling for reconstruction cost. Batching or SQL identifier reads can optimize it if it becomes a bottleneck.
- **Deferred**: renaming the `ord` schema (e.g. to `structure`) and/or `mappers.py` → `ord_mappers.py` — cosmetic, highest churn, cross-repo; their own PR if desired.

## Testing

Validated end to end against Postgres + the RDKit cartridge: the full `ord_schema/orm` suite passes (28 passed, 1 skipped — the skip is the reaction-class test, which needs the optional extra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reorganizes ORM storage into role-based schemas. The main changes are:

- Moves served reaction protos and dataset metadata into `public` tables.
- Moves generated SMILES and RDKit links into `derived` tables.
- Populates derived SMILES before RDKit linking during ingest.
- Updates classification, RDKit queries, docs, and tests for the new schema layout.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Updates ingest, dataset metadata access, derived SMILES population, and RDKit linking for the new schema split. |
| ord_schema/orm/mappers.py | Removes non-proto storage from `ord` mappers and connects dataset/reaction rows to public-schema payload tables. |
| ord_schema/orm/public_mappers.py | Adds public-schema tables for serialized reactions and dataset metadata. |
| ord_schema/orm/derived_mappers.py | Adds derived SMILES tables and partial indexes used by RDKit linking. |
| ord_schema/orm/reaction_class.py | Reads reaction classification input from derived reaction SMILES. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Document the derived-vs-rdkit deduplicat..."](https://github.com/open-reaction-database/ord-schema/commit/2d08ea8cb4018a7d1f85be71950c80673eb9f56e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40405379)</sub>

<!-- /greptile_comment -->