### PR TITLE
Shard Parquet ingest by row group for intra-dataset parallelism

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -17,6 +17,7 @@
 import datetime
 import os
 import time
+import uuid
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -352,24 +353,115 @@ def _copy_rows(
                     copy.write_row(row)
 
 
-def add_parquet_dataset(path: str, session: Session) -> None:
-    """Streams a Parquet-serialized Dataset into the ORM tables with COPY.
+def add_parquet_dataset_row(
+    path: str, dataset_uuid: uuid.UUID, session: Session
+) -> None:
+    """Inserts the ``ord.dataset`` search-index row (scalars only, no reactions or metadata).
 
-    Two streaming passes over the Parquet file:
+    The surrogate ``id`` is supplied by the caller so a subsequent sharded reaction load can
+    reference it without a round trip. The ``public.datasets`` metadata row is written last, by
+    ``add_parquet_dataset_metadata``, so its presence marks a fully loaded dataset.
 
-    1. ``parquet.streaming_md5`` computes ``md5`` and ``num_reactions`` without holding
-       Reactions in memory.
-    2. ``iter_reactions`` builds ORM trees a batch at a time; each tree is assigned UUIDv7
-       primary keys with foreign keys wired from the relationship metadata (``_collect_rows``),
-       and the rows are streamed with ``COPY`` (``_copy_rows``) rather than the ORM unit of
-       work. Peak memory is bounded to one row group plus ``_COPY_BATCH`` trees.
+    Args:
+        path: Path to the Parquet-serialized Dataset.
+        dataset_uuid: Surrogate primary key for the ``ord.dataset`` row.
+        session: SQLAlchemy session.
+    """
+    metadata = parquet.load_metadata(path)
+    session.add(
+        Mappers.Dataset(
+            id=dataset_uuid,
+            name=metadata.name,
+            description=metadata.description,
+            dataset_id=metadata.dataset_id,
+        )
+    )
+    session.flush()
 
-    Derived data is populated separately by ``update_derived_data``.
+
+def add_parquet_reactions(
+    path: str,
+    dataset_uuid: uuid.UUID,
+    session: Session,
+    *,
+    row_group: int | None = None,
+    progress: bool = False,
+) -> None:
+    """Streams a Parquet dataset's Reactions into the ``ord.*``/``public.reactions`` tables with COPY.
+
+    Builds ORM trees a batch at a time via ``from_proto``; each tree is assigned UUIDv7 primary
+    keys with foreign keys wired from the relationship metadata (``_collect_rows``), and the rows
+    are streamed with ``COPY`` (``_copy_rows``) rather than the ORM unit of work. Peak memory is
+    bounded to one row group plus ``_COPY_BATCH`` trees. The parent ``ord.dataset`` row identified
+    by ``dataset_uuid`` must already exist (see ``add_parquet_dataset_row``).
 
     Because rows are streamed with COPY rather than the unit of work, SQLAlchemy instrumentation
     does not run for this path: ``@validates`` methods and ``before_insert``/``after_insert`` event
     hooks on the mapper classes do not fire. ``add_dataset`` (used by ord-interface) still goes
     through the ORM, so any such hook must be reflected here as well to keep the two paths in sync.
+
+    Args:
+        path: Path to the Parquet-serialized Dataset.
+        dataset_uuid: Surrogate key of the parent ``ord.dataset`` row (foreign key target).
+        session: SQLAlchemy session.
+        row_group: If set, only that Parquet row group is loaded; the unit of parallelism for
+            sharded ingest. ``None`` loads every reaction in the file.
+        progress: Whether to show a per-reaction tqdm progress bar.
+    """
+    reaction_child_class = Mappers.Dataset.reactions.mapper.class_
+    dbapi_connection = session.connection().connection
+    batch: list = []
+
+    def copy_batch() -> None:
+        if not batch:
+            return
+        rows_by_table: dict[str, tuple[Any, list]] = {}
+        for reaction in batch:
+            reaction_mapper = from_proto(reaction, mapper=reaction_child_class)
+            reaction_mapper.dataset_id = dataset_uuid
+            _collect_rows(reaction_mapper, rows_by_table)
+        _copy_rows(dbapi_connection, rows_by_table)
+        batch.clear()
+
+    reactions: Any = parquet.iter_reactions(path, row_group=row_group)
+    if progress:
+        reactions = tqdm(reactions, desc="ingest", unit="rxn", leave=False)
+    for _, reaction in reactions:
+        batch.append(reaction)
+        if len(batch) >= _COPY_BATCH:
+            copy_batch()
+    copy_batch()
+
+
+def add_parquet_dataset_metadata(
+    dataset_id: str, md5_hex: str, num_reactions: int, session: Session
+) -> None:
+    """Writes the ``public.datasets`` metadata row and populates ``submitted_at``.
+
+    Written after the reactions are loaded, so the presence of this row marks a fully loaded
+    dataset (``get_dataset_md5`` reads it); a crashed load leaves an ``ord.dataset`` row with no
+    metadata row, which the next ingest deletes and reloads.
+
+    Args:
+        dataset_id: Dataset ID (``public.datasets`` primary key).
+        md5_hex: Streaming MD5 of the Parquet file.
+        num_reactions: Reaction count from the streaming pass.
+        session: SQLAlchemy session.
+    """
+    session.add(
+        DatasetMetadata(dataset_id=dataset_id, md5=md5_hex, num_reactions=num_reactions)
+    )
+    session.flush()
+    set_submitted_at(dataset_id, session)
+
+
+def add_parquet_dataset(path: str, session: Session) -> None:
+    """Streams a Parquet-serialized Dataset into the ORM tables with COPY, in one transaction.
+
+    Composes ``add_parquet_dataset_row`` (search-index row), ``add_parquet_reactions`` (the
+    reactions), and ``add_parquet_dataset_metadata`` (the ``public.datasets`` marker). Sharded
+    ingest calls the same primitives across worker processes; here they run serially so the whole
+    dataset lands atomically. Derived data is populated separately by ``update_derived_data``.
 
     Args:
         path: Path to the Parquet-serialized Dataset.
@@ -379,42 +471,10 @@ def add_parquet_dataset(path: str, session: Session) -> None:
     metadata = parquet.load_metadata(path)
     logger.debug(f"Streaming Parquet Dataset {metadata.dataset_id}")
     md5_hex, num_reactions = parquet.streaming_md5(path)
-    reaction_child_class = Mappers.Dataset.reactions.mapper.class_
-    dataset = Mappers.Dataset(
-        name=metadata.name,
-        description=metadata.description,
-        dataset_id=metadata.dataset_id,
-        metadata_row=DatasetMetadata(md5=md5_hex, num_reactions=num_reactions),
-    )
-    dbapi_connection = session.connection().connection
-    dataset_rows: dict[str, tuple[Any, list]] = {}
-    _collect_rows(dataset, dataset_rows)
-    _copy_rows(dbapi_connection, dataset_rows)
-    batch: list = []
-
-    def copy_batch() -> None:
-        if not batch:
-            return
-        rows_by_table: dict[str, tuple[Any, list]] = {}
-        for reaction in batch:
-            reaction_mapper = from_proto(reaction, mapper=reaction_child_class)
-            reaction_mapper.dataset_id = dataset.id
-            _collect_rows(reaction_mapper, rows_by_table)
-        _copy_rows(dbapi_connection, rows_by_table)
-        batch.clear()
-
-    for _, reaction in tqdm(
-        parquet.iter_reactions(path),
-        total=num_reactions,
-        desc=f"ingest {metadata.dataset_id}",
-        unit="rxn",
-        leave=False,
-    ):
-        batch.append(reaction)
-        if len(batch) >= _COPY_BATCH:
-            copy_batch()
-    copy_batch()
-    set_submitted_at(metadata.dataset_id, session)
+    dataset_uuid = uuid7()
+    add_parquet_dataset_row(path, dataset_uuid, session)
+    add_parquet_reactions(path, dataset_uuid, session, progress=True)
+    add_parquet_dataset_metadata(metadata.dataset_id, md5_hex, num_reactions, session)
     logger.debug(
         f"add_parquet_dataset() took {time.time() - start:g}s ({num_reactions} reactions)"
     )

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -385,7 +385,8 @@ def add_parquet_reactions(
     session: Session,
     *,
     row_group: int | None = None,
-    progress: bool = False,
+    progress_desc: str | None = None,
+    progress_total: int | None = None,
 ) -> None:
     """Streams a Parquet dataset's Reactions into the ``ord.*``/``public.reactions`` tables with COPY.
 
@@ -406,7 +407,9 @@ def add_parquet_reactions(
         session: SQLAlchemy session.
         row_group: If set, only that Parquet row group is loaded; the unit of parallelism for
             sharded ingest. ``None`` loads every reaction in the file.
-        progress: Whether to show a per-reaction tqdm progress bar.
+        progress_desc: If set, show a tqdm progress bar with this label (the single-process path
+            passes it; shards leave it None so the pool-level bar is the only one).
+        progress_total: Total reaction count for the progress bar's percentage/ETA.
     """
     reaction_child_class = Mappers.Dataset.reactions.mapper.class_
     dbapi_connection = session.connection().connection
@@ -424,8 +427,14 @@ def add_parquet_reactions(
         batch.clear()
 
     reactions: Any = parquet.iter_reactions(path, row_group=row_group)
-    if progress:
-        reactions = tqdm(reactions, desc="ingest", unit="rxn", leave=False)
+    if progress_desc is not None:
+        reactions = tqdm(
+            reactions,
+            total=progress_total,
+            desc=progress_desc,
+            unit="rxn",
+            leave=False,
+        )
     for _, reaction in reactions:
         batch.append(reaction)
         if len(batch) >= _COPY_BATCH:
@@ -473,7 +482,13 @@ def add_parquet_dataset(path: str, session: Session) -> None:
     md5_hex, num_reactions = parquet.streaming_md5(path)
     dataset_uuid = uuid7()
     add_parquet_dataset_row(path, dataset_uuid, session)
-    add_parquet_reactions(path, dataset_uuid, session, progress=True)
+    add_parquet_reactions(
+        path,
+        dataset_uuid,
+        session,
+        progress_desc=f"ingest {metadata.dataset_id}",
+        progress_total=num_reactions,
+    )
     add_parquet_dataset_metadata(metadata.dataset_id, md5_hex, num_reactions, session)
     logger.debug(
         f"add_parquet_dataset() took {time.time() - start:g}s ({num_reactions} reactions)"

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -23,24 +23,31 @@ dataset files; the per-dataset helpers (``ingest_dataset``, ``derive_dataset``,
 ``add_rdkit``) are exposed for callers that compose their own pipeline.
 """
 
+import dataclasses
 import time
+import uuid
 from collections.abc import Callable, Iterable
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 from contextlib import ExitStack
 from functools import partial
 from glob import glob
 from hashlib import md5
+from typing import TypeVar
 
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 from tqdm import tqdm
+from uuid6 import uuid7
 
 from ord_schema import parquet
 from ord_schema.logging import get_logger
 from ord_schema.message_helpers import load_message
 from ord_schema.orm import database
 from ord_schema.proto import dataset_pb2
+
+_Item = TypeVar("_Item")
+_Result = TypeVar("_Result")
 
 logger = get_logger(__name__)
 
@@ -162,20 +169,20 @@ def add_rdkit(engine: Engine, dataset_id: str) -> None:
 
 
 def _run_parallel(
-    func: Callable[[str], str],
-    items: Iterable[str],
+    func: Callable[[_Item], _Result],
+    items: Iterable[_Item],
     *,
     n_jobs: int,
     desc: str,
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[_Result], list[_Item]]:
     """Runs ``func`` over ``items`` with ``n_jobs`` workers.
 
     Returns ``(results, failures)``: the successful return values and the inputs whose
     call raised.
     """
     items = list(items)
-    results: list[str] = []
-    failures: list[str] = []
+    results: list[_Result] = []
+    failures: list[_Item] = []
     with ExitStack() as stack:
         if n_jobs > 1:
             executor = stack.enter_context(ProcessPoolExecutor(n_jobs))
@@ -190,6 +197,149 @@ def _run_parallel(
                 failures.append(item)
                 logger.exception(f"{desc} failed for {item}")
     return results, failures
+
+
+@dataclasses.dataclass(frozen=True)
+class _ParquetPlan:
+    """Per-dataset outcome of the prep phase of sharded Parquet ingest.
+
+    ``needs_load`` is False for datasets skipped as unchanged; those carry only ``dataset_id``
+    (for the derived stage). Datasets that need loading also carry the surrogate ``dataset_uuid``
+    the shard phase wires reactions to and the ``num_row_groups`` to shard over.
+    """
+
+    filename: str
+    dataset_id: str
+    md5_hex: str
+    num_reactions: int
+    needs_load: bool
+    dataset_uuid: uuid.UUID | None = None
+    num_row_groups: int = 0
+
+
+def _prep_parquet_dataset(filename: str, *, dsn: str, overwrite: bool) -> _ParquetPlan:
+    """Prep phase: decide skip/overwrite and insert the empty ``ord.dataset`` row.
+
+    Skips datasets whose streaming MD5 is unchanged; otherwise deletes any existing full or
+    partial rows and inserts a fresh search-index row whose surrogate id the shard phase
+    references. The ``public.datasets`` marker is written only after all shards succeed
+    (``_finalize_parquet_dataset``), so a crashed load leaves no marker and is cleanly redone.
+
+    Raises:
+        ValueError: If the dataset exists with changed content and ``overwrite`` is not set.
+    """
+    footer = parquet.load_footer(filename)
+    dataset_id = footer.dataset.dataset_id
+    md5_hex, num_reactions = parquet.streaming_md5(filename)
+    engine = create_engine(dsn)
+    try:
+        with Session(engine) as session, session.begin():
+            existing_md5 = database.get_dataset_md5(dataset_id, session)
+            if existing_md5 is not None:
+                if existing_md5 == md5_hex:
+                    logger.debug(f"existing dataset {dataset_id} unchanged; skipping")
+                    return _ParquetPlan(
+                        filename, dataset_id, md5_hex, num_reactions, needs_load=False
+                    )
+                if not overwrite:
+                    raise ValueError(
+                        f"`overwrite` is required when a dataset already exists: {dataset_id}"
+                    )
+                logger.debug(f"existing dataset {dataset_id} changed; reloading")
+            # Wipe any full or partial prior rows, then insert a fresh search-index row.
+            database.delete_dataset(dataset_id, session)
+            dataset_uuid = uuid7()
+            database.add_parquet_dataset_row(filename, dataset_uuid, session)
+    finally:
+        engine.dispose()
+    return _ParquetPlan(
+        filename,
+        dataset_id,
+        md5_hex,
+        num_reactions,
+        needs_load=True,
+        dataset_uuid=dataset_uuid,
+        num_row_groups=footer.num_row_groups,
+    )
+
+
+def _ingest_parquet_shard(item: tuple[str, uuid.UUID, int], *, dsn: str) -> None:
+    """Shard phase: COPY-load one Parquet row group's reactions in its own transaction."""
+    filename, dataset_uuid, row_group = item
+    engine = create_engine(dsn)
+    try:
+        with Session(engine) as session, session.begin():
+            database.add_parquet_reactions(
+                filename, dataset_uuid, session, row_group=row_group
+            )
+    finally:
+        engine.dispose()
+
+
+def _finalize_parquet_dataset(plan: _ParquetPlan, *, dsn: str) -> str:
+    """Finalize phase: write the ``public.datasets`` completeness marker and ``submitted_at``."""
+    engine = create_engine(dsn)
+    try:
+        with Session(engine) as session, session.begin():
+            database.add_parquet_dataset_metadata(
+                plan.dataset_id, plan.md5_hex, plan.num_reactions, session
+            )
+    finally:
+        engine.dispose()
+    return plan.dataset_id
+
+
+def _ingest_parquet_sharded(
+    filenames: list[str], *, dsn: str, overwrite: bool, n_jobs: int
+) -> tuple[list[str], list[str]]:
+    """Ingests Parquet datasets by sharding their row groups across a worker pool.
+
+    Three phases, each a barrier so the next reads the previous one's committed rows: prep inserts
+    each dataset's search-index row, shards COPY the reactions row-group by row-group, and finalize
+    writes the ``public.datasets`` marker for datasets whose shards all succeeded. The row group is
+    the unit of parallelism, so one large dataset's shards fill the pool instead of pinning a
+    single worker. A dataset with any failed shard is left unmarked (skipped in finalize) and
+    reported, so a re-run redoes it from scratch.
+
+    Returns ``(dataset_ids, failures)``: ids of skipped and fully loaded datasets (for the derived
+    stage), and the filenames that failed in any phase.
+    """
+    failures: list[str] = []
+    plans, prep_failures = _run_parallel(
+        partial(_prep_parquet_dataset, dsn=dsn, overwrite=overwrite),
+        filenames,
+        n_jobs=n_jobs,
+        desc="Prep",
+    )
+    failures.extend(prep_failures)
+    skipped_ids = [plan.dataset_id for plan in plans if not plan.needs_load]
+    to_load = [plan for plan in plans if plan.needs_load]
+    shard_items: list[tuple[str, uuid.UUID, int]] = []
+    for plan in to_load:
+        assert (
+            plan.dataset_uuid is not None
+        )  # Set by prep for datasets that need loading.
+        shard_items.extend(
+            (plan.filename, plan.dataset_uuid, row_group)
+            for row_group in range(plan.num_row_groups)
+        )
+    _, shard_failures = _run_parallel(
+        partial(_ingest_parquet_shard, dsn=dsn),
+        shard_items,
+        n_jobs=n_jobs,
+        desc="Ingest",
+    )
+    failed_uuids = {dataset_uuid for _, dataset_uuid, _ in shard_failures}
+    failures.extend(sorted({filename for filename, _, _ in shard_failures}))
+    finalize_plans = [plan for plan in to_load if plan.dataset_uuid not in failed_uuids]
+    finalized_ids, finalize_failures = _run_parallel(
+        partial(_finalize_parquet_dataset, dsn=dsn),
+        finalize_plans,
+        n_jobs=n_jobs,
+        desc="Finalize",
+    )
+    failures.extend(plan.filename for plan in finalize_failures)
+    return skipped_ids + finalized_ids, failures
 
 
 def load_datasets(
@@ -238,13 +388,30 @@ def load_datasets(
 
     if "ingest" in stages:
         logger.info("Ingesting datasets")
-        dataset_ids, stage_failures = _run_parallel(
-            partial(ingest_dataset, dsn=dsn, overwrite=overwrite),
-            filenames,
-            n_jobs=n_jobs,
-            desc="Ingest",
-        )
-        failures.extend(stage_failures)
+        dataset_ids: list[str] = []
+        # Parquet datasets are sharded by row group across the pool so one large dataset does not
+        # pin a single worker; the atomic single-process path handles n_jobs == 1 and non-parquet
+        # inputs (which cannot be sharded).
+        if n_jobs > 1:
+            parquet_files = [f for f in filenames if f.endswith(".parquet")]
+            other_files = [f for f in filenames if not f.endswith(".parquet")]
+        else:
+            parquet_files, other_files = [], filenames
+        if parquet_files:
+            ids, stage_failures = _ingest_parquet_sharded(
+                parquet_files, dsn=dsn, overwrite=overwrite, n_jobs=n_jobs
+            )
+            dataset_ids.extend(ids)
+            failures.extend(stage_failures)
+        if other_files:
+            ids, stage_failures = _run_parallel(
+                partial(ingest_dataset, dsn=dsn, overwrite=overwrite),
+                other_files,
+                n_jobs=n_jobs,
+                desc="Ingest",
+            )
+            dataset_ids.extend(ids)
+            failures.extend(stage_failures)
     else:
         dataset_ids = [dataset_id_for_file(filename) for filename in filenames]
 

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -316,9 +316,12 @@ def _ingest_parquet_sharded(
     to_load = [plan for plan in plans if plan.needs_load]
     shard_items: list[tuple[str, uuid.UUID, int]] = []
     for plan in to_load:
-        assert (
-            plan.dataset_uuid is not None
-        )  # Set by prep for datasets that need loading.
+        if plan.dataset_uuid is None:
+            # Prep sets dataset_uuid for every needs_load plan; enforce the contract explicitly
+            # (a bare assert is dropped under -O and would surface later as an obscure error).
+            raise ValueError(
+                f"prep returned needs_load with no dataset_uuid: {plan.filename}"
+            )
         shard_items.extend(
             (plan.filename, plan.dataset_uuid, row_group)
             for row_group in range(plan.num_row_groups)

--- a/ord_schema/orm/loading_test.py
+++ b/ord_schema/orm/loading_test.py
@@ -170,6 +170,37 @@ def test_load_datasets_parquet_parallel(prepared_engine, tmp_path):
     assert _derived_counts(prepared_engine)["reaction_smiles"] > 0
 
 
+def test_parquet_sharded_ingest_recovers_from_partial_load(tmp_path):
+    """A crashed shard phase (dataset row + some reactions, no marker) is cleanly redone.
+
+    Simulates the failure the completeness marker guards against: prep inserts the ord.dataset row
+    and one shard loads part of the reactions, but finalize never runs, so public.datasets has no
+    marker. A subsequent load must detect the missing marker, wipe the partial rows, and produce a
+    complete, correct ingest.
+    """
+    parquet_path, dataset = _write_parquet_dataset(tmp_path, row_group_size=10)
+    with Postgresql() as postgres:
+        url = re.sub("postgresql://", "postgresql+psycopg://", postgres.url())
+        engine = create_engine(url, future=True)
+        database.prepare_database(engine)
+        # Prep inserts the ord.dataset row; load only the first row group; skip finalize.
+        plan = loading._prep_parquet_dataset(parquet_path, dsn=url, overwrite=False)
+        assert plan.needs_load
+        assert plan.num_row_groups > 1
+        assert plan.dataset_uuid is not None
+        loading._ingest_parquet_shard((plan.filename, plan.dataset_uuid, 0), dsn=url)
+        with Session(engine) as session:
+            # Partial state: some reactions present, but no completeness marker.
+            assert database.get_dataset_md5(dataset.dataset_id, session) is None
+            partial = session.query(Mappers.Reaction).count()
+            assert 0 < partial < len(dataset.reactions)
+        # A fresh run wipes the orphaned rows and reloads to completion, marker and all.
+        loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=2)
+        with Session(engine) as session:
+            assert database.get_dataset_md5(dataset.dataset_id, session) is not None
+            assert session.query(Mappers.Reaction).count() == len(dataset.reactions)
+
+
 def test_load_datasets(prepared_engine):
     loading.load_datasets(_PBTXT_FIXTURE, str(prepared_engine.url))
     with Session(prepared_engine) as session:

--- a/ord_schema/orm/loading_test.py
+++ b/ord_schema/orm/loading_test.py
@@ -32,10 +32,12 @@ _PBTXT_FIXTURE = str(
 )
 
 
-def _write_parquet_dataset(tmp_path) -> tuple[str, dataset_pb2.Dataset]:
+def _write_parquet_dataset(
+    tmp_path, *, row_group_size: int = 1000
+) -> tuple[str, dataset_pb2.Dataset]:
     dataset = message_helpers.load_message(_PBTXT_FIXTURE, dataset_pb2.Dataset)
     parquet_path = (tmp_path / "dataset.parquet").as_posix()
-    parquet.save_dataset(dataset, parquet_path)
+    parquet.save_dataset(dataset, parquet_path, row_group_size=row_group_size)
     return parquet_path, dataset
 
 
@@ -107,6 +109,65 @@ def test_parquet_copy_ingest_matches_orm(tmp_path):
         if table == "public.datasets":
             continue
         assert result["copy"][table] == result["orm"][table], table
+
+
+def test_parquet_sharded_ingest_matches_single_process(tmp_path):
+    """Row-group-sharded ingest (n_jobs>1) yields the same content as the single-process path.
+
+    The dataset is written with several small row groups so the sharded path actually splits work
+    across shards; the two ingests must then agree on every non-key column of every table.
+    """
+    parquet_path, _ = _write_parquet_dataset(tmp_path, row_group_size=10)
+    assert parquet.num_row_groups(parquet_path) > 1  # Sharding is actually exercised.
+    result: dict[str, dict[str, tuple[int, str | None]]] = {}
+    for label, n_jobs in (("sharded", 2), ("single", 1)):
+        with Postgresql() as postgres:
+            url = re.sub("postgresql://", "postgresql+psycopg://", postgres.url())
+            engine = create_engine(url, future=True)
+            database.prepare_database(engine)
+            loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=n_jobs)
+            result[label] = _content_digests(engine)
+    assert result["sharded"] == result["single"]
+
+
+def test_parquet_sharded_ingest_skip_and_overwrite(tmp_path):
+    """The sharded path skips unchanged datasets, rejects changed ones, and reloads with overwrite."""
+    parquet_path, dataset = _write_parquet_dataset(tmp_path, row_group_size=10)
+    expected_count = len(dataset.reactions)
+    with Postgresql() as postgres:
+        url = re.sub("postgresql://", "postgresql+psycopg://", postgres.url())
+        engine = create_engine(url, future=True)
+        database.prepare_database(engine)
+
+        def reaction_count() -> int:
+            with Session(engine) as session:
+                return session.query(Mappers.Reaction).count()
+
+        loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=2)
+        assert reaction_count() == expected_count
+        # An unchanged re-ingest is skipped on the matching md5, not loaded again.
+        loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=2)
+        assert reaction_count() == expected_count
+        # Changed content without overwrite fails and leaves the original intact.
+        dataset.reactions[0].outcomes[0].conversion.value = 999.0
+        parquet.save_dataset(dataset, parquet_path, row_group_size=10)
+        with pytest.raises(RuntimeError):
+            loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=2)
+        assert reaction_count() == expected_count
+        # With overwrite the dataset is deleted and reloaded, still a single copy.
+        loading.load_datasets(
+            parquet_path, url, stages=["ingest"], n_jobs=2, overwrite=True
+        )
+        assert reaction_count() == expected_count
+
+
+def test_load_datasets_parquet_parallel(prepared_engine, tmp_path):
+    """End-to-end n_jobs>1 run: sharded ingest then the parallel derived stage populate both."""
+    parquet_path, dataset = _write_parquet_dataset(tmp_path, row_group_size=10)
+    loading.load_datasets(parquet_path, str(prepared_engine.url), n_jobs=2)
+    with Session(prepared_engine) as session:
+        assert session.query(Mappers.Reaction).count() == len(dataset.reactions)
+    assert _derived_counts(prepared_engine)["reaction_smiles"] > 0
 
 
 def test_load_datasets(prepared_engine):


### PR DESCRIPTION
Progresses #878 (lever 2, intra-dataset parallelism).

## Problem

Cross-dataset parallelism (`n_jobs` over files) is already free, but it leaves the single largest dataset a single-threaded long pole — one worker ingests 1.77M of 2.4M reactions serially while the others sit idle. The COPY loader (#877) sped each reaction up 4.3×, but that one dataset still dominates wall-clock.

## Change

Make the **row group the unit of parallel work**, so a single pool covers both cross- and intra-dataset parallelism and the big dataset's ~1770 shards fill the workers instead of pinning one. UUIDv7 keys (#875) make this coordination-free: each shard mints its own ids and wires foreign keys with no server round trip.

`database.py` — split `add_parquet_dataset` into composable primitives, reusing the #877 COPY loader unchanged per shard:
- `add_parquet_dataset_row` — the `ord.dataset` search-index row (caller supplies the surrogate id).
- `add_parquet_reactions` — a whole file or a single row group.
- `add_parquet_dataset_metadata` — the `public.datasets` marker + `submitted_at`.
- `add_parquet_dataset` composes them serially in one transaction, so the single-process path is byte-identical to before and stays atomic.

`loading.py` — `_ingest_parquet_sharded` runs three barriered phases over the existing worker pool: **prep** (skip/overwrite decision + insert the dataset row), **shard** (COPY each row group in its own transaction), **finalize** (write the `public.datasets` marker for datasets whose shards all succeeded). `load_datasets` routes parquet datasets here when `n_jobs > 1`; `n_jobs == 1` and non-parquet inputs keep the atomic single-process path.

## One behavior change (parallel path only)

`public.datasets` is written **last**, as a completeness marker. A crashed parallel load leaves an `ord.dataset` row with no marker, which the next run's prep deletes and reloads — self-healing recovery in place of the old single-transaction atomicity. `n_jobs == 1` is unchanged and remains atomic, so existing behavior/tests are untouched. Skip-unchanged and overwrite semantics are preserved in both paths.

## Tests

- `test_parquet_sharded_ingest_matches_single_process` — sharded (multi-row-group) ingest matches the single-process path on every non-key column of every table.
- `test_parquet_sharded_ingest_skip_and_overwrite` — skip-unchanged, reject-changed, and overwrite-reload all behave under `n_jobs > 1`.
- `test_load_datasets_parquet_parallel` — first end-to-end `n_jobs > 1` run; sharded ingest then the parallel derived stage populate both the search index and derived tables.

Full ORM suite green (loading, database, mappers, CLI script).

## Not in this PR

Chunking multiple row groups per shard to amortize per-shard connection setup (negligible at current sizes), and dropping the non-parquet ingest branch (a small separate cleanup — `add_dataset`/`from_proto` stay for the in-memory API path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces row-group-level sharding for Parquet ingest so that a single large dataset's work fills the entire worker pool rather than pinning one worker. The single-process path (`n_jobs == 1`) is preserved unchanged and remains atomic; the sharded path runs three barriered phases (prep, shard, finalize) with `public.datasets` written last as a completeness marker, enabling self-healing recovery from crashes.

- `database.py` splits the old monolithic `add_parquet_dataset` into three composable primitives (`add_parquet_dataset_row`, `add_parquet_reactions`, `add_parquet_dataset_metadata`); `add_parquet_dataset` now composes them in one transaction, keeping the single-process path byte-identical.
- `loading.py` adds `_ingest_parquet_sharded` with three explicit barrier phases; `load_datasets` routes parquet files to the sharded path when `n_jobs > 1` and falls back to the atomic path otherwise.
- `loading_test.py` adds four new tests: content equivalence between paths, skip/overwrite semantics, an end-to-end parallel run, and the partial-load recovery scenario.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the single-process path is byte-identical to before and the sharded path is well-tested including crash-recovery.

The refactor cleanly separates the three phases with explicit barriers, shard failures correctly gate finalize so partial loads are never marked complete, and the self-healing recovery path is exercised by a dedicated test. The _run_parallel generics, failure aggregation, and dataset_uuid contract check all hold up under scrutiny. No data loss or correctness gap was found.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Clean decomposition of add_parquet_dataset into three composable primitives; the public function composes them serially preserving the single-process atomic contract; no logic regressions identified. |
| ord_schema/orm/loading.py | Three-phase barrier design is correct: prep/shard/finalize ordering is enforced, shard failures correctly gate finalize, and the _run_parallel generics are properly typed; no missing error handling or data loss paths found. |
| ord_schema/orm/loading_test.py | New tests cover content equivalence between sharded and single-process paths, skip/overwrite semantics, end-to-end parallel run, and partial-load recovery; _content_digests correctly excludes surrogate keys so UUID differences between runs do not produce false failures. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as load_datasets
    participant S as _ingest_parquet_sharded
    participant P as _prep_parquet_dataset
    participant SH as _ingest_parquet_shard
    participant F as _finalize_parquet_dataset
    participant DB as PostgreSQL

    C->>S: parquet_files, n_jobs, overwrite
    Note over S: Phase 1 Prep barrier
    S->>P: _run_parallel over filenames
    P->>DB: streaming_md5 + get_dataset_md5
    alt unchanged
        P-->>S: "_ParquetPlan needs_load=False"
    else needs load
        P->>DB: delete_dataset + add_parquet_dataset_row commit
        P-->>S: "_ParquetPlan needs_load=True dataset_uuid num_row_groups"
    end
    Note over S: Phase 2 Shard barrier
    S->>SH: _run_parallel over file uuid row_group tuples
    SH->>DB: add_parquet_reactions via COPY commit per shard
    SH-->>S: success or failure
    Note over S: Phase 3 Finalize barrier
    S->>F: _run_parallel over plans with no failed shards
    F->>DB: add_parquet_dataset_metadata public.datasets marker commit
    F-->>S: dataset_id
    S-->>C: skipped_ids plus finalized_ids and failures
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as load_datasets
    participant S as _ingest_parquet_sharded
    participant P as _prep_parquet_dataset
    participant SH as _ingest_parquet_shard
    participant F as _finalize_parquet_dataset
    participant DB as PostgreSQL

    C->>S: parquet_files, n_jobs, overwrite
    Note over S: Phase 1 Prep barrier
    S->>P: _run_parallel over filenames
    P->>DB: streaming_md5 + get_dataset_md5
    alt unchanged
        P-->>S: "_ParquetPlan needs_load=False"
    else needs load
        P->>DB: delete_dataset + add_parquet_dataset_row commit
        P-->>S: "_ParquetPlan needs_load=True dataset_uuid num_row_groups"
    end
    Note over S: Phase 2 Shard barrier
    S->>SH: _run_parallel over file uuid row_group tuples
    SH->>DB: add_parquet_reactions via COPY commit per shard
    SH-->>S: success or failure
    Note over S: Phase 3 Finalize barrier
    S->>F: _run_parallel over plans with no failed shards
    F->>DB: add_parquet_dataset_metadata public.datasets marker commit
    F-->>S: dataset_id
    S-->>C: skipped_ids plus finalized_ids and failures
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into sharded-parquet..."](https://github.com/open-reaction-database/ord-schema/commit/d831c2178a31be30b218387d3f2405bf4776be5c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41002667)</sub>

<!-- /greptile_comment -->