### PR TITLE
Shard reaction classification within datasets (memory-bounded)

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -34,6 +34,7 @@ from ord_schema import message_helpers, parquet
 from ord_schema.logging import get_logger
 from ord_schema.orm.mappers import Base, Mappers, from_proto, to_proto
 from ord_schema.orm.public_mappers import DatasetMetadata
+from ord_schema.orm.sharding import shard_predicate as _shard_predicate
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 # COPY the ingest tables parents-first so foreign keys resolve; sorted_tables orders by FK
@@ -55,23 +56,28 @@ else:
 logger = get_logger(__name__)
 
 
-def _classify_reactions(dataset_id: str, session: Session) -> None:
+def _classify_reactions(
+    dataset_id: str, session: Session, *, shard: tuple[int, int] | None = None
+) -> None:
     """Populates reaction class/name columns, requiring the optional extra."""
     if update_reaction_classes is None:
         raise ImportError(
             "Reaction classification requires the 'reaction-class' extra: "
             "pip install ord-schema[reaction-class]"
         ) from _reaction_class_import_error
-    update_reaction_classes(dataset_id, session)
+    update_reaction_classes(dataset_id, session, shard=shard)
 
 
-def classify_dataset(dataset_id: str, session: Session) -> None:
+def classify_dataset(
+    dataset_id: str, session: Session, *, shard: tuple[int, int] | None = None
+) -> None:
     """Assigns reaction class/name labels for an already-derived dataset (classification only).
 
     SMILES derivation is done separately (and, in the loader, sharded); this does not re-derive it,
-    so a failed SMILES shard is not silently backfilled here. Requires the ``reaction-class`` extra.
+    so a failed SMILES shard is not silently backfilled here. ``shard`` (index, num_shards) restricts
+    to one hash-partition of the dataset's reaction ids. Requires the ``reaction-class`` extra.
     """
-    _classify_reactions(dataset_id, session)
+    _classify_reactions(dataset_id, session, shard=shard)
 
 
 def get_connection_string(
@@ -534,26 +540,6 @@ def delete_dataset(dataset_id: str, session: Session) -> None:
         delete(Mappers.Dataset).where(Mappers.Dataset.dataset_id == dataset_id)
     )
     logger.debug(f"delete took {time.time() - start}s")
