### PR TITLE
Shard the RDKit cartridge pass within datasets

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -773,31 +773,44 @@ def _update_compound_smiles(
             session.execute(insert_smiles, inserts)
 
 
-def update_rdkit_tables(dataset_id: str, session: Session) -> None:
-    """Updates RDKit PostgreSQL cartridge data."""
+def update_rdkit_tables(
+    dataset_id: str, session: Session, *, shard: tuple[int, int] | None = None
+) -> None:
+    """Updates RDKit PostgreSQL cartridge data.
+
+    ``shard`` (index, num_shards) restricts the inserts to one hash-partition of the SMILES values,
+    so a dataset's RDKit work can be split across workers. Because every RDKit sub-step (here and in
+    ``update_rdkit_ids``) partitions by the *same* SMILES hash, shard ``k`` inserts exactly the
+    structures its links will reference -- disjoint key sets across shards, so concurrent shards
+    never collide on the shared ``rdkit.*`` unique indexes (datasets still run serially).
+    """
     logger.debug(f"Updating RDKit tables for {dataset_id=}")
-    _update_rdkit_reactions(dataset_id, session)
-    _update_rdkit_mols(dataset_id, session)
+    _update_rdkit_reactions(dataset_id, session, shard=shard)
+    _update_rdkit_mols(dataset_id, session, shard=shard)
 
 
-def _update_rdkit_reactions(dataset_id: str, session: Session) -> None:
+def _update_rdkit_reactions(
+    dataset_id: str, session: Session, *, shard: tuple[int, int] | None = None
+) -> None:
     """Updates the RDKit reactions table."""
     logger.debug("Updating RDKit reactions")
     start = time.time()
+    shard_sql, shard_params = _shard_predicate(
+        "derived.reaction_smiles.reaction_smiles", shard
+    )
     result = session.execute(
-        text("""
+        text(f"""
             INSERT INTO rdkit.reactions (reaction_smiles, reaction)
             SELECT reaction_smiles, reaction
             FROM (
                 SELECT reaction_smiles, reaction_from_smiles(reaction_smiles::cstring) AS reaction
                 FROM (
                     -- NOTE(skearnes): NOT EXISTS probes the unique reaction_smiles index per candidate instead
-                    -- of EXCEPT-scanning all of rdkit.reactions; DISTINCT dedupes within the dataset. There is no
-                    -- ON CONFLICT backstop here, so this relies on the RDKit phase running serially (see
-                    -- add_datasets) to avoid unique violations on concurrent inserts of the same reaction_smiles.
+                    -- of EXCEPT-scanning all of rdkit.reactions; DISTINCT dedupes within the dataset.
                     -- reaction_smiles IS NOT NULL is required: unlike EXCEPT (which treats NULLs as equal),
                     -- NOT EXISTS never matches a NULL, so without it a no-SMILES reaction would re-insert a junk
-                    -- (NULL, NULL) row on every run.
+                    -- (NULL, NULL) row on every run. The ON CONFLICT below is a backstop; sharded runs also keep
+                    -- concurrent inserts on disjoint reaction_smiles hash-partitions so they never collide.
                     SELECT DISTINCT derived.reaction_smiles.reaction_smiles
                         FROM derived.reaction_smiles
                         JOIN ord.reaction ON ord.reaction.id = derived.reaction_smiles.reaction_id
@@ -809,25 +822,30 @@ def _update_rdkit_reactions(dataset_id: str, session: Session) -> None:
                               SELECT 1 FROM rdkit.reactions
                               WHERE rdkit.reactions.reaction_smiles = derived.reaction_smiles.reaction_smiles
                           )
+                          {shard_sql}
                 ) candidates
             ) computed
             -- reaction_from_smiles returns NULL for an unparseable reaction SMILES; skip those so we never
             -- insert a NULL-reaction row (mirrors the mol IS NOT NULL guard in _update_rdkit_mols).
             WHERE reaction IS NOT NULL
-            """),
-        {"dataset_id": dataset_id},
+            ON CONFLICT (reaction_smiles) DO NOTHING
+            """),  # noqa: S608  (shard predicate is an internal constant fragment)
+        {"dataset_id": dataset_id, **shard_params},
     )
     logger.debug(
         f"Updating reactions took {time.time() - start:g}s ({cast(Any, result).rowcount} rows)"
     )
 
 
