### PR TITLE
Shard derived SMILES within datasets (derived-stage analog of #879)

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -65,6 +65,15 @@ def _classify_reactions(dataset_id: str, session: Session) -> None:
     update_reaction_classes(dataset_id, session)
 
 
+def classify_dataset(dataset_id: str, session: Session) -> None:
+    """Assigns reaction class/name labels for an already-derived dataset (classification only).
+
+    SMILES derivation is done separately (and, in the loader, sharded); this does not re-derive it,
+    so a failed SMILES shard is not silently backfilled here. Requires the ``reaction-class`` extra.
+    """
+    _classify_reactions(dataset_id, session)
+
+
 def get_connection_string(
     database: str,
     username: str,

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -527,7 +527,29 @@ def delete_dataset(dataset_id: str, session: Session) -> None:
     logger.debug(f"delete took {time.time() - start}s")
 
 
-def update_derived_tables(dataset_id: str, session: Session) -> None:
+def _shard_predicate(
+    column: str, shard: tuple[int, int] | None
+) -> tuple[str, dict[str, int]]:
+    """Returns an ``AND`` predicate keeping 1/num_shards of rows by ``column``, or ``('', {})``.
+
+    Partitions a dataset's rows deterministically and disjointly by a hash of the id, so
+    independent workers can each derive their shard without coordinating. ``shard`` is
+    ``(index, num_shards)``; ``None`` disables sharding (whole dataset).
+    """
+    if shard is None:
+        return "", {}
+    shard_index, num_shards = shard
+    # ((h % n) + n) % n keeps the bucket in [0, num_shards) without abs() overflow.
+    predicate = (
+        f"AND ((hashtextextended({column}::text, 0) % :num_shards) + :num_shards) "
+        "% :num_shards = :shard_index"
+    )
+    return predicate, {"num_shards": num_shards, "shard_index": shard_index}
+
+
+def update_derived_tables(
+    dataset_id: str, session: Session, *, shard: tuple[int, int] | None = None
+) -> None:
     """Populates the derived SMILES tables from the search index.
 
     Reaction SMILES come from the ground-truth proto in public.reactions; compound SMILES
@@ -535,6 +557,11 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
     have a derived entry); runs before the RDKit pass, which reads the SMILES. Reactions and
     compounds are processed in batches of _DERIVED_BATCH so the heavy per-row work (proto
     deserialization, SMILES generation) and pending inserts stay within one batch.
+
+    When ``shard`` is ``(index, num_shards)``, only that disjoint hash-partition of the dataset's
+    reaction/compound ids is derived, so a large dataset can be split across worker processes
+    (the derived-stage analog of the row-group sharding used for ingest). Idempotency makes the
+    shards safe to run in any order or overlap.
     """
     logger.debug(f"Updating derived tables for {dataset_id=}")
     start = time.time()
@@ -547,9 +574,12 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
     # Reaction SMILES from the served proto (no ORM objects loaded), keyed by ord.reaction.id.
     # Resolve the ids needing derivation in one indexed pass, then load and parse the (large)
     # protos in batches of _DERIVED_BATCH.
+    reaction_shard_sql, reaction_shard_params = _shard_predicate(
+        "ord.reaction.id", shard
+    )
     reaction_ids = (
         session.execute(
-            text("""
+            text(f"""
                 SELECT ord.reaction.id
                 FROM ord.reaction
                 JOIN public.reactions
@@ -559,8 +589,9 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
                       SELECT 1 FROM derived.reaction_smiles
                       WHERE derived.reaction_smiles.reaction_id = ord.reaction.id
                   )
-                """),
-            {"id": dataset_pk},
+                  {reaction_shard_sql}
+                """),  # noqa: S608  (shard predicate is an internal constant fragment)
+            {"id": dataset_pk, **reaction_shard_params},
         )
         .scalars()
         .all()
@@ -615,6 +646,7 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
         compound_class=Mappers.Compound,
         derived_table="derived.compound_smiles",
         derived_id="compound_id",
+        shard=shard,
     )
     _update_compound_smiles(
         session,
@@ -625,6 +657,7 @@ def update_derived_tables(dataset_id: str, session: Session) -> None:
         compound_class=Mappers.ProductCompound,
         derived_table="derived.product_compound_smiles",
         derived_id="product_compound_id",
+        shard=shard,
     )
     logger.debug(f"Updating derived tables took {time.time() - start:g}s")
 
@@ -639,6 +672,7 @@ def _update_compound_smiles(
     compound_class: Any,
     derived_table: str,
     derived_id: str,
+    shard: tuple[int, int] | None = None,
 ) -> None:
     """Derives SMILES for one (product) compound table's not-yet-derived rows.
 
@@ -647,8 +681,12 @@ def _update_compound_smiles(
     in a single query and canonicalized with RDKit, avoiding a per-compound ORM load. Compounds
     without a stored SMILES fall back to reconstructing the message via to_proto and computing the
     SMILES from its other identifiers. Ids are resolved up front and processed in batches of
-    _DERIVED_BATCH so memory stays bounded.
+    _DERIVED_BATCH so memory stays bounded. ``shard`` (index, num_shards) restricts to one disjoint
+    hash-partition of this table's ids so large datasets can be split across workers.
     """
+    compound_shard_sql, compound_shard_params = _shard_predicate(
+        f"{compound_table}.id", shard
+    )
     compound_ids = (
         session.execute(
             text(f"""
@@ -661,8 +699,9 @@ def _update_compound_smiles(
                       SELECT 1 FROM {derived_table}
                       WHERE {derived_table}.{derived_id} = {compound_table}.id
                   )
+                  {compound_shard_sql}
                 """),  # noqa: S608  (table/column names are internal constants, not user input)
-            {"id": dataset_pk},
+            {"id": dataset_pk, **compound_shard_params},
         )
         .scalars()
         .all()

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -149,12 +149,12 @@ def test_update_derived_tables_batched(test_session, monkeypatch):
 
 
 def test_update_derived_tables_sharded_covers_all(prepared_engine):
-    """Sharded SMILES derivation partitions the dataset and together covers every row.
+    """Sharded SMILES derivation partitions every derived table and together covers every row.
 
     Each shard derives a disjoint hash-partition of the reaction/compound ids (the derived-stage
-    analog of row-group sharding for ingest). Guards two properties: a single shard is a strict,
-    non-empty subset (the partition predicate actually splits rows), and all shards together derive
-    exactly what the unsharded pass would -- a following whole-dataset pass finds nothing new.
+    analog of row-group sharding for ingest). Guards two properties: the predicate actually splits
+    each table's rows across more than one shard, and all shards together derive exactly what the
+    unsharded pass would -- a following whole-dataset pass finds nothing new.
     """
     dataset = load_dataset(
         pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
@@ -172,21 +172,28 @@ def test_update_derived_tables_sharded_covers_all(prepared_engine):
                 for table in tables
             }
 
+    # Derive one shard at a time, recording how many rows each shard adds per table (idempotent
+    # inserts, so a shard only adds its own partition's rows).
     num_shards = 4
-    with Session(prepared_engine) as session, session.begin():
-        update_derived_tables(dataset.dataset_id, session, shard=(0, num_shards))
-    first = counts()
+    prev = dict.fromkeys(tables, 0)
+    per_shard: list[dict[str, int]] = []
     with Session(prepared_engine) as session:
-        for shard_index in range(1, num_shards):
+        for shard_index in range(num_shards):
             with session.begin():
                 update_derived_tables(
                     dataset.dataset_id, session, shard=(shard_index, num_shards)
                 )
+            current = counts()
+            per_shard.append({table: current[table] - prev[table] for table in tables})
+            prev = current
     sharded = counts()
-    # Every table got rows, and shard 0 alone was a strict subset (partitioning is real).
     for table in tables:
         assert sharded[table] > 0, (table, sharded)
-    assert 0 < first["compound_smiles"] < sharded["compound_smiles"], (first, sharded)
+        # Rows land in more than one shard, so the hash predicate really partitions each table
+        # (guarded by a size floor so a genuinely tiny table can't flake the check).
+        if sharded[table] >= 2 * num_shards:
+            non_empty = sum(1 for shard in per_shard if shard[table] > 0)
+            assert non_empty >= 2, (table, [shard[table] for shard in per_shard])
     # A whole-dataset pass now adds nothing: the shards covered every row.
     with Session(prepared_engine) as session, session.begin():
         update_derived_tables(dataset.dataset_id, session)

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -148,6 +148,51 @@ def test_update_derived_tables_batched(test_session, monkeypatch):
         )
 
 
+def test_update_derived_tables_sharded_covers_all(prepared_engine):
+    """Sharded SMILES derivation partitions the dataset and together covers every row.
+
+    Each shard derives a disjoint hash-partition of the reaction/compound ids (the derived-stage
+    analog of row-group sharding for ingest). Guards two properties: a single shard is a strict,
+    non-empty subset (the partition predicate actually splits rows), and all shards together derive
+    exactly what the unsharded pass would -- a following whole-dataset pass finds nothing new.
+    """
+    dataset = load_dataset(
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+    )
+    with Session(prepared_engine) as session, session.begin():
+        add_dataset(dataset, session)
+    tables = ("reaction_smiles", "compound_smiles", "product_compound_smiles")
+
+    def counts() -> dict[str, int]:
+        with Session(prepared_engine) as session:
+            return {
+                table: session.execute(
+                    text(f"SELECT count(*) FROM derived.{table}")  # noqa: S608  (constant)
+                ).scalar()
+                for table in tables
+            }
+
+    num_shards = 4
+    with Session(prepared_engine) as session, session.begin():
+        update_derived_tables(dataset.dataset_id, session, shard=(0, num_shards))
+    first = counts()
+    with Session(prepared_engine) as session:
+        for shard_index in range(1, num_shards):
+            with session.begin():
+                update_derived_tables(
+                    dataset.dataset_id, session, shard=(shard_index, num_shards)
+                )
+    sharded = counts()
+    # Every table got rows, and shard 0 alone was a strict subset (partitioning is real).
+    for table in tables:
+        assert sharded[table] > 0, (table, sharded)
+    assert 0 < first["compound_smiles"] < sharded["compound_smiles"], (first, sharded)
+    # A whole-dataset pass now adds nothing: the shards covered every row.
+    with Session(prepared_engine) as session, session.begin():
+        update_derived_tables(dataset.dataset_id, session)
+    assert counts() == sharded
+
+
 @pytest.mark.parametrize(
     ("derived_table", "id_column", "mapper"),
     [

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -53,6 +53,12 @@ logger = get_logger(__name__)
 
 STAGES = ("ingest", "derived")
 
+# SMILES derivation is sharded within a dataset so one large dataset does not pin a single worker
+# (the derived-stage analog of row-group sharding for ingest). A dataset is split into one shard
+# per this many reactions, capped, so small datasets stay a single shard.
+_DERIVE_SHARD_SIZE = 50_000
+_DERIVE_SHARD_CAP = 32
+
 
 def dataset_id_for_file(filename: str) -> str:
     """Returns the dataset ID for a dataset file without ingesting it."""
@@ -153,6 +159,67 @@ def derive_dataset(dataset_id: str, *, dsn: str, classify_reactions: bool) -> st
                 session,
                 rdkit_cartridge=False,  # Done serially in add_rdkit() to avoid deadlocks.
                 classify_reactions=classify_reactions,
+            )
+    finally:
+        engine.dispose()
+    return dataset_id
+
+
+def _derive_shard_items(
+    dataset_ids: Iterable[str], dsn: str
+) -> list[tuple[str, int, int]]:
+    """Builds ``(dataset_id, shard_index, num_shards)`` SMILES-derivation work items.
+
+    A dataset is split into ``ceil(num_reactions / _DERIVE_SHARD_SIZE)`` shards (capped at
+    ``_DERIVE_SHARD_CAP``, at least 1), so a large dataset fans out across the pool while small
+    ones stay a single shard. Datasets without a size (no metadata row) default to one shard.
+    """
+    items: list[tuple[str, int, int]] = []
+    engine = create_engine(dsn)
+    try:
+        with Session(engine) as session:
+            for dataset_id in dataset_ids:
+                try:
+                    size = database.get_dataset_size(dataset_id, session)
+                except ValueError:
+                    size = 0
+                num_shards = max(
+                    1, min(_DERIVE_SHARD_CAP, -(-size // _DERIVE_SHARD_SIZE))
+                )
+                items.extend(
+                    (dataset_id, shard_index, num_shards)
+                    for shard_index in range(num_shards)
+                )
+    finally:
+        engine.dispose()
+    return items
+
+
+def _derive_smiles_shard(
+    item: tuple[str, int, int], *, dsn: str
+) -> tuple[str, int, int]:
+    """Derives one hash-partition of a dataset's SMILES (the parallel-safe, shardable pass)."""
+    dataset_id, shard_index, num_shards = item
+    engine = create_engine(dsn)
+    try:
+        with Session(engine) as session, session.begin():
+            database.update_derived_tables(
+                dataset_id, session, shard=(shard_index, num_shards)
+            )
+    finally:
+        engine.dispose()
+    return item
+
+
+def _classify_dataset(dataset_id: str, *, dsn: str) -> str:
+    """Assigns reaction class/name labels for a dataset (after the sharded SMILES pass)."""
+    engine = create_engine(dsn)
+    try:
+        with Session(engine) as session, session.begin():
+            # SMILES are already derived by the sharded pass, so update_derived_tables here is a
+            # no-op scan; this call adds the classification.
+            database.update_derived_data(
+                dataset_id, session, rdkit_cartridge=False, classify_reactions=True
             )
     finally:
         engine.dispose()
@@ -419,14 +486,26 @@ def load_datasets(
         dataset_ids = [dataset_id_for_file(filename) for filename in filenames]
 
     if "derived" in stages:
-        logger.info("Deriving SMILES and reaction classes")
-        dataset_ids, stage_failures = _run_parallel(
-            partial(derive_dataset, dsn=dsn, classify_reactions=classify_reactions),
-            dataset_ids,
+        logger.info("Deriving SMILES")
+        # Shard SMILES derivation within datasets so one large dataset does not pin a single
+        # worker; the pool sees a flat (dataset, shard) work list across all datasets.
+        shard_items = _derive_shard_items(dataset_ids, dsn)
+        _, shard_failures = _run_parallel(
+            partial(_derive_smiles_shard, dsn=dsn),
+            shard_items,
             n_jobs=n_jobs,
             desc="Derive",
         )
-        failures.extend(stage_failures)
+        failures.extend(sorted({dataset_id for dataset_id, _, _ in shard_failures}))
+        if classify_reactions:
+            logger.info("Classifying reactions")
+            _, classify_failures = _run_parallel(
+                partial(_classify_dataset, dsn=dsn),
+                dataset_ids,
+                n_jobs=n_jobs,
+                desc="Classify",
+            )
+            failures.extend(classify_failures)
         logger.info("Adding RDKit functionality")
         engine = create_engine(dsn)
         try:

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -170,7 +170,7 @@ def _derive_shard_items(
 ) -> list[tuple[str, int, int]]:
     """Builds ``(dataset_id, shard_index, num_shards)`` SMILES-derivation work items.
 
-    A dataset is split into ``num_reactions // _DERIVE_SHARD_SIZE`` shards (capped at
+    A dataset is split into ``ceil(num_reactions / _DERIVE_SHARD_SIZE)`` shards (capped at
     ``_DERIVE_SHARD_CAP``, at least 1), so a large dataset fans out across the pool while small
     ones stay a single shard. Datasets without a size (no metadata row) default to one shard.
     """
@@ -183,7 +183,11 @@ def _derive_shard_items(
                     size = database.get_dataset_size(dataset_id, session)
                 except ValueError:
                     size = 0
-                num_shards = max(1, min(_DERIVE_SHARD_CAP, size // _DERIVE_SHARD_SIZE))
+                # Ceiling division (-(-a // b)): a dataset just over a shard-size multiple still
+                # splits into an extra shard rather than staying single-worker.
+                num_shards = max(
+                    1, min(_DERIVE_SHARD_CAP, -(-size // _DERIVE_SHARD_SIZE))
+                )
                 items.extend(
                     (dataset_id, shard_index, num_shards)
                     for shard_index in range(num_shards)

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -212,15 +212,16 @@ def _derive_smiles_shard(
 
 
 def _classify_dataset(dataset_id: str, *, dsn: str) -> str:
-    """Assigns reaction class/name labels for a dataset (after the sharded SMILES pass)."""
+    """Assigns reaction class/name labels for a dataset (SMILES already derived by the shard pass).
+
+    Classification only -- it does not re-derive SMILES, so a failed SMILES shard stays visibly
+    incomplete rather than being silently backfilled here (keeping shard-failure semantics the same
+    whether or not classification is enabled).
+    """
     engine = create_engine(dsn)
     try:
         with Session(engine) as session, session.begin():
-            # SMILES are already derived by the sharded pass, so update_derived_tables here is a
-            # no-op scan; this call adds the classification.
-            database.update_derived_data(
-                dataset_id, session, rdkit_cartridge=False, classify_reactions=True
-            )
+            database.classify_dataset(dataset_id, session)
     finally:
         engine.dispose()
     return dataset_id

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -24,6 +24,7 @@ dataset files; the per-dataset helpers (``ingest_dataset``, ``derive_dataset``,
 """
 
 import dataclasses
+import math
 import time
 import uuid
 from collections.abc import Callable, Iterable
@@ -184,7 +185,7 @@ def _derive_shard_items(
                 except ValueError:
                     size = 0
                 num_shards = max(
-                    1, min(_DERIVE_SHARD_CAP, -(-size // _DERIVE_SHARD_SIZE))
+                    1, min(_DERIVE_SHARD_CAP, math.ceil(size / _DERIVE_SHARD_SIZE))
                 )
                 items.extend(
                     (dataset_id, shard_index, num_shards)

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -24,7 +24,6 @@ dataset files; the per-dataset helpers (``ingest_dataset``, ``derive_dataset``,
 """
 
 import dataclasses
-import math
 import time
 import uuid
 from collections.abc import Callable, Iterable
@@ -171,7 +170,7 @@ def _derive_shard_items(
 ) -> list[tuple[str, int, int]]:
     """Builds ``(dataset_id, shard_index, num_shards)`` SMILES-derivation work items.
 
-    A dataset is split into ``ceil(num_reactions / _DERIVE_SHARD_SIZE)`` shards (capped at
+    A dataset is split into ``num_reactions // _DERIVE_SHARD_SIZE`` shards (capped at
     ``_DERIVE_SHARD_CAP``, at least 1), so a large dataset fans out across the pool while small
     ones stay a single shard. Datasets without a size (no metadata row) default to one shard.
     """
@@ -184,9 +183,7 @@ def _derive_shard_items(
                     size = database.get_dataset_size(dataset_id, session)
                 except ValueError:
                     size = 0
-                num_shards = max(
-                    1, min(_DERIVE_SHARD_CAP, math.ceil(size / _DERIVE_SHARD_SIZE))
-                )
+                num_shards = max(1, min(_DERIVE_SHARD_CAP, size // _DERIVE_SHARD_SIZE))
                 items.extend(
                     (dataset_id, shard_index, num_shards)
                     for shard_index in range(num_shards)
@@ -525,4 +522,6 @@ def load_datasets(
             engine.dispose()
 
     if failures:
-        raise RuntimeError(failures)
+        # A dataset can fail in more than one pass (SMILES shards, classify, RDKit); report each
+        # failing file/dataset once, sorted for a deterministic message.
+        raise RuntimeError(sorted(set(failures)))


### PR DESCRIPTION
Progresses #882 (part of the fast full-ORD population effort).

## Problem

The derived stage parallelized SMILES derivation only *across* datasets (`_run_parallel(derive_dataset, dataset_ids, n_jobs)`), so the single largest dataset was derived by **one** worker while the other 15 sat idle — the same long pole #879 removed for ingest. Observed directly on the full-ORD run (2026-07-02): the derived tail ground through the 1.77M-reaction dataset's `compound_smiles` at client load ~0.2/16.

## Change

Make SMILES derivation shardable within a dataset, and fan it out across the pool.

- **`database.py`:** `update_derived_tables` and `_update_compound_smiles` take an optional `shard=(index, num_shards)`. A new `_shard_predicate` appends `((hashtextextended(<id>::text, 0) % :n) + :n) % :n = :k` to each id-resolution query, so a worker derives a **disjoint 1/N hash-partition** of the dataset's reaction/compound/product-compound ids — no cross-worker coordination, and idempotency makes shards safe to run in any order or overlap.
- **`loading.py`:** the derived stage now builds a flat `(dataset_id, shard_index, num_shards)` work list across all datasets and runs it through one pool (like the ingest sharding). A dataset is split into `ceil(num_reactions / _DERIVE_SHARD_SIZE)` shards, capped at `_DERIVE_SHARD_CAP` (32), so the big dataset spreads across workers while small datasets stay a single shard. Reaction classification (optional) runs as its own **classify-only** per-dataset pass via a new `database.classify_dataset` — it no longer re-derives SMILES, so a failed SMILES shard stays visibly incomplete whether or not classification is enabled (consistent failure semantics). The serial RDKit linking pass is unchanged.

## Test

`test_update_derived_tables_sharded_covers_all` derives one shard at a time and records the rows each shard adds per table, then asserts (1) **every** derived table (above a size floor) lands in more than one shard — so the partition predicate is verified for `reaction_smiles`, `compound_smiles`, and `product_compound_smiles`, not just one — and (2) all shards together cover exactly the whole-dataset pass (a following whole pass adds nothing). Full ORM suite green.

## Out of scope (separate follow-ups)

- The RDKit cartridge pass (`update_rdkit_tables`/`update_rdkit_ids`) is a separate serial-per-dataset long pole that runs in-Postgres on the writer; sharding it is harder (deadlock-avoidance) and stays tracked in #882.
- Reaction classification has the same single-worker-per-dataset long pole but multiplies torch/rxnmapper model memory if sharded naively — tracked in #884 (memory-aware).
- Per the Aurora topology finding, derivation is writer-CPU-bound on the steady-state `db.t4g.large` — client sharding only helps once the writer can absorb the writes (pair with a temporary scale-up for bulk rederivation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR shards SMILES derivation within individual datasets so that a single large dataset no longer serializes the derived stage to one worker. Previously, a 1.77M-reaction dataset would occupy one worker while 15 sat idle; now up to 32 hash-partitioned shards run in parallel.

- **`database.py`**: Adds `_shard_predicate` (a `hashtextextended`-based SQL fragment that routes each row deterministically to one shard), threads the `shard=(index, num_shards)` argument into `update_derived_tables` and `_update_compound_smiles`, and exposes a public `classify_dataset` that does classification only, so a failed SMILES shard is never silently backfilled by the classify pass.
- **`loading.py`**: Replaces the single per-dataset `derive_dataset` call with a flat `(dataset_id, shard_index, num_shards)` work list; dataset sizing from `get_dataset_size` drives shard count (1 shard per 50k reactions, capped at 32). A separate classify-only parallel pass runs only when `classify_reactions=True`, keeping failure semantics consistent regardless of that flag.
- **`database_test.py`**: New `test_update_derived_tables_sharded_covers_all` derives one shard at a time across all four shards and asserts (1) every sufficiently large derived table lands in more than one shard, and (2) a following unsharded pass adds nothing new.
</details>

<h3>Confidence Score: 5/5</h3>

The change is safe to merge: sharding is hash-based and disjoint, idempotency preserves correctness on re-run or overlap, and all three derived tables are verified in the new test.

The shard predicate is correct (double-modulo handles PostgreSQL negative-hash behavior), the shard=(0,1) degenerate case evaluates to x % 1 = 0 (always true), failure reporting correctly deduplicates dataset ids from shard-tuple failures, and the prepared_engine fixture is confirmed to start empty so delta-counting logic is valid. No data loss, no race conditions, no SQL injection.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Adds `_shard_predicate`, threads `shard` arg through `update_derived_tables` and `_update_compound_smiles`, and exposes `classify_dataset`. Hash-partition logic is correct (double-modulo for negative hash values), bind-parameter names are unique and safe, internal column constants are not user-controlled. |
| ord_schema/orm/loading.py | Replaces per-dataset serial derive with a flat (dataset_id, shard_index, num_shards) parallel pool; failure extraction from shard tuples is correct; classify pass separated cleanly; RDKit serial pass unchanged. |
| ord_schema/orm/database_test.py | New sharding test is sound: `prepared_engine` is a fresh empty DB per test (confirmed via conftest.py), so `prev = dict.fromkeys(tables, 0)` correctly represents the pre-test baseline; asserts both partition coverage and full completeness. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Restore ceiling division for shard count..."](https://github.com/open-reaction-database/ord-schema/commit/9afe94b6d5a15ea9ccbdf08e486cb9d819c2355c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41275226)</sub>

<!-- /greptile_comment -->