-
-
-def _shard_predicate(
-    column: str, shard: tuple[int, int] | None
-) -> tuple[str, dict[str, int]]:
-    """Returns an ``AND`` predicate keeping 1/num_shards of rows by ``column``, or ``('', {})``.
-
-    Partitions a dataset's rows deterministically and disjointly by a hash of the id, so
-    independent workers can each derive their shard without coordinating. ``shard`` is
-    ``(index, num_shards)``; ``None`` disables sharding (whole dataset).
-    """
-    if shard is None:
-        return "", {}
-    shard_index, num_shards = shard
-    # ((h % n) + n) % n keeps the bucket in [0, num_shards) without abs() overflow.
-    predicate = (
-        f"AND ((hashtextextended({column}::text, 0) % :num_shards) + :num_shards) "
-        "% :num_shards = :shard_index"
-    )
-    return predicate, {"num_shards": num_shards, "shard_index": shard_index}
 
 
 def update_derived_tables(

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -25,9 +25,11 @@ from sqlalchemy.orm import Session
 
 from ord_schema import message_helpers
 from ord_schema.datasets import load_dataset
+from ord_schema.orm import database as _orm_database
 from ord_schema.orm.database import (
     add_dataset,
     backfill_submission_times,
+    classify_dataset,
     delete_dataset,
     get_dataset_md5,
     get_dataset_size,
@@ -38,6 +40,8 @@ from ord_schema.orm.database import (
 from ord_schema.orm.mappers import Mappers, to_proto
 from ord_schema.orm.public_mappers import DatasetMetadata
 from ord_schema.proto import reaction_pb2
+
+_HAS_REACTION_CLASS = _orm_database.update_reaction_classes is not None
 
 
 def test_orm(test_session):
@@ -259,6 +263,51 @@ def test_rdkit_sharded_matches_serial(prepared_engine):
     # A serial (whole-dataset) pass now inserts and links nothing new: the shards covered it all.
     run_shard(None)
     assert counts() == sharded
+
+
+@pytest.mark.skipif(
+    not _HAS_REACTION_CLASS, reason="reaction-class extra not installed"
+)
+def test_classify_sharded_covers_all(prepared_engine):
+    """Sharded classification partitions reactions and together classifies every one.
+
+    Analogous to the SMILES/RDKit sharding tests; skipped unless the reaction-class extra is
+    installed (it loads a transformer model per call). Shard 0 is a strict, non-empty subset and
+    all shards together classify exactly what the unsharded pass would -- a following whole-dataset
+    pass adds nothing.
+    """
+    dataset = load_dataset(
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+    )
+    with Session(prepared_engine) as session, session.begin():
+        add_dataset(dataset, session)
+    with Session(prepared_engine) as session, session.begin():
+        update_derived_tables(
+            dataset.dataset_id, session
+        )  # SMILES; classification reads them.
+
+    def count() -> int:
+        with Session(prepared_engine) as session:
+            return session.execute(
+                text("SELECT count(*) FROM derived.reaction_classes")
+            ).scalar()
+
+    num_shards = 4
+    with Session(prepared_engine) as session, session.begin():
+        classify_dataset(dataset.dataset_id, session, shard=(0, num_shards))
+    first = count()
+    with Session(prepared_engine) as session:
+        for shard_index in range(1, num_shards):
+            with session.begin():
+                classify_dataset(
+                    dataset.dataset_id, session, shard=(shard_index, num_shards)
+                )
+    sharded = count()
+    assert 0 < first < sharded, (first, sharded)  # shard 0 a strict, non-empty subset
+    # A whole-dataset pass now adds nothing: the shards classified every reaction.
+    with Session(prepared_engine) as session, session.begin():
+        classify_dataset(dataset.dataset_id, session)
+    assert count() == sharded
 
 
 @pytest.mark.parametrize(

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -303,7 +303,9 @@ def test_classify_sharded_covers_all(prepared_engine):
                     dataset.dataset_id, session, shard=(shard_index, num_shards)
                 )
     sharded = count()
-    assert 0 < first < sharded, (first, sharded)  # shard 0 a strict, non-empty subset
+    # Shard 0 is a strict, non-empty subset: the fixture's ~80 reactions reliably hash into more
+    # than one of the 4 buckets, so this holds for it (a 1-reaction fixture would not).
+    assert 0 < first < sharded, (first, sharded)
     # A whole-dataset pass now adds nothing: the shards classified every reaction.
     with Session(prepared_engine) as session, session.begin():
         classify_dataset(dataset.dataset_id, session)

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -455,6 +455,7 @@ def load_datasets(
     overwrite: bool = False,
     classify_reactions: bool = False,
     n_jobs: int = 1,
+    classify_jobs: int | None = None,
 ) -> None:
     """Runs the selected stages over the datasets matching ``pattern``.
 
@@ -469,6 +470,9 @@ def load_datasets(
         overwrite: If True, update changed datasets during ingest.
         classify_reactions: If True, assign reaction class/name labels during derivation.
         n_jobs: Number of parallel workers.
+        classify_jobs: Worker count for the classification pass; each worker loads a transformer
+            model, so this is bounded separately from ``n_jobs``. Defaults to
+            ``min(n_jobs, _CLASSIFY_JOBS_CAP)``. Raise it only if the models fit in memory.
 
     Raises:
         ValueError: If ``stages`` is empty or names an unknown stage.
@@ -536,13 +540,18 @@ def load_datasets(
             logger.info("Classifying reactions")
             # Shard classification within datasets by reaction-id hash, like SMILES, but through a
             # smaller pool: each worker loads a Rxn-INSIGHT/rxnmapper model, so running n_jobs of
-            # them would multiply the model memory.
-            classify_jobs = max(1, min(n_jobs, _CLASSIFY_JOBS_CAP))
+            # them would multiply the model memory. Defaults to a capped fraction of n_jobs; the
+            # caller can override via classify_jobs once they know the models fit.
+            resolved_classify_jobs = (
+                max(1, min(n_jobs, _CLASSIFY_JOBS_CAP))
+                if classify_jobs is None
+                else max(1, classify_jobs)
+            )
             classify_items = _derive_shard_items(dataset_ids, dsn)
             _, classify_failures = _run_parallel(
                 partial(_classify_shard, dsn=dsn),
                 classify_items,
-                n_jobs=classify_jobs,
+                n_jobs=resolved_classify_jobs,
                 desc="Classify",
             )
             failures.extend(

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -547,7 +547,13 @@ def load_datasets(
                 if classify_jobs is None
                 else max(1, classify_jobs)
             )
-            classify_items = _derive_shard_items(dataset_ids, dsn)
+            # Each shard reloads the transformer model, so sharding only pays off when the shards
+            # can run in parallel. With a single worker, keep one shard (one model load) per
+            # dataset, matching the pre-sharding behaviour.
+            if resolved_classify_jobs == 1:
+                classify_items = [(dataset_id, 0, 1) for dataset_id in dataset_ids]
+            else:
+                classify_items = _derive_shard_items(dataset_ids, dsn)
             _, classify_failures = _run_parallel(
                 partial(_classify_shard, dsn=dsn),
                 classify_items,

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -59,6 +59,10 @@ STAGES = ("ingest", "derived")
 _DERIVE_SHARD_SIZE = 50_000
 _DERIVE_SHARD_CAP = 32
 
+# Reaction classification loads a Rxn-INSIGHT/rxnmapper transformer model per worker, so its shard
+# pool is capped well below the ingest/SMILES n_jobs to keep the models within memory.
+_CLASSIFY_JOBS_CAP = 4
+
 
 def dataset_id_for_file(filename: str) -> str:
     """Returns the dataset ID for a dataset file without ingesting it."""
@@ -213,20 +217,24 @@ def _derive_smiles_shard(
     return item
 
 
-def _classify_dataset(dataset_id: str, *, dsn: str) -> str:
-    """Assigns reaction class/name labels for a dataset (SMILES already derived by the shard pass).
+def _classify_shard(item: tuple[str, int, int], *, dsn: str) -> tuple[str, int, int]:
+    """Classifies one hash-partition of a dataset's reactions (SMILES already derived).
 
     Classification only -- it does not re-derive SMILES, so a failed SMILES shard stays visibly
-    incomplete rather than being silently backfilled here (keeping shard-failure semantics the same
-    whether or not classification is enabled).
+    incomplete rather than being silently backfilled here. Each worker loads its own Rxn-INSIGHT /
+    rxnmapper model, so the classify pool is bounded (``_CLASSIFY_JOBS_CAP``) to keep the models in
+    memory.
     """
+    dataset_id, shard_index, num_shards = item
     engine = create_engine(dsn)
     try:
         with Session(engine) as session, session.begin():
-            database.classify_dataset(dataset_id, session)
+            database.classify_dataset(
+                dataset_id, session, shard=(shard_index, num_shards)
+            )
     finally:
         engine.dispose()
-    return dataset_id
+    return item
 
 
 def add_rdkit(engine: Engine, dataset_id: str) -> None:
@@ -526,13 +534,20 @@ def load_datasets(
         failures.extend(sorted({dataset_id for dataset_id, _, _ in shard_failures}))
         if classify_reactions:
             logger.info("Classifying reactions")
+            # Shard classification within datasets by reaction-id hash, like SMILES, but through a
+            # smaller pool: each worker loads a Rxn-INSIGHT/rxnmapper model, so running n_jobs of
+            # them would multiply the model memory.
+            classify_jobs = max(1, min(n_jobs, _CLASSIFY_JOBS_CAP))
+            classify_items = _derive_shard_items(dataset_ids, dsn)
             _, classify_failures = _run_parallel(
-                partial(_classify_dataset, dsn=dsn),
-                dataset_ids,
-                n_jobs=n_jobs,
+                partial(_classify_shard, dsn=dsn),
+                classify_items,
+                n_jobs=classify_jobs,
                 desc="Classify",
             )
-            failures.extend(classify_failures)
+            failures.extend(
+                sorted({dataset_id for dataset_id, _, _ in classify_failures})
+            )
         logger.info("Adding RDKit functionality")
         # Datasets are processed serially (the rdkit.* dedup tables are shared, so cross-dataset
         # concurrency could collide on the same structure), but each dataset's pass is sharded by

--- a/ord_schema/orm/reaction_class.py
+++ b/ord_schema/orm/reaction_class.py
@@ -28,6 +28,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from ord_schema.logging import get_logger
+from ord_schema.orm.sharding import shard_predicate
 
 logger = get_logger(__name__)
 
@@ -62,18 +63,25 @@ def classify_reaction_smiles(
     return reaction_class, reaction_name
 
 
-def update_reaction_classes(dataset_id: str, session: Session) -> None:
+def update_reaction_classes(
+    dataset_id: str, session: Session, *, shard: tuple[int, int] | None = None
+) -> None:
     """Classifies a dataset's not-yet-attempted reactions into derived.reaction_classes.
 
     Selects reactions that have a SMILES but no row yet, classifies each distinct SMILES
     once (cached), and inserts one row per reaction. The row records the attempt -- NULL
     class/name mean Rxn-INSIGHT could not classify it -- so repeated runs converge rather
     than re-running the model over deterministic failures.
+
+    ``shard`` (index, num_shards) restricts to one disjoint hash-partition of the dataset's
+    reaction ids, so a large dataset can be split across workers. Each worker loads its own model,
+    so the caller should keep the shard pool small enough to fit the models in memory.
     """
     logger.debug(f"Updating reaction classes for {dataset_id=}")
     start = time.time()
+    shard_sql, shard_params = shard_predicate("ord.reaction.id", shard)
     result = session.execute(
-        text("""
+        text(f"""
             SELECT ord.reaction.id, derived.reaction_smiles.reaction_smiles
             FROM ord.reaction
             JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
@@ -85,8 +93,9 @@ def update_reaction_classes(dataset_id: str, session: Session) -> None:
                   SELECT 1 FROM derived.reaction_classes
                   WHERE derived.reaction_classes.reaction_id = ord.reaction.id
               )
-            """),
-        {"dataset_id": dataset_id},
+              {shard_sql}
+            """),  # noqa: S608  (shard predicate is an internal constant fragment)
+        {"dataset_id": dataset_id, **shard_params},
     )
     reactions = result.all()
     if not reactions:

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -59,6 +59,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--n_jobs", type=int, default=1, help="Number of parallel workers"
     )
+    parser.add_argument(
+        "--classify_jobs",
+        type=int,
+        default=None,
+        help="Worker count for the classification pass (each loads a transformer model, so it is "
+        "bounded separately from --n_jobs); defaults to a capped fraction of --n_jobs",
+    )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     return parser.parse_args(argv)
 
@@ -98,6 +105,7 @@ def main(args: argparse.Namespace) -> None:
         overwrite=args.overwrite,
         classify_reactions=args.classify_reactions,
         n_jobs=args.n_jobs,
+        classify_jobs=args.classify_jobs,
     )
 
 

--- a/ord_schema/orm/sharding.py
+++ b/ord_schema/orm/sharding.py
@@ -27,6 +27,10 @@ def shard_predicate(
     Partitions a dataset's rows deterministically and disjointly by a hash of ``column``, so
     independent workers can each process their shard without coordinating. ``shard`` is
     ``(index, num_shards)``; ``None`` disables sharding (whole dataset).
+
+    ``column`` is interpolated into the SQL, so it must be a trusted, hardcoded column reference
+    (e.g. ``"ord.reaction.id"``) -- never a user-supplied string. The shard bounds are passed as
+    bind parameters.
     """
     if shard is None:
         return "", {}

--- a/ord_schema/orm/sharding.py
+++ b/ord_schema/orm/sharding.py
@@ -1,0 +1,39 @@
+# Copyright 2022 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Hash-partition predicate shared by the sharded derived passes.
+
+Kept in its own module so ``database`` and ``reaction_class`` can both use it without an import
+cycle (``database`` imports ``reaction_class``).
+"""
+
+
+def shard_predicate(
+    column: str, shard: tuple[int, int] | None
+) -> tuple[str, dict[str, int]]:
+    """Returns an ``AND`` predicate keeping 1/num_shards of rows by ``column``, or ``('', {})``.
+
+    Partitions a dataset's rows deterministically and disjointly by a hash of ``column``, so
+    independent workers can each process their shard without coordinating. ``shard`` is
+    ``(index, num_shards)``; ``None`` disables sharding (whole dataset).
+    """
+    if shard is None:
+        return "", {}
+    shard_index, num_shards = shard
+    # ((h % n) + n) % n keeps the bucket in [0, num_shards) without abs() overflow.
+    predicate = (
+        f"AND ((hashtextextended({column}::text, 0) % :num_shards) + :num_shards) "
+        "% :num_shards = :shard_index"
+    )
+    return predicate, {"num_shards": num_shards, "shard_index": shard_index}


### PR DESCRIPTION
Closes #884. The last derived-stage parallelization target, after SMILES (#883) and RDKit (#887).

## Problem

Reaction classification (`--classify_reactions`) ran as a per-dataset parallel pass, so the single largest dataset was classified by one worker. Same long pole as SMILES/RDKit — but with a memory twist: `update_reaction_classes` loads a Rxn-INSIGHT/rxnmapper **transformer model per worker**, so naively sharding it across the full `n_jobs` would multiply the model footprint (exactly the memory blow-up flagged in #884).

## Change

Shard classification within a dataset by **reaction-id hash** (like SMILES), but run it through a **separate, capped pool** so the model memory stays bounded.

- **`sharding.py` (new):** the hash-partition predicate helper, extracted from `database.py` so `reaction_class` can use it without an import cycle (`database` imports `reaction_class`). `database.py` now imports it (aliased), no call-site changes.
- **`reaction_class.py` / `database.py`:** `update_reaction_classes` / `classify_dataset` / `_classify_reactions` take `shard=(index, num_shards)`, partitioning the reaction SELECT by `ord.reaction.id` hash. The insert already has `ON CONFLICT (reaction_id) DO NOTHING` + a `NOT EXISTS` selector, so disjoint shards are safe.
- **`loading.py`:** the classify stage fans out `(dataset, shard)` items across a pool capped at `_CLASSIFY_JOBS_CAP` (4), independent of the ingest/SMILES `n_jobs`, since each worker holds a model.

## Tests

`test_classify_sharded_covers_all` mirrors the SMILES/RDKit shard-parity tests (shard 0 a strict subset; all shards together classify exactly what the unsharded pass would). It's **skipped unless the `reaction-class` extra is installed** (it loads the transformer model), so it doesn't run in the default local/CI env — the sharding SQL is the same shared helper the SMILES/RDKit tests already exercise. Full ORM suite green (31 passed, 2 skipped).

## Follow-up (noted, not done)

`_CLASSIFY_JOBS_CAP` is a fixed conservative default rather than a measured/parameterized value — if operators want to tune it to their box's memory, exposing a `classify_jobs` knob is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR shards reaction classification within datasets by reaction-id hash (mirroring the existing SMILES/RDKit sharding), running classification through a separate pool capped at `_CLASSIFY_JOBS_CAP = 4` to keep transformer model memory bounded. The `_shard_predicate` helper is extracted from `database.py` into a new `sharding.py` module to avoid an import cycle.

- **`sharding.py`**: New module containing `shard_predicate`, extracted from `database.py` to break the import cycle between `database` and `reaction_class`.
- **`loading.py`**: `_classify_dataset` is replaced by `_classify_shard` (per shard); `load_datasets` gains a `classify_jobs` knob (defaults to `min(n_jobs, 4)`), with a special-case for `resolved_classify_jobs == 1` that produces a single whole-dataset shard to avoid N model loads for no parallelism gain.
- **`reaction_class.py` / `database.py`**: `update_reaction_classes` / `classify_dataset` accept a `shard` tuple, injecting the hash-partition predicate into the reaction SELECT.
</details>

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; sharding logic is disjoint by construction and the ON CONFLICT guard makes concurrent inserts idempotent.

The sharding SQL is the same hashtextextended predicate already validated by the SMILES and RDKit passes. The resolved_classify_jobs == 1 guard correctly collapses to a single whole-dataset item per dataset, preserving pre-PR behaviour. No correctness issues were found.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/sharding.py | New helper module extracting `shard_predicate` from `database.py`; docstring now correctly warns that `column` must be a hardcoded literal, not user input. |
| ord_schema/orm/reaction_class.py | Adds `shard` parameter to `update_reaction_classes`; injects `shard_predicate` into the reaction SELECT as an outer WHERE condition; placement and SQL are correct. |
| ord_schema/orm/loading.py | Replaces per-dataset `_classify_dataset` with per-shard `_classify_shard`; adds `_CLASSIFY_JOBS_CAP` and `classify_jobs` knob; `resolved_classify_jobs == 1` guard avoids redundant model loads on single-worker runs. |
| ord_schema/orm/database.py | Imports `shard_predicate` from new `sharding.py` (aliased); `_classify_reactions` / `classify_dataset` gain `shard` passthrough; dead copy of `_shard_predicate` removed. |
| ord_schema/orm/database_test.py | Adds `test_classify_sharded_covers_all` mirroring the SMILES/RDKit parity tests; skipped unless `reaction-class` extra is installed; logic is sound. |
| ord_schema/orm/scripts/add_datasets.py | Adds `--classify_jobs` CLI argument and threads it through to `load_datasets`; straightforward plumbing. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[load_datasets] --> B{classify_reactions?}
    B -- No --> E[RDKit pass]
    B -- Yes --> C[Resolve classify_jobs\nmin of n_jobs and CAP=4]
    C --> D{resolved_classify_jobs == 1?}
    D -- Yes --> F["classify_items = one whole-dataset shard per dataset"]
    D -- No --> G["classify_items = _derive_shard_items() up to 32 shards"]
    F --> H[_run_parallel _classify_shard pool=1]
    G --> H
    H --> I[_classify_shard]
    I --> J[classify_dataset with shard tuple]
    J --> K[update_reaction_classes]
    K --> L[shard_predicate hash filter]
    L --> M[SELECT unclassified reactions in shard]
    M --> N[RXNMapper loads model]
    N --> O[INSERT ON CONFLICT DO NOTHING]
    O --> E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[load_datasets] --> B{classify_reactions?}
    B -- No --> E[RDKit pass]
    B -- Yes --> C[Resolve classify_jobs\nmin of n_jobs and CAP=4]
    C --> D{resolved_classify_jobs == 1?}
    D -- Yes --> F["classify_items = one whole-dataset shard per dataset"]
    D -- No --> G["classify_items = _derive_shard_items() up to 32 shards"]
    F --> H[_run_parallel _classify_shard pool=1]
    G --> H
    H --> I[_classify_shard]
    I --> J[classify_dataset with shard tuple]
    J --> K[update_reaction_classes]
    K --> L[shard_predicate hash filter]
    L --> M[SELECT unclassified reactions in shard]
    M --> N[RXNMapper loads model]
    N --> O[INSERT ON CONFLICT DO NOTHING]
    O --> E
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address Greptile on #888: avoid model re..."](https://github.com/open-reaction-database/ord-schema/commit/63d095d3e24855c42daf1d66e5d7a638960a8853) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41534958)</sub>

<!-- /greptile_comment -->