-def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
+def _update_rdkit_mols(
+    dataset_id: str, session: Session, *, shard: tuple[int, int] | None = None
+) -> None:
     """Updates the RDKit mols table."""
     logger.debug("Updating RDKit mols")
     start = time.time()
+    shard_sql, shard_params = _shard_predicate("smiles", shard)
     result = session.execute(
-        text("""
+        text(f"""
             WITH new_smiles AS MATERIALIZED (
                 -- Materialization barrier (AS MATERIALIZED): resolve the dataset's not-yet-linked SMILES that
                 -- aren't already in rdkit.mols FIRST -- a cheap per-candidate probe of the unique smiles index --
@@ -862,6 +880,7 @@ def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
                 ) candidates
                 WHERE smiles NOT LIKE '%[Ti+5]%'  -- See https://github.com/open-reaction-database/ord-schema/issues/672.
                   AND NOT EXISTS (SELECT 1 FROM rdkit.mols WHERE rdkit.mols.smiles = candidates.smiles)
+                  {shard_sql}
             )
             INSERT INTO rdkit.mols (smiles, mol, morgan_bfp, morgan_sfp)
             SELECT smiles, mol, morganbv_fp(mol) AS morgan_bfp, morgan_fp(mol) AS morgan_sfp
@@ -872,8 +891,8 @@ def _update_rdkit_mols(dataset_id: str, session: Session) -> None:
             -- row (which ON CONFLICT would not catch for a genuinely new SMILES) or feed NULL to the fingerprints.
             WHERE mol IS NOT NULL
             ON CONFLICT (smiles) DO NOTHING
-            """),
-        {"dataset_id": dataset_id},
+            """),  # noqa: S608  (shard predicate is an internal constant fragment)
+        {"dataset_id": dataset_id, **shard_params},
     )
     logger.debug(
         f"Updating mols took {time.time() - start:g}s ({cast(Any, result).rowcount} rows)"
@@ -889,6 +908,7 @@ def _link_mol_ids(
     link_table: str,
     link_column: str,
     dataset_id: str,
+    shard: tuple[int, int] | None = None,
 ) -> int:
     """Links rdkit.mols ids into a derived compound-SMILES table for one dataset.
 
@@ -909,10 +929,14 @@ def _link_mol_ids(
         link_column: Foreign-key column on ``compound_table`` that references
             ``link_table`` (e.g. ``"reaction_input_id"``).
         dataset_id: Dataset to scope the update to.
+        shard: Optional ``(index, num_shards)`` partition (by the derived table's SMILES hash)
+            to restrict the update to, matching the mol-insert partition so a shard links exactly
+            the rows it inserted.
 
     Returns:
         The number of rows updated.
     """
+    shard_sql, shard_params = _shard_predicate(f"{derived_table}.smiles", shard)
     result = session.execute(
         text(f"""
             UPDATE {derived_table}
@@ -925,14 +949,22 @@ def _link_mol_ids(
               AND ord.reaction.dataset_id = ord.dataset.id
               AND ord.dataset.dataset_id = :dataset_id
               AND {derived_table}.rdkit_mol_id IS NULL
+              {shard_sql}
             """),  # noqa: S608  (table/column names are internal constants, not user input)
-        {"dataset_id": dataset_id},
+        {"dataset_id": dataset_id, **shard_params},
     )
     return cast(Any, result).rowcount
 
 
-def update_rdkit_ids(dataset_id: str, session: Session) -> None:
-    """Updates RDKit reaction and mol ID associations in the ORD tables."""
+def update_rdkit_ids(
+    dataset_id: str, session: Session, *, shard: tuple[int, int] | None = None
+) -> None:
+    """Updates RDKit reaction and mol ID associations in the ORD tables.
+
+    ``shard`` (index, num_shards) restricts the links to one SMILES-hash partition, matching the
+    insert partition in ``update_rdkit_tables`` so shard ``k`` links exactly the structures it
+    inserted.
+    """
     logger.debug("Updating RDKit ID associations")
     start = time.time()
     # NOTE(skearnes): These use the flat ``UPDATE ... FROM`` form (target updated in place) rather than
@@ -940,8 +972,11 @@ def update_rdkit_ids(dataset_id: str, session: Session) -> None:
     # re-joined the target by id. The rdkit join keys (reaction_smiles/smiles) are unique-indexed, and the
     # dataset scope is reached via the indexed foreign keys.
     # Update derived.reaction_smiles (reaction_smiles and rdkit_reaction_id live there).
+    reaction_shard_sql, reaction_shard_params = _shard_predicate(
+        "derived.reaction_smiles.reaction_smiles", shard
+    )
     reaction_result = session.execute(
-        text("""
+        text(f"""
             UPDATE derived.reaction_smiles
             SET rdkit_reaction_id = rdkit.reactions.id
             FROM rdkit.reactions, ord.reaction, ord.dataset
@@ -950,8 +985,9 @@ def update_rdkit_ids(dataset_id: str, session: Session) -> None:
               AND ord.reaction.dataset_id = ord.dataset.id
               AND ord.dataset.dataset_id = :dataset_id
               AND derived.reaction_smiles.rdkit_reaction_id IS NULL
-            """),
-        {"dataset_id": dataset_id},
+              {reaction_shard_sql}
+            """),  # noqa: S608  (shard predicate is an internal constant fragment)
+        {"dataset_id": dataset_id, **reaction_shard_params},
     )
     reaction_rows = cast(Any, reaction_result).rowcount
     compound_rows = _link_mol_ids(
@@ -962,6 +998,7 @@ def update_rdkit_ids(dataset_id: str, session: Session) -> None:
         link_table="ord.reaction_input",
         link_column="reaction_input_id",
         dataset_id=dataset_id,
+        shard=shard,
     )
     product_compound_rows = _link_mol_ids(
         session,
@@ -971,6 +1008,7 @@ def update_rdkit_ids(dataset_id: str, session: Session) -> None:
         link_table="ord.reaction_outcome",
         link_column="reaction_outcome_id",
         dataset_id=dataset_id,
+        shard=shard,
     )
     logger.debug(
         f"Updating RDKit IDs took {time.time() - start:g}s "

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -843,7 +843,7 @@ def _update_rdkit_mols(
     """Updates the RDKit mols table."""
     logger.debug("Updating RDKit mols")
     start = time.time()
-    shard_sql, shard_params = _shard_predicate("smiles", shard)
+    shard_sql, shard_params = _shard_predicate("candidates.smiles", shard)
     result = session.execute(
         text(f"""
             WITH new_smiles AS MATERIALIZED (

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -248,7 +248,13 @@ def test_rdkit_sharded_matches_serial(prepared_engine):
     sharded = counts()
     # Shard 0 alone was a strict, non-empty subset of the inserted structures.
     assert 0 < first["mols"] < sharded["mols"], (first, sharded)
-    for key in ("mols", "reactions", "linked_reactions", "linked_compounds"):
+    for key in (
+        "mols",
+        "reactions",
+        "linked_reactions",
+        "linked_compounds",
+        "linked_products",
+    ):
         assert sharded[key] > 0, (key, sharded)
     # A serial (whole-dataset) pass now inserts and links nothing new: the shards covered it all.
     run_shard(None)

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -32,6 +32,7 @@ from ord_schema.orm.database import (
     get_dataset_md5,
     get_dataset_size,
     update_derived_tables,
+    update_rdkit_ids,
     update_rdkit_tables,
 )
 from ord_schema.orm.mappers import Mappers, to_proto
@@ -197,6 +198,60 @@ def test_update_derived_tables_sharded_covers_all(prepared_engine):
     # A whole-dataset pass now adds nothing: the shards covered every row.
     with Session(prepared_engine) as session, session.begin():
         update_derived_tables(dataset.dataset_id, session)
+    assert counts() == sharded
+
+
+def test_rdkit_sharded_matches_serial(prepared_engine):
+    """Sharded RDKit population inserts + links the same rows as the serial pass, shards disjoint.
+
+    Every RDKit sub-step partitions by the same SMILES hash, so a shard inserts exactly the
+    structures its links reference. Guards that a single shard is a strict subset (partitioning is
+    real) and that all shards together produce what the unsharded pass would -- a following serial
+    pass inserts and links nothing new.
+    """
+    dataset = load_dataset(
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+    )
+    with Session(prepared_engine) as session, session.begin():
+        add_dataset(dataset, session)
+    with Session(prepared_engine) as session, session.begin():
+        update_derived_tables(
+            dataset.dataset_id, session
+        )  # SMILES first; RDKit reads them.
+
+    def counts() -> dict[str, int]:
+        with Session(prepared_engine) as session:
+            queries = {
+                "mols": "SELECT count(*) FROM rdkit.mols",
+                "reactions": "SELECT count(*) FROM rdkit.reactions",
+                "linked_reactions": "SELECT count(*) FROM derived.reaction_smiles WHERE rdkit_reaction_id IS NOT NULL",
+                "linked_compounds": "SELECT count(*) FROM derived.compound_smiles WHERE rdkit_mol_id IS NOT NULL",
+                "linked_products": "SELECT count(*) FROM derived.product_compound_smiles WHERE rdkit_mol_id IS NOT NULL",
+            }
+            return {
+                key: session.execute(text(query)).scalar()
+                for key, query in queries.items()
+            }
+
+    def run_shard(shard: tuple[int, int] | None) -> None:
+        with Session(prepared_engine) as session:
+            with session.begin():
+                update_rdkit_tables(dataset.dataset_id, session, shard=shard)
+            with session.begin():
+                update_rdkit_ids(dataset.dataset_id, session, shard=shard)
+
+    num_shards = 4
+    run_shard((0, num_shards))
+    first = counts()
+    for shard_index in range(1, num_shards):
+        run_shard((shard_index, num_shards))
+    sharded = counts()
+    # Shard 0 alone was a strict, non-empty subset of the inserted structures.
+    assert 0 < first["mols"] < sharded["mols"], (first, sharded)
+    for key in ("mols", "reactions", "linked_reactions", "linked_compounds"):
+        assert sharded[key] > 0, (key, sharded)
+    # A serial (whole-dataset) pass now inserts and links nothing new: the shards covered it all.
+    run_shard(None)
     assert counts() == sharded
 
 

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -238,6 +238,30 @@ def add_rdkit(engine: Engine, dataset_id: str) -> None:
             database.update_rdkit_ids(dataset_id, session)
 
 
+def _rdkit_shard(item: tuple[str, int, int], *, dsn: str) -> tuple[str, int, int]:
+    """Populates + links the RDKit tables for one SMILES-hash partition of a dataset.
+
+    Every RDKit sub-step partitions by the same SMILES hash, so this shard inserts exactly the
+    structures its links reference and touches a key set disjoint from the other shards -- safe to
+    run concurrently against the shared ``rdkit.*`` tables (datasets are still processed serially).
+    """
+    dataset_id, shard_index, num_shards = item
+    engine = create_engine(dsn)
+    try:
+        with Session(engine) as session:
+            with session.begin():
+                database.update_rdkit_tables(
+                    dataset_id, session, shard=(shard_index, num_shards)
+                )
+            with session.begin():
+                database.update_rdkit_ids(
+                    dataset_id, session, shard=(shard_index, num_shards)
+                )
+    finally:
+        engine.dispose()
+    return item
+
+
 def _run_parallel(
     func: Callable[[_Item], _Result],
     items: Iterable[_Item],
@@ -510,18 +534,38 @@ def load_datasets(
             )
             failures.extend(classify_failures)
         logger.info("Adding RDKit functionality")
+        # Datasets are processed serially (the rdkit.* dedup tables are shared, so cross-dataset
+        # concurrency could collide on the same structure), but each dataset's pass is sharded by
+        # SMILES hash across the pool -- disjoint partitions keep concurrent inserts off each
+        # other's rdkit.* keys, so one large dataset no longer runs single-threaded.
         engine = create_engine(dsn)
         try:
             for dataset_id in tqdm(dataset_ids, desc="RDKit"):
-                try:
-                    add_rdkit(
-                        engine, dataset_id
-                    )  # NOTE(skearnes): Do this serially to avoid deadlocks.
-                except Exception:
-                    failures.append(dataset_id)
-                    logger.exception(
-                        f"Adding RDKit functionality for {dataset_id} failed"
+                with Session(engine) as session:
+                    try:
+                        size = database.get_dataset_size(dataset_id, session)
+                    except ValueError:
+                        size = 0
+                num_shards = max(
+                    1, min(_DERIVE_SHARD_CAP, -(-size // _DERIVE_SHARD_SIZE))
+                )
+                if num_shards == 1:
+                    try:
+                        add_rdkit(engine, dataset_id)
+                    except Exception:
+                        failures.append(dataset_id)
+                        logger.exception(
+                            f"Adding RDKit functionality for {dataset_id} failed"
+                        )
+                else:
+                    _, rdkit_failures = _run_parallel(
+                        partial(_rdkit_shard, dsn=dsn),
+                        [(dataset_id, k, num_shards) for k in range(num_shards)],
+                        n_jobs=n_jobs,
+                        desc="RDKit",
                     )
+                    if rdkit_failures:
+                        failures.append(dataset_id)
         finally:
             engine.dispose()
 

--- a/ord_schema/orm/loading_test.py
+++ b/ord_schema/orm/loading_test.py
@@ -170,6 +170,34 @@ def test_load_datasets_parquet_parallel(prepared_engine, tmp_path):
     assert _derived_counts(prepared_engine)["reaction_smiles"] > 0
 
 
+def test_derived_stage_shards_smiles_and_rdkit(prepared_engine, tmp_path, monkeypatch):
+    """With a small shard size, the derived stage fans SMILES and RDKit into multiple shards.
+
+    Shrinking _DERIVE_SHARD_SIZE forces the small fixture into several shards, exercising the
+    (dataset, shard) SMILES pool and the per-dataset RDKit shard pool -- not just the single-shard
+    path the default size gives this fixture. Both derived SMILES and the RDKit cartridge tables
+    (with links) must be populated.
+    """
+    monkeypatch.setattr("ord_schema.orm.loading._DERIVE_SHARD_SIZE", 10)
+    parquet_path, dataset = _write_parquet_dataset(tmp_path, row_group_size=10)
+    loading.load_datasets(parquet_path, str(prepared_engine.url), n_jobs=2)
+    with Session(prepared_engine) as session:
+        assert session.query(Mappers.Reaction).count() == len(dataset.reactions)
+        assert _derived_counts(prepared_engine)["reaction_smiles"] > 0
+        assert session.execute(text("SELECT count(*) FROM rdkit.mols")).scalar() > 0
+        assert (
+            session.execute(text("SELECT count(*) FROM rdkit.reactions")).scalar() > 0
+        )
+        assert (
+            session.execute(
+                text(
+                    "SELECT count(*) FROM derived.reaction_smiles WHERE rdkit_reaction_id IS NOT NULL"
+                )
+            ).scalar()
+            > 0
+        )
+
+
 def test_parquet_sharded_ingest_recovers_from_partial_load(tmp_path):
     """A crashed shard phase (dataset row + some reactions, no marker) is cleanly redone.
 


### PR DESCRIPTION
Closes #886. The last derived-stage long pole after SMILES sharding (#883).

## Problem

`add_rdkit` ran **serially per dataset** ("to avoid deadlocks"), and the cartridge work (`mol_from_smiles`, morgan fingerprints, `reaction_from_smiles`) happens in-Postgres on the writer — so a large dataset's RDKit pass was single-threaded. On the full-ORD run this was the remaining writer-bound serial pole.

## Change

Shard **every** RDKit sub-step by the **SMILES-value hash**, so shard `k` inserts exactly the structures its links reference and touches a key set **disjoint** from every other shard. Disjoint keys mean concurrent shards never collide on the shared `rdkit.*` unique indexes — no unique violations, no deadlocks, no `ON CONFLICT` gymnastics. Datasets stay serial (the `rdkit.mols`/`rdkit.reactions` dedup tables are shared across datasets, so cross-dataset concurrency *could* collide on a shared structure).

- **`database.py`:** `update_rdkit_tables` / `update_rdkit_ids` (and `_update_rdkit_reactions`, `_update_rdkit_mols`, `_link_mol_ids`) take `shard=(index, num_shards)`, partitioning their candidate/link queries by `((hashtextextended(<smiles>::text, 0) % n) + n) % n = k`. Added `ON CONFLICT (reaction_smiles) DO NOTHING` to the reactions insert as a backstop (mols already had `ON CONFLICT (smiles)`).
- **`loading.py`:** the RDKit stage fans each dataset's pass out as `(dataset, shard)` items across the pool (shard count scaled by size; single-shard datasets run inline on the shared engine); datasets remain serial.

Why sharding by the SMILES value (not row id) matters: the reaction/mol **links** join to the cartridge tables on the SMILES value, so sharding the links by the same hash as the inserts makes each shard self-contained (it links exactly what it inserted) with no barrier between insert and link phases.

## Tests

- `test_rdkit_sharded_matches_serial`: sharded inserts + links match the serial pass — shard 0 is a strict non-empty subset (partitioning is real), all shards together are complete, and a following **serial** pass inserts and links nothing new.
- `test_derived_stage_shards_smiles_and_rdkit`: an end-to-end `n_jobs=2` derived run with a shrunk shard size actually exercises the SMILES **and** RDKit shard pools (not just the single-shard path), and populates `rdkit.mols`/`rdkit.reactions` with links.
- Full ORM suite green (30 passed).

## Follow-up

Reaction classification is the last parallelization target (same long pole, but memory-aware since it loads torch/rxnmapper per worker) — #884, coming as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR shards the per-dataset RDKit cartridge work (`mol_from_smiles`, morgan fingerprints, `reaction_from_smiles`) across the existing worker pool by hash-partitioning on the SMILES value, eliminating the last serial long-pole in the writer stage. Datasets still run sequentially to avoid cross-dataset collisions on the shared `rdkit.*` dedup tables, but each dataset's work now fans out.

- **`database.py`:** `update_rdkit_tables`, `update_rdkit_ids`, `_update_rdkit_reactions`, `_update_rdkit_mols`, and `_link_mol_ids` each accept an optional `shard=(index, num_shards)` parameter that injects a `hashtextextended`-based `AND` predicate; added `ON CONFLICT (reaction_smiles) DO NOTHING` to reactions insert as a backstop.
- **`loading.py`:** Adds `_rdkit_shard` worker function and updates the RDKit stage loop to compute `num_shards` from dataset size and fan shards through `_run_parallel` for large datasets, while small (single-shard) datasets stay on the inline `add_rdkit` path.
- **Tests:** `test_rdkit_sharded_matches_serial` verifies disjoint-and-complete sharding; `test_derived_stage_shards_smiles_and_rdkit` exercises the full sharded end-to-end path with a monkeypatched small shard size.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The sharding is correctly scoped to within-dataset concurrency; cross-dataset serialization is preserved.

The SMILES-value-hash partitioning is applied consistently to every insert and link step — inserts and links for the same SMILES always land in the same shard, so concurrent shards never touch overlapping rows in the shared rdkit.* unique indexes. The ON CONFLICT DO NOTHING backstop on reactions matches the existing one on mols. The _rdkit_shard worker correctly creates and disposes its own engine for process-pool isolation. Failure handling degrades gracefully: partial shard success is idempotent on retry due to the NOT EXISTS / rdkit_mol_id IS NULL guards. The new tests verify the disjoint-and-complete invariant and the full end-to-end sharded path. No correctness issues were found.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Core sharding logic added to update_rdkit_tables, update_rdkit_ids, _update_rdkit_reactions, _update_rdkit_mols, and _link_mol_ids. The _shard_predicate helper injects a hashtextextended-based AND clause consistently across insert and link steps, ensuring each shard is self-contained. The added ON CONFLICT (reaction_smiles) DO NOTHING is a correct backstop. Column references are fully qualified. No logic issues found. |
| ord_schema/orm/loading.py | New _rdkit_shard function correctly creates a fresh engine per worker (required for process-pool workers) and disposes it in a finally block. The dispatch logic in load_datasets correctly uses num_shards==1 as the gate for the inline path, and the failure handling for the multi-shard path correctly maps shard-level failures back to the dataset-level failures list. Idempotent on retry due to NOT EXISTS / IS NULL guards. |
| ord_schema/orm/database_test.py | New test_rdkit_sharded_matches_serial verifies the disjoint-and-complete invariant: shard 0 is a strict non-empty subset, all shards together equal the full population, and a following serial pass adds nothing. All five count keys are asserted > 0 after all shards complete. |
| ord_schema/orm/loading_test.py | New end-to-end test monkeypatches _DERIVE_SHARD_SIZE=10 to force the fixture into multiple shards, exercising both the SMILES and RDKit shard pools. Verifies rdkit.mols, rdkit.reactions, and reaction SMILES links are populated. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[load_datasets RDKit stage] --> B{get_dataset_size}
    B -->|ValueError| C[size = 0]
    B -->|ok| D[size = N]
    C --> E[num_shards = 1]
    D --> E
    E -->|num_shards == 1| F[add_rdkit engine, dataset_id\nserial inline path]
    E -->|num_shards > 1| G[_run_parallel\nn_jobs workers]
    G --> H["_rdkit_shard(dataset_id, k, num_shards)"]
    H --> I[create_engine dsn]
    I --> J["update_rdkit_tables\n(shard=(k, num_shards))\nTx 1"]
    J --> K["_update_rdkit_reactions\nfilter: hash(reaction_smiles) % n == k"]
    J --> L["_update_rdkit_mols\nfilter: hash(candidates.smiles) % n == k\nUNION compound + product_compound"]
    K --> M["INSERT rdkit.reactions\nON CONFLICT DO NOTHING"]
    L --> N["INSERT rdkit.mols\nON CONFLICT DO NOTHING"]
    M --> O["update_rdkit_ids\n(shard=(k, num_shards))\nTx 2"]
    N --> O
    O --> P["UPDATE derived.reaction_smiles\nfilter: hash(reaction_smiles) % n == k"]
    O --> Q["_link_mol_ids derived.compound_smiles\nfilter: hash(smiles) % n == k"]
    O --> R["_link_mol_ids derived.product_compound_smiles\nfilter: hash(smiles) % n == k"]
    F --> S[next dataset]
    H --> T{shard failures?}
    T -->|yes| U[failures.append dataset_id]
    T -->|no| S
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[load_datasets RDKit stage] --> B{get_dataset_size}
    B -->|ValueError| C[size = 0]
    B -->|ok| D[size = N]
    C --> E[num_shards = 1]
    D --> E
    E -->|num_shards == 1| F[add_rdkit engine, dataset_id\nserial inline path]
    E -->|num_shards > 1| G[_run_parallel\nn_jobs workers]
    G --> H["_rdkit_shard(dataset_id, k, num_shards)"]
    H --> I[create_engine dsn]
    I --> J["update_rdkit_tables\n(shard=(k, num_shards))\nTx 1"]
    J --> K["_update_rdkit_reactions\nfilter: hash(reaction_smiles) % n == k"]
    J --> L["_update_rdkit_mols\nfilter: hash(candidates.smiles) % n == k\nUNION compound + product_compound"]
    K --> M["INSERT rdkit.reactions\nON CONFLICT DO NOTHING"]
    L --> N["INSERT rdkit.mols\nON CONFLICT DO NOTHING"]
    M --> O["update_rdkit_ids\n(shard=(k, num_shards))\nTx 2"]
    N --> O
    O --> P["UPDATE derived.reaction_smiles\nfilter: hash(reaction_smiles) % n == k"]
    O --> Q["_link_mol_ids derived.compound_smiles\nfilter: hash(smiles) % n == k"]
    O --> R["_link_mol_ids derived.product_compound_smiles\nfilter: hash(smiles) % n == k"]
    F --> S[next dataset]
    H --> T{shard failures?}
    T -->|yes| U[failures.append dataset_id]
    T -->|no| S
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile on #887: qualify mols s..."](https://github.com/open-reaction-database/ord-schema/commit/36d4caa4e73a8aedd66a76fef291bb609332d269) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41531791)</sub>

<!-- /greptile_comment -->