### PR TITLE
Stream Parquet ingest with COPY instead of the ORM unit of work

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -321,6 +321,15 @@ def _collect_rows(root: Any, rows_by_table: dict[str, tuple[Any, list]]) -> None
         if entry is None:
             entry = (table, [])
             rows_by_table[table.fullname] = entry
+        # Every primary key must be populated by now: Uuid PKs are minted above, and text PKs
+        # (e.g. public.datasets.dataset_id, public.reactions.reaction_id) are set either from the
+        # proto or by FK wiring when the owning parent was visited. A NULL here means a table was
+        # added with a PK that is neither, which would otherwise fail deep inside COPY.
+        for key_column in table.primary_key:
+            assert getattr(node, key_column.key, None) is not None, (
+                f"unpopulated primary key {table.fullname}.{key_column.name}; a new table needs "
+                "a Uuid primary key or one wired from a parent foreign key"
+            )
         # Under single-table polymorphic inheritance, a sibling subclass's foreign-key column
         # shares the table but is not an attribute of this instance, so it is NULL for this row.
         entry[1].append(tuple(getattr(node, c.key, None) for c in table.columns))
@@ -356,6 +365,11 @@ def add_parquet_dataset(path: str, session: Session) -> None:
        work. Peak memory is bounded to one row group plus ``_COPY_BATCH`` trees.
 
     Derived data is populated separately by ``update_derived_data``.
+
+    Because rows are streamed with COPY rather than the unit of work, SQLAlchemy instrumentation
+    does not run for this path: ``@validates`` methods and ``before_insert``/``after_insert`` event
+    hooks on the mapper classes do not fire. ``add_dataset`` (used by ord-interface) still goes
+    through the ORM, so any such hook must be reflected here as well to keep the two paths in sync.
 
     Args:
         path: Path to the Parquet-serialized Dataset.

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -21,17 +21,22 @@ from typing import Any, cast
 from unittest.mock import patch
 
 from dateutil import parser
-from sqlalchemy import bindparam, delete, select, text
+from sqlalchemy import Uuid, bindparam, delete, inspect, select, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NotSupportedError, OperationalError, ProgrammingError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import RelationshipDirection, Session
 from tqdm import tqdm
+from uuid6 import uuid7
 
 from ord_schema import message_helpers, parquet
 from ord_schema.logging import get_logger
 from ord_schema.orm.mappers import Base, Mappers, from_proto, to_proto
 from ord_schema.orm.public_mappers import DatasetMetadata
 from ord_schema.proto import dataset_pb2, reaction_pb2
+
+# COPY the ingest tables parents-first so foreign keys resolve; sorted_tables orders by FK
+# dependency. Precomputed once; only the tables populated by a given batch are written.
+_COPY_TABLE_ORDER = [table.fullname for table in Base.metadata.sorted_tables]
 
 try:
     from ord_schema.orm.reaction_class import update_reaction_classes
@@ -266,10 +271,9 @@ def backfill_submission_times(session: Session) -> None:
         set_submitted_at(dataset_id, session)
 
 
-# Reactions are flushed and expunged in batches of this size during streaming
-# ingest. Larger values reduce SQL roundtrips at the cost of more pending ORM
-# objects held in memory.
-_PARQUET_FLUSH_BATCH = 1000
+# Reactions are built into ORM trees and COPYed in batches of this size during streaming
+# ingest. Larger values reduce COPY roundtrips at the cost of more trees held in memory.
+_COPY_BATCH = 1000
 
 # Number of reactions/compounds the derived passes load and process at a time. The ids needing
 # derivation are fetched up front, but the heavy work (proto deserialization, SMILES generation)
@@ -277,19 +281,80 @@ _PARQUET_FLUSH_BATCH = 1000
 _DERIVED_BATCH = 1000
 
 
