### PR TITLE
Derive SMILES for workup and product-measurement compounds

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -542,6 +542,48 @@ def delete_dataset(dataset_id: str, session: Session) -> None:
     logger.debug(f"delete took {time.time() - start}s")
 
 
+# Every derived/RDKit pass scopes its work to one dataset, which means walking from a
+# compound up to ord.reaction. ord.compound hangs off three different parents, so no single
+# join reaches them all:
+#
+#   * a reaction's own input (ord.reaction_input.reaction_id is set);
+#   * a workup's input (that ord.reaction_input row has reaction_id NULL and
+#     reaction_workup_id set instead);
+#   * a product measurement (ord.compound.reaction_input_id is NULL) -- authentic standards.
+#
+# Each path is listed separately and the callers UNION them rather than reaching ord.reaction
+# through a COALESCE of the parent keys: an equality against COALESCE(...) is not sargable, so
+# the planner could not drive from the dataset's reactions through the indexed foreign keys.
+# The paths are disjoint -- a compound sets exactly one of reaction_input_id /
+# product_measurement_id, and a reaction_input belongs to exactly one of a reaction or a workup
+# -- so UNION ALL never double-counts a compound.
+_COMPOUND_REACTION_JOINS: tuple[str, ...] = (
+    """
+    JOIN ord.reaction_input ON ord.compound.reaction_input_id = ord.reaction_input.id
+    JOIN ord.reaction ON ord.reaction_input.reaction_id = ord.reaction.id
+    """,
+    """
+    JOIN ord.reaction_input ON ord.compound.reaction_input_id = ord.reaction_input.id
+    JOIN ord.reaction_workup ON ord.reaction_input.reaction_workup_id = ord.reaction_workup.id
+    JOIN ord.reaction ON ord.reaction_workup.reaction_id = ord.reaction.id
+    """,
+    """
+    JOIN ord.product_measurement ON ord.compound.product_measurement_id = ord.product_measurement.id
+    JOIN ord.product_compound ON ord.product_measurement.product_compound_id = ord.product_compound.id
+    JOIN ord.reaction_outcome ON ord.product_compound.reaction_outcome_id = ord.reaction_outcome.id
+    JOIN ord.reaction ON ord.reaction_outcome.reaction_id = ord.reaction.id
+    """,
+)
+
+# ord.product_compound has a single parent, so one path suffices.
+_PRODUCT_COMPOUND_REACTION_JOINS: tuple[str, ...] = (
+    """
+    JOIN ord.reaction_outcome ON ord.product_compound.reaction_outcome_id = ord.reaction_outcome.id
+    JOIN ord.reaction ON ord.reaction_outcome.reaction_id = ord.reaction.id
+    """,
+)
+
+
 def update_derived_tables(
     dataset_id: str, session: Session, *, shard: tuple[int, int] | None = None
 ) -> None:
@@ -636,8 +678,7 @@ def update_derived_tables(
         session,
         dataset_pk=dataset_pk,
         compound_table="ord.compound",
-        link_table="ord.reaction_input",
-        link_column="reaction_input_id",
+        reaction_joins=_COMPOUND_REACTION_JOINS,
         compound_class=Mappers.Compound,
         derived_table="derived.compound_smiles",
         derived_id="compound_id",
@@ -647,8 +688,7 @@ def update_derived_tables(
         session,
         dataset_pk=dataset_pk,
         compound_table="ord.product_compound",
-        link_table="ord.reaction_outcome",
-        link_column="reaction_outcome_id",
+        reaction_joins=_PRODUCT_COMPOUND_REACTION_JOINS,
         compound_class=Mappers.ProductCompound,
         derived_table="derived.product_compound_smiles",
         derived_id="product_compound_id",
@@ -662,8 +702,7 @@ def _update_compound_smiles(
     *,
     dataset_pk: int,
     compound_table: str,
-    link_table: str,
-    link_column: str,
+    reaction_joins: tuple[str, ...],
     compound_class: Any,
     derived_table: str,
     derived_id: str,
@@ -678,24 +717,30 @@ def _update_compound_smiles(
     SMILES from its other identifiers. Ids are resolved up front and processed in batches of
     _DERIVED_BATCH so memory stays bounded. ``shard`` (index, num_shards) restricts to one disjoint
     hash-partition of this table's ids so large datasets can be split across workers.
+
+    ``reaction_joins`` are the disjoint join paths from ``compound_table`` to ord.reaction; one id
+    query runs per path and the results are concatenated. See _COMPOUND_REACTION_JOINS.
     """
     compound_shard_sql, compound_shard_params = _shard_predicate(
         f"{compound_table}.id", shard
     )
-    compound_ids = (
-        session.execute(
-            text(f"""
+    select_ids = "\nUNION ALL\n".join(
+        f"""
                 SELECT {compound_table}.id
                 FROM {compound_table}
-                JOIN {link_table} ON {compound_table}.{link_column} = {link_table}.id
-                JOIN ord.reaction ON {link_table}.reaction_id = ord.reaction.id
+                {reaction_join}
                 WHERE ord.reaction.dataset_id = :id
                   AND NOT EXISTS (
                       SELECT 1 FROM {derived_table}
                       WHERE {derived_table}.{derived_id} = {compound_table}.id
                   )
                   {compound_shard_sql}
-                """),  # noqa: S608  (table/column names are internal constants, not user input)
+        """  # noqa: S608  (table/column names are internal constants, not user input)
+        for reaction_join in reaction_joins
+    )
+    compound_ids = (
+        session.execute(
+            text(select_ids),
             {"id": dataset_pk, **compound_shard_params},
         )
         .scalars()
@@ -830,6 +875,35 @@ def _update_rdkit_mols(
     logger.debug("Updating RDKit mols")
     start = time.time()
     shard_sql, shard_params = _shard_predicate("candidates.smiles", shard)
+    # One candidate SELECT per join path (see _COMPOUND_REACTION_JOINS); UNION dedupes the SMILES
+    # a dataset repeats across compounds.
+    candidates = "\nUNION\n".join(
+        [
+            f"""
+                    SELECT derived.compound_smiles.smiles
+                        FROM derived.compound_smiles
+                        JOIN ord.compound ON ord.compound.id = derived.compound_smiles.compound_id
+                        {reaction_join}
+                        JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
+                        WHERE ord.dataset.dataset_id = :dataset_id
+                          AND derived.compound_smiles.rdkit_mol_id IS NULL
+            """  # noqa: S608  (the join path is an internal constant, not user input)
+            for reaction_join in _COMPOUND_REACTION_JOINS
+        ]
+        + [
+            f"""
+                    SELECT derived.product_compound_smiles.smiles
+                        FROM derived.product_compound_smiles
+                        JOIN ord.product_compound
+                            ON ord.product_compound.id = derived.product_compound_smiles.product_compound_id
+                        {reaction_join}
+                        JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
+                        WHERE ord.dataset.dataset_id = :dataset_id
+                          AND derived.product_compound_smiles.rdkit_mol_id IS NULL
+            """  # noqa: S608  (the join path is an internal constant, not user input)
+            for reaction_join in _PRODUCT_COMPOUND_REACTION_JOINS
+        ]
+    )
     result = session.execute(
         text(f"""
             WITH new_smiles AS MATERIALIZED (
@@ -842,27 +916,7 @@ def _update_rdkit_mols(
                 -- to materialize for this same reason.
                 SELECT smiles
                 FROM (
-                    SELECT derived.compound_smiles.smiles
-                        -- NOTE(skearnes): This join path does not include non-input compounds like workups,
-                        -- internal standards, etc.
-                        FROM derived.compound_smiles
-                        JOIN ord.compound ON ord.compound.id = derived.compound_smiles.compound_id
-                        JOIN ord.reaction_input ON ord.compound.reaction_input_id = ord.reaction_input.id
-                        JOIN ord.reaction ON ord.reaction_input.reaction_id = ord.reaction.id
-                        JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
-                        WHERE ord.dataset.dataset_id = :dataset_id
-                          AND derived.compound_smiles.rdkit_mol_id IS NULL
-                    UNION
-                    SELECT derived.product_compound_smiles.smiles
-                        FROM derived.product_compound_smiles
-                        JOIN ord.product_compound
-                            ON ord.product_compound.id = derived.product_compound_smiles.product_compound_id
-                        JOIN ord.reaction_outcome
-                            ON ord.product_compound.reaction_outcome_id = ord.reaction_outcome.id
-                        JOIN ord.reaction ON ord.reaction_outcome.reaction_id = ord.reaction.id
-                        JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
-                        WHERE ord.dataset.dataset_id = :dataset_id
-                          AND derived.product_compound_smiles.rdkit_mol_id IS NULL
+                    {candidates}
                 ) candidates
                 WHERE smiles NOT LIKE '%[Ti+5]%'  -- See https://github.com/open-reaction-database/ord-schema/issues/672.
                   AND NOT EXISTS (SELECT 1 FROM rdkit.mols WHERE rdkit.mols.smiles = candidates.smiles)
@@ -891,29 +945,29 @@ def _link_mol_ids(
     derived_table: str,
     derived_id_column: str,
     compound_table: str,
-    link_table: str,
-    link_column: str,
+    reaction_joins: tuple[str, ...],
     dataset_id: str,
     shard: tuple[int, int] | None = None,
 ) -> int:
     """Links rdkit.mols ids into a derived compound-SMILES table for one dataset.
 
     The Compound and ProductCompound updates are identical apart from the tables
-    and join path, so they share this helper. Identifier arguments are trusted
+    and join paths, so they share this helper. Identifier arguments are trusted
     literals supplied by ``update_rdkit_ids`` (never user input) and are
     interpolated into the statement; ``dataset_id`` is passed as a bind param.
+
+    One statement runs per join path. The paths select disjoint compounds, so a row is
+    linked by exactly one of them, and each keeps the flat ``UPDATE ... FROM`` form whose
+    join keys stay indexed.
 
     Args:
         session: Active SQLAlchemy session.
         derived_table: Derived table to update (e.g. ``"derived.compound_smiles"``).
         derived_id_column: ``derived_table`` foreign key to ``compound_table.id``
             (e.g. ``"compound_id"``).
-        compound_table: ORD compound table (e.g. ``"ord.compound"``), joined to
-            reach the dataset via ``link_table``.
-        link_table: Join table connecting ``compound_table`` to ``ord.reaction``
-            (e.g. ``"ord.reaction_input"``).
-        link_column: Foreign-key column on ``compound_table`` that references
-            ``link_table`` (e.g. ``"reaction_input_id"``).
+        compound_table: ORD compound table (e.g. ``"ord.compound"``).
+        reaction_joins: Disjoint join paths from ``compound_table`` to ord.reaction
+            (e.g. ``_COMPOUND_REACTION_JOINS``).
         dataset_id: Dataset to scope the update to.
         shard: Optional ``(index, num_shards)`` partition (by the derived table's SMILES hash)
             to restrict the update to, matching the mol-insert partition so a shard links exactly
@@ -923,23 +977,25 @@ def _link_mol_ids(
         The number of rows updated.
     """
     shard_sql, shard_params = _shard_predicate(f"{derived_table}.smiles", shard)
-    result = session.execute(
-        text(f"""
-            UPDATE {derived_table}
-            SET rdkit_mol_id = rdkit.mols.id
-            FROM rdkit.mols, {compound_table}, {link_table}, ord.reaction, ord.dataset
-            WHERE rdkit.mols.smiles = {derived_table}.smiles
-              AND {derived_table}.{derived_id_column} = {compound_table}.id
-              AND {compound_table}.{link_column} = {link_table}.id
-              AND {link_table}.reaction_id = ord.reaction.id
-              AND ord.reaction.dataset_id = ord.dataset.id
-              AND ord.dataset.dataset_id = :dataset_id
-              AND {derived_table}.rdkit_mol_id IS NULL
-              {shard_sql}
-            """),  # noqa: S608  (table/column names are internal constants, not user input)
-        {"dataset_id": dataset_id, **shard_params},
-    )
-    return cast(Any, result).rowcount
+    rows = 0
+    for reaction_join in reaction_joins:
+        result = session.execute(
+            text(f"""
+                UPDATE {derived_table}
+                SET rdkit_mol_id = rdkit.mols.id
+                FROM rdkit.mols, {compound_table}
+                    {reaction_join}
+                    JOIN ord.dataset ON ord.reaction.dataset_id = ord.dataset.id
+                WHERE rdkit.mols.smiles = {derived_table}.smiles
+                  AND {derived_table}.{derived_id_column} = {compound_table}.id
+                  AND ord.dataset.dataset_id = :dataset_id
+                  AND {derived_table}.rdkit_mol_id IS NULL
+                  {shard_sql}
+                """),  # noqa: S608  (table/column names are internal constants, not user input)
+            {"dataset_id": dataset_id, **shard_params},
+        )
+        rows += cast(Any, result).rowcount
+    return rows
 
 
 def update_rdkit_ids(
@@ -981,8 +1037,7 @@ def update_rdkit_ids(
         derived_table="derived.compound_smiles",
         derived_id_column="compound_id",
         compound_table="ord.compound",
-        link_table="ord.reaction_input",
-        link_column="reaction_input_id",
+        reaction_joins=_COMPOUND_REACTION_JOINS,
         dataset_id=dataset_id,
         shard=shard,
     )
@@ -991,8 +1046,7 @@ def update_rdkit_ids(
         derived_table="derived.product_compound_smiles",
         derived_id_column="product_compound_id",
         compound_table="ord.product_compound",
-        link_table="ord.reaction_outcome",
-        link_column="reaction_outcome_id",
+        reaction_joins=_PRODUCT_COMPOUND_REACTION_JOINS,
         dataset_id=dataset_id,
         shard=shard,
     )

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -33,6 +33,7 @@ from ord_schema.orm.database import (
     delete_dataset,
     get_dataset_md5,
     get_dataset_size,
+    update_derived_data,
     update_derived_tables,
     update_rdkit_ids,
     update_rdkit_tables,
@@ -390,6 +391,74 @@ def test_compound_smiles_fallback_without_stored_smiles(prepared_engine):
             .all()
         )
     assert fallback_smiles == [expected], fallback_smiles
+
+
+# Counts every ord.compound by how it reaches its reaction, alongside how many of those rows made
+# it into derived.compound_smiles and how many of those are still missing an rdkit.mols link.
+# [Ti+5] structures are excluded from the unlinked tally because _update_rdkit_mols deliberately
+# keeps them out of rdkit.mols (see the NOT LIKE guard there, and issue #672).
+_COMPOUND_ATTACHMENT_COVERAGE = text("""
+    SELECT CASE
+             WHEN ord.reaction_input.reaction_id IS NOT NULL THEN 'reaction_input'
+             WHEN ord.compound.reaction_input_id IS NOT NULL THEN 'workup_input'
+             ELSE 'product_measurement'
+           END AS attachment,
+           count(*) AS compounds,
+           count(derived.compound_smiles.compound_id) AS derived,
+           count(*) FILTER (
+               WHERE derived.compound_smiles.compound_id IS NOT NULL
+                 AND derived.compound_smiles.rdkit_mol_id IS NULL
+                 AND derived.compound_smiles.smiles NOT LIKE '%[Ti+5]%'
+           ) AS unlinked
+    FROM ord.compound
+    LEFT JOIN ord.reaction_input ON ord.compound.reaction_input_id = ord.reaction_input.id
+    LEFT JOIN derived.compound_smiles ON derived.compound_smiles.compound_id = ord.compound.id
+    GROUP BY 1
+""")
+
+
+def test_derived_compound_smiles_covers_every_attachment(prepared_engine):
+    """Every ord.compound is derived and RDKit-linked, whichever parent it hangs off.
+
+    A compound reaches its reaction as a reaction input, as a workup's input (whose
+    ord.reaction_input row has reaction_id NULL), or as a product measurement's authentic
+    standard. A dataset-scoping join that follows only reaction_input.reaction_id silently drops
+    the latter two, so assert all three attachments appear and none loses rows to the derived or
+    RDKit passes.
+    """
+    dataset = load_dataset(
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+    )
+    # The fixture has workup inputs but no authentic standard; attach one so the
+    # product_measurement path is populated.
+    measurement = next(
+        measurement
+        for reaction in dataset.reactions
+        for outcome in reaction.outcomes
+        for product in outcome.products
+        for measurement in product.measurements
+    )
+    measurement.uses_authentic_standard = True
+    measurement.authentic_standard.identifiers.add(
+        type=reaction_pb2.CompoundIdentifier.SMILES, value="c1ccccc1"
+    )
+    with Session(prepared_engine) as session:
+        with session.begin():
+            add_dataset(dataset, session)
+            update_derived_data(dataset.dataset_id, session)
+        coverage = {
+            row.attachment: row
+            for row in session.execute(_COMPOUND_ATTACHMENT_COVERAGE)
+        }
+    # Guard against the assertions below passing vacuously on an attachment the fixture lacks.
+    assert set(coverage) == {
+        "reaction_input",
+        "workup_input",
+        "product_measurement",
+    }, coverage
+    for attachment, row in coverage.items():
+        assert row.compounds == row.derived, (attachment, row.compounds, row.derived)
+        assert row.unlinked == 0, (attachment, row.unlinked)
 
 
 def test_unlinked_partial_indexes(test_session):


### PR DESCRIPTION
## Problem

`ord.compound` reaches its reaction through three different parents, but the derived and RDKit passes all scoped their work with one join:

```sql
JOIN ord.reaction_input ON ord.compound.reaction_input_id = ord.reaction_input.id
JOIN ord.reaction       ON ord.reaction_input.reaction_id = ord.reaction.id
```

That join exists to reach `reaction.dataset_id`, not to filter — but it silently drops two of the three attachments. A workup's input has `reaction_id` NULL (it hangs off `reaction_workup`), and an authentic standard has `reaction_input_id` NULL (it hangs off `product_measurement`), so the inner joins discard both.

Measured against the current production data:

| Attachment | Compounds | Derived rows (before) |
|---|---|---|
| `reaction_input` → `reaction` | 11,950,037 | 11,544,019 |
| `reaction_input` → `reaction_workup` | 5,071,264 | **0** |
| `product_measurement` (authentic standards) | 21,856 | **0** |

(The 406,018 shortfall in the first row is legitimate: those compounds have name-only identifiers and no derivable SMILES.)

This is a regression against the pre-reorg ORM, where `Compound.smiles` was assigned in `from_proto` at ingest, so a compound's position in the proto tree was irrelevant. It also contradicts `CompoundSmiles`' documented *"one row per ord.compound"* invariant.

Nothing in ord-interface reads those SMILES today — its own queries join `reaction_input.reaction_id` too — but SQL written directly against `derived.compound_smiles`, notably the natural-language query interface, silently under-counts rather than erroring. "What quench solvents does this dataset use?" returns nothing.

## Fix

Hoist the join into `_COMPOUND_REACTION_JOINS`, one path per parent, and use it from `_update_compound_smiles`, `_update_rdkit_mols`, and `_link_mol_ids`. The stale `NOTE` in `_update_rdkit_mols` recording the old exclusion is removed.

Reaching `ord.reaction` through a `COALESCE` of the parent keys would read better, but an equality against `COALESCE(...)` is not sargable — the planner could no longer drive from the dataset's reactions through the indexed foreign keys, which would hurt incremental loads. So the paths are `UNION`ed (id selects, mol candidates) or run as one statement each (`_link_mol_ids`, preserving the flat `UPDATE ... FROM` form its perf `NOTE` calls for).

`UNION ALL` is safe because the paths select disjoint compounds. Verified on production data rather than assumed — zero rows violate any of these:

- a compound sets exactly one of `reaction_input_id` / `product_measurement_id` (never both, never neither);
- a `reaction_input` belongs to exactly one of a reaction or a workup.

## Backfill

Every derived pass is `NOT EXISTS`-guarded, so existing databases backfill in place with `add_datasets --stages derived`. **No reload required.** On production data this adds ~5.1M `compound_smiles` rows and 3,084 new `rdkit.mols` structures (+0.2%) — the other 22,707 distinct SMILES are already present via non-workup uses.

## Testing

The Nielsen fixture already carries 80 workup inputs, so this gap was an untested assertion, not a missing fixture. `test_derived_compound_smiles_covers_every_attachment` groups compounds by attachment and asserts each class is fully derived and RDKit-linked, after first asserting all three classes are present so it cannot pass vacuously. It synthesizes an authentic standard, which the fixture lacks.

- Fails on the unfixed code: `AssertionError: ('product_measurement', 1, 0)`
- Passes on this branch.
- Full ORM suite: **51 passed, 2 skipped** — including `test_update_derived_tables_sharded_covers_all` and `test_rdkit_sharded_matches_serial`, which matter because the sharded queries were rewritten.

Unlinked `[Ti+5]` structures stay exempt, matching the existing guard in `_update_rdkit_mols` (#672). That carve-out surfaced while writing the test: titanium(V) ethoxide is derived but deliberately never linked, in the fixture and in production alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR expands compound SMILES derivation to cover every compound attachment path. The main changes are:

- Adds shared reaction-join paths for direct inputs, workup inputs, and product measurements.
- Reuses those paths for derived SMILES generation and RDKit mol linking.
- Adds a regression test for all three compound attachment classes.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Adds shared SQL join paths and applies them to compound SMILES derivation, RDKit mol candidate insertion, and mol ID linking. |
| ord_schema/orm/database_test.py | Adds coverage for direct reaction inputs, workup inputs, and product-measurement authentic standards. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  C[ord.compound] -->|reaction_input_id| RI[ord.reaction_input]
  RI -->|reaction_id| R[ord.reaction]
  RI -->|reaction_workup_id| RW[ord.reaction_workup]
  RW -->|reaction_id| R
  C -->|product_measurement_id| PM[ord.product_measurement]
  PM -->|product_compound_id| PC[ord.product_compound]
  PC -->|reaction_outcome_id| RO[ord.reaction_outcome]
  RO -->|reaction_id| R
  R -->|dataset_id filter| D[ord.dataset]
  C --> DCS[derived.compound_smiles]
  PC --> PCS[derived.product_compound_smiles]
  DCS --> RM[rdkit.mols]
  PCS --> RM
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
  C[ord.compound] -->|reaction_input_id| RI[ord.reaction_input]
  RI -->|reaction_id| R[ord.reaction]
  RI -->|reaction_workup_id| RW[ord.reaction_workup]
  RW -->|reaction_id| R
  C -->|product_measurement_id| PM[ord.product_measurement]
  PM -->|product_compound_id| PC[ord.product_compound]
  PC -->|reaction_outcome_id| RO[ord.reaction_outcome]
  RO -->|reaction_id| R
  R -->|dataset_id filter| D[ord.dataset]
  C --> DCS[derived.compound_smiles]
  PC --> PCS[derived.product_compound_smiles]
  DCS --> RM[rdkit.mols]
  PCS --> RM
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Derive SMILES for workup and product-mea..."](https://github.com/open-reaction-database/ord-schema/commit/2af2382373d663ef9fd798c22f28f1e4cd422f59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43192828)</sub>

<!-- /greptile_comment -->