### PR TITLE
Batch the derived passes to bound ingest memory

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -273,8 +273,8 @@ _PARQUET_FLUSH_BATCH = 1000
 
 # Number of reactions/compounds the derived passes load and process at a time. The ids needing
 # derivation are fetched up front, but the heavy work (proto deserialization, SMILES generation)
-# and the pending inserts are kept to this many rows so peak memory does not scale with the
-# dataset size.
+# and the pending inserts are limited to this many rows at a time, bounding peak memory to one
+# batch.
 _DERIVED_BATCH = 1000
 
 
@@ -377,8 +377,7 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
     Reaction SMILES come from the ground-truth proto in public.reactions; compound SMILES
     from each ord.compound row's reconstructed message. Idempotent (skips rows that already
     have a derived entry); runs before the RDKit pass, which reads the SMILES. Reactions and
-    compounds are processed in batches of _DERIVED_BATCH so peak memory does not scale with
-    the dataset size.
+    compounds are processed in batches of _DERIVED_BATCH, bounding peak memory to one batch.
     """
     logger.debug(f"Updating derived tables for {dataset_id=}")
     start = time.time()
@@ -390,12 +389,14 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
     ).scalar_one()
     # Reaction SMILES from the served proto (no ORM objects loaded), keyed by ord.reaction.id.
     # Resolve the ids needing derivation in one indexed pass, then load and parse the (large)
-    # protos in batches of _DERIVED_BATCH so peak memory does not scale with the dataset.
+    # protos in batches of _DERIVED_BATCH, bounding peak memory to one batch.
     reaction_ids = (
         session.execute(
             text("""
                 SELECT ord.reaction.id
                 FROM ord.reaction