+def _collect_rows(root: Any, rows_by_table: dict[str, tuple[Any, list]]) -> None:
+    """Walks one ORM object tree, minting keys and wiring FKs, into per-table column tuples.
+
+    Each surrogate (Uuid) primary key is assigned a UUIDv7 value, and every child's foreign-key
+    column is set from the parent's referenced column (from the relationship metadata), so the
+    rows are self-consistent without a database round trip. The resulting tuples can be streamed
+    with COPY. ``rows_by_table`` maps a table's full name to ``(table, rows)``.
+    """
+    stack = [root]
+    seen: set[int] = set()
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+        mapper = inspect(node).mapper
+        table = mapper.local_table
+        for key_column in table.primary_key:
+            if (
+                isinstance(key_column.type, Uuid)
+                and getattr(node, key_column.key) is None
+            ):
+                setattr(node, key_column.key, uuid7())
+        for relationship in mapper.relationships:
+            if relationship.direction is RelationshipDirection.MANYTOONE:
+                continue  # The foreign key is on this side; the owning parent sets it.
+            children = getattr(node, relationship.key)
+            if children is None:
+                continue
+            if not isinstance(children, list):
+                children = [children]
+            for child in children:
+                for local, remote in relationship.local_remote_pairs:
+                    setattr(child, remote.key, getattr(node, local.key))
+                stack.append(child)
+        entry = rows_by_table.get(table.fullname)
+        if entry is None:
+            entry = (table, [])
+            rows_by_table[table.fullname] = entry
+        # Under single-table polymorphic inheritance, a sibling subclass's foreign-key column
+        # shares the table but is not an attribute of this instance, so it is NULL for this row.
+        entry[1].append(tuple(getattr(node, c.key, None) for c in table.columns))
+
+
+def _copy_rows(
+    dbapi_connection: Any, rows_by_table: dict[str, tuple[Any, list]]
+) -> None:
+    """Streams collected rows into each table with COPY, parents before children."""
+    with dbapi_connection.cursor() as cursor:
+        for fullname in _COPY_TABLE_ORDER:
+            entry = rows_by_table.get(fullname)
+            if entry is None:
+                continue
+            table, rows = entry
+            columns = ", ".join(f'"{column.name}"' for column in table.columns)
+            # fullname/columns are internal schema constants, not user input.
+            with cursor.copy(f"COPY {fullname} ({columns}) FROM STDIN") as copy:
+                for row in rows:
+                    copy.write_row(row)
+
+
 def add_parquet_dataset(path: str, session: Session) -> None:
-    """Streams a Parquet-serialized Dataset into the ORM tables.
+    """Streams a Parquet-serialized Dataset into the ORM tables with COPY.
 
     Two streaming passes over the Parquet file:
 
-    1. ``parquet.streaming_md5`` to compute ``md5`` and
-       ``num_reactions`` without holding Reactions in memory.
-    2. ``iter_reactions`` to insert Reaction rows in flush/expunge batches.
+    1. ``parquet.streaming_md5`` computes ``md5`` and ``num_reactions`` without holding
+       Reactions in memory.
+    2. ``iter_reactions`` builds ORM trees a batch at a time; each tree is assigned UUIDv7
+       primary keys with foreign keys wired from the relationship metadata (``_collect_rows``),
+       and the rows are streamed with ``COPY`` (``_copy_rows``) rather than the ORM unit of
+       work. Peak memory is bounded to one row group plus ``_COPY_BATCH`` trees.
 
-    This keeps the canonical Parquet MD5 formula in one place and bounds
-    peak memory to one row group plus ``_PARQUET_FLUSH_BATCH`` ORM objects,
-    regardless of dataset size. Derived data is populated separately by
-    ``update_derived_data``.
+    Derived data is populated separately by ``update_derived_data``.
 
     Args:
         path: Path to the Parquet-serialized Dataset.
@@ -300,23 +365,28 @@ def add_parquet_dataset(path: str, session: Session) -> None:
     logger.debug(f"Streaming Parquet Dataset {metadata.dataset_id}")
     md5_hex, num_reactions = parquet.streaming_md5(path)
     reaction_child_class = Mappers.Dataset.reactions.mapper.class_
