### PR TITLE
Pin setuptools<81 in the reaction-class extra for pkg_resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ reaction-class = [
     # caps <5). Revisit when rxnmapper supports transformers 5. See issue #858.
     "transformers>=4.53,<5",
     "rxn-insight @ git+https://github.com/skearnes/Rxn-INSIGHT.git@eb71946997e81801ba56c66c9a564263743c7eee",
+    # rxnmapper imports pkg_resources at module load but does not declare setuptools;
+    # setuptools>=81 dropped pkg_resources, so pin below that to keep the import working.
+    "setuptools<81",
 ]
 tests = [
     "ruff>=0.9.9",

--- a/uv.lock
+++ b/uv.lock
@@ -2420,6 +2420,7 @@ orm = [
 ]
 reaction-class = [
     { name = "rxn-insight" },
+    { name = "setuptools" },
     { name = "transformers" },
 ]
 tests = [
@@ -2463,6 +2464,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'tests'", specifier = ">=0.9.9" },
     { name = "rxn-insight", marker = "extra == 'reaction-class'", git = "https://github.com/skearnes/Rxn-INSIGHT.git?rev=eb71946997e81801ba56c66c9a564263743c7eee" },
     { name = "scikit-learn", marker = "extra == 'examples'", specifier = ">=0.24.1" },
+    { name = "setuptools", marker = "extra == 'reaction-class'", specifier = "<81" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=5.3.0" },
     { name = "sphinx-rtd-theme", marker = "extra == 'docs'", specifier = ">=1.1.1" },
     { name = "sphinx-tabs", marker = "extra == 'docs'", specifier = ">=3.4.0" },
@@ -4031,11 +4033,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Setting up the `reaction-class` extra in a fresh environment, reaction classification was silently disabled:

```
ModuleNotFoundError: No module named 'pkg_resources'
  File ".../rxnmapper/batched_mapper.py", line 4, in <module>
    import pkg_resources
```

`rxnmapper` imports `pkg_resources` at module load (`batched_mapper.py`, `core.py`) but doesn't declare `setuptools` as a dependency. Two things make this bite:

1. uv-managed virtualenvs don't include `setuptools`/`pkg_resources` by default.
2. Even when `setuptools` is present transitively, `setuptools>=81` removed the bundled `pkg_resources`.

When the import fails, `ord_schema.orm.database` catches it and sets `update_reaction_classes = None`, so `--classify_reactions` becomes a no-op instead of an error — the kind of silent disablement that's easy to miss.

## Fix

Pin `setuptools<81` in the `reaction-class` extra so `pkg_resources` is importable. Regenerated `uv.lock` (setuptools 82.0.1 → 80.10.2).

## Deployment note (not pip-installable)

On a headless host the extra also needs the X11 render lib that RDKit's drawing module loads transitively (`rxn_insight` → `rdkit.Chem.Draw`), otherwise:

```
ImportError: libXrender.so.1: cannot open shared object file
```

Install via the system package manager, e.g. `apt-get install -y libxrender1 libxext6 libsm6`. This is environment provisioning, outside `pyproject.toml`.

## Validation

With both fixes applied, verified end-to-end against the prod RDS instance: `update_reaction_classes` loads and a derived pass with `--classify_reactions` populates `derived.reaction_classes` (e.g. "Functional Group Interconversion").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR pins `setuptools<81` in the `reaction-class` optional extra to fix a silent-failure path: `rxnmapper` imports `pkg_resources` at module load without declaring `setuptools` as a dependency, and `setuptools>=81` removed `pkg_resources`, causing the import to silently fall back to `update_reaction_classes = None`.

- Adds `\"setuptools<81\"` to the `reaction-class` extra in `pyproject.toml` with a clear explanatory comment, and regenerates `uv.lock` (82.0.1 → 80.10.2).
- The lock file resolves cleanly at 80.10.2 — no conflicts with other extras in the unified lockfile.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-scoped dependency pin that addresses a known upstream gap in rxnmapper's declared dependencies.

The only changed files are `pyproject.toml` (one added dependency line with a clear comment) and the regenerated `uv.lock`. The pin resolves without conflicts in the unified lockfile, the comment accurately describes the upstream issue, and the fix is limited to the optional `reaction-class` extra so it does not affect the default install surface.

No files require special attention. When rxnmapper eventually declares its own `setuptools` dependency or migrates to `importlib.metadata`, the `setuptools<81` pin in `pyproject.toml` should be revisited.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | Adds `setuptools<81` to the `reaction-class` extra with a well-documented comment explaining the upstream gap; change is minimal and correctly scoped to only the affected extra. |
| uv.lock | Lock file regenerated consistently with the new pin; setuptools downgraded from 82.0.1 to 80.10.2, entry added to the `reaction-class` extra dependency list, no other packages affected. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant user as User (--classify_reactions)
    participant db as ord_schema.orm.database
    participant rc as reaction_class (rxn-insight→rxnmapper)
    participant pkg as pkg_resources (setuptools<81)

    user->>db: import database
    db->>rc: try: from reaction_class import update_reaction_classes
    rc->>pkg: import pkg_resources
    alt "setuptools>=81 or absent (before fix)"
        pkg-->>rc: ModuleNotFoundError
        rc-->>db: Exception caught
        db->>db: "update_reaction_classes = None"
        user->>db: "classify_reactions=True"
        db-->>user: ImportError (requires reaction-class extra)
    else "setuptools<81 pinned (after fix)"
        pkg-->>rc: ok
        rc-->>db: update_reaction_classes loaded
        user->>db: "classify_reactions=True"
        db->>rc: update_reaction_classes(dataset_id, session)
        rc-->>user: reaction classes populated
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant user as User (--classify_reactions)
    participant db as ord_schema.orm.database
    participant rc as reaction_class (rxn-insight→rxnmapper)
    participant pkg as pkg_resources (setuptools<81)

    user->>db: import database
    db->>rc: try: from reaction_class import update_reaction_classes
    rc->>pkg: import pkg_resources
    alt "setuptools>=81 or absent (before fix)"
        pkg-->>rc: ModuleNotFoundError
        rc-->>db: Exception caught
        db->>db: "update_reaction_classes = None"
        user->>db: "classify_reactions=True"
        db-->>user: ImportError (requires reaction-class extra)
    else "setuptools<81 pinned (after fix)"
        pkg-->>rc: ok
        rc-->>db: update_reaction_classes loaded
        user->>db: "classify_reactions=True"
        db->>rc: update_reaction_classes(dataset_id, session)
        rc-->>user: reaction classes populated
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Pin setuptools&lt;81 in the reaction-class ..."](https://github.com/open-reaction-database/ord-schema/commit/3c8c9d7fdb81adbd1ef7ebea14ce5820a847df77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40682419)</sub>

<!-- /greptile_comment -->