### PR TITLE
Default the database search_path to public in prepare_database

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -23,7 +23,7 @@ from unittest.mock import patch
 from dateutil import parser
 from sqlalchemy import delete, select, text
 from sqlalchemy.engine import Engine
-from sqlalchemy.exc import NotSupportedError, OperationalError
+from sqlalchemy.exc import NotSupportedError, OperationalError, ProgrammingError
 from sqlalchemy.orm import Session
 
 from ord_schema import message_helpers, parquet
@@ -91,6 +91,23 @@ def prepare_database(engine: Engine) -> bool:
         connection.execute(text("CREATE SCHEMA IF NOT EXISTS rdkit"))
         # Derived, best-effort data that is not part of the proto (e.g. reaction class).
         connection.execute(text("CREATE SCHEMA IF NOT EXISTS derived"))
+    with engine.begin() as connection:
+        # Pin the database's default search_path to public. The connecting role is often
+        # named "ord", which would make Postgres's default ("$user", public) resolve the
+        # ord schema first; instead require explicit ord/derived/rdkit qualification (the
+        # ORM qualifies every table) and keep only public on the path, where the RDKit
+        # cartridge functions live. Best-effort: a non-owner connection cannot ALTER
+        # DATABASE, but the ORM still works since it never relies on the default path.
+        try:
+            connection.execute(
+                text(
+                    "DO $$ BEGIN EXECUTE format("
+                    "'ALTER DATABASE %I SET search_path TO public', "
+                    "current_database()); END $$;"
+                )
+            )
+        except (OperationalError, ProgrammingError) as error:
+            logger.warning(f"Could not set the default search_path to public: {error}")
     try:
         with engine.begin() as connection:
             # NOTE(skearnes): The RDKit PostgreSQL extension works best in the public schema.

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -135,6 +135,19 @@ def test_unlinked_partial_indexes(test_session):
         )
 
 
+def test_default_search_path_is_public(test_session):
+    """prepare_database pins the database default search_path to public, not the role's ord schema."""
+    setting = test_session.execute(
+        text(
+            "SELECT array_to_string(s.setconfig, ',') "
+            "FROM pg_db_role_setting s JOIN pg_database d ON d.oid = s.setdatabase "
+            "WHERE d.datname = current_database() AND s.setrole = 0"
+        )
+    ).scalar()
+    assert setting is not None
+    assert "search_path=public" in setting
+
+
 def test_get_dataset_md5(test_session):
     assert (
         get_dataset_md5("test_dataset", test_session)


### PR DESCRIPTION
## Summary

The ORM connects as a role usually named **`ord`**, so Postgres's default `search_path` (`"$user", public`) resolves the **`ord` schema** first — making it the de-facto default schema for the database. That's surprising for a search index that's meant to be addressed explicitly.

`prepare_database` now pins the database default to **`public`** (`ALTER DATABASE <current> SET search_path TO public`). Nothing relies on `ord` being on the default path:

- the ORM **schema-qualifies every table**, so it never depends on `search_path`;
- **ord-interface** connects with `options="-c search_path=public,ord"` per connection;
- only the **RDKit cartridge** functions/operators benefit from being on the path, and they live in `public`.

So `public` is the only thing the default path needs; `ord`/`derived`/`rdkit` are referenced explicitly.

## Notes

- Runs as a **best-effort** `ALTER DATABASE` in its **own transaction**, so a non-owner connection that can't `ALTER DATABASE` logs a warning instead of rolling back the schema creation — mirroring the existing `tsm_system_rows`/`rdkit` extension-setup pattern in the same function.
- Harmless in tests (the testing role is `postgres`, where `public` is already effectively the default).
- New test `test_default_search_path_is_public` asserts the database-level setting via `pg_db_role_setting`.

This is the standing home for the fix (single source of truth across prod/dev/test); `pulumi-postgresql` has no `ALTER DATABASE … SET` resource, so it doesn't belong in the infra stack.

## Testing

`pytest ord_schema/orm/database_test.py` → 10 passed (Postgres + RDKit cartridge). `ruff` + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR defaults the prepared database search path to `public`. The main changes are:

- Adds a best-effort database-level `search_path` update in `prepare_database`.
- Catches database permission errors while keeping schema setup intact.
- Adds a test that checks the persisted database setting.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Adds the best-effort database default `search_path` update during database preparation. |
| ord_schema/orm/database_test.py | Adds coverage for the persisted database-level `search_path` setting. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into prepare-databas..."](https://github.com/open-reaction-database/ord-schema/commit/0aac5783713db990efdad9ddcb6f5301d7211653) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40417730)</sub>

<!-- /greptile_comment -->