-    mapped_dataset = Mappers.Dataset(
+    dataset = Mappers.Dataset(
         name=metadata.name,
         description=metadata.description,
         dataset_id=metadata.dataset_id,
         metadata_row=DatasetMetadata(md5=md5_hex, num_reactions=num_reactions),
     )
-    session.add(mapped_dataset)
-    session.flush()
-    pending: list = []
+    dbapi_connection = session.connection().connection
+    dataset_rows: dict[str, tuple[Any, list]] = {}
+    _collect_rows(dataset, dataset_rows)
+    _copy_rows(dbapi_connection, dataset_rows)
+    batch: list = []
 
-    def flush_batch() -> None:
-        if not pending:
+    def copy_batch() -> None:
+        if not batch:
             return
-        session.flush()
-        for obj in pending:
-            session.expunge(obj)
-        pending.clear()
+        rows_by_table: dict[str, tuple[Any, list]] = {}
+        for reaction in batch:
+            reaction_mapper = from_proto(reaction, mapper=reaction_child_class)
+            reaction_mapper.dataset_id = dataset.id
+            _collect_rows(reaction_mapper, rows_by_table)
+        _copy_rows(dbapi_connection, rows_by_table)
+        batch.clear()
 
     for _, reaction in tqdm(
         parquet.iter_reactions(path),
@@ -325,17 +395,14 @@ def add_parquet_dataset(path: str, session: Session) -> None:
         unit="rxn",
         leave=False,
     ):
-        reaction_mapper = from_proto(reaction, mapper=reaction_child_class)
-        reaction_mapper.parent = mapped_dataset
-        session.add(reaction_mapper)
-        pending.append(reaction_mapper)
-        if len(pending) >= _PARQUET_FLUSH_BATCH:
-            flush_batch()
-    flush_batch()
+        batch.append(reaction)
+        if len(batch) >= _COPY_BATCH:
+            copy_batch()
+    copy_batch()
+    set_submitted_at(metadata.dataset_id, session)
     logger.debug(
         f"add_parquet_dataset() took {time.time() - start:g}s ({num_reactions} reactions)"
     )
-    set_submitted_at(metadata.dataset_id, session)
 
 
 def get_dataset_md5(dataset_id: str, session: Session) -> str | None:

--- a/ord_schema/orm/loading_test.py
+++ b/ord_schema/orm/loading_test.py
@@ -72,8 +72,11 @@ def _content_digests(engine) -> dict[str, tuple[int, str | None]]:
             ).scalar()
             digest = None
             if content and count:
+                # json_build_array encodes NULL distinctly from any string and escapes the values,
+                # so there is no delimiter for a value to collide with (concat_ws instead drops
+                # NULLs, letting a NULL alias a value that contains the delimiter).
                 order = ", ".join(f'"{c}"' for c in content)
-                query = f"SELECT md5(string_agg(x, '|' ORDER BY x)) FROM (SELECT concat_ws(chr(1), {order}) AS x FROM {table.fullname}) t"  # noqa: S608  (internal schema constants)
+                query = f"SELECT md5(string_agg(x, '|' ORDER BY x)) FROM (SELECT md5(json_build_array({order})::text) AS x FROM {table.fullname}) t"  # noqa: S608  (internal schema constants)
                 digest = session.execute(text(query)).scalar()
             digests[table.fullname] = (count, digest)
     return digests

--- a/ord_schema/orm/loading_test.py
+++ b/ord_schema/orm/loading_test.py
@@ -15,13 +15,15 @@
 """Tests for ord_schema.orm.loading."""
 
 import pathlib
+import re
 
 import pytest
-from sqlalchemy import select, text
+from sqlalchemy import create_engine, select, text
 from sqlalchemy.orm import Session
+from testing.postgresql import Postgresql
 
 from ord_schema import message_helpers, parquet
-from ord_schema.orm import database, loading
+from ord_schema.orm import Base, database, loading
 from ord_schema.orm.mappers import Mappers
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
@@ -49,6 +51,59 @@ def _derived_counts(engine) -> dict[str, int]:
                 "product_compound_smiles",
             )
         }
