### PR TITLE
Add pyrightconfig to defer type-checking to ty

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,4 @@
+{
+    "typeCheckingMode": "off",
+    "reportMissingImports": "none"
+}


### PR DESCRIPTION
Quiets the IDE type-checker so it stops fighting `ty` (the enforced checker) and generating noise.

## Why

The repo gates on **`ty`** (pre-commit `ty-check` → `uv run ty check ord_schema`), but there's no pyright config, so Pylance/pyright runs unconfigured in the IDE and mostly surfaces noise that either duplicates or conflicts with `ty`:
- `scalar() -> Any | None` "not assignable" reports on test helpers — pyright is stricter than the gate (`ty` passes).
- `"could not resolve <module>"` for `uuid6` (a real dep) and `rxnmapper` (the optional `reaction-class` extra) — an artifact of Pylance not being pointed at the conda env, not a real problem.

## What

A `pyrightconfig.json`:
- `typeCheckingMode: "off"` — defer type checking to `ty`. Pylance still gives completions, hover, and go-to-definition.
- `reportMissingImports: "none"` — silence the interpreter-dependent import-resolution noise. Genuinely broken imports are still caught at commit by ruff and `ty`.

Net: keep the useful IDE features, drop the diagnostics that were pure noise, and keep a single source of truth (`ty`) for type-checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a minimal `pyrightconfig.json` to silence Pylance's IDE diagnostics (type errors and unresolved imports) so they stop conflicting with the repo's enforced `ty` type-checker run via pre-commit. Pylance completions, hover, and go-to-definition remain active.

- `typeCheckingMode: \"off\"` defers all type checking to `ty`; Pylance continues to provide language-server features without emitting diagnostics.
- `reportMissingImports: \"none\"` explicitly suppresses import-resolution noise for optional extras (e.g. `rxnmapper`) and packages like `uuid6` that aren't visible to the default Pylance interpreter — belt-and-suspenders since `\"off\"` mode already defaults all report rules to `\"none\"`, but the explicit setting documents the intent clearly.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — adds a developer-tooling config file with no effect on runtime behavior or the enforced `ty` pre-commit gate.

The change is a single four-line JSON file that only affects Pylance's IDE behavior. The enforced type-checking gate (`ty` via pre-commit) is completely unchanged, so no type errors can slip through undetected. `reportMissingImports: "none"` is technically redundant alongside `typeCheckingMode: "off"` but harmless and documents intent clearly.

No files require special attention.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyrightconfig.json | New file: disables Pyright/Pylance type-checking and import-resolution diagnostics in the IDE, deferring to the enforced `ty` pre-commit hook. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Developer edits Python file] --> B{Which checker?}
    B -->|IDE / Pylance| C[pyrightconfig.json]
    C --> D[typeCheckingMode: off\nreportMissingImports: none]
    D --> E[Completions, hover,\ngo-to-definition only\nNo diagnostics emitted]
    B -->|git commit / pre-commit| F[ty-check hook]
    F --> G[uv run ty check ord_schema]
    G --> H{ty passes?}
    H -- Yes --> I[Commit succeeds]
    H -- No --> J[Commit blocked\nfix required]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Developer edits Python file] --> B{Which checker?}
    B -->|IDE / Pylance| C[pyrightconfig.json]
    C --> D[typeCheckingMode: off\nreportMissingImports: none]
    D --> E[Completions, hover,\ngo-to-definition only\nNo diagnostics emitted]
    B -->|git commit / pre-commit| F[ty-check hook]
    F --> G[uv run ty check ord_schema]
    G --> H{ty passes?}
    H -- Yes --> I[Commit succeeds]
    H -- No --> J[Commit blocked\nfix required]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Add pyrightconfig to defer type-checking..."](https://github.com/open-reaction-database/ord-schema/commit/cd0d6f0cc9f530c50a6b7b9a8bb3d9e173f3343d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41535749)</sub>

<!-- /greptile_comment -->