### PR TITLE
Separate ingest and derived stages in add_datasets (#860)

### DIFF
--- a/ord_schema/orm/README.md
+++ b/ord_schema/orm/README.md
@@ -209,6 +209,9 @@ default; `--stages` selects them independently — `--stages ingest` loads `ord.
 (re)computes the derived data for the already-ingested datasets matching `--pattern`. Add `--classify_reactions` to
 assign reaction class/name labels during derivation (requires the `reaction-class` extra).
 
+The script is a thin CLI over `ord_schema.orm.loading.load_datasets`, which runs the same staged, parallel loading and is
+the entry point for programmatic callers.
+
 ### Run queries
 
 Use the [SQLAlchemy ORM query engine](https://docs.sqlalchemy.org/en/14/orm/quickstart.html#simple-select) to search for

--- a/ord_schema/orm/README.md
+++ b/ord_schema/orm/README.md
@@ -162,14 +162,17 @@ These definitions must stay in sync with the `Index(...)` declarations in `deriv
 
 ### Add data
 
-Load ORD datasets into the database with the `add_parquet_dataset` function:
+Loading a dataset is two stages: `add_parquet_dataset`/`add_dataset` *ingest* the `ord.*` search index and
+`public.*` payload, then `update_derived_data` populates the `derived.*` SMILES, RDKit links, and (optionally)
+reaction classes. The stages are independent — derivation is idempotent, so it can be re-run to backfill or recompute
+derived data over already-ingested datasets.
 
 ```python
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from ord_schema import huggingface, message_helpers
-from ord_schema.orm.database import add_parquet_dataset
+from ord_schema.orm.database import add_parquet_dataset, update_derived_data
 
 # huggingface.fetch_dataset downloads the dataset (preferring the Parquet
 # serialization) and returns its local path; it needs the optional `huggingface`
@@ -178,12 +181,15 @@ from ord_schema.orm.database import add_parquet_dataset
 # memory. Datasets not yet migrated to Parquet come back as .pb.gz; load those
 # instead with add_dataset(message_helpers.load_message(path, dataset_pb2.Dataset)).
 path = huggingface.fetch_dataset("ord_dataset-fc83743b978f4deea7d6856deacbfe53")
+dataset_id = "ord_dataset-fc83743b978f4deea7d6856deacbfe53"
 
 connection_string = f"postgresql+psycopg://{username}:{password}@{host}:{port}/{database}"
 engine = create_engine(connection_string)
 with Session(engine) as session:
     with session.begin():
         add_parquet_dataset(path, session)
+    with session.begin():
+        update_derived_data(dataset_id, session)
 ```
 
 To load multiple datasets from disk (e.g., from a clone of
@@ -197,8 +203,11 @@ python scripts/add_datasets.py \
     --database <database>
 ```
 
-Note that the database password will be read from the `PGPASSWORD` environment variable if `--password` is not
-specified on the command line. To update an existing dataset in the database, use the `--overwrite` flag.
+The database password will be read from the `PGPASSWORD` environment variable if `--password` is not specified on the
+command line. To update an existing dataset in the database, use the `--overwrite` flag. The script runs both stages by
+default; `--stages` selects them independently — `--stages ingest` loads `ord.*`/`public.*` only, and `--stages derived`
+(re)computes the derived data for the already-ingested datasets matching `--pattern`. Add `--classify_reactions` to
+assign reaction class/name labels during derivation (requires the `reaction-class` extra).
 
 ### Run queries
 

--- a/ord_schema/orm/conftest.py
+++ b/ord_schema/orm/conftest.py
@@ -37,6 +37,13 @@ def test_engine_fixture() -> Iterator[Engine]:
         yield engine
 
 
+@pytest.fixture(name="prepared_engine")
+def prepared_engine_fixture(test_engine: Engine) -> Engine:
+    """``test_engine`` with the ORM schema (and RDKit cartridge) installed."""
+    assert prepare_database(test_engine)
+    return test_engine
+
+
 @pytest.fixture(name="test_session")
 def test_session_fixture(test_engine: Engine) -> Iterator[Session]:
     datasets = [

--- a/ord_schema/orm/conftest.py
+++ b/ord_schema/orm/conftest.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Session
 from testing.postgresql import Postgresql
 
 from ord_schema.datasets import load_dataset
-from ord_schema.orm.database import add_dataset, prepare_database
+from ord_schema.orm.database import add_dataset, prepare_database, update_derived_data
 
 
 @pytest.fixture(name="test_engine")
@@ -48,6 +48,9 @@ def test_session_fixture(test_engine: Engine) -> Iterator[Session]:
     with Session(test_engine) as session:
         for dataset in datasets:
             with session.begin():
-                add_dataset(dataset, session, rdkit_cartridge=rdkit_cartridge)
+                add_dataset(dataset, session)
+                update_derived_data(
+                    dataset.dataset_id, session, rdkit_cartridge=rdkit_cartridge
+                )
     with Session(test_engine) as session:
         yield session

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -110,20 +110,15 @@ def prepare_database(engine: Engine) -> bool:
     return rdkit_cartridge
 
 
-def add_dataset(
-    dataset: dataset_pb2.Dataset,
-    session: Session,
-    rdkit_cartridge: bool = True,
-    classify_reactions: bool = False,
-) -> None:
-    """Adds a dataset to the database.
+def add_dataset(dataset: dataset_pb2.Dataset, session: Session) -> None:
+    """Ingests a dataset, writing the ``ord.*`` search index and ``public.*`` payload.
+
+    Derived data (SMILES, RDKit links, reaction classes) is populated separately by
+    ``update_derived_data`` so ingest and derivation can run independently.
 
     Args:
         dataset: Dataset to add.
         session: SQLAlchemy session.
-        rdkit_cartridge: Whether to populate RDKit cartridge tables.
-        classify_reactions: Whether to assign reaction class/name labels as a
-            post-pass; requires the optional ``reaction-class`` extra.
     """
     logger.debug(f"Adding dataset {dataset.dataset_id}")
     start = time.time()
@@ -131,16 +126,37 @@ def add_dataset(
     logger.debug(f"from_proto() took {time.time() - start:g}s")
     session.add(mapped_dataset)
     session.flush()
-    update_derived_tables(dataset.dataset_id, session)
+    set_submitted_at(dataset.dataset_id, session)
+
+
+def update_derived_data(
+    dataset_id: str,
+    session: Session,
+    *,
+    rdkit_cartridge: bool = True,
+    classify_reactions: bool = False,
+) -> None:
+    """Populates the derived tables for an already-ingested dataset.
+
+    Idempotent (NOT EXISTS guards), so it is safe to re-run to backfill or recompute
+    derived data over datasets that are already present.
+
+    Args:
+        dataset_id: Dataset to derive.
+        session: SQLAlchemy session.
+        rdkit_cartridge: Whether to populate RDKit cartridge tables and links.
+        classify_reactions: Whether to assign reaction class/name labels; requires the
+            optional ``reaction-class`` extra.
+    """
+    update_derived_tables(dataset_id, session)
     if rdkit_cartridge:
         session.flush()
-        update_rdkit_tables(dataset.dataset_id, session)
+        update_rdkit_tables(dataset_id, session)
         session.flush()
-        update_rdkit_ids(dataset.dataset_id, session)
+        update_rdkit_ids(dataset_id, session)
     if classify_reactions:
         session.flush()
-        _classify_reactions(dataset.dataset_id, session)
-    set_submitted_at(dataset.dataset_id, session)
+        _classify_reactions(dataset_id, session)
 
 
 def _parse_date(value: str) -> datetime.date | None:
@@ -239,12 +255,7 @@ def backfill_submission_times(session: Session) -> None:
 _PARQUET_FLUSH_BATCH = 200
 
 
-def add_parquet_dataset(
-    path: str,
-    session: Session,
-    rdkit_cartridge: bool = True,
-    classify_reactions: bool = False,
-) -> None:
+def add_parquet_dataset(path: str, session: Session) -> None:
     """Streams a Parquet-serialized Dataset into the ORM tables.
 
     Two streaming passes over the Parquet file:
@@ -255,14 +266,12 @@ def add_parquet_dataset(
 
     This keeps the canonical Parquet MD5 formula in one place and bounds
     peak memory to one row group plus ``_PARQUET_FLUSH_BATCH`` ORM objects,
-    regardless of dataset size.
+    regardless of dataset size. Derived data is populated separately by
+    ``update_derived_data``.
 
     Args:
         path: Path to the Parquet-serialized Dataset.
         session: SQLAlchemy session.
-        rdkit_cartridge: Whether to populate RDKit cartridge tables.
-        classify_reactions: Whether to assign reaction class/name labels as a
-            post-pass; requires the optional ``reaction-class`` extra.
     """
     start = time.time()
     metadata = parquet.load_metadata(path)
@@ -298,14 +307,6 @@ def add_parquet_dataset(
     logger.debug(
         f"add_parquet_dataset() took {time.time() - start:g}s ({num_reactions} reactions)"
     )
-    update_derived_tables(metadata.dataset_id, session)
-    if rdkit_cartridge:
-        update_rdkit_tables(metadata.dataset_id, session)
-        session.flush()
-        update_rdkit_ids(metadata.dataset_id, session)
-    if classify_reactions:
-        session.flush()
-        _classify_reactions(metadata.dataset_id, session)
     set_submitted_at(metadata.dataset_id, session)
 
 

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -1,0 +1,277 @@
+# Copyright 2022 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Staged loading of ORD datasets into the ORM database.
+
+Loading is two independent stages: *ingest* writes the ``ord.*`` search index and
+``public.*`` payload, and *derivation* writes the ``derived.*`` SMILES, RDKit links,
+and (optionally) reaction classes. Either stage can run without the other; derivation
+is idempotent, so the derived-only stage backfills or recomputes derived data over
+already-ingested datasets. ``load_datasets`` orchestrates both stages over a glob of
+dataset files; the per-dataset helpers (``ingest_dataset``, ``derive_dataset``,
+``add_rdkit``) are exposed for callers that compose their own pipeline.
+"""
+
+import time
+from collections.abc import Callable, Iterable
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
+from contextlib import ExitStack
+from functools import partial
+from glob import glob
+from hashlib import md5
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+from tqdm import tqdm
+
+from ord_schema import parquet
+from ord_schema.logging import get_logger
+from ord_schema.message_helpers import load_message
+from ord_schema.orm import database
+from ord_schema.proto import dataset_pb2
+
+logger = get_logger(__name__)
+
+STAGES = ("ingest", "derived")
+
+
+def dataset_id_for_file(filename: str) -> str:
+    """Returns the dataset ID for a dataset file without ingesting it."""
+    if filename.endswith(".parquet"):
+        return parquet.load_metadata(filename).dataset_id
+    return load_message(filename, dataset_pb2.Dataset).dataset_id
+
+
+def ingest_dataset(filename: str, *, dsn: str, overwrite: bool) -> str:
+    """Ingests a single dataset (``ord.*`` + ``public.*``); skips unchanged datasets.
+
+    Derived data is populated separately by ``derive_dataset``/``add_rdkit``.
+
+    Args:
+        filename: Dataset filename. ``.parquet`` inputs are streamed via
+            ``database.add_parquet_dataset``; other formats load the whole
+            Dataset proto and call ``database.add_dataset``.
+        dsn: Database connection string.
+        overwrite: If True, update the dataset if the MD5 hash has changed.
+
+    Returns:
+        Dataset ID.
+
+    Raises:
+        ValueError: If the dataset already exists in the database and `overwrite` is not set.
+    """
+    if filename.endswith(".parquet"):
+        logger.debug(f"Streaming {filename}")
+        dataset_id = parquet.load_metadata(filename).dataset_id
+
+        def compute_md5() -> str:
+            md5_hex, _ = parquet.streaming_md5(filename)
+            return md5_hex
+
+        def insert(session: Session) -> None:
+            database.add_parquet_dataset(filename, session)
+    else:
+        logger.debug(f"Loading {filename}")
+        dataset = load_message(filename, dataset_pb2.Dataset)
+        dataset_id = dataset.dataset_id
+
+        def compute_md5() -> str:
+            return md5(
+                dataset.SerializeToString(deterministic=True), usedforsecurity=False
+            ).hexdigest()
+
+        def insert(session: Session) -> None:
+            database.add_dataset(dataset, session)
+
+    # NOTE(skearnes): Multiprocessing is hard to get right for shared connection pools, so we don't even try; see
+    # https://docs.sqlalchemy.org/en/20/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork.
+    # Each call owns its engine and disposes it so pooled connections don't accumulate in reused pool workers.
+    engine = create_engine(dsn)
+    try:
+        with Session(engine) as session:
+            with session.begin():
+                existing_md5 = database.get_dataset_md5(dataset_id, session)
+            if existing_md5 is not None:
+                if compute_md5() != existing_md5:
+                    if not overwrite:
+                        raise ValueError(
+                            f"`overwrite` is required when a dataset already exists: {dataset_id}"
+                        )
+                    logger.debug(f"existing dataset {dataset_id} changed; updating")
+                    with session.begin():
+                        database.delete_dataset(dataset_id, session)
+                else:
+                    logger.debug(f"existing dataset {dataset_id} unchanged; skipping")
+                    return dataset_id
+            start = time.time()
+            with session.begin():
+                insert(session)
+            logger.debug(f"insert took {time.time() - start:g}s")
+    finally:
+        engine.dispose()
+    return dataset_id
+
+
+def derive_dataset(dataset_id: str, *, dsn: str, classify_reactions: bool) -> str:
+    """Runs the parallel-safe derived passes (SMILES + optional classification).
+
+    The RDKit linking pass is excluded here and run serially in ``add_rdkit`` to avoid
+    deadlocks. Idempotent, so it is safe to re-run over already-derived datasets.
+
+    Args:
+        dataset_id: Dataset to derive.
+        dsn: Database connection string.
+        classify_reactions: Whether to assign reaction class/name labels.
+
+    Returns:
+        Dataset ID.
+    """
+    engine = create_engine(dsn)
+    try:
+        with Session(engine) as session, session.begin():
+            database.update_derived_data(
+                dataset_id,
+                session,
+                rdkit_cartridge=False,  # Done serially in add_rdkit() to avoid deadlocks.
+                classify_reactions=classify_reactions,
+            )
+    finally:
+        engine.dispose()
+    return dataset_id
+
+
+def add_rdkit(engine: Engine, dataset_id: str) -> None:
+    """Populates and links the RDKit cartridge tables for a dataset."""
+    with Session(engine) as session:
+        with session.begin():
+            database.update_rdkit_tables(dataset_id, session)
+        with session.begin():
+            database.update_rdkit_ids(dataset_id, session)
+
+
+def _run_parallel(
+    func: Callable[[str], str],
+    items: Iterable[str],
+    *,
+    n_jobs: int,
+    desc: str,
+) -> tuple[list[str], list[str]]:
+    """Runs ``func`` over ``items`` with ``n_jobs`` workers.
+
+    Returns ``(results, failures)``: the successful return values and the inputs whose
+    call raised.
+    """
+    items = list(items)
+    results: list[str] = []
+    failures: list[str] = []
+    with ExitStack() as stack:
+        if n_jobs > 1:
+            executor = stack.enter_context(ProcessPoolExecutor(n_jobs))
+        else:
+            executor = stack.enter_context(ThreadPoolExecutor(n_jobs))
+        futures = {executor.submit(func, item): item for item in items}
+        for future in tqdm(as_completed(futures), total=len(futures), desc=desc):
+            try:
+                results.append(future.result())
+            except Exception:
+                item = futures[future]
+                failures.append(item)
+                logger.exception(f"{desc} failed for {item}")
+    return results, failures
+
+
+def load_datasets(
+    pattern: str,
+    dsn: str,
+    *,
+    stages: Iterable[str] = STAGES,
+    overwrite: bool = False,
+    classify_reactions: bool = False,
+    n_jobs: int = 1,
+) -> None:
+    """Runs the selected stages over the datasets matching ``pattern``.
+
+    The parallel-safe work (ingest, SMILES/classification) runs in a worker pool; the
+    RDKit linking pass runs serially to avoid deadlocks. When ingest is skipped, dataset
+    IDs are resolved from ``pattern`` so derivation runs over the already-ingested rows.
+
+    Args:
+        pattern: Glob for dataset filenames.
+        dsn: Database connection string.
+        stages: Stages to run (any of ``STAGES``); defaults to all.
+        overwrite: If True, update changed datasets during ingest.
+        classify_reactions: If True, assign reaction class/name labels during derivation.
+        n_jobs: Number of parallel workers.
+
+    Raises:
+        ValueError: If ``stages`` is empty or names an unknown stage.
+        ImportError: If ``classify_reactions`` is set without the ``reaction-class`` extra.
+        RuntimeError: If any dataset failed in any stage; the inputs are the message.
+    """
+    stages = tuple(stages)
+    unknown = set(stages) - set(STAGES)
+    if unknown:
+        raise ValueError(
+            f"unknown stages {sorted(unknown)}; choose from {list(STAGES)}"
+        )
+    if not stages:
+        raise ValueError(f"stages must include at least one of {list(STAGES)}")
+    if classify_reactions and database.update_reaction_classes is None:
+        raise ImportError(
+            "reaction classification requires the 'reaction-class' extra: "
+            "pip install ord-schema[reaction-class]"
+        )
+    filenames = sorted(glob(pattern))
+    failures: list[str] = []
+
+    if "ingest" in stages:
+        logger.info("Ingesting datasets")
+        dataset_ids, stage_failures = _run_parallel(
+            partial(ingest_dataset, dsn=dsn, overwrite=overwrite),
+            filenames,
+            n_jobs=n_jobs,
+            desc="Ingest",
+        )
+        failures.extend(stage_failures)
+    else:
+        dataset_ids = [dataset_id_for_file(filename) for filename in filenames]
+
+    if "derived" in stages:
+        logger.info("Deriving SMILES and reaction classes")
+        dataset_ids, stage_failures = _run_parallel(
+            partial(derive_dataset, dsn=dsn, classify_reactions=classify_reactions),
+            dataset_ids,
+            n_jobs=n_jobs,
+            desc="Derive",
+        )
+        failures.extend(stage_failures)
+        logger.info("Adding RDKit functionality")
+        engine = create_engine(dsn)
+        try:
+            for dataset_id in tqdm(dataset_ids, desc="RDKit"):
+                try:
+                    add_rdkit(
+                        engine, dataset_id
+                    )  # NOTE(skearnes): Do this serially to avoid deadlocks.
+                except Exception:
+                    failures.append(dataset_id)
+                    logger.exception(
+                        f"Adding RDKit functionality for {dataset_id} failed"
+                    )
+        finally:
+            engine.dispose()
+
+    if failures:
+        raise RuntimeError(failures)

--- a/ord_schema/orm/loading_test.py
+++ b/ord_schema/orm/loading_test.py
@@ -1,0 +1,139 @@
+# Copyright 2022 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.orm.loading."""
+
+import pathlib
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.orm import Session
+
+from ord_schema import message_helpers, parquet
+from ord_schema.orm import database, loading
+from ord_schema.orm.mappers import Mappers
+from ord_schema.proto import dataset_pb2, reaction_pb2
+
+_PBTXT_FIXTURE = str(
+    pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+)
+
+
+def _write_parquet_dataset(tmp_path) -> tuple[str, dataset_pb2.Dataset]:
+    dataset = message_helpers.load_message(_PBTXT_FIXTURE, dataset_pb2.Dataset)
+    parquet_path = (tmp_path / "dataset.parquet").as_posix()
+    parquet.save_dataset(dataset, parquet_path)
+    return parquet_path, dataset
+
+
+def _derived_counts(engine) -> dict[str, int]:
+    with Session(engine) as session:
+        return {
+            table: session.execute(
+                text(f"SELECT count(*) FROM derived.{table}")  # noqa: S608  (constant)
+            ).scalar()
+            for table in (
+                "reaction_smiles",
+                "compound_smiles",
+                "product_compound_smiles",
+            )
+        }
+
+
+def test_load_datasets(prepared_engine):
+    loading.load_datasets(_PBTXT_FIXTURE, str(prepared_engine.url))
+    with Session(prepared_engine) as session:
+        assert session.query(Mappers.Reaction).count() > 0
+    assert _derived_counts(prepared_engine)["reaction_smiles"] > 0
+
+
+def test_load_datasets_parquet(prepared_engine, tmp_path):
+    """Streaming Parquet ingest stores the streaming MD5, reaction count, and Reaction rows."""
+    parquet_path, dataset = _write_parquet_dataset(tmp_path)
+    loading.load_datasets(parquet_path, str(prepared_engine.url))
+    expected_md5, expected_count = parquet.streaming_md5(parquet_path)
+    with Session(prepared_engine) as session:
+        # Dataset row's metadata columns reflect the streaming MD5/count.
+        assert database.get_dataset_md5(dataset.dataset_id, session) == expected_md5
+        assert database.get_dataset_size(dataset.dataset_id, session) == expected_count
+        # Reaction rows were actually inserted (not just the num_reactions column).
+        mapped_dataset = session.scalar(
+            select(Mappers.Dataset).where(
+                Mappers.Dataset.dataset_id == dataset.dataset_id
+            )
+        )
+        assert mapped_dataset is not None
+        assert len(mapped_dataset.reactions) == expected_count
+        # Spot-check that one reaction round-trips byte-identical through public.reactions.
+        original = dataset.reactions[0]
+        stored = next(
+            r for r in mapped_dataset.reactions if r.reaction_id == original.reaction_id
+        )
+        assert reaction_pb2.Reaction.FromString(stored.proto_row.proto) == original
+
+
+def test_load_datasets_parquet_skip_unchanged(prepared_engine, tmp_path):
+    """A second invocation without overwrite is a no-op when the MD5 matches."""
+    parquet_path, dataset = _write_parquet_dataset(tmp_path)
+    loading.load_datasets(parquet_path, str(prepared_engine.url))
+    loading.load_datasets(parquet_path, str(prepared_engine.url))
+    # Skip path must not re-insert: reaction count is unchanged after the second call.
+    _, expected_count = parquet.streaming_md5(parquet_path)
+    with Session(prepared_engine) as session:
+        mapped_dataset = session.scalar(
+            select(Mappers.Dataset).where(
+                Mappers.Dataset.dataset_id == dataset.dataset_id
+            )
+        )
+        assert mapped_dataset is not None
+        assert len(mapped_dataset.reactions) == expected_count
+
+
+def test_load_datasets_parquet_rejects_changed_without_overwrite(
+    prepared_engine, tmp_path
+):
+    """A re-ingest with mutated content but no overwrite raises."""
+    parquet_path, dataset = _write_parquet_dataset(tmp_path)
+    loading.load_datasets(parquet_path, str(prepared_engine.url))
+    dataset.reactions[0].outcomes[0].conversion.value = 999.0
+    parquet.save_dataset(dataset, parquet_path)
+    with pytest.raises(
+        RuntimeError
+    ):  # load_datasets collects per-future failures and raises in aggregate.
+        loading.load_datasets(parquet_path, str(prepared_engine.url))
+
+
+def test_stages_ingest_then_derived(prepared_engine):
+    """stages=ingest writes ord.*/public.* with no derived rows; a later stages=derived backfills them."""
+    url = str(prepared_engine.url)
+    loading.load_datasets(_PBTXT_FIXTURE, url, stages=["ingest"])
+    with Session(prepared_engine) as session:
+        assert session.query(Mappers.Reaction).count() > 0
+    assert _derived_counts(prepared_engine) == {
+        "reaction_smiles": 0,
+        "compound_smiles": 0,
+        "product_compound_smiles": 0,
+    }
+    loading.load_datasets(_PBTXT_FIXTURE, url, stages=["derived"])
+    assert _derived_counts(prepared_engine)["reaction_smiles"] > 0
+    with Session(prepared_engine) as session:
+        assert (
+            session.execute(text("SELECT count(*) FROM rdkit.reactions")).scalar() > 0
+        )
+
+
+def test_unknown_stage_raises():
+    # Stage validation happens before any database access, so no engine is needed.
+    with pytest.raises(ValueError, match="unknown stages"):
+        loading.load_datasets(_PBTXT_FIXTURE, "postgresql://", stages=["bogus"])

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -12,14 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Adds datasets to the ORM database."""
+"""Adds datasets to the ORM database.
+
+Ingest (``ord.*`` search index + ``public.*`` payload) and derivation (``derived.*``
+SMILES, RDKit links, and reaction classes) are separate stages selected with
+``--stages``; either can run without the other. Derivation is idempotent, so the
+derived-only stage backfills or recomputes derived data over already-ingested datasets.
+"""
 
 import argparse
 import logging
 import os
 import time
+from collections.abc import Callable, Iterable
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from contextlib import ExitStack
+from functools import partial
 from glob import glob
 from hashlib import md5
 
@@ -36,15 +44,26 @@ from ord_schema.proto import dataset_pb2
 
 logger = get_logger(__name__)
 
+_STAGES = ("ingest", "derived")
 
-def add_dataset(dsn: str, filename: str, overwrite: bool) -> str:
-    """Adds a single dataset to the database.
+
+def dataset_id_for_file(filename: str) -> str:
+    """Returns the dataset ID for a dataset file without ingesting it."""
+    if filename.endswith(".parquet"):
+        return parquet.load_metadata(filename).dataset_id
+    return load_message(filename, dataset_pb2.Dataset).dataset_id
+
+
+def ingest_dataset(filename: str, *, dsn: str, overwrite: bool) -> str:
+    """Ingests a single dataset (``ord.*`` + ``public.*``); skips unchanged datasets.
+
+    Derived data is populated separately by ``derive_dataset``/``add_rdkit``.
 
     Args:
-        dsn: Database connection string.
         filename: Dataset filename. ``.parquet`` inputs are streamed via
             ``database.add_parquet_dataset``; other formats load the whole
             Dataset proto and call ``database.add_dataset``.
+        dsn: Database connection string.
         overwrite: If True, update the dataset if the MD5 hash has changed.
 
     Returns:
@@ -65,9 +84,7 @@ def add_dataset(dsn: str, filename: str, overwrite: bool) -> str:
             return md5_hex
 
         def insert(session: Session) -> None:
-            database.add_parquet_dataset(
-                filename, session, rdkit_cartridge=False
-            )  # Done separately in add_rdkit().
+            database.add_parquet_dataset(filename, session)
     else:
         logger.debug(f"Loading {filename}")
         dataset = load_message(filename, dataset_pb2.Dataset)
@@ -79,9 +96,7 @@ def add_dataset(dsn: str, filename: str, overwrite: bool) -> str:
             ).hexdigest()
 
         def insert(session: Session) -> None:
-            database.add_dataset(
-                dataset, session, rdkit_cartridge=False
-            )  # Done separately in add_rdkit().
+            database.add_dataset(dataset, session)
 
     with Session(engine) as session:
         with session.begin():
@@ -105,6 +120,31 @@ def add_dataset(dsn: str, filename: str, overwrite: bool) -> str:
     return dataset_id
 
 
+def derive_dataset(dataset_id: str, *, dsn: str, classify_reactions: bool) -> str:
+    """Runs the parallel-safe derived passes (SMILES + optional classification).
+
+    The RDKit linking pass is excluded here and run serially in ``add_rdkit`` to avoid
+    deadlocks. Idempotent, so it is safe to re-run over already-derived datasets.
+
+    Args:
+        dataset_id: Dataset to derive.
+        dsn: Database connection string.
+        classify_reactions: Whether to assign reaction class/name labels.
+
+    Returns:
+        Dataset ID.
+    """
+    engine = create_engine(dsn)
+    with Session(engine) as session, session.begin():
+        database.update_derived_data(
+            dataset_id,
+            session,
+            rdkit_cartridge=False,  # Done serially in add_rdkit() to avoid deadlocks.
+            classify_reactions=classify_reactions,
+        )
+    return dataset_id
+
+
 def add_rdkit(engine: Engine, dataset_id: str) -> None:
     """Updates RDKit tables."""
     with Session(engine) as session:
@@ -114,11 +154,54 @@ def add_rdkit(engine: Engine, dataset_id: str) -> None:
             database.update_rdkit_ids(dataset_id, session)
 
 
+def _run_parallel(
+    func: Callable[[str], str],
+    items: Iterable[str],
+    *,
+    n_jobs: int,
+    desc: str,
+    failures: list[str],
+) -> list[str]:
+    """Runs ``func`` over ``items`` with ``n_jobs`` workers.
+
+    Returns the successful results; appends each failed input to ``failures``.
+    """
+    items = list(items)
+    results = []
+    with ExitStack() as stack:
+        if n_jobs > 1:
+            executor = stack.enter_context(ProcessPoolExecutor(n_jobs))
+        else:
+            executor = stack.enter_context(ThreadPoolExecutor(n_jobs))
+        futures = {executor.submit(func, item): item for item in items}
+        for future in tqdm(as_completed(futures), total=len(futures), desc=desc):
+            try:
+                results.append(future.result())
+            except Exception:
+                item = futures[future]
+                failures.append(item)
+                logger.exception(f"{desc} failed for {item}")
+    return results
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parses command-line arguments."""
     parser = argparse.ArgumentParser(description="Add datasets to the ORM database")
     parser.add_argument(
         "--pattern", required=True, help="Pattern for dataset filenames"
+    )
+    parser.add_argument(
+        "--stages",
+        default=",".join(_STAGES),
+        help="Comma-separated stages to run: 'ingest' (ord.*/public.*) and/or 'derived' "
+        "(derived.* SMILES, RDKit links, reaction classes). Derived-only runs over "
+        "already-ingested datasets matching --pattern.",
+    )
+    parser.add_argument(
+        "--classify_reactions",
+        action="store_true",
+        help="Assign reaction class/name labels in the derived stage "
+        "(requires the 'reaction-class' extra)",
     )
     parser.add_argument(
         "--overwrite", action="store_true", help="Update changed datasets"
@@ -137,10 +220,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> None:
-    """Loads matching datasets into the ORM database and adds RDKit functionality."""
+    """Runs the selected ingest and/or derived stages over the matching datasets."""
     silence_rdkit_logs()
     if args.debug:
         get_logger(database.__name__, level=logging.DEBUG)
+    stages = [stage.strip() for stage in args.stages.split(",") if stage.strip()]
+    unknown = set(stages) - set(_STAGES)
+    if unknown:
+        raise SystemExit(
+            f"Unknown --stages values {sorted(unknown)}; choose from {list(_STAGES)}"
+        )
+    if not stages:
+        raise SystemExit(f"--stages must select at least one of {list(_STAGES)}")
+    if args.classify_reactions and database.update_reaction_classes is None:
+        raise SystemExit(
+            "--classify_reactions requires the 'reaction-class' extra: "
+            "pip install ord-schema[reaction-class]"
+        )
     if args.dsn:
         dsn = args.dsn
     else:
@@ -152,38 +248,42 @@ def main(args: argparse.Namespace) -> None:
             port=args.port,
         )
     filenames = sorted(glob(args.pattern))
-    with ExitStack() as stack:
-        max_workers = args.n_jobs
-        if max_workers > 1:
-            executor = stack.enter_context(ProcessPoolExecutor(max_workers))
-        else:
-            executor = stack.enter_context(ThreadPoolExecutor(max_workers))
-        logger.info("Adding datasets")
-        futures = {}
-        for filename in filenames:
-            future = executor.submit(
-                add_dataset, dsn=dsn, filename=filename, overwrite=args.overwrite
-            )
-            futures[future] = filename
-        dataset_ids = []
-        failures = []
-        for future in tqdm(as_completed(futures), total=len(futures)):
+    failures: list[str] = []
+
+    if "ingest" in stages:
+        logger.info("Ingesting datasets")
+        dataset_ids = _run_parallel(
+            partial(ingest_dataset, dsn=dsn, overwrite=args.overwrite),
+            filenames,
+            n_jobs=args.n_jobs,
+            desc="Ingest",
+            failures=failures,
+        )
+    else:
+        dataset_ids = [dataset_id_for_file(filename) for filename in filenames]
+
+    if "derived" in stages:
+        logger.info("Deriving SMILES and reaction classes")
+        dataset_ids = _run_parallel(
+            partial(
+                derive_dataset, dsn=dsn, classify_reactions=args.classify_reactions
+            ),
+            dataset_ids,
+            n_jobs=args.n_jobs,
+            desc="Derive",
+            failures=failures,
+        )
+        logger.info("Adding RDKit functionality")
+        engine = create_engine(dsn)
+        for dataset_id in tqdm(dataset_ids, desc="RDKit"):
             try:
-                dataset_ids.append(future.result())
+                add_rdkit(
+                    engine, dataset_id
+                )  # NOTE(skearnes): Do this serially to avoid deadlocks.
             except Exception:
-                filename = futures[future]
-                failures.append(filename)
-                logger.exception(f"Adding dataset {filename} failed")
-    logger.info("Adding RDKit functionality")
-    engine = create_engine(dsn)
-    for dataset_id in tqdm(dataset_ids):
-        try:
-            add_rdkit(
-                engine, dataset_id
-            )  # NOTE(skearnes): Do this serially to avoid deadlocks.
-        except Exception:
-            failures.append(dataset_id)
-            logger.exception(f"Adding RDKit functionality for {dataset_id} failed")
+                failures.append(dataset_id)
+                logger.exception(f"Adding RDKit functionality for {dataset_id} failed")
+
     if failures:
         raise RuntimeError(failures)
 

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -12,176 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Adds datasets to the ORM database.
+"""CLI for loading ORD datasets into the ORM database.
 
-Ingest (``ord.*`` search index + ``public.*`` payload) and derivation (``derived.*``
-SMILES, RDKit links, and reaction classes) are separate stages selected with
-``--stages``; either can run without the other. Derivation is idempotent, so the
-derived-only stage backfills or recomputes derived data over already-ingested datasets.
+Thin wrapper over ``ord_schema.orm.loading.load_datasets``; see that module for the
+ingest/derivation staging the ``--stages`` flag selects.
 """
 
 import argparse
 import logging
 import os
-import time
-from collections.abc import Callable, Iterable
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
-from contextlib import ExitStack
-from functools import partial
-from glob import glob
-from hashlib import md5
 
-from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
-from sqlalchemy.orm import Session
-from tqdm import tqdm
-
-from ord_schema import parquet
 from ord_schema.logging import get_logger, silence_rdkit_logs
-from ord_schema.message_helpers import load_message
-from ord_schema.orm import database
-from ord_schema.proto import dataset_pb2
+from ord_schema.orm import database, loading
 
 logger = get_logger(__name__)
-
-_STAGES = ("ingest", "derived")
-
-
-def dataset_id_for_file(filename: str) -> str:
-    """Returns the dataset ID for a dataset file without ingesting it."""
-    if filename.endswith(".parquet"):
-        return parquet.load_metadata(filename).dataset_id
-    return load_message(filename, dataset_pb2.Dataset).dataset_id
-
-
-def ingest_dataset(filename: str, *, dsn: str, overwrite: bool) -> str:
-    """Ingests a single dataset (``ord.*`` + ``public.*``); skips unchanged datasets.
-
-    Derived data is populated separately by ``derive_dataset``/``add_rdkit``.
-
-    Args:
-        filename: Dataset filename. ``.parquet`` inputs are streamed via
-            ``database.add_parquet_dataset``; other formats load the whole
-            Dataset proto and call ``database.add_dataset``.
-        dsn: Database connection string.
-        overwrite: If True, update the dataset if the MD5 hash has changed.
-
-    Returns:
-        Dataset ID.
-
-    Raises:
-        ValueError: If the dataset already exists in the database and `overwrite` is not set.
-    """
-    # NOTE(skearnes): Multiprocessing is hard to get right for shared connection pools, so we don't even try; see
-    # https://docs.sqlalchemy.org/en/20/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork.
-    engine = create_engine(dsn)
-    if filename.endswith(".parquet"):
-        logger.debug(f"Streaming {filename}")
-        dataset_id = parquet.load_metadata(filename).dataset_id
-
-        def compute_md5() -> str:
-            md5_hex, _ = parquet.streaming_md5(filename)
-            return md5_hex
-
-        def insert(session: Session) -> None:
-            database.add_parquet_dataset(filename, session)
-    else:
-        logger.debug(f"Loading {filename}")
-        dataset = load_message(filename, dataset_pb2.Dataset)
-        dataset_id = dataset.dataset_id
-
-        def compute_md5() -> str:
-            return md5(
-                dataset.SerializeToString(deterministic=True), usedforsecurity=False
-            ).hexdigest()
-
-        def insert(session: Session) -> None:
-            database.add_dataset(dataset, session)
-
-    with Session(engine) as session:
-        with session.begin():
-            existing_md5 = database.get_dataset_md5(dataset_id, session)
-        if existing_md5 is not None:
-            if compute_md5() != existing_md5:
-                if not overwrite:
-                    raise ValueError(
-                        f"`overwrite` is required when a dataset already exists: {dataset_id}"
-                    )
-                logger.debug(f"existing dataset {dataset_id} changed; updating")
-                with session.begin():
-                    database.delete_dataset(dataset_id, session)
-            else:
-                logger.debug(f"existing dataset {dataset_id} unchanged; skipping")
-                return dataset_id
-        start = time.time()
-        with session.begin():
-            insert(session)
-        logger.debug(f"insert took {time.time() - start:g}s")
-    return dataset_id
-
-
-def derive_dataset(dataset_id: str, *, dsn: str, classify_reactions: bool) -> str:
-    """Runs the parallel-safe derived passes (SMILES + optional classification).
-
-    The RDKit linking pass is excluded here and run serially in ``add_rdkit`` to avoid
-    deadlocks. Idempotent, so it is safe to re-run over already-derived datasets.
-
-    Args:
-        dataset_id: Dataset to derive.
-        dsn: Database connection string.
-        classify_reactions: Whether to assign reaction class/name labels.
-
-    Returns:
-        Dataset ID.
-    """
-    engine = create_engine(dsn)
-    with Session(engine) as session, session.begin():
-        database.update_derived_data(
-            dataset_id,
-            session,
-            rdkit_cartridge=False,  # Done serially in add_rdkit() to avoid deadlocks.
-            classify_reactions=classify_reactions,
-        )
-    return dataset_id
-
-
-def add_rdkit(engine: Engine, dataset_id: str) -> None:
-    """Updates RDKit tables."""
-    with Session(engine) as session:
-        with session.begin():
-            database.update_rdkit_tables(dataset_id, session)
-        with session.begin():
-            database.update_rdkit_ids(dataset_id, session)
-
-
-def _run_parallel(
-    func: Callable[[str], str],
-    items: Iterable[str],
-    *,
-    n_jobs: int,
-    desc: str,
-    failures: list[str],
-) -> list[str]:
-    """Runs ``func`` over ``items`` with ``n_jobs`` workers.
-
-    Returns the successful results; appends each failed input to ``failures``.
-    """
-    items = list(items)
-    results = []
-    with ExitStack() as stack:
-        if n_jobs > 1:
-            executor = stack.enter_context(ProcessPoolExecutor(n_jobs))
-        else:
-            executor = stack.enter_context(ThreadPoolExecutor(n_jobs))
-        futures = {executor.submit(func, item): item for item in items}
-        for future in tqdm(as_completed(futures), total=len(futures), desc=desc):
-            try:
-                results.append(future.result())
-            except Exception:
-                item = futures[future]
-                failures.append(item)
-                logger.exception(f"{desc} failed for {item}")
-    return results
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -192,7 +36,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--stages",
-        default=",".join(_STAGES),
+        default=",".join(loading.STAGES),
         help="Comma-separated stages to run: 'ingest' (ord.*/public.*) and/or 'derived' "
         "(derived.* SMILES, RDKit links, reaction classes). Derived-only runs over "
         "already-ingested datasets matching --pattern.",
@@ -225,13 +69,13 @@ def main(args: argparse.Namespace) -> None:
     if args.debug:
         get_logger(database.__name__, level=logging.DEBUG)
     stages = [stage.strip() for stage in args.stages.split(",") if stage.strip()]
-    unknown = set(stages) - set(_STAGES)
+    unknown = set(stages) - set(loading.STAGES)
     if unknown:
         raise SystemExit(
-            f"Unknown --stages values {sorted(unknown)}; choose from {list(_STAGES)}"
+            f"Unknown --stages values {sorted(unknown)}; choose from {list(loading.STAGES)}"
         )
     if not stages:
-        raise SystemExit(f"--stages must select at least one of {list(_STAGES)}")
+        raise SystemExit(f"--stages must select at least one of {list(loading.STAGES)}")
     if args.classify_reactions and database.update_reaction_classes is None:
         raise SystemExit(
             "--classify_reactions requires the 'reaction-class' extra: "
@@ -247,45 +91,14 @@ def main(args: argparse.Namespace) -> None:
             host=args.host,
             port=args.port,
         )
-    filenames = sorted(glob(args.pattern))
-    failures: list[str] = []
-
-    if "ingest" in stages:
-        logger.info("Ingesting datasets")
-        dataset_ids = _run_parallel(
-            partial(ingest_dataset, dsn=dsn, overwrite=args.overwrite),
-            filenames,
-            n_jobs=args.n_jobs,
-            desc="Ingest",
-            failures=failures,
-        )
-    else:
-        dataset_ids = [dataset_id_for_file(filename) for filename in filenames]
-
-    if "derived" in stages:
-        logger.info("Deriving SMILES and reaction classes")
-        dataset_ids = _run_parallel(
-            partial(
-                derive_dataset, dsn=dsn, classify_reactions=args.classify_reactions
-            ),
-            dataset_ids,
-            n_jobs=args.n_jobs,
-            desc="Derive",
-            failures=failures,
-        )
-        logger.info("Adding RDKit functionality")
-        engine = create_engine(dsn)
-        for dataset_id in tqdm(dataset_ids, desc="RDKit"):
-            try:
-                add_rdkit(
-                    engine, dataset_id
-                )  # NOTE(skearnes): Do this serially to avoid deadlocks.
-            except Exception:
-                failures.append(dataset_id)
-                logger.exception(f"Adding RDKit functionality for {dataset_id} failed")
-
-    if failures:
-        raise RuntimeError(failures)
+    loading.load_datasets(
+        args.pattern,
+        dsn,
+        stages=stages,
+        overwrite=args.overwrite,
+        classify_reactions=args.classify_reactions,
+        n_jobs=args.n_jobs,
+    )
 
 
 if __name__ == "__main__":

--- a/ord_schema/orm/scripts/add_datasets_test.py
+++ b/ord_schema/orm/scripts/add_datasets_test.py
@@ -12,139 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for ord_schema.orm.scripts.add_datasets."""
+"""Tests for ord_schema.orm.scripts.add_datasets.
+
+Loading behavior is covered in ord_schema.orm.loading_test; these cover the CLI wiring
+(argument parsing, stage validation) and that main delegates to loading.load_datasets.
+"""
 
 import pathlib
 
 import pytest
-from sqlalchemy import select, text
-from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
-from ord_schema import message_helpers, parquet
-from ord_schema.orm import database
-from ord_schema.orm.database import prepare_database
 from ord_schema.orm.mappers import Mappers
 from ord_schema.orm.scripts import add_datasets
-from ord_schema.proto import dataset_pb2, reaction_pb2
 
 _PBTXT_FIXTURE = str(
     pathlib.Path(__file__).parent / ".." / "testdata" / "ord-nielsen-example.pbtxt"
 )
 
 
-@pytest.fixture(name="prepared_engine")
-def prepared_engine_fixture(test_engine) -> Engine:
-    """``test_engine`` with the ORM schema (and RDKit cartridge) installed."""
-    assert prepare_database(test_engine)
-    return test_engine
-
-
-def _write_parquet_dataset(tmp_path) -> tuple[str, dataset_pb2.Dataset]:
-    dataset = message_helpers.load_message(_PBTXT_FIXTURE, dataset_pb2.Dataset)
-    parquet_path = (tmp_path / "dataset.parquet").as_posix()
-    parquet.save_dataset(dataset, parquet_path)
-    return parquet_path, dataset
-
-
 def test_main(prepared_engine):
+    """main() parses args and runs both stages over the matching datasets."""
     argv = ["--dsn", str(prepared_engine.url), "--pattern", _PBTXT_FIXTURE]
     add_datasets.main(add_datasets.parse_args(argv))
-
-
-def test_main_parquet(prepared_engine, tmp_path):
-    """Streaming Parquet ingest stores the streaming MD5, reaction count, and Reaction rows."""
-    parquet_path, dataset = _write_parquet_dataset(tmp_path)
-    argv = ["--dsn", str(prepared_engine.url), "--pattern", parquet_path]
-    add_datasets.main(add_datasets.parse_args(argv))
-    expected_md5, expected_count = parquet.streaming_md5(parquet_path)
-    with Session(prepared_engine) as session:
-        # Dataset row's metadata columns reflect the streaming MD5/count.
-        assert database.get_dataset_md5(dataset.dataset_id, session) == expected_md5
-        assert database.get_dataset_size(dataset.dataset_id, session) == expected_count
-        # Reaction rows were actually inserted (not just the num_reactions column).
-        mapped_dataset = session.scalar(
-            select(Mappers.Dataset).where(
-                Mappers.Dataset.dataset_id == dataset.dataset_id
-            )
-        )
-        assert mapped_dataset is not None
-        assert len(mapped_dataset.reactions) == expected_count
-        # Spot-check that one reaction round-trips byte-identical through public.reactions.
-        original = dataset.reactions[0]
-        stored = next(
-            r for r in mapped_dataset.reactions if r.reaction_id == original.reaction_id
-        )
-        assert reaction_pb2.Reaction.FromString(stored.proto_row.proto) == original
-
-
-def test_main_parquet_skip_unchanged(prepared_engine, tmp_path):
-    """A second invocation without --overwrite is a no-op when the MD5 matches."""
-    parquet_path, dataset = _write_parquet_dataset(tmp_path)
-    argv = ["--dsn", str(prepared_engine.url), "--pattern", parquet_path]
-    add_datasets.main(add_datasets.parse_args(argv))
-    add_datasets.main(add_datasets.parse_args(argv))
-    # Skip path must not re-insert: reaction count is unchanged after the second call.
-    _, expected_count = parquet.streaming_md5(parquet_path)
-    with Session(prepared_engine) as session:
-        mapped_dataset = session.scalar(
-            select(Mappers.Dataset).where(
-                Mappers.Dataset.dataset_id == dataset.dataset_id
-            )
-        )
-        assert mapped_dataset is not None
-        assert len(mapped_dataset.reactions) == expected_count
-
-
-def test_main_parquet_rejects_changed_without_overwrite(prepared_engine, tmp_path):
-    """A re-ingest with mutated content but no --overwrite raises."""
-    parquet_path, dataset = _write_parquet_dataset(tmp_path)
-    argv = ["--dsn", str(prepared_engine.url), "--pattern", parquet_path]
-    add_datasets.main(add_datasets.parse_args(argv))
-    dataset.reactions[0].outcomes[0].conversion.value = 999.0
-    parquet.save_dataset(dataset, parquet_path)
-    with pytest.raises(
-        RuntimeError
-    ):  # main() collects per-future failures and raises in aggregate.
-        add_datasets.main(add_datasets.parse_args(argv))
-
-
-def _derived_counts(engine) -> dict[str, int]:
-    with Session(engine) as session:
-        return {
-            table: session.execute(
-                text(f"SELECT count(*) FROM derived.{table}")  # noqa: S608  (constant)
-            ).scalar()
-            for table in (
-                "reaction_smiles",
-                "compound_smiles",
-                "product_compound_smiles",
-            )
-        }
-
-
-def test_stages_ingest_then_derived(prepared_engine):
-    """--stages=ingest writes ord.*/public.* with no derived rows; a later --stages=derived backfills them."""
-    base = ["--dsn", str(prepared_engine.url), "--pattern", _PBTXT_FIXTURE]
-    add_datasets.main(add_datasets.parse_args([*base, "--stages", "ingest"]))
     with Session(prepared_engine) as session:
         assert session.query(Mappers.Reaction).count() > 0
-    assert _derived_counts(prepared_engine) == {
-        "reaction_smiles": 0,
-        "compound_smiles": 0,
-        "product_compound_smiles": 0,
-    }
-    add_datasets.main(add_datasets.parse_args([*base, "--stages", "derived"]))
-    counts = _derived_counts(prepared_engine)
-    assert counts["reaction_smiles"] > 0
-    with Session(prepared_engine) as session:
-        assert (
-            session.execute(text("SELECT count(*) FROM rdkit.reactions")).scalar() > 0
-        )
 
 
 def test_unknown_stage_rejected():
     with pytest.raises(SystemExit):
         add_datasets.main(
             add_datasets.parse_args(["--pattern", _PBTXT_FIXTURE, "--stages", "bogus"])
+        )
+
+
+def test_classify_reactions_requires_extra(monkeypatch):
+    """--classify_reactions exits early with a clear message when the extra is missing."""
+    monkeypatch.setattr(add_datasets.database, "update_reaction_classes", None)
+    with pytest.raises(SystemExit, match="reaction-class"):
+        add_datasets.main(
+            add_datasets.parse_args(
+                ["--pattern", _PBTXT_FIXTURE, "--classify_reactions"]
+            )
         )

--- a/ord_schema/orm/scripts/add_datasets_test.py
+++ b/ord_schema/orm/scripts/add_datasets_test.py
@@ -17,7 +17,7 @@
 import pathlib
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 
@@ -107,3 +107,44 @@ def test_main_parquet_rejects_changed_without_overwrite(prepared_engine, tmp_pat
         RuntimeError
     ):  # main() collects per-future failures and raises in aggregate.
         add_datasets.main(add_datasets.parse_args(argv))
+
+
+def _derived_counts(engine) -> dict[str, int]:
+    with Session(engine) as session:
+        return {
+            table: session.execute(
+                text(f"SELECT count(*) FROM derived.{table}")  # noqa: S608  (constant)
+            ).scalar()
+            for table in (
+                "reaction_smiles",
+                "compound_smiles",
+                "product_compound_smiles",
+            )
+        }
+
+
+def test_stages_ingest_then_derived(prepared_engine):
+    """--stages=ingest writes ord.*/public.* with no derived rows; a later --stages=derived backfills them."""
+    base = ["--dsn", str(prepared_engine.url), "--pattern", _PBTXT_FIXTURE]
+    add_datasets.main(add_datasets.parse_args([*base, "--stages", "ingest"]))
+    with Session(prepared_engine) as session:
+        assert session.query(Mappers.Reaction).count() > 0
+    assert _derived_counts(prepared_engine) == {
+        "reaction_smiles": 0,
+        "compound_smiles": 0,
+        "product_compound_smiles": 0,
+    }
+    add_datasets.main(add_datasets.parse_args([*base, "--stages", "derived"]))
+    counts = _derived_counts(prepared_engine)
+    assert counts["reaction_smiles"] > 0
+    with Session(prepared_engine) as session:
+        assert (
+            session.execute(text("SELECT count(*) FROM rdkit.reactions")).scalar() > 0
+        )
+
+
+def test_unknown_stage_rejected():
+    with pytest.raises(SystemExit):
+        add_datasets.main(
+            add_datasets.parse_args(["--pattern", _PBTXT_FIXTURE, "--stages", "bogus"])
+        )


### PR DESCRIPTION
## Summary

Splits ORM loading into two independently runnable stages so derived data can be backfilled or recomputed without re-ingesting (follow-up to #859, closes #860).

- **`database.add_dataset` / `add_parquet_dataset` are now ingest-only** — they write the `ord.*` search index and `public.*` payload (and `set_submitted_at`) and nothing else.
- **New `database.update_derived_data(dataset_id, session, *, rdkit_cartridge=True, classify_reactions=False)`** orchestrates the derived passes (generated SMILES → RDKit links → optional reaction classes) over an already-ingested dataset. It is idempotent (NOT EXISTS guards), so a derived-only re-run is safe.
- **New library module `ord_schema.orm.loading`** holds the staged, parallel orchestration: `load_datasets(pattern, dsn, *, stages, overwrite, classify_reactions, n_jobs)` plus the per-dataset helpers `ingest_dataset`, `derive_dataset`, `add_rdkit`, and `dataset_id_for_file`. This is the entry point for programmatic callers (e.g. `ord-interface`) so they import from a library rather than reaching into `scripts/`.
- **`add_datasets.py` is now a thin CLI** over `loading.load_datasets`: argument parsing, stage/extra validation, and a delegating `main()`. It gains `--stages` (`ingest`, `derived`; default both) and an opt-in `--classify_reactions` flag. Derived-only resolves dataset IDs from `--pattern` without re-ingesting. The parallel-safe SMILES/classification work runs in the worker pool; the RDKit linking pass stays serial to avoid deadlocks.

This gives the previously missing "skip-ingest-but-do-derived" path: e.g. backfill SMILES, RDKit links, or reaction classes over datasets that are already loaded.

### Engine lifecycle / cleanup
- Each worker now disposes the engine it creates (`try/finally`), so pooled connections don't accumulate in reused `ProcessPoolExecutor` workers; the serial RDKit engine is disposed too.
- `_run_parallel` returns `(results, failures)` instead of mutating a caller-owned list.

## Usage

```shell
# both stages (default, unchanged behavior)
python scripts/add_datasets.py --pattern '.../*.parquet' ...

# ingest only
python scripts/add_datasets.py --pattern '.../*.parquet' --stages ingest ...

# (re)compute derived data over already-ingested datasets, with classification
python scripts/add_datasets.py --pattern '.../*.parquet' --stages derived --classify_reactions ...
```

Programmatically:

```python
from ord_schema.orm.loading import load_datasets

load_datasets("path/to/*.parquet", dsn, stages=("derived",), classify_reactions=True, n_jobs=8)
```

## Testing

- `pytest ord_schema/orm` → 34 passed, 1 skipped (live-resolver smoke test) against Postgres + the RDKit cartridge.
- `ord_schema/orm/loading_test.py` covers the staged loading behavior (`load_datasets` directly): both-stage load, streaming Parquet ingest, skip-unchanged, reject-changed-without-overwrite, ingest-then-derived backfill, and unknown-stage validation. `add_datasets_test.py` keeps the CLI-level cases (delegation smoke test, `SystemExit` on bad `--stages`, `--classify_reactions` without the extra).
- `ruff` + `ty` clean.

## Follow-up

`ord-interface` (sibling repo, pins `ord-schema[orm]`) still calls `add_dataset(..., rdkit_cartridge=...)`. It will need to switch to `add_dataset(...)` + `update_derived_data(...)`, or simply call `ord_schema.orm.loading.load_datasets(...)`, before it picks up this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR splits dataset loading into separate ingest and derived-data stages. The main changes are:

- `add_dataset` and `add_parquet_dataset` now perform ingest only.
- `update_derived_data` runs SMILES, RDKit links, and optional reaction classification.
- `loading.load_datasets` orchestrates staged loading for programmatic callers.
- `scripts/add_datasets.py` adds `--stages` and `--classify_reactions` CLI options.
- Tests cover staged ingest, derived-only backfill, Parquet loading, and CLI validation.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Separates ingest-only dataset writes from derived-data population through the new `update_derived_data` entry point. |
| ord_schema/orm/loading.py | Adds staged loading helpers for ingest, derived data, serial RDKit linking, and failure aggregation. |
| ord_schema/orm/scripts/add_datasets.py | Updates the CLI to parse stage and classification options before delegating to staged loading. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Extract staged loading into ord\_schema.o..."](https://github.com/open-reaction-database/ord-schema/commit/f450c2433aa44884e394e6bfe7ce87a29af6aafc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40412657)</sub>

<!-- /greptile_comment -->