+
+
+def _content_digests(engine) -> dict[str, tuple[int, str | None]]:
+    """Per-table (row count, order-independent digest of non-key columns), keyed by table name.
+
+    Excludes primary- and foreign-key columns so the digest depends only on payload, not on the
+    surrogate ids (which differ between two independent ingests).
+    """
+    digests: dict[str, tuple[int, str | None]] = {}
+    with Session(engine) as session:
+        for table in Base.metadata.sorted_tables:
+            content = [
+                c.name
+                for c in table.columns
+                if not c.primary_key and not c.foreign_keys
+            ]
+            count = session.execute(
+                text(f"SELECT count(*) FROM {table.fullname}")  # noqa: S608  (constant)
+            ).scalar()
+            digest = None
+            if content and count:
+                order = ", ".join(f'"{c}"' for c in content)
+                query = f"SELECT md5(string_agg(x, '|' ORDER BY x)) FROM (SELECT concat_ws(chr(1), {order}) AS x FROM {table.fullname}) t"  # noqa: S608  (internal schema constants)
+                digest = session.execute(text(query)).scalar()
+            digests[table.fullname] = (count, digest)
+    return digests
+
+
+def test_parquet_copy_ingest_matches_orm(tmp_path):
+    """The COPY parquet ingest yields the same ord.*/public.reactions content as the ORM path.
+
+    add_parquet_dataset builds the same from_proto trees as add_dataset but streams them with
+    COPY instead of the unit of work; the relational content must be byte-identical. (The
+    public.datasets metadata row is written only by the parquet path and is checked separately
+    in test_load_datasets_parquet.)
+    """
+    parquet_path, dataset = _write_parquet_dataset(tmp_path)
+    result: dict[str, dict[str, tuple[int, str | None]]] = {}
+    for label in ("copy", "orm"):
+        with Postgresql() as postgres:
+            url = re.sub("postgresql://", "postgresql+psycopg://", postgres.url())
+            engine = create_engine(url, future=True)
+            database.prepare_database(engine)
+            with Session(engine) as session, session.begin():
+                if label == "copy":
+                    database.add_parquet_dataset(parquet_path, session)
+                else:
+                    database.add_dataset(dataset, session)
+            result[label] = _content_digests(engine)
+    for table in result["copy"]:
+        if table == "public.datasets":
+            continue
+        assert result["copy"][table] == result["orm"][table], table
 
 
 def test_load_datasets(prepared_engine):


### PR DESCRIPTION
Progresses #873.

## Problem

`add_parquet_dataset` built a tree of ~30 ORM objects per reaction and flushed them through the unit of work — roughly **ten INSERT statements per reaction**, with **~66% of ingest time in `flush`**. Profiled at **~45 rxn/s even over a local unix socket**, so the bottleneck is SQLAlchemy CPU, not the database (a 2.4M-reaction population billed only ~34M Aurora I/O over 30h). 2.4M reactions is small; the loading strategy was the problem.

## Change

Keep the ORM for reads/serving; stop using it for bulk loading:

