### PR TITLE
Make polymorphic foreign-key indexes partial (WHERE col IS NOT NULL)

### DIFF
--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -249,6 +249,29 @@ def test_unlinked_partial_indexes(test_session):
         )
 
 
+def test_polymorphic_fk_indexes_are_partial(test_session):
+    """Each polymorphic foreign-key index is partial (WHERE ... IS NOT NULL).
+
+    Under single-table inheritance a message's FK column is NULL for every row of a sibling
+    subclass, so a full index would store a NULL entry for most rows and every insert would touch
+    all of them. Indexing only the non-NULL rows keeps the index and the per-insert write
+    proportional to the rows that use each parent. ord.time is the widest such table (one FK per
+    possible parent), so it is a good representative.
+    """
+    indexes = dict(
+        test_session.execute(
+            text(
+                "SELECT indexname, indexdef FROM pg_indexes "
+                "WHERE schemaname = 'ord' AND tablename = 'time'"
+            )
+        ).all()
+    )
+    fk_indexes = {name: d for name, d in indexes.items() if name.startswith("ix_")}
+    assert len(fk_indexes) >= 3, indexes  # ord.time has many parent FK columns.
+    for name, indexdef in fk_indexes.items():
+        assert "IS NOT NULL" in indexdef, f"{name} is not partial: {indexdef}"
+
+
 def test_enum_types_in_ord_schema(test_session):
     """Mapped enum types live in the ord schema so they are rendered schema-qualified.
 

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -43,10 +43,12 @@ from sqlalchemy import (
     Enum,
     Float,
     ForeignKey,
+    Index,
     Integer,
     LargeBinary,
     Text,
     Uuid,
+    text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import relationship
@@ -254,11 +256,13 @@ def build_mapper(
     logger.debug(f"Creating mapper {msg_desc.name}: {attrs}")
     mapper_class = type(msg_desc.name, (Base,), attrs)
     # Create polymorphic child classes.
+    table = mapper_class.__table__
     for parent_type, field_name, _ in parents[message_type]:
         parent_desc = parent_type.DESCRIPTOR
         assert parent_desc is not None  # Type hint.
         foreign_table_name = underscore(parent_desc.name)
         foreign_key = f"ord.{foreign_table_name}.id"
+        fk_name = f"{foreign_table_name}_id"
         child_attrs = {
             "__mapper_args__": {
                 "polymorphic_identity": f"{parent_desc.name}.{field_name}"
@@ -267,9 +271,9 @@ def build_mapper(
             # https://docs.sqlalchemy.org/en/14/orm/inheritance.html#resolving-column-conflicts.
             #
             # NOTE(skearnes): We are not enforcing unique constraints on this column; see the module docstring.
-            f"{foreign_table_name}_id": mapper_class.__table__.c.get(
-                f"{foreign_table_name}_id",
-                Column(Uuid, ForeignKey(foreign_key, ondelete="CASCADE"), index=True),
+            fk_name: table.c.get(
+                fk_name,
+                Column(Uuid, ForeignKey(foreign_key, ondelete="CASCADE")),
             ),
             "parent": relationship(
                 parent_desc.name, back_populates=field_name, uselist=False
@@ -278,6 +282,18 @@ def build_mapper(
         child_class_name = f"_{parent_desc.name}{field_name.capitalize()}"
         logger.debug(f"Creating child mapper {child_class_name}: {child_attrs}")
         type(child_class_name, (mapper_class,), child_attrs)
+        # Partial index on the polymorphic foreign key. Under single-table inheritance this column
+        # is NULL for every row belonging to a sibling subclass, so indexing only the non-NULL rows
+        # keeps both the index and the per-insert index write proportional to the rows that actually
+        # reference this parent. A parent reused across fields shares one column and one index,
+        # created on first use. See derived_mappers for the same partial-index pattern.
+        index_name = f"ix_{table.name}_{fk_name}"
+        if not any(index.name == index_name for index in table.indexes):
+            Index(
+                index_name,
+                table.c[fk_name],
+                postgresql_where=text(f"{fk_name} IS NOT NULL"),
+            )
     return mapper_class
 
 


### PR DESCRIPTION
Closes #876.

## Problem

Each proto message maps to one table, and a message that can appear under several parents gets one nullable foreign-key column per possible parent. `build_mapper` created each with `index=True`, so every FK is a full B-tree index. Under single-table inheritance only **one** of those FK columns is non-NULL per row, so the rest store a NULL entry for that row. The widest tables:

- `ord.time`: 8 FK columns → 8 indexes (7 NULL per row)
- `ord.data`: 6; `ord.texture`, `ord.amount`: 4; `ord.analysis`, `ord.length`, `ord.temperature`, `ord.date_time`: 3

A large share of the ~167 indexes in the `ord` schema are these mostly-NULL FK indexes.

## Change

Emit a partial `Index(..., postgresql_where=text("<col> IS NOT NULL"))` for each polymorphic child FK column instead of `index=True`, created once per column (a parent reused across fields shares one column and one index). This is the same pattern the derived "unlinked" indexes already use.

## Why

- **Smaller indexes** — only the ~1/N non-NULL rows per FK are indexed.
- **Faster ingest** — a `time` insert touches 1 partial index instead of 8, cutting the server-side index-write cost the COPY loader (#877) now bottlenecks on. Good companion to the ingest rebuild.
- **No query regression** — a specific-parent filter (`WHERE compound_id = :x`) only ever matches non-NULL rows, which remain indexed.

## Tests

`test_polymorphic_fk_indexes_are_partial` asserts every `ord.time` FK index carries an `IS NOT NULL` predicate (introspected from `pg_indexes`), alongside the existing `test_unlinked_partial_indexes`. Full ORM suite green.

## Notes

Applies to a freshly created schema (the UUIDv7 rebuild, #875); no online migration of an existing database is included. The one-table-per-message design with discrete nullable FKs is kept — only the indexing was wasteful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR converts every polymorphic foreign-key index in the `ord` schema from a full B-tree index (`index=True`) to a PostgreSQL partial index (`WHERE col IS NOT NULL`), consistent with the pattern already used by `derived_mappers.py`. Under single-table inheritance only one FK column is non-NULL per row, so the previous full indexes stored a NULL entry for the majority of rows and made every insert touch all indexes for the table.

- **`mappers.py`**: Removes `index=True` from the `Column` definition and creates an explicit `Index(name, col, postgresql_where=text("col IS NOT NULL"))` after each child class is registered; a shared-parent deduplication guard (`if not any(...)`) prevents duplicate index objects when the same FK column is reused across fields.
- **`database_test.py`**: Adds `test_polymorphic_fk_indexes_are_partial` that queries `pg_indexes` for `ord.time` (the table with the most FK columns) and asserts every `ix_*` index carries an `IS NOT NULL` clause.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change only affects index DDL emitted at schema-creation time and leaves all ORM read/write paths untouched.

The deduplication guard correctly prevents duplicate Index objects for shared FK columns, the postgresql_where predicate uses the same unqualified-column-name pattern already proven in derived_mappers, and the column is guaranteed to be in table.c before the Index constructor is called because SQLAlchemy's DeclarativeMeta adds it synchronously during the type() call. The test introspects pg_indexes directly, giving high fidelity that the partial index is actually created in the database. No query path, migration, or data is altered.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/mappers.py | Replaces index=True on polymorphic FK columns with explicit partial Index(..., postgresql_where=text("col IS NOT NULL")); deduplication via table.indexes set-check is correct for shared-parent columns. |
| ord_schema/orm/database_test.py | Adds test_polymorphic_fk_indexes_are_partial that introspects pg_indexes on ord.time and asserts every ix_* index carries an IS NOT NULL predicate; consistent with the existing unlinked-index test pattern. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["build_mapper(message_type)"] --> B["Create mapper_class via type()"]
    B --> C["table = mapper_class.__table__"]
    C --> D["For each parent in parents[message_type]"]
    D --> E["fk_name = foreign_table_name + '_id'"]
    E --> F{"table.c.get(fk_name) exists?"}
    F -- "Yes (shared parent)" --> G["Reuse existing Column"]
    F -- "No (first use)" --> H["Create new Column(Uuid, FK, no index=True)"]
    G & H --> I["child_attrs = {fk_name: column, ...}"]
    I --> J["type(child_class_name, mapper_class, child_attrs)"]
    J --> K["SQLAlchemy adds column to table.c (STI)"]
    K --> L{"Index 'ix_table_fk_name'\nalready in table.indexes?"}
    L -- "Yes (shared parent)" --> M["Skip – index already created"]
    L -- "No" --> N["Index(name, table.c[fk_name],\npostgresql_where=fk_name IS NOT NULL)"]
    N --> O["Index registered in table.indexes"]
    M & O --> D
    D --> P["return mapper_class"]
    P --> Q["create_all() emits:\nCREATE INDEX ix_time_X ON ord.time(X)\nWHERE X IS NOT NULL"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["build_mapper(message_type)"] --> B["Create mapper_class via type()"]
    B --> C["table = mapper_class.__table__"]
    C --> D["For each parent in parents[message_type]"]
    D --> E["fk_name = foreign_table_name + '_id'"]
    E --> F{"table.c.get(fk_name) exists?"}
    F -- "Yes (shared parent)" --> G["Reuse existing Column"]
    F -- "No (first use)" --> H["Create new Column(Uuid, FK, no index=True)"]
    G & H --> I["child_attrs = {fk_name: column, ...}"]
    I --> J["type(child_class_name, mapper_class, child_attrs)"]
    J --> K["SQLAlchemy adds column to table.c (STI)"]
    K --> L{"Index 'ix_table_fk_name'\nalready in table.indexes?"}
    L -- "Yes (shared parent)" --> M["Skip – index already created"]
    L -- "No" --> N["Index(name, table.c[fk_name],\npostgresql_where=fk_name IS NOT NULL)"]
    N --> O["Index registered in table.indexes"]
    M & O --> D
    D --> P["return mapper_class"]
    P --> Q["create_all() emits:\nCREATE INDEX ix_time_X ON ord.time(X)\nWHERE X IS NOT NULL"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Make polymorphic foreign-key indexes par..."](https://github.com/open-reaction-database/ord-schema/commit/c052ac100a52297b45121e95cd4f35e5fa37c28a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41004015)</sub>

<!-- /greptile_comment -->