### PR TITLE
Pin mapped enum types to the ord schema

### DIFF
--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -175,9 +175,7 @@ def test_enum_types_in_ord_schema(test_session):
         text(
             "SELECT t.typname, n.nspname FROM pg_type t "
             "JOIN pg_namespace n ON n.oid = t.typnamespace "
-            "WHERE t.typtype = 'e' "
-            "AND t.typname IN ('ReactionIdentifierType', 'CompoundIdentifierType', "
-            "'ReactionRoleType')"
+            "WHERE t.typtype = 'e'"
         )
     ).all()
     assert schemas, "no mapped enum types found"

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -162,6 +162,29 @@ def test_unlinked_partial_indexes(test_session):
         )
 
 
+def test_enum_types_in_ord_schema(test_session):
+    """Mapped enum types live in the ord schema so they are rendered schema-qualified.
+
+    Without inherit_schema the enum type is created wherever the create-time
+    search_path points and referenced unqualified; that breaks ingest when the
+    default search_path is pinned to public and the connecting role owns an
+    eponymous ord schema (the prod 'ord' role), so the unqualified cast cannot find
+    the type. Pinning the types to ord makes resolution search_path-independent.
+    """
+    schemas = test_session.execute(
+        text(
+            "SELECT t.typname, n.nspname FROM pg_type t "
+            "JOIN pg_namespace n ON n.oid = t.typnamespace "
+            "WHERE t.typtype = 'e' "
+            "AND t.typname IN ('ReactionIdentifierType', 'CompoundIdentifierType', "
+            "'ReactionRoleType')"
+        )
+    ).all()
+    assert schemas, "no mapped enum types found"
+    for typname, schema in schemas:
+        assert schema == "ord", f"{typname} is in {schema}, expected ord"
+
+
 def test_default_search_path_is_public(test_session):
     """prepare_database pins the database default search_path to public, not the role's ord schema."""
     setting = test_session.execute(

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -199,8 +199,18 @@ def build_mapper(
             )
         elif field.type == FieldDescriptor.TYPE_ENUM:
             assert field.enum_type is not None  # Type hint.
+            # inherit_schema pins the enum type to the mapped table's schema (ord)
+            # so it is always rendered schema-qualified. Without this the type is
+            # created wherever the connection's search_path points at create time and
+            # referenced unqualified, which breaks when the default search_path does
+            # not include ord (e.g. a role with an eponymous schema connecting to a
+            # public-only search_path).
             attrs[field.name] = Column(
-                Enum(*field.enum_type.values_by_name.keys(), name=field.enum_type.name)
+                Enum(
+                    *field.enum_type.values_by_name.keys(),
+                    name=field.enum_type.name,
+                    inherit_schema=True,
+                )
             )
         else:
             attrs[field.name] = Column(_FIELD_TYPES[field.type])


### PR DESCRIPTION
## Summary

Ingesting into a fresh prod database failed with:

```
sqlalchemy.exc.ProgrammingError: (psycopg.errors.UndefinedObject)
type "ReactionIdentifierType" does not exist
LINE 1: ..., is_mapped, reaction_id) SELECT p0::VARCHAR, p1::"ReactionI...
```

### Root cause

Enum columns were declared without a schema:

```python
Enum(*field.enum_type.values_by_name.keys(), name=field.enum_type.name)
```

With no `schema=` / `inherit_schema=True`, the Postgres enum type is created wherever the connection's `search_path` points at `create_all` time and then referenced **unqualified** in generated SQL (`p1::"ReactionIdentifierType"`).

That is fine until the default `search_path` stops including the schema that holds the types. Two things combine to trigger it in prod:

1. `prepare_database` pins the database default `search_path` to `public` (#862).
2. The prod `ord` role owns an eponymous `ord` schema, so `create_all` as that role lands the enum types in `ord` (via `"$user", public`).

The later unqualified cast then resolves against `public` only and fails.

### Why CI didn't catch it

`testing.postgresql` connects as a role with **no eponymous schema**, so its create-time `search_path` collapses to `public`. The enum types land in `public` — exactly where the pinned `search_path` looks — so the unqualified cast resolves and ingest succeeds. The bug only fires when the connecting role has a schema that shadows the create-time default, which is true for prod (`ord`) but not for the test role.

### Fix

Set `inherit_schema=True` so the enum types are pinned to the mapped table's schema (`ord`) and always rendered schema-qualified (`ord."ReactionIdentifierType"`), independent of `search_path` or the connecting role. Add a regression test asserting the enum types live in `ord`.

### Validation

Verified end-to-end against the prod RDS instance (new `ord_20260629` database, `search_path = public`, connecting as `ord`): ingest + derived + RDKit stages all complete; previously the ingest stage raised on the first enum cast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a production ingest failure caused by unqualified Postgres enum casts failing when the database's default `search_path` is pinned to `public` but enum types were created in a different schema (the `ord` role's eponymous schema). The fix adds `inherit_schema=True` to every `Enum` column in `mappers.py`, ensuring enum types are always created and referenced with an explicit `ord.` prefix.

- **`mappers.py`**: `inherit_schema=True` is added to the `Enum(...)` constructor so each mapped enum type is pinned to the owning table's schema (`ord`), making the DDL and casts schema-qualified and `search_path`-independent.
- **`database_test.py`**: A new regression test queries all `pg_type` entries of kind `'e'` and asserts every one lives in `ord`, directly verifying the invariant the fix establishes.
</details>

<h3>Confidence Score: 5/5</h3>

The change is a targeted one-liner fix to enum schema qualification with a matching regression test; no existing behaviour is altered for correctly-configured databases.

The fix correctly uses `inherit_schema=True` so every ORM-mapped enum type is created and cast as `ord."TypeName"` regardless of the connecting role's `search_path`. The regression test exercises the full `prepare_database` + `add_dataset` path and then queries `pg_type` directly, giving high confidence the invariant holds. No edge cases were found: all mapped tables share the `ord` schema, so schema inheritance is unambiguous.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/mappers.py | Adds `inherit_schema=True` to all dynamically-created `Enum` columns so enum types are schema-qualified in the `ord` schema; straightforward and correct fix. |
| ord_schema/orm/database_test.py | Adds a regression test querying all Postgres enum types and asserting they reside in `ord`; covers the full set of ORM-mapped enums and correctly validates the fix. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PG as PostgreSQL (prod)
    participant SA as SQLAlchemy create_all
    participant ORM as ORM Mapper (mappers.py)

    note over PG: search_path = public (pinned by prepare_database)
    note over PG: connecting role owns "ord" schema

    SA->>ORM: "build_mapper() — Enum(..., inherit_schema=True)"
    ORM-->>SA: Enum type schema inherited from table (ord)
    SA->>PG: CREATE TYPE ord."ReactionIdentifierType" AS ENUM (...)
    SA->>PG: CREATE TABLE ord.reaction_identifier (..., type ord."ReactionIdentifierType", ...)

    note over PG: Ingest INSERT
    SA->>PG: INSERT ... p1::ord."ReactionIdentifierType" ...
    PG-->>SA: ✅ Type found in ord schema, cast succeeds
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PG as PostgreSQL (prod)
    participant SA as SQLAlchemy create_all
    participant ORM as ORM Mapper (mappers.py)

    note over PG: search_path = public (pinned by prepare_database)
    note over PG: connecting role owns "ord" schema

    SA->>ORM: "build_mapper() — Enum(..., inherit_schema=True)"
    ORM-->>SA: Enum type schema inherited from table (ord)
    SA->>PG: CREATE TYPE ord."ReactionIdentifierType" AS ENUM (...)
    SA->>PG: CREATE TABLE ord.reaction_identifier (..., type ord."ReactionIdentifierType", ...)

    note over PG: Ingest INSERT
    SA->>PG: INSERT ... p1::ord."ReactionIdentifierType" ...
    PG-->>SA: ✅ Type found in ord schema, cast succeeds
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile: assert all enum types,..."](https://github.com/open-reaction-database/ord-schema/commit/1c3aed684e958d7a5ec2b8fb34d666302c73c1cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40676801)</sub>

<!-- /greptile_comment -->