- Reuse `from_proto` to build the reaction trees, so the proto→columns mapping stays **exactly consistent with the generated schema** (no reimplementation).
- `_collect_rows` walks each tree, assigns **UUIDv7** primary keys, and wires each child's foreign key from the parent's referenced column using the ORM relationship metadata — so rows are self-consistent with no round trip to learn ids (enabled by the client-generated keys from #857).
- `_copy_rows` streams the rows per table with **psycopg `COPY`**, in `Base.metadata.sorted_tables` (FK-dependency) order.
- Batches of `_COPY_BATCH` reaction trees keep peak memory bounded.

`add_dataset` (the in-memory proto path used by ord-interface) is unchanged; this targets the bulk parquet path used by population.

## Results

- **210 rxn/s vs 45 → 4.3×** on a 2000-reaction sample (single-threaded, still including `from_proto`).
- **Byte-identical output.** New `test_parquet_copy_ingest_matches_orm` ingests the same dataset via COPY and via the ORM into separate databases and asserts an order-independent digest of **every non-key column of every table** matches (surrogate ids excluded). The existing `test_load_datasets_parquet` continues to check the streaming md5/count and a byte-identical proto round-trip. Full ORM suite green.

## Follow-ups (measured, not in this PR)

- Bypass `from_proto` (walk the proto straight to tuples) — it's now the dominant remaining cost, toward the ~10× ceiling.
- Intra-dataset parallelism for the single largest dataset (cross-dataset parallelism is already free via `n_jobs`).
- Partial FK indexes (#876) — reduces the per-row index writes this loader now bottlenecks on server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the SQLAlchemy unit-of-work path in `add_parquet_dataset` with a COPY-based bulk loader that achieves ~4.3× throughput improvement (45 → 210 rxn/s). The ORM is still used to build reaction trees via `from_proto`, but `_collect_rows` then walks each tree to mint UUIDv7 primary keys and wire foreign keys using relationship metadata, and `_copy_rows` streams the resulting tuples directly to PostgreSQL via psycopg's `COPY` protocol.

- `_collect_rows` / `_copy_rows` are new helpers that collect per-table tuples from an ORM object tree and stream them with `COPY FROM STDIN` in FK-dependency order; the dataset row and each reaction batch are written in two separate passes.
- A new integration test (`test_parquet_copy_ingest_matches_orm`) spins up two isolated PostgreSQL instances, ingests the same dataset via each code path, and asserts an order-independent MD5 digest of every non-key column in every table is identical — confirming byte-identical relational content.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is well-scoped — only the parquet bulk-load path changes, the ORM read/serving path and the in-memory add_dataset path are untouched.

The implementation is carefully constructed: FK dependency ordering is precomputed from metadata, UUIDs are minted before children are wired so no round-trip is needed, and the MANYTOONE skip prevents cycles. The byte-identical integration test using two isolated databases with json_build_array digests gives strong correctness assurance. Previous review concerns (PK assertion, json_build_array NULL safety, ORM hook documentation) are all addressed in this revision. No new correctness issues found.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Replaces ORM flush/expunge loop with _collect_rows + _copy_rows helpers; FK dependency order is precomputed at import time; dataset row and reaction batches written in separate COPY passes; docstring explicitly documents ORM hook bypass; assertion guards against unpopulated PKs. |
| ord_schema/orm/loading_test.py | Adds test_parquet_copy_ingest_matches_orm which uses json_build_array for NULL-safe per-row digests; correctly excludes public.datasets and all PK/FK columns from comparison; two-database isolation is sound. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as add_parquet_dataset
    participant CR as _collect_rows
    participant CP as _copy_rows
    participant DB as PostgreSQL (psycopg COPY)

    C->>C: streaming_md5(path) → md5_hex, num_reactions
    C->>C: Mappers.Dataset(...) → dataset (no id yet)
    C->>CR: _collect_rows(dataset, dataset_rows)
    Note over CR: mint uuid7 for dataset.id<br/>wire FK on metadata_row child
    C->>CP: _copy_rows(dbapi_conn, dataset_rows)
    CP->>DB: COPY public.datasets FROM STDIN
    CP->>DB: COPY ord.dataset FROM STDIN

    loop batches of _COPY_BATCH reactions
        C->>C: accumulate raw proto Reactions in batch[]
        C->>C: copy_batch() triggered
        loop for each reaction in batch
            C->>C: from_proto(reaction) → reaction_mapper
            C->>C: "reaction_mapper.dataset_id = dataset.id"
            C->>CR: _collect_rows(reaction_mapper, rows_by_table)
            Note over CR: mint uuid7 for reaction.id<br/>wire all child FKs recursively<br/>emit column tuples per table
        end
        C->>CP: _copy_rows(dbapi_conn, rows_by_table)
        CP->>DB: COPY ord.reaction FROM STDIN (parents first)
        CP->>DB: COPY ord.reaction_setup, ord.conditions ... FROM STDIN
        CP->>DB: COPY public.reactions FROM STDIN
    end

    C->>DB: set_submitted_at (ORM UPDATE via session)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as add_parquet_dataset
    participant CR as _collect_rows
    participant CP as _copy_rows
    participant DB as PostgreSQL (psycopg COPY)

    C->>C: streaming_md5(path) → md5_hex, num_reactions
    C->>C: Mappers.Dataset(...) → dataset (no id yet)
    C->>CR: _collect_rows(dataset, dataset_rows)
    Note over CR: mint uuid7 for dataset.id<br/>wire FK on metadata_row child
    C->>CP: _copy_rows(dbapi_conn, dataset_rows)
    CP->>DB: COPY public.datasets FROM STDIN
    CP->>DB: COPY ord.dataset FROM STDIN

    loop batches of _COPY_BATCH reactions
        C->>C: accumulate raw proto Reactions in batch[]
        C->>C: copy_batch() triggered
        loop for each reaction in batch
            C->>C: from_proto(reaction) → reaction_mapper
            C->>C: "reaction_mapper.dataset_id = dataset.id"
            C->>CR: _collect_rows(reaction_mapper, rows_by_table)
            Note over CR: mint uuid7 for reaction.id<br/>wire all child FKs recursively<br/>emit column tuples per table
        end
        C->>CP: _copy_rows(dbapi_conn, rows_by_table)
        CP->>DB: COPY ord.reaction FROM STDIN (parents first)
        CP->>DB: COPY ord.reaction_setup, ord.conditions ... FROM STDIN
        CP->>DB: COPY public.reactions FROM STDIN
    end

    C->>DB: set_submitted_at (ORM UPDATE via session)
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Address Greptile on #877: PK assertion, ..."](https://github.com/open-reaction-database/ord-schema/commit/b6009f1d7634ad38208361b91efefe52714f94bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40994526)</sub>

<!-- /greptile_comment -->