### PR TITLE
Use UUIDv7 surrogate keys instead of integer serial ids

### DIFF
--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -183,6 +183,31 @@ def test_enum_types_in_ord_schema(test_session):
         assert schema == "ord", f"{typname} is in {schema}, expected ord"
 
 
+def test_surrogate_keys_are_uuidv7(test_session):
+    """ord.* surrogate keys are uuid columns populated with version-7 (time-sortable) values."""
+    types = dict(
+        test_session.execute(
+            text(
+                "SELECT table_name || '.' || column_name, data_type "
+                "FROM information_schema.columns "
+                "WHERE table_schema = 'ord' "
+                "AND ((table_name = 'reaction' AND column_name = 'id') "
+                "  OR (table_name = 'compound' AND column_name IN ('id', 'reaction_input_id')))"
+            )
+        ).all()
+    )
+    assert types == {
+        "reaction.id": "uuid",
+        "compound.id": "uuid",
+        "compound.reaction_input_id": "uuid",
+    }, types
+    # psycopg returns uuid columns as uuid.UUID; ingest mints version-7 ids.
+    reaction_id = test_session.execute(
+        text("SELECT id FROM ord.reaction LIMIT 1")
+    ).scalar_one()
+    assert reaction_id.version == 7
+
+
 def test_default_search_path_is_public(test_session):
     """prepare_database pins the database default search_path to public, not the role's ord schema."""
     setting = test_session.execute(

--- a/ord_schema/orm/derived_mappers.py
+++ b/ord_schema/orm/derived_mappers.py
@@ -18,7 +18,7 @@ These live in a separate "derived" schema to keep the proto-mirroring "ord" sche
 canonical. Populated by post-passes (not from_proto); the ORM works without them.
 """
 
-from sqlalchemy import Column, ForeignKey, Index, Integer, Text, text
+from sqlalchemy import Column, ForeignKey, Index, Integer, Text, Uuid, text
 from sqlalchemy.orm import relationship
 
 from ord_schema.orm import Base
@@ -32,9 +32,9 @@ class ReactionSmiles(Base):
     """
 
     __tablename__ = "reaction_smiles"
-    # Integer FK to ord.reaction.id, per the ORM's reaction FK convention (see mappers).
+    # FK to the ord.reaction UUIDv7 surrogate key (see mappers).
     reaction_id = Column(
-        Integer, ForeignKey("ord.reaction.id", ondelete="CASCADE"), primary_key=True
+        Uuid, ForeignKey("ord.reaction.id", ondelete="CASCADE"), primary_key=True
     )
     reaction_smiles = Column(Text, index=True)
     rdkit_reaction_id = Column(
@@ -64,7 +64,7 @@ class CompoundSmiles(Base):
 
     __tablename__ = "compound_smiles"
     compound_id = Column(
-        Integer, ForeignKey("ord.compound.id", ondelete="CASCADE"), primary_key=True
+        Uuid, ForeignKey("ord.compound.id", ondelete="CASCADE"), primary_key=True
     )
     smiles = Column(Text, index=True)
     rdkit_mol_id = Column(
@@ -91,7 +91,7 @@ class ProductCompoundSmiles(Base):
 
     __tablename__ = "product_compound_smiles"
     product_compound_id = Column(
-        Integer,
+        Uuid,
         ForeignKey("ord.product_compound.id", ondelete="CASCADE"),
         primary_key=True,
     )
@@ -121,9 +121,9 @@ class ReactionClasses(Base):
     """
 
     __tablename__ = "reaction_classes"
-    # Integer FK to ord.reaction.id, per the ORM's reaction FK convention (see mappers).
+    # FK to the ord.reaction UUIDv7 surrogate key (see mappers).
     reaction_id = Column(
-        Integer,
+        Uuid,
         ForeignKey("ord.reaction.id", ondelete="CASCADE"),
         primary_key=True,
     )

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -46,9 +46,11 @@ from sqlalchemy import (
     Integer,
     LargeBinary,
     Text,
+    Uuid,
 )
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import relationship
+from uuid6 import uuid7
 
 # Register the rdkit and derived tables on Base for string relationship() targets.
 import ord_schema.orm.derived_mappers
@@ -168,7 +170,9 @@ def build_mapper(
     assert msg_desc is not None  # Type hint.
     attrs: dict[str, Any] = {
         "__tablename__": underscore(msg_desc.name),
-        "id": Column(Integer, primary_key=True),
+        # UUIDv7 surrogate key: time-sortable (index locality) and client-generatable, so bulk
+        # loads can mint ids and wire foreign keys without a server round trip. See pyproject.
+        "id": Column(Uuid, primary_key=True, default=uuid7),
         "ord_schema_context": Column(Text, nullable=False),
         "__table_args__": ({"schema": "ord"},),
     }
@@ -265,9 +269,7 @@ def build_mapper(
             # NOTE(skearnes): We are not enforcing unique constraints on this column; see the module docstring.
             f"{foreign_table_name}_id": mapper_class.__table__.c.get(
                 f"{foreign_table_name}_id",
-                Column(
-                    Integer, ForeignKey(foreign_key, ondelete="CASCADE"), index=True
-                ),
+                Column(Uuid, ForeignKey(foreign_key, ondelete="CASCADE"), index=True),
             ),
             "parent": relationship(
                 parent_desc.name, back_populates=field_name, uselist=False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,10 @@ orm = [
     "inflection>=0.5.1",
     "psycopg[binary,pool]>=3",
     "sqlalchemy>=2",
+    # UUIDv7 surrogate primary keys: time-sortable (index locality) and client-generatable
+    # (no server round-trip / sequence reservation for bulk COPY loads). Backports uuid7()
+    # for Python < 3.14. See ord_schema.orm.mappers.
+    "uuid6>=2023",
 ]
 # Optional: ord_schema.orm.reaction_class assigns a best-effort reaction class and
 # named reaction to each reaction (for faceted search) via Rxn-INSIGHT. It pulls in

--- a/uv.lock
+++ b/uv.lock
@@ -2417,6 +2417,7 @@ orm = [
     { name = "inflection" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "sqlalchemy" },
+    { name = "uuid6" },
 ]
 reaction-class = [
     { name = "rxn-insight" },
@@ -2437,6 +2438,7 @@ tests = [
     { name = "testing-postgresql" },
     { name = "treon" },
     { name = "ty" },
+    { name = "uuid6" },
 ]
 
 [package.metadata]
@@ -2475,6 +2477,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'reaction-class'", specifier = ">=4.53,<5" },
     { name = "treon", marker = "extra == 'tests'", specifier = ">=0.1.3" },
     { name = "ty", marker = "extra == 'tests'", specifier = ">=0.0.28" },
+    { name = "uuid6", marker = "extra == 'orm'", specifier = ">=2023" },
     { name = "wget", marker = "extra == 'examples'", specifier = ">=3.2" },
 ]
 provides-extras = ["docs", "examples", "github", "huggingface", "orm", "reaction-class", "tests"]
@@ -4777,6 +4780,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uuid6"
+version = "2025.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b7/4c0f736ca824b3a25b15e8213d1bcfc15f8ac2ae48d1b445b310892dc4da/uuid6-2025.0.1.tar.gz", hash = "sha256:cd0af94fa428675a44e32c5319ec5a3485225ba2179eefcf4c3f205ae30a81bd", size = 13932, upload-time = "2025-07-04T18:30:35.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b2/93faaab7962e2aa8d6e174afb6f76be2ca0ce89fde14d3af835acebcaa59/uuid6-2025.0.1-py3-none-any.whl", hash = "sha256:80530ce4d02a93cdf82e7122ca0da3ebbbc269790ec1cb902481fa3e9cc9ff99", size = 6979, upload-time = "2025-07-04T18:30:34.001Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #857.

## Why

The `ord.*` surrogate primary keys (and the child→parent and derived-table FKs that reference them) were integer serial ids assigned by the database on insert. That forces a bulk loader to either reserve id blocks from sequences or round-trip per row to learn the ids — the main friction blocking the COPY-based ingest in #873.

Switching to **UUIDv7** removes it: the ids are **client-generatable** (mint in Python, wire FKs, COPY — no server round-trip) and **time-sortable**, so they preserve B-tree index locality on insert the way serial ids do and random UUIDv4 would not. UUIDv7 drops into the native Postgres `uuid` type with standard tooling; ULID would need bespoke encoding to do the same (and its string-form advantages don't apply to internal surrogate keys). See the logbook entry for the analysis.

## Scope

- `mappers.build_mapper`: the generated `ord.*` PK becomes `Column(Uuid, primary_key=True, default=uuid7)` and the generated child→parent FK becomes `Uuid`.
- `derived_mappers`: the FK columns referencing `ord.*` (`reaction_id`, `compound_id`, `product_compound_id`) become `Uuid`.
- **`rdkit.*` tables keep integer serial ids** — they're populated server-side by the RDKit pass (`INSERT … SELECT`), so there's no client-generation benefit; the `derived.*` `rdkit_*_id` FKs stay `Integer` to match.
- **`public.*` unchanged** — keyed on the `reaction_id` / `dataset_id` business strings, not surrogate ids.
- Adds `uuid6` to the `orm` extra (pure-Python `uuid7()` backport for Python < 3.14).

## Compatibility

Reads are unaffected: ord-interface issues raw SQL against the tables and joins ids by equality only (no `::int` casts, no `ORDER BY id`, no integer range ops), which is type-agnostic. No online migration — the database is rebuilt.

## Tests

Full ORM suite passes (38). New `test_surrogate_keys_are_uuidv7` asserts the `ord.*` id/FK columns are `uuid` and that ingest mints version-7 values. Verified end-to-end that ingest + derive still produce identical SMILES with uuid keys.

Follow-up: #873 (direct proto→tuples COPY loader) builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Replaces integer serial surrogate keys on all `ord.*` tables with UUIDv7 (`uuid6.uuid7()`), updating child→parent FK columns in `mappers.py` and the `derived.*` FK columns in `derived_mappers.py` to match. The `rdkit.*` tables and `public.*` business-key FKs are intentionally untouched.

- `build_mapper` now emits `Column(Uuid, primary_key=True, default=uuid7)` for every `ord.*` PK; child→parent FK columns change from `Integer` to `Uuid` in the same code path, keeping the schema consistent end-to-end.
- `derived_mappers.py` updates `reaction_id`, `compound_id`, and `product_compound_id` FK columns to `Uuid`; `rdkit_*_id` columns stay `Integer` to match the server-side RDKit integer serial scheme.
- Adds `uuid6>=2023` to the `orm` extra (backport of `uuid7()` for Python < 3.14) and pins it at `2025.0.1` in the lockfile; a new `test_surrogate_keys_are_uuidv7` test verifies both the Postgres column type and the UUID version bit.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the schema change is internally consistent, all affected FK columns are updated, and the unaffected schemas (rdkit.*, public.*) are correctly left alone.

The change is narrow and mechanical: one code path in build_mapper generates every ord.* PK and child→parent FK, so updating it once updates them all uniformly. derived_mappers.py updates the three explicit derived→ord FKs and leaves the rdkit integer FKs intact. No existing SQL in database.py casts ids to integers or uses integer-range operations, making the type change transparent. The new test verifies both the Postgres column type and the UUID version bit.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/mappers.py | Switches ord.* surrogate PK from Integer serial to Uuid with a Python-side default=uuid7; child→parent FK columns updated to Uuid in the same build_mapper call path — consistent and correct. |
| ord_schema/orm/derived_mappers.py | FK columns referencing ord.* surrogate keys (reaction_id, compound_id, product_compound_id) updated to Uuid; rdkit_*_id FK columns correctly remain Integer — matches the split described in the PR. |
| ord_schema/orm/database_test.py | New test_surrogate_keys_are_uuidv7 verifies schema types and version-7 values for representative ord.* columns; uses scalar_one() relying on fixture data, which is fine but worth noting. |
| pyproject.toml | Adds uuid6>=2023 to the orm extra; calendar-versioned constraint is consistent with the locked 2025.0.1 wheel. |
| uv.lock | Locks uuid6 at 2025.0.1 with hashes; also adds it to the tests extras group so the test suite has the package available. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Py as Python (ingest)
    participant ORM as SQLAlchemy ORM
    participant PG as PostgreSQL

    Note over Py,PG: ORM path (existing)
    Py->>Py: uuid7() → new UUID
    Py->>ORM: "from_proto(message) → mapper(id=uuid7())"
    ORM->>PG: INSERT INTO ord.reaction (id, ...) VALUES (uuid, ...)
    ORM->>PG: INSERT INTO ord.compound (id, reaction_input_id, ...) VALUES (uuid, parent_uuid, ...)
    ORM->>PG: INSERT INTO derived.reaction_smiles (reaction_id, ...) VALUES (uuid, ...)

    Note over Py,PG: Upcoming COPY path (#873)
    Py->>Py: uuid7() → mint PKs and wire FKs in Python
    Py->>PG: COPY ord.reaction (id, ...) FROM STDIN
    Py->>PG: COPY ord.compound (id, reaction_input_id, ...) FROM STDIN
    Note right of PG: No server round-trip for ids
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Py as Python (ingest)
    participant ORM as SQLAlchemy ORM
    participant PG as PostgreSQL

    Note over Py,PG: ORM path (existing)
    Py->>Py: uuid7() → new UUID
    Py->>ORM: "from_proto(message) → mapper(id=uuid7())"
    ORM->>PG: INSERT INTO ord.reaction (id, ...) VALUES (uuid, ...)
    ORM->>PG: INSERT INTO ord.compound (id, reaction_input_id, ...) VALUES (uuid, parent_uuid, ...)
    ORM->>PG: INSERT INTO derived.reaction_smiles (reaction_id, ...) VALUES (uuid, ...)

    Note over Py,PG: Upcoming COPY path (#873)
    Py->>Py: uuid7() → mint PKs and wire FKs in Python
    Py->>PG: COPY ord.reaction (id, ...) FROM STDIN
    Py->>PG: COPY ord.compound (id, reaction_input_id, ...) FROM STDIN
    Note right of PG: No server round-trip for ids
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Use UUIDv7 surrogate keys instead of int..."](https://github.com/open-reaction-database/ord-schema/commit/d63c47466e96ea4a74eefef909e5701ac83ffaef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40990730)</sub>

<!-- /greptile_comment -->