### PR TITLE
Derive compound SMILES set-based instead of per-compound ORM loads

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -539,6 +539,9 @@ def _update_compound_smiles(
         inserts = []
         for compound_id in batch_ids:
             value = stored_smiles.get(compound_id)
+            # An absent or empty SMILES identifier both fall through to the reconstruction path,
+            # matching smiles_from_compound's `get_compound_smiles(...) or ...` falsiness (an
+            # empty string is not a parseable structure to canonicalize).
             if value:
                 # Canonicalize the stored SMILES, matching smiles_from_compound's default.
                 mol = Chem.MolFromSmiles(value)

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -21,6 +21,7 @@ from typing import Any, cast
 from unittest.mock import patch
 
 from dateutil import parser
+from rdkit import Chem
 from sqlalchemy import bindparam, delete, select, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NotSupportedError, OperationalError, ProgrammingError
@@ -485,11 +486,12 @@ def _update_compound_smiles(
 ) -> None:
     """Derives SMILES for one (product) compound table's not-yet-derived rows.
 
-    Compounds aren't stored as protos, so each is reconstructed from its identifiers via
-    to_proto. The ids needing derivation are resolved up front, then the compounds are loaded
-    one at a time and inserted in batches of _DERIVED_BATCH. SQLAlchemy's weak identity map
-    releases each compound (and the children to_proto lazily loads) once it falls out of use,
-    so the session stays small.
+    The common case -- a compound with a stored SMILES identifier -- is served set-based: the
+    first SMILES identifier for each compound in the batch is fetched from ord.compound_identifier
+    in a single query and canonicalized with RDKit, avoiding a per-compound ORM load. Compounds
+    without a stored SMILES fall back to reconstructing the message via to_proto and computing the
+    SMILES from its other identifiers. Ids are resolved up front and processed in batches of
+    _DERIVED_BATCH so memory stays bounded.
     """
     compound_ids = (
         session.execute(
@@ -509,7 +511,17 @@ def _update_compound_smiles(
         .scalars()
         .all()
     )
-    # The interpolated names are internal constants (not user input); see S608 below.
+    # The first SMILES identifier (lowest id == proto order) for each requested compound. The FK
+    # column is indexed, so one query per batch replaces an ORM load plus lazy child fetches per
+    # compound. Interpolated names are internal constants (not user input); see S608 below.
+    select_smiles = text(f"""
+        SELECT DISTINCT ON (ord.compound_identifier.{derived_id})
+               ord.compound_identifier.{derived_id}, ord.compound_identifier.value
+        FROM ord.compound_identifier
+        WHERE ord.compound_identifier.{derived_id} IN :ids
+          AND ord.compound_identifier.type = 'SMILES'
+        ORDER BY ord.compound_identifier.{derived_id}, ord.compound_identifier.id
+        """).bindparams(bindparam("ids", expanding=True))  # noqa: S608
     insert_smiles = text(
         f"INSERT INTO {derived_table} ({derived_id}, smiles) "  # noqa: S608
         f"VALUES (:{derived_id}, :smiles)"
@@ -520,19 +532,35 @@ def _update_compound_smiles(
         unit="batch",
         leave=False,
     ):
+        batch_ids = compound_ids[batch_start : batch_start + _DERIVED_BATCH]
+        stored_smiles = {
+            row[0]: row[1] for row in session.execute(select_smiles, {"ids": batch_ids})
+        }
         inserts = []
-        for compound_id in compound_ids[batch_start : batch_start + _DERIVED_BATCH]:
-            compound = session.get(compound_class, compound_id)
-            assert compound is not None  # Selected by id above.
-            try:
-                smiles = message_helpers.smiles_from_compound(
-                    cast(
-                        "reaction_pb2.Compound | reaction_pb2.ProductCompound",
-                        to_proto(compound),
+        for compound_id in batch_ids:
+            value = stored_smiles.get(compound_id)
+            if value:
+                # Canonicalize the stored SMILES, matching smiles_from_compound's default.
+                mol = Chem.MolFromSmiles(value)
+                if mol is None:
+                    logger.debug(
+                        f"Cannot parse SMILES for compound id={compound_id}: {value}"
                     )
-                )
-            except ValueError:
-                continue
+                    continue
+                smiles = Chem.MolToSmiles(mol)
+            else:
+                # No stored SMILES: reconstruct the message and derive from other identifiers.
+                compound = session.get(compound_class, compound_id)
+                assert compound is not None  # Selected by id above.
+                try:
+                    smiles = message_helpers.smiles_from_compound(
+                        cast(
+                            "reaction_pb2.Compound | reaction_pb2.ProductCompound",
+                            to_proto(compound),
+                        )
+                    )
+                except ValueError:
+                    continue
             inserts.append({derived_id: compound_id, "smiles": smiles})
         if inserts:
             session.execute(insert_smiles, inserts)

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -15,13 +15,18 @@
 """Tests for ord_schema.orm.database."""
 
 import datetime
+import pathlib
 from typing import cast
 
 import pytest
+from rdkit import Chem
 from sqlalchemy import select, text
+from sqlalchemy.orm import Session
 
 from ord_schema import message_helpers
+from ord_schema.datasets import load_dataset
 from ord_schema.orm.database import (
+    add_dataset,
     backfill_submission_times,
     delete_dataset,
     get_dataset_md5,
@@ -159,8 +164,9 @@ def test_compound_smiles_match_reference(
 ):
     """The set-based compound SMILES equal the per-compound smiles_from_compound reference.
 
-    Guards value parity of the bulk SMILES-identifier path (and the fallback for compounds
-    without a stored SMILES) against the message-reconstruction reference.
+    Guards value parity of the bulk SMILES-identifier path against the message-reconstruction
+    reference. The fallback (compounds without a stored SMILES, which this fixture does not
+    contain) is covered by test_compound_smiles_fallback_without_stored_smiles.
     """
     rows = test_session.execute(
         text(f"SELECT {id_column}, smiles FROM {derived_table}")  # noqa: S608  (constant)
@@ -175,6 +181,51 @@ def test_compound_smiles_match_reference(
             )
         )
         assert smiles == expected, (derived_table, compound_id, smiles, expected)
+
+
+def test_compound_smiles_fallback_without_stored_smiles(prepared_engine):
+    """A compound with no stored SMILES is derived via the message-reconstruction fallback.
+
+    The set-based fast path only covers compounds with a SMILES identifier; this exercises the
+    session.get + to_proto + smiles_from_compound branch, which the standard fixture (every
+    compound carries a SMILES) never reaches.
+    """
+    dataset = load_dataset(
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+    )
+    # Replace one compound's SMILES identifier with the equivalent InChI so only the fallback
+    # (structure reconstruction from a non-SMILES identifier) can derive its SMILES.
+    compound = next(
+        component
+        for reaction in dataset.reactions
+        for reaction_input in reaction.inputs.values()
+        for component in reaction_input.components
+    )
+    inchi = Chem.MolToInchi(
+        Chem.MolFromSmiles(message_helpers.get_compound_smiles(compound))
+    )
+    del compound.identifiers[:]
+    compound.identifiers.add(type=reaction_pb2.CompoundIdentifier.INCHI, value=inchi)
+    expected = Chem.MolToSmiles(Chem.MolFromInchi(inchi))
+    with Session(prepared_engine) as session:
+        with session.begin():
+            add_dataset(dataset, session)
+        with session.begin():
+            update_derived_tables(dataset.dataset_id, session)
+        # Exactly the modified compound lacks a SMILES identifier, so its derived row proves the
+        # fallback ran and produced the InChI-derived canonical SMILES.
+        fallback_smiles = (
+            session.execute(
+                text(
+                    "SELECT smiles FROM derived.compound_smiles cs "
+                    "WHERE NOT EXISTS (SELECT 1 FROM ord.compound_identifier ci "
+                    "WHERE ci.compound_id = cs.compound_id AND ci.type = 'SMILES')"
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert fallback_smiles == [expected], fallback_smiles
 
 
 def test_unlinked_partial_indexes(test_session):

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -15,10 +15,12 @@
 """Tests for ord_schema.orm.database."""
 
 import datetime
+from typing import cast
 
 import pytest
 from sqlalchemy import select, text
 
+from ord_schema import message_helpers
 from ord_schema.orm.database import (
     backfill_submission_times,
     delete_dataset,
@@ -27,7 +29,7 @@ from ord_schema.orm.database import (
     update_derived_tables,
     update_rdkit_tables,
 )
-from ord_schema.orm.mappers import Mappers
+from ord_schema.orm.mappers import Mappers, to_proto
 from ord_schema.orm.public_mappers import DatasetMetadata
 from ord_schema.proto import reaction_pb2
 
@@ -139,6 +141,40 @@ def test_update_derived_tables_batched(test_session, monkeypatch):
             ).scalar()
             == count
         )
+
+
+@pytest.mark.parametrize(
+    ("derived_table", "id_column", "mapper"),
+    [
+        ("derived.compound_smiles", "compound_id", Mappers.Compound),
+        (
+            "derived.product_compound_smiles",
+            "product_compound_id",
+            Mappers.ProductCompound,
+        ),
+    ],
+)
+def test_compound_smiles_match_reference(
+    test_session, derived_table, id_column, mapper
+):
+    """The set-based compound SMILES equal the per-compound smiles_from_compound reference.
+
+    Guards value parity of the bulk SMILES-identifier path (and the fallback for compounds
+    without a stored SMILES) against the message-reconstruction reference.
+    """
+    rows = test_session.execute(
+        text(f"SELECT {id_column}, smiles FROM {derived_table}")  # noqa: S608  (constant)
+    ).all()
+    assert rows, derived_table
+    for compound_id, smiles in rows:
+        compound = test_session.get(mapper, compound_id)
+        expected = message_helpers.smiles_from_compound(
+            cast(
+                "reaction_pb2.Compound | reaction_pb2.ProductCompound",
+                to_proto(compound),
+            )
+        )
+        assert smiles == expected, (derived_table, compound_id, smiles, expected)
 
 
 def test_unlinked_partial_indexes(test_session):


### PR DESCRIPTION
Closes #872.

## Problem

`_update_compound_smiles` fetched each compound with its own `session.get()` and lazily loaded its children via `to_proto` just to read one SMILES identifier — millions of latency-bound round-trips. On the 1.77M-reaction dataset the compound-SMILES pass ran ~13h and was the single dominant cost of a full population.

## Change

Serve the common case set-based:

- Fetch the first `SMILES`-type identifier for each compound in the batch from `ord.compound_identifier` in **one indexed query** (the FK columns `compound_id` / `product_compound_id` are indexed), then canonicalize with RDKit — matching `smiles_from_compound`'s default `canonical=True` path exactly.
- Compounds **without** a stored SMILES fall back to the existing message-reconstruction path (`session.get` + `to_proto` + `smiles_from_compound`), so behavior is unchanged for those.

This mirrors the batched proto-fetch already used for reaction SMILES (#864). Ids are still resolved up front and processed in `_DERIVED_BATCH` chunks, so memory stays bounded.

## Correctness

Value parity was checked directly: on the example dataset the set-based output is byte-identical to the previous per-compound output (e.g. `c1ccccc1CCC(O)C` → `CC(O)CCc1ccccc1`). A new parametrized test (`test_compound_smiles_match_reference`) asserts, for every fixture compound in both `derived.compound_smiles` and `derived.product_compound_smiles`, that the stored SMILES equals `smiles_from_compound(to_proto(compound))` — guarding both the fast path and the fallback. Full `database_test.py` passes (14 tests); ruff + ty clean.

## Follow-up

Real-scale timing will come from re-running the derived stage over the already-ingested prod dataset (`ord_20260629` has the 1.77M-reaction dataset ingested but underived) — that gives a true before/after on ~8M compounds, alongside the COPY-ingest work (#873).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the per-compound `session.get()` loop in `_update_compound_smiles` with a single `SELECT DISTINCT ON` query that bulk-fetches the first `SMILES`-type identifier for each compound in the batch, canonicalizes with RDKit directly, and falls back to the original `to_proto` + `smiles_from_compound` path only for compounds without a stored SMILES identifier.

- **`database.py`**: A `SELECT DISTINCT ON (compound_id)` query prefetches all SMILES identifiers for each batch; compounds in the result go through `Chem.MolFromSmiles` → `Chem.MolToSmiles` (matching `smiles_from_compound`'s canonical=True default); compounds absent from the result retain the existing ORM-load fallback.
- **`database_test.py`**: Two new tests added — a parametrized parity check against the `smiles_from_compound` reference for both compound tables, and a dedicated fallback test that replaces a compound's SMILES with an InChI before ingestion to force the reconstruction path.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the optimization is structurally sound, the fast and fallback paths produce byte-identical output to the original, and both are now exercised by dedicated tests.

The change is a pure performance optimization with no behavioral difference: the bulk query matches smiles_from_compound's canonical=True path exactly, the fallback is the original code unchanged, and the test suite covers both compound tables on both paths. No correctness or safety concerns were found.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Replaces per-compound ORM load with a single bulk DISTINCT ON query; fallback path for compounds without stored SMILES is unchanged and correct. |
| ord_schema/orm/database_test.py | Adds parametrized parity test and a dedicated fallback test that exercises the session.get + to_proto branch via InChI substitution; covers both compound tables. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Resolve compound_ids needing derivation] --> B[Chunk into _DERIVED_BATCH slices]
    B --> C["Bulk SELECT DISTINCT ON (compound_id)\nWHERE type = 'SMILES' IN batch_ids"]
    C --> D{For each compound_id in batch}
    D --> E{value in stored_smiles?}
    E -- "Yes (truthy SMILES)" --> F["Chem.MolFromSmiles(value)"]
    F --> G{mol is None?}
    G -- Yes --> H[logger.debug + continue — skip]
    G -- No --> I["Chem.MolToSmiles(mol) → canonical SMILES"]
    E -- "No (absent or empty)" --> J["session.get + to_proto + smiles_from_compound"]
    J --> K{ValueError?}
    K -- Yes --> H
    K -- No --> I
    I --> L[Append to inserts list]
    L --> M[Batch INSERT into derived table]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Resolve compound_ids needing derivation] --> B[Chunk into _DERIVED_BATCH slices]
    B --> C["Bulk SELECT DISTINCT ON (compound_id)\nWHERE type = 'SMILES' IN batch_ids"]
    C --> D{For each compound_id in batch}
    D --> E{value in stored_smiles?}
    E -- "Yes (truthy SMILES)" --> F["Chem.MolFromSmiles(value)"]
    F --> G{mol is None?}
    G -- Yes --> H[logger.debug + continue — skip]
    G -- No --> I["Chem.MolToSmiles(mol) → canonical SMILES"]
    E -- "No (absent or empty)" --> J["session.get + to_proto + smiles_from_compound"]
    J --> K{ValueError?}
    K -- Yes --> H
    K -- No --> I
    I --> L[Append to inserts list]
    L --> M[Batch INSERT into derived table]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/open-reaction-database/ord-schema/commit/1f3ffb48a687e970fdc785451810c45ab8d9b73f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40987800)</sub>

<!-- /greptile_comment -->