+                JOIN public.reactions
+                    ON public.reactions.reaction_id = ord.reaction.reaction_id
                 WHERE ord.reaction.dataset_id = :id
                   AND NOT EXISTS (
                       SELECT 1 FROM derived.reaction_smiles
@@ -486,8 +487,8 @@ def _update_compound_smiles(
 
     Compounds aren't stored as protos, so each is reconstructed from its identifiers via
     to_proto. The ids needing derivation are resolved up front, then loaded and inserted in
-    batches of _DERIVED_BATCH (expunging each compound after use) so the session and peak
-    memory stay bounded regardless of dataset size.
+    batches of _DERIVED_BATCH, expunging each compound after use to bound the session and
+    peak memory to one batch.
     """
     compound_ids = (
         session.execute(

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -273,8 +273,7 @@ _PARQUET_FLUSH_BATCH = 1000
 
 # Number of reactions/compounds the derived passes load and process at a time. The ids needing
 # derivation are fetched up front, but the heavy work (proto deserialization, SMILES generation)
-# and the pending inserts are limited to this many rows at a time, bounding peak memory to one
-# batch.
+# and the pending inserts are limited to this many rows at a time.
 _DERIVED_BATCH = 1000
 
 
@@ -377,7 +376,8 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
     Reaction SMILES come from the ground-truth proto in public.reactions; compound SMILES
     from each ord.compound row's reconstructed message. Idempotent (skips rows that already
     have a derived entry); runs before the RDKit pass, which reads the SMILES. Reactions and
-    compounds are processed in batches of _DERIVED_BATCH, bounding peak memory to one batch.
+    compounds are processed in batches of _DERIVED_BATCH so the heavy per-row work (proto
+    deserialization, SMILES generation) and pending inserts stay within one batch.
     """
     logger.debug(f"Updating derived tables for {dataset_id=}")
     start = time.time()
@@ -389,7 +389,7 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
     ).scalar_one()
     # Reaction SMILES from the served proto (no ORM objects loaded), keyed by ord.reaction.id.
     # Resolve the ids needing derivation in one indexed pass, then load and parse the (large)
-    # protos in batches of _DERIVED_BATCH, bounding peak memory to one batch.
+    # protos in batches of _DERIVED_BATCH.
     reaction_ids = (
         session.execute(
             text("""
@@ -486,9 +486,10 @@ def _update_compound_smiles(
     """Derives SMILES for one (product) compound table's not-yet-derived rows.
 
     Compounds aren't stored as protos, so each is reconstructed from its identifiers via
-    to_proto. The ids needing derivation are resolved up front, then loaded and inserted in
-    batches of _DERIVED_BATCH, expunging each compound after use to bound the session and
-    peak memory to one batch.
+    to_proto. The ids needing derivation are resolved up front, then the compounds are loaded
+    one at a time and inserted in batches of _DERIVED_BATCH. SQLAlchemy's weak identity map
+    releases each compound (and the children to_proto lazily loads) once it falls out of use,
+    so the session stays small.
     """
     compound_ids = (
         session.execute(
@@ -531,12 +532,8 @@ def _update_compound_smiles(
                     )
                 )
             except ValueError:
-                session.expunge(
-                    compound
-                )  # Release the ORM object; keep the session small.
                 continue
             inserts.append({derived_id: compound_id, "smiles": smiles})
-            session.expunge(compound)  # Release the ORM object; keep the session small.
         if inserts:
             session.execute(insert_smiles, inserts)
 

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -21,10 +21,11 @@ from typing import Any, cast
 from unittest.mock import patch
 
 from dateutil import parser
-from sqlalchemy import delete, select, text
+from sqlalchemy import bindparam, delete, select, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NotSupportedError, OperationalError, ProgrammingError
 from sqlalchemy.orm import Session
+from tqdm import tqdm
 
 from ord_schema import message_helpers, parquet
 from ord_schema.logging import get_logger
@@ -267,9 +268,14 @@ def backfill_submission_times(session: Session) -> None:
 
 # Reactions are flushed and expunged in batches of this size during streaming
 # ingest. Larger values reduce SQL roundtrips at the cost of more pending ORM
-# objects held in memory; 200 is unmeasured and worked fine on the existing
-# ord-data fixtures.
-_PARQUET_FLUSH_BATCH = 200
+# objects held in memory.
+_PARQUET_FLUSH_BATCH = 1000
+
+# Number of reactions/compounds the derived passes load and process at a time. The ids needing
+# derivation are fetched up front, but the heavy work (proto deserialization, SMILES generation)
+# and the pending inserts are kept to this many rows so peak memory does not scale with the
+# dataset size.
+_DERIVED_BATCH = 1000
 
 
 def add_parquet_dataset(path: str, session: Session) -> None:
@@ -313,7 +319,13 @@ def add_parquet_dataset(path: str, session: Session) -> None:
             session.expunge(obj)
         pending.clear()
 
-    for _, reaction in parquet.iter_reactions(path):
+    for _, reaction in tqdm(
+        parquet.iter_reactions(path),
+        total=num_reactions,
+        desc=f"ingest {metadata.dataset_id}",
+        unit="rxn",
+        leave=False,
+    ):
         reaction_mapper = from_proto(reaction, mapper=reaction_child_class)
         reaction_mapper.parent = mapped_dataset
         session.add(reaction_mapper)
@@ -364,8 +376,9 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
 
     Reaction SMILES come from the ground-truth proto in public.reactions; compound SMILES
     from each ord.compound row's reconstructed message. Idempotent (skips rows that already
-    have a derived entry); runs before the RDKit pass, which reads the SMILES. Rows are
-    streamed and inserted in bulk so the session does not grow with the dataset.
+    have a derived entry); runs before the RDKit pass, which reads the SMILES. Reactions and
+    compounds are processed in batches of _DERIVED_BATCH so peak memory does not scale with
+    the dataset size.
     """
     logger.debug(f"Updating derived tables for {dataset_id=}")
     start = time.time()
@@ -375,44 +388,66 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
         text("SELECT id FROM ord.dataset WHERE dataset_id = :dataset_id"),
         {"dataset_id": dataset_id},
     ).scalar_one()
-    # Reaction SMILES from the served proto (no ORM objects loaded); keyed by ord.reaction.id.
-    rows = session.execute(
-        text("""
-            SELECT ord.reaction.id, public.reactions.proto
-            FROM ord.reaction
-            JOIN public.reactions
-                ON public.reactions.reaction_id = ord.reaction.reaction_id
-            WHERE ord.reaction.dataset_id = :id
-              AND NOT EXISTS (
-                  SELECT 1 FROM derived.reaction_smiles
-                  WHERE derived.reaction_smiles.reaction_id = ord.reaction.id
-              )
-            """),
-        {"id": dataset_pk},
-    )
-    inserts = []
-    for reaction_id, proto in rows:
-        try:
-            reaction_smiles = message_helpers.get_reaction_smiles(
-                reaction_pb2.Reaction.FromString(proto),
-                generate_if_missing=True,
-                allow_incomplete=False,
-                validate=True,
-            )
-        except ValueError as error:
-            logger.debug(f"No reaction SMILES for reaction id={reaction_id}: {error}")
-            continue
-        tokens = reaction_smiles.split() if reaction_smiles else []  # Handle CXSMILES.
-        if tokens:
-            inserts.append({"reaction_id": reaction_id, "reaction_smiles": tokens[0]})
-    if inserts:
+    # Reaction SMILES from the served proto (no ORM objects loaded), keyed by ord.reaction.id.
+    # Resolve the ids needing derivation in one indexed pass, then load and parse the (large)
+    # protos in batches of _DERIVED_BATCH so peak memory does not scale with the dataset.
+    reaction_ids = (
         session.execute(
-            text(
-                "INSERT INTO derived.reaction_smiles (reaction_id, reaction_smiles) "
-                "VALUES (:reaction_id, :reaction_smiles)"
-            ),
-            inserts,
+            text("""
+                SELECT ord.reaction.id
+                FROM ord.reaction
+                WHERE ord.reaction.dataset_id = :id
+                  AND NOT EXISTS (
+                      SELECT 1 FROM derived.reaction_smiles
+                      WHERE derived.reaction_smiles.reaction_id = ord.reaction.id
+                  )
+                """),
+            {"id": dataset_pk},
         )
+        .scalars()
+        .all()
+    )
+    select_protos = text("""
+        SELECT ord.reaction.id, public.reactions.proto
+        FROM ord.reaction
+        JOIN public.reactions
+            ON public.reactions.reaction_id = ord.reaction.reaction_id
+        WHERE ord.reaction.id IN :ids
+        """).bindparams(bindparam("ids", expanding=True))
+    insert_reaction_smiles = text(
+        "INSERT INTO derived.reaction_smiles (reaction_id, reaction_smiles) "
+        "VALUES (:reaction_id, :reaction_smiles)"
+    )
+    for batch_start in tqdm(
+        range(0, len(reaction_ids), _DERIVED_BATCH),
+        desc=f"reaction SMILES {dataset_id}",
+        unit="batch",
+        leave=False,
+    ):
+        batch_ids = reaction_ids[batch_start : batch_start + _DERIVED_BATCH]
+        inserts = []
+        for reaction_id, proto in session.execute(select_protos, {"ids": batch_ids}):
+            try:
+                reaction_smiles = message_helpers.get_reaction_smiles(
+                    reaction_pb2.Reaction.FromString(proto),
+                    generate_if_missing=True,
+                    allow_incomplete=False,
+                    validate=True,
+                )
+            except ValueError as error:
+                logger.debug(
+                    f"No reaction SMILES for reaction id={reaction_id}: {error}"
+                )
+                continue
+            tokens = (
+                reaction_smiles.split() if reaction_smiles else []
+            )  # Handle CXSMILES.
+            if tokens:
+                inserts.append(
+                    {"reaction_id": reaction_id, "reaction_smiles": tokens[0]}
+                )
+        if inserts:
+            session.execute(insert_reaction_smiles, inserts)
     _update_compound_smiles(
         session,
         dataset_pk=dataset_pk,
@@ -450,46 +485,59 @@ def _update_compound_smiles(
     """Derives SMILES for one (product) compound table's not-yet-derived rows.
 
     Compounds aren't stored as protos, so each is reconstructed from its identifiers via
-    to_proto; rows load one at a time (SQLAlchemy's weak identity map releases each after
-    use) and SMILES are inserted in bulk.
+    to_proto. The ids needing derivation are resolved up front, then loaded and inserted in
+    batches of _DERIVED_BATCH (expunging each compound after use) so the session and peak
+    memory stay bounded regardless of dataset size.
     """
-    compound_ids = session.execute(
-        text(f"""
-            SELECT {compound_table}.id
-            FROM {compound_table}
-            JOIN {link_table} ON {compound_table}.{link_column} = {link_table}.id
-            JOIN ord.reaction ON {link_table}.reaction_id = ord.reaction.id
-            WHERE ord.reaction.dataset_id = :id
-              AND NOT EXISTS (
-                  SELECT 1 FROM {derived_table}
-                  WHERE {derived_table}.{derived_id} = {compound_table}.id
-              )
-            """),  # noqa: S608  (table/column names are internal constants, not user input)
-        {"id": dataset_pk},
-    ).scalars()
-    inserts = []
-    for compound_id in compound_ids:
-        compound = session.get(compound_class, compound_id)
-        assert compound is not None  # Selected by id above.
-        try:
-            smiles = message_helpers.smiles_from_compound(
-                cast(
-                    "reaction_pb2.Compound | reaction_pb2.ProductCompound",
-                    to_proto(compound),
-                )
-            )
-        except ValueError:
-            continue
-        inserts.append({derived_id: compound_id, "smiles": smiles})
-    if inserts:
-        # The interpolated names are internal constants (not user input); see S608 below.
+    compound_ids = (
         session.execute(
-            text(
-                f"INSERT INTO {derived_table} ({derived_id}, smiles) "  # noqa: S608
-                f"VALUES (:{derived_id}, :smiles)"
-            ),
-            inserts,
+            text(f"""
+                SELECT {compound_table}.id
+                FROM {compound_table}
+                JOIN {link_table} ON {compound_table}.{link_column} = {link_table}.id
+                JOIN ord.reaction ON {link_table}.reaction_id = ord.reaction.id
+                WHERE ord.reaction.dataset_id = :id
+                  AND NOT EXISTS (
+                      SELECT 1 FROM {derived_table}
+                      WHERE {derived_table}.{derived_id} = {compound_table}.id
+                  )
+                """),  # noqa: S608  (table/column names are internal constants, not user input)
+            {"id": dataset_pk},
         )
+        .scalars()
+        .all()
+    )
+    # The interpolated names are internal constants (not user input); see S608 below.
+    insert_smiles = text(
+        f"INSERT INTO {derived_table} ({derived_id}, smiles) "  # noqa: S608
+        f"VALUES (:{derived_id}, :smiles)"
+    )
+    for batch_start in tqdm(
+        range(0, len(compound_ids), _DERIVED_BATCH),
+        desc=derived_table.rsplit(".", maxsplit=1)[-1],
+        unit="batch",
+        leave=False,
+    ):
+        inserts = []
+        for compound_id in compound_ids[batch_start : batch_start + _DERIVED_BATCH]:
+            compound = session.get(compound_class, compound_id)
+            assert compound is not None  # Selected by id above.
+            try:
+                smiles = message_helpers.smiles_from_compound(
+                    cast(
+                        "reaction_pb2.Compound | reaction_pb2.ProductCompound",
+                        to_proto(compound),
+                    )
+                )
+            except ValueError:
+                session.expunge(
+                    compound
+                )  # Release the ORM object; keep the session small.
+                continue
+            inserts.append({derived_id: compound_id, "smiles": smiles})
+            session.expunge(compound)  # Release the ORM object; keep the session small.
+        if inserts:
+            session.execute(insert_smiles, inserts)
 
 
 def update_rdkit_tables(dataset_id: str, session: Session) -> None:

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -114,6 +114,31 @@ def test_update_derived_tables_idempotent(test_session):
         )
 
 
+def test_update_derived_tables_batched(test_session, monkeypatch):
+    """A small batch size reproduces the full result, exercising the multi-batch path."""
+    tables = ("reaction_smiles", "compound_smiles", "product_compound_smiles")
+    full = {
+        table: test_session.execute(
+            text(f"SELECT count(*) FROM derived.{table}")  # noqa: S608  (constant)
+        ).scalar()
+        for table in tables
+    }
+    assert full["reaction_smiles"] > 0
+    # Clear the derived rows, then re-derive in batches far smaller than the dataset (80
+    # reactions) so the result is built across many batches rather than one.
+    for table in tables:
+        test_session.execute(text(f"DELETE FROM derived.{table}"))  # noqa: S608  (constant)
+    monkeypatch.setattr("ord_schema.orm.database._DERIVED_BATCH", 7)
+    update_derived_tables("test_dataset", test_session)
+    for table, count in full.items():
+        assert (
+            test_session.execute(
+                text(f"SELECT count(*) FROM derived.{table}")  # noqa: S608  (constant)
+            ).scalar()
+            == count
+        )
+
+
 def test_unlinked_partial_indexes(test_session):
     """prepare_database creates partial indexes over unlinked rows to keep incremental linking cheap."""
     indexes = dict(

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -123,7 +123,9 @@ def test_update_derived_tables_batched(test_session, monkeypatch):
         ).scalar()
         for table in tables
     }
-    assert full["reaction_smiles"] > 0
+    # Every derived table must be populated up front, otherwise the re-derivation below would
+    # pass trivially (0 == 0) without exercising the reaction or compound batch paths.
+    assert all(count > 0 for count in full.values()), full
     # Clear the derived rows, then re-derive in batches far smaller than the dataset (80
     # reactions) so the result is built across many batches rather than one.
     for table in tables:


### PR DESCRIPTION
## Summary

The import's peak memory was dominated by the **derived passes**, which loaded an entire dataset into client memory at once:

- `update_derived_tables` ran one `SELECT id, proto` over the whole dataset (buffering **every reaction proto**) and accumulated **all** insert rows before a single bulk insert.
- `_update_compound_smiles` buffered all compound ids and accumulated **all** insert rows.

On a large dataset (e.g. the 1.77M-reaction USPTO set, ~1 GB Parquet) that's a multi-GB spike — the thing that forced the 128 GB box. The Parquet *ingest* was already streamed, and the RDKit pass is server-side SQL (no client buffering), so the derived passes were the only offenders.

## Change

Both derived passes now **operate in batches instead of whole datasets**:

1. Resolve the ids needing derivation in one indexed pass (`scalars().all()` — ints only).
2. Process the heavy work (proto deserialization / SMILES generation) in **`_DERIVED_BATCH` (1000)** chunks: fetch that batch's protos (`WHERE id IN :ids`), flush its inserts, and `expunge` each compound after use.

Peak memory is now bounded by **one batch** (a few MB of protos + pending inserts) plus the id list, rather than the full dataset. Same session/transaction, so it still works when ingest and derivation share a transaction (as in the test fixture), and the `NOT EXISTS` idempotency guard is preserved.

Also:
- **Parquet flush batch 200 → 1000** (`_PARQUET_FLUSH_BATCH`).
- **tqdm progress bars** for the Parquet ingest (per reaction) and the derived batches (per batch), so a long run is observable.

## Honest residual

The per-dataset **id lists** are still materialized: ~64 MB for 1.77M reaction ids, and a few hundred MB for the compound ids of the largest dataset. That's far below the previous multi-GB proto/insert buffering (enough to run on a much smaller machine), but it's not constant. Driving it to constant memory would need keyset pagination over `(dataset_id, id)` — deferred unless we need to go smaller still.

## Testing

- New `test_update_derived_tables_batched`: clears the fixture's derived rows and re-derives with `_DERIVED_BATCH = 7` (dataset is 80 reactions), asserting the multi-batch result matches the full-dataset counts.
- Full `pytest ord_schema/orm` → **36 passed, 1 skipped** against Postgres + the RDKit cartridge. `ruff` + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces whole-dataset buffering in the two derived-data passes (`update_derived_tables` and `_update_compound_smiles`) with `_DERIVED_BATCH`-sized (1000) chunked processing, bounding peak memory to one batch of protos + pending inserts rather than the full dataset. The `_PARQUET_FLUSH_BATCH` constant is also increased from 200 → 1000, and `tqdm` progress bars are added to both the Parquet ingest loop and the derived-batch loops.

- **Reaction SMILES pass**: materialises the id list in one indexed query (still joined to `public.reactions`), then fetches and processes protos in `_DERIVED_BATCH` chunks using SQLAlchemy's `expanding=True` `IN`-clause bindparam, flushing inserts after every chunk.
- **Compound SMILES pass**: same two-phase pattern — full id list upfront, per-batch load via `session.get`, per-batch insert flush; SQLAlchemy's weak identity map handles per-compound GC between batches.
- **New test** (`test_update_derived_tables_batched`): clears all derived rows and re-derives with `_DERIVED_BATCH=7` (dataset: 80 reactions), asserting the batched result matches the original full counts across all three derived tables.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the batching logic is correct, the id-fetch query retains its JOIN public.reactions guard from the pre-PR code, and the new test verifies multi-batch correctness end-to-end.

Both derived passes split correctly into a materialised-ids phase and a chunked-process phase. The expanding=True bindparam is used correctly and is reusable across different batch sizes. The NOT EXISTS idempotency guard is applied only in the id-collection query, which is the same semantic as the old single-query design. The new test clears the derived tables and re-derives with a tiny batch size, catching any off-by-one or batch-boundary bugs. No logic regressions are apparent.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Core batching refactor: reaction SMILES and compound SMILES passes now use a two-phase id-fetch + chunked-process loop; tqdm progress bars added; _PARQUET_FLUSH_BATCH raised to 1000. |
| ord_schema/orm/database_test.py | New test_update_derived_tables_batched exercises the multi-batch code path via monkeypatching _DERIVED_BATCH=7 on an 80-reaction fixture, asserting per-table counts match original. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as Caller
    participant F as update_derived_tables
    participant DB as PostgreSQL

    C->>F: update_derived_tables(dataset_id, session)
    F->>DB: "SELECT id FROM ord.dataset WHERE dataset_id=?"
    DB-->>F: dataset_pk

    Note over F,DB: Phase 1 — materialise id list (one indexed pass)
    F->>DB: "SELECT ord.reaction.id JOIN public.reactions WHERE dataset_id=? AND NOT EXISTS(derived.reaction_smiles)"
    DB-->>F: reaction_ids (all ints)

    loop For each _DERIVED_BATCH chunk of reaction_ids
        F->>DB: SELECT id, proto WHERE id IN :batch_ids (expanding)
        DB-->>F: (reaction_id, proto) rows
        Note over F: deserialise proto → get_reaction_smiles
        F->>DB: INSERT INTO derived.reaction_smiles (batch)
    end

    Note over F: _update_compound_smiles x2 (same pattern)
    F->>DB: SELECT compound.id WHERE NOT EXISTS(derived.compound_smiles)
    DB-->>F: compound_ids (all ints)

    loop For each _DERIVED_BATCH chunk of compound_ids
        loop per compound_id in chunk
            F->>DB: session.get(compound_class, id)
            DB-->>F: compound ORM object
            Note over F: to_proto → smiles_from_compound
        end
        F->>DB: INSERT INTO derived.compound_smiles (batch)
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as Caller
    participant F as update_derived_tables
    participant DB as PostgreSQL

    C->>F: update_derived_tables(dataset_id, session)
    F->>DB: "SELECT id FROM ord.dataset WHERE dataset_id=?"
    DB-->>F: dataset_pk

    Note over F,DB: Phase 1 — materialise id list (one indexed pass)
    F->>DB: "SELECT ord.reaction.id JOIN public.reactions WHERE dataset_id=? AND NOT EXISTS(derived.reaction_smiles)"
    DB-->>F: reaction_ids (all ints)

    loop For each _DERIVED_BATCH chunk of reaction_ids
        F->>DB: SELECT id, proto WHERE id IN :batch_ids (expanding)
        DB-->>F: (reaction_id, proto) rows
        Note over F: deserialise proto → get_reaction_smiles
        F->>DB: INSERT INTO derived.reaction_smiles (batch)
    end

    Note over F: _update_compound_smiles x2 (same pattern)
    F->>DB: SELECT compound.id WHERE NOT EXISTS(derived.compound_smiles)
    DB-->>F: compound_ids (all ints)

    loop For each _DERIVED_BATCH chunk of compound_ids
        loop per compound_id in chunk
            F->>DB: session.get(compound_class, id)
            DB-->>F: compound ORM object
            Note over F: to_proto → smiles_from_compound
        end
        F->>DB: INSERT INTO derived.compound_smiles (batch)
    end
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["Assert all derived tables non-empty befo..."](https://github.com/open-reaction-database/ord-schema/commit/096cb4c475002fceb2b3541412c2e15ef54518a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40670698)</sub>

<!-- /greptile_comment -->