### PR TITLE
Wrap over-length comments in ord-schema to 88 chars

### DIFF
--- a/.github/scripts/check_direct_dependencies.py
+++ b/.github/scripts/check_direct_dependencies.py
@@ -53,8 +53,8 @@ def read_metadata(path: Path) -> str:
     if path.name.endswith(".tar.gz"):
         with tarfile.open(path) as archive:
             for member in archive.getmembers():
-                # Only the top-level PKG-INFO describes the distribution itself; the sdist
-                # also carries one per .egg-info directory.
+                # Only the top-level PKG-INFO describes the distribution itself; the
+                # sdist also carries one per .egg-info directory.
                 if member.name.count("/") == 1 and member.name.endswith("/PKG-INFO"):
                     handle = archive.extractfile(member)
                     if handle is not None:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,8 @@
 # -- Project information -----------------------------------------------------
 
 project = "Open Reaction Database"
-copyright = "2020–2026 Open Reaction Database Project Authors"  # noqa: A001  (sphinx requires this exact name)
+# (sphinx requires this exact name)
+copyright = "2020–2026 Open Reaction Database Project Authors"  # noqa: A001
 author = "Open Reaction Database Project Authors"
 
 # -- General configuration ---------------------------------------------------

--- a/ord_schema/atomic_io_test.py
+++ b/ord_schema/atomic_io_test.py
@@ -57,7 +57,8 @@ def test_atomic_path_replaces_existing_destination(tmp_path):
 
 def test_atomic_path_removes_temp_on_exception(tmp_path):
     dest = (tmp_path / "out.bin").as_posix()
-    with pytest.raises(RuntimeError, match="boom"), atomic_io.atomic_path(dest) as tmp:  # noqa: PT012  (abort-on-exception test: the multi-statement body in the context is under test)
+    # (abort-on-exception test: the multi-statement body in the context is under test)
+    with pytest.raises(RuntimeError, match="boom"), atomic_io.atomic_path(dest) as tmp:  # noqa: PT012
         _write(tmp, b"partial")
         raise RuntimeError("boom")
     assert sorted(q.name for q in pathlib.Path(tmp_path).iterdir()) == []
@@ -66,7 +67,8 @@ def test_atomic_path_removes_temp_on_exception(tmp_path):
 def test_atomic_path_preserves_destination_on_exception(tmp_path):
     dest = (tmp_path / "out.bin").as_posix()
     _write(dest, b"original")
-    with pytest.raises(RuntimeError, match="boom"), atomic_io.atomic_path(dest) as tmp:  # noqa: PT012  (abort-on-exception test: the multi-statement body in the context is under test)
+    # (abort-on-exception test: the multi-statement body in the context is under test)
+    with pytest.raises(RuntimeError, match="boom"), atomic_io.atomic_path(dest) as tmp:  # noqa: PT012
         _write(tmp, b"partial")
         raise RuntimeError("boom")
     assert _read(dest) == b"original"
@@ -76,7 +78,8 @@ def test_atomic_path_preserves_destination_on_exception(tmp_path):
 def test_atomic_path_removes_temp_on_keyboard_interrupt(tmp_path):
     """KeyboardInterrupt (a BaseException) also triggers cleanup; documents the contract."""
     dest = (tmp_path / "out.bin").as_posix()
-    with pytest.raises(KeyboardInterrupt), atomic_io.atomic_path(dest) as tmp:  # noqa: PT012  (abort-on-exception test: the multi-statement body in the context is under test)
+    # (abort-on-exception test: the multi-statement body in the context is under test)
+    with pytest.raises(KeyboardInterrupt), atomic_io.atomic_path(dest) as tmp:  # noqa: PT012
         _write(tmp, b"partial")
         raise KeyboardInterrupt
     assert sorted(q.name for q in pathlib.Path(tmp_path).iterdir()) == []
@@ -85,7 +88,8 @@ def test_atomic_path_removes_temp_on_keyboard_interrupt(tmp_path):
 def test_atomic_path_swallows_missing_temp_on_exception(tmp_path):
     """Cleanup must succeed even if the temp was already removed by something else."""
     dest = (tmp_path / "out.bin").as_posix()
-    with pytest.raises(RuntimeError, match="boom"), atomic_io.atomic_path(dest) as tmp:  # noqa: PT012  (abort-on-exception test: the multi-statement body in the context is under test)
+    # (abort-on-exception test: the multi-statement body in the context is under test)
+    with pytest.raises(RuntimeError, match="boom"), atomic_io.atomic_path(dest) as tmp:  # noqa: PT012
         pathlib.Path(tmp).unlink()  # Remove the temp out from under us.
         raise RuntimeError("boom")
     assert sorted(q.name for q in pathlib.Path(tmp_path).iterdir()) == []

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -911,7 +911,8 @@ def id_filename(filename: str) -> str:
             f'basename does not have the required "ord" prefix: {basename}'
         )
     shard = suffix[:2]
-    # Reject anything that could let the shard escape the "data/" root (e.g. "..", "/x").
+    # Reject anything that could let the shard escape the "data/" root
+    # (e.g. "..", "/x").
     if not shard.isalnum():
         raise ValueError(f"basename shard must be alphanumeric: {basename}")
     result = posixpath.join("data", shard, basename)

--- a/ord_schema/orm/conftest.py
+++ b/ord_schema/orm/conftest.py
@@ -31,7 +31,8 @@ from ord_schema.orm.database import add_dataset, prepare_database, update_derive
 @pytest.fixture(name="test_engine")
 def test_engine_fixture() -> Iterator[Engine]:
     with Postgresql() as postgres:
-        # See https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg.
+        # See
+        # https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg.
         url = re.sub("postgresql://", "postgresql+psycopg://", postgres.url())
         engine = create_engine(url, future=True)
         yield engine

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -37,16 +37,18 @@ from ord_schema.orm.public_mappers import DatasetMetadata
 from ord_schema.orm.sharding import shard_predicate as _shard_predicate
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
-# COPY the ingest tables parents-first so foreign keys resolve; sorted_tables orders by FK
-# dependency. Precomputed once; only the tables populated by a given batch are written.
+# COPY the ingest tables parents-first so foreign keys resolve; sorted_tables orders by
+# FK dependency. Precomputed once; only the tables populated by a given batch are
+# written.
 _COPY_TABLE_ORDER = [table.fullname for table in Base.metadata.sorted_tables]
 
 try:
     from ord_schema.orm.reaction_class import update_reaction_classes
 except Exception as error:  # noqa: BLE001
-    # The optional 'reaction-class' extra pulls in rxn-insight -> rxnmapper/torch, which can fail
-    # to import many ways (missing package, native-library OSError). Catch all so the ORM stays
-    # usable without it; _classify_reactions re-raises with this error as the cause.
+    # The optional 'reaction-class' extra pulls in rxn-insight -> rxnmapper/torch, which
+    # can fail to import many ways (missing package, native-library OSError). Catch all
+    # so the ORM stays usable without it; _classify_reactions re-raises with this error
+    # as the cause.
     update_reaction_classes = None  # ty: ignore[invalid-assignment]
     _reaction_class_import_error: Exception | None = error
 else:
@@ -90,8 +92,8 @@ def get_connection_string(
     return f"postgresql+psycopg://{username}:{password}@{host}:{port}/{database}?client_encoding=utf8"
 
 
-# PostgreSQL 12 (server_version_num 120000), when AS MATERIALIZED CTEs -- used throughout the
-# derived/RDKit passes -- were introduced.
+# PostgreSQL 12 (server_version_num 120000), when AS MATERIALIZED CTEs -- used
+# throughout the derived/RDKit passes -- were introduced.
 _MIN_SERVER_VERSION_NUM = 120000
 
 
@@ -147,10 +149,11 @@ def prepare_database(engine: Engine) -> bool:
         # Derived, best-effort data that is not part of the proto (e.g. reaction class).
         connection.execute(text("CREATE SCHEMA IF NOT EXISTS derived"))
     with engine.begin() as connection:
-        # Pin the default search_path to public. The role is often named "ord", so Postgres's
-        # default ("$user", public) would resolve the ord schema first; the ORM qualifies every
-        # table, so keep only public -- where the RDKit cartridge functions live. Best-effort: a
-        # non-owner connection cannot ALTER DATABASE, but the ORM never relies on the path anyway.
+        # Pin the default search_path to public. The role is often named "ord", so
+        # Postgres's default ("$user", public) would resolve the ord schema first; the
+        # ORM qualifies every table, so keep only public -- where the RDKit cartridge
+        # functions live. Best-effort: a non-owner connection cannot ALTER DATABASE, but
+        # the ORM never relies on the path anyway.
         try:
             connection.execute(
                 text(
@@ -163,7 +166,8 @@ def prepare_database(engine: Engine) -> bool:
             logger.warning(f"Could not set the default search_path to public: {error}")
     try:
         with engine.begin() as connection:
-            # NOTE(skearnes): The RDKit PostgreSQL extension works best in the public schema.
+            # NOTE(skearnes): The RDKit PostgreSQL extension works best in the public
+            # schema.
             connection.execute(text("CREATE EXTENSION IF NOT EXISTS rdkit"))
         rdkit_cartridge = True
     except (OperationalError, NotSupportedError):
@@ -319,9 +323,9 @@ def backfill_submission_times(session: Session) -> None:
 # ingest. Larger values reduce COPY roundtrips at the cost of more trees held in memory.
 _COPY_BATCH = 1000
 
-# Number of reactions/compounds the derived passes load and process at a time. The ids needing
-# derivation are fetched up front, but the heavy work (proto deserialization, SMILES generation)
-# and the pending inserts are limited to this many rows at a time.
+# Number of reactions/compounds the derived passes load and process at a time. The ids
+# needing derivation are fetched up front, but the heavy work (proto deserialization,
+# SMILES generation) and the pending inserts are limited to this many rows at a time.
 _DERIVED_BATCH = 1000
 
 
@@ -365,15 +369,17 @@ def _collect_rows(root: Any, rows_by_table: dict[str, tuple[Any, list]]) -> None
             entry = (table, [])
             rows_by_table[table.fullname] = entry
         # Every PK must be populated now: Uuid PKs are minted above; text PKs (e.g.
-        # public.reactions.reaction_id) come from the proto or FK wiring from the parent. A NULL
-        # here means a new table has a PK that is neither, which would otherwise fail inside COPY.
+        # public.reactions.reaction_id) come from the proto or FK wiring from the
+        # parent. A NULL here means a new table has a PK that is neither, which would
+        # otherwise fail inside COPY.
         for key_column in table.primary_key:
             assert getattr(node, key_column.key, None) is not None, (
                 f"unpopulated primary key {table.fullname}.{key_column.name}; a new table needs "
                 "a Uuid primary key or one wired from a parent foreign key"
             )
-        # Under single-table polymorphic inheritance, a sibling subclass's foreign-key column
-        # shares the table but is not an attribute of this instance, so it is NULL for this row.
+        # Under single-table polymorphic inheritance, a sibling subclass's foreign-key
+        # column shares the table but is not an attribute of this instance, so it is
+        # NULL for this row.
         entry[1].append(tuple(getattr(node, c.key, None) for c in table.columns))
 
 
@@ -568,15 +574,16 @@ def delete_dataset(dataset_id: str, session: Session) -> None:
     logger.debug(f"delete took {time.time() - start}s")
 
 
-# The derived/RDKit passes scope to a dataset by walking from a compound up to ord.reaction, but
-# ord.compound hangs off three parents, so no single join reaches all of them:
+# The derived/RDKit passes scope to a dataset by walking from a compound up to
+# ord.reaction, but ord.compound hangs off three parents, so no single join reaches all
+# of them:
 #   * a reaction input (reaction_input.reaction_id set);
 #   * a workup input (that reaction_input has reaction_id NULL, reaction_workup_id set);
 #   * a product measurement (compound.reaction_input_id NULL) -- authentic standards.
-# Callers UNION the paths rather than joining through COALESCE of the parent keys, which is not
-# sargable and would keep the planner off the foreign-key indexes. The paths are disjoint (a
-# compound sets exactly one of reaction_input_id/product_measurement_id; a reaction_input belongs
-# to a reaction xor a workup), so UNION ALL never double-counts.
+# Callers UNION the paths rather than joining through COALESCE of the parent keys, which
+# is not sargable and would keep the planner off the foreign-key indexes. The paths are
+# disjoint (a compound sets exactly one of reaction_input_id/product_measurement_id; a
+# reaction_input belongs to a reaction xor a workup), so UNION ALL never double-counts.
 _COMPOUND_REACTION_JOINS: tuple[str, ...] = (
     """
     JOIN ord.reaction_input ON ord.compound.reaction_input_id = ord.reaction_input.id
@@ -643,9 +650,9 @@ def update_derived_tables(
     # dataset_id and the compound link columns live on the polymorphic child mappers, so
     # rows are scoped to the dataset via raw SQL (like the RDKit pass).
     dataset_pk = _resolve_dataset_pk(dataset_id, session)
-    # Reaction SMILES from the served proto (no ORM objects loaded), keyed by ord.reaction.id.
-    # Resolve the ids needing derivation in one indexed pass, then load and parse the (large)
-    # protos in batches of _DERIVED_BATCH.
+    # Reaction SMILES from the served proto (no ORM objects loaded), keyed by
+    # ord.reaction.id. Resolve the ids needing derivation in one indexed pass, then load
+    # and parse the (large) protos in batches of _DERIVED_BATCH.
     reaction_shard_sql, reaction_shard_params = _shard_predicate(
         "ord.reaction.id", shard
     )
@@ -781,9 +788,10 @@ def _update_compound_smiles(
         .scalars()
         .all()
     )
-    # The first SMILES identifier (lowest id == proto order) for each requested compound. The FK
-    # column is indexed, so one query per batch replaces an ORM load plus lazy child fetches per
-    # compound. Interpolated names are internal constants (not user input); see S608 below.
+    # The first SMILES identifier (lowest id == proto order) for each requested
+    # compound. The FK column is indexed, so one query per batch replaces an ORM load
+    # plus lazy child fetches per compound. Interpolated names are internal constants
+    # (not user input); see S608 below.
     select_smiles = text(f"""
         SELECT DISTINCT ON (ord.compound_identifier.{derived_id})
                ord.compound_identifier.{derived_id}, ord.compound_identifier.value
@@ -809,11 +817,13 @@ def _update_compound_smiles(
         inserts = []
         for compound_id in batch_ids:
             value = stored_smiles.get(compound_id)
-            # An absent or empty SMILES identifier both fall through to the reconstruction path,
-            # matching smiles_from_compound's `get_compound_smiles(...) or ...` falsiness (an
-            # empty string is not a parseable structure to canonicalize).
+            # An absent or empty SMILES identifier both fall through to the
+            # reconstruction path, matching smiles_from_compound's
+            # `get_compound_smiles(...) or ...` falsiness (an empty string is not a
+            # parseable structure to canonicalize).
             if value:
-                # Canonicalize the stored SMILES, matching smiles_from_compound's default.
+                # Canonicalize the stored SMILES, matching smiles_from_compound's
+                # default.
                 mol = Chem.MolFromSmiles(value)
                 if mol is None:
                     logger.debug(
@@ -822,7 +832,8 @@ def _update_compound_smiles(
                     continue
                 smiles = Chem.MolToSmiles(mol)
             else:
-                # No stored SMILES: reconstruct the message and derive from other identifiers.
+                # No stored SMILES: reconstruct the message and derive from other
+                # identifiers.
                 compound = session.get(compound_class, compound_id)
                 assert compound is not None  # Selected by id above.
                 try:
@@ -922,11 +933,12 @@ def _update_rdkit_mols(
     start = time.time()
     dataset_pk = _resolve_dataset_pk(dataset_id, session)
     shard_sql, shard_params = _shard_predicate("candidates.smiles", shard)
-    # Scope each compound table to the dataset via the surrogate key, in a MATERIALIZED CTE with no
-    # rdkit_mol_id predicate, so the planner reaches the compounds through ix_reaction_dataset_id
-    # rather than the whole-database "unlinked rows" partial index; new_smiles then joins the
-    # derived tables to these bounded id sets. See _link_mol_ids and #895. UNION ALL is safe: the
-    # join paths select disjoint compounds (see _COMPOUND_REACTION_JOINS).
+    # Scope each compound table to the dataset via the surrogate key, in a MATERIALIZED
+    # CTE with no rdkit_mol_id predicate, so the planner reaches the compounds through
+    # ix_reaction_dataset_id rather than the whole-database "unlinked rows" partial
+    # index; new_smiles then joins the derived tables to these bounded id sets. See
+    # _link_mol_ids and #895. UNION ALL is safe: the join paths select disjoint
+    # compounds (see _COMPOUND_REACTION_JOINS).
     scoped_compound_ids = "\nUNION ALL\n".join(
         f"""
                 SELECT ord.compound.id AS id
@@ -1051,7 +1063,8 @@ def _link_mol_ids(
                   AND rdkit.mols.smiles = {derived_table}.smiles
                   AND {derived_table}.rdkit_mol_id IS NULL
                   {shard_sql}
-                """),  # noqa: S608  (table/column names are internal constants, not user input)
+                """),  # noqa: S608
+            # (table/column names are internal constants, not user input)
             {"dataset_pk": dataset_pk, **shard_params},
         )
         rows += cast(Any, result).rowcount
@@ -1073,12 +1086,13 @@ def update_rdkit_ids(
     logger.debug("Updating RDKit ID associations")
     _check_server_version(session.connection())
     start = time.time()
-    # Each UPDATE scopes to the dataset in a MATERIALIZED CTE keyed on the surrogate, carrying no
-    # rdkit_*_id predicate, so the planner reaches the rows through ix_reaction_dataset_id. The
-    # earlier flat ``UPDATE ... FROM ord.reaction WHERE ... rdkit_*_id IS NULL`` let it drive from
-    # the "unlinked rows" partial index -- fine on an end-to-end load (the set drains dataset by
-    # dataset) but quadratic on a backfill, where every dataset is unlinked at once and each
-    # (dataset, shard) rescans the whole set. See #895.
+    # Each UPDATE scopes to the dataset in a MATERIALIZED CTE keyed on the surrogate,
+    # carrying no rdkit_*_id predicate, so the planner reaches the rows through
+    # ix_reaction_dataset_id. The earlier flat ``UPDATE ... FROM ord.reaction WHERE
+    # ... rdkit_*_id IS NULL`` let it drive from the "unlinked rows" partial index --
+    # fine on an end-to-end load (the set drains dataset by dataset) but quadratic on a
+    # backfill, where every dataset is unlinked at once and each (dataset, shard)
+    # rescans the whole set. See #895.
     dataset_pk = _resolve_dataset_pk(dataset_id, session)
     reaction_shard_sql, reaction_shard_params = _shard_predicate(
         "derived.reaction_smiles.reaction_smiles", shard

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -93,7 +93,8 @@ def test_update_rdkit_tables_idempotent(test_session):
         test_session.execute(text("SELECT count(*) FROM rdkit.mols")).scalar()
         == before_mols
     )
-    # Invariant: the IS NOT NULL guards keep NULL mol/reaction rows out of the cartridge tables.
+    # Invariant: the IS NOT NULL guards keep NULL mol/reaction rows out of the cartridge
+    # tables.
     assert (
         test_session.execute(
             text("SELECT count(*) FROM rdkit.mols WHERE mol IS NULL")
@@ -137,8 +138,9 @@ def test_update_derived_tables_batched(test_session, monkeypatch):
         ).scalar()
         for table in tables
     }
-    # Every derived table must be populated up front, otherwise the re-derivation below would
-    # pass trivially (0 == 0) without exercising the reaction or compound batch paths.
+    # Every derived table must be populated up front, otherwise the re-derivation below
+    # would pass trivially (0 == 0) without exercising the reaction or compound batch
+    # paths.
     assert all(count > 0 for count in full.values()), full
     # Clear the derived rows, then re-derive in batches far smaller than the dataset (80
     # reactions) so the result is built across many batches rather than one.
@@ -179,8 +181,8 @@ def test_update_derived_tables_sharded_covers_all(prepared_engine):
                 for table in tables
             }
 
-    # Derive one shard at a time, recording how many rows each shard adds per table (idempotent
-    # inserts, so a shard only adds its own partition's rows).
+    # Derive one shard at a time, recording how many rows each shard adds per table
+    # (idempotent inserts, so a shard only adds its own partition's rows).
     num_shards = 4
     prev = dict.fromkeys(tables, 0)
     per_shard: list[dict[str, int]] = []
@@ -196,8 +198,9 @@ def test_update_derived_tables_sharded_covers_all(prepared_engine):
     sharded = counts()
     for table in tables:
         assert sharded[table] > 0, (table, sharded)
-        # Rows land in more than one shard, so the hash predicate really partitions each table
-        # (guarded by a size floor so a genuinely tiny table can't flake the check).
+        # Rows land in more than one shard, so the hash predicate really partitions each
+        # table (guarded by a size floor so a genuinely tiny table can't flake the
+        # check).
         if sharded[table] >= 2 * num_shards:
             non_empty = sum(1 for shard in per_shard if shard[table] > 0)
             assert non_empty >= 2, (table, [shard[table] for shard in per_shard])
@@ -262,7 +265,8 @@ def test_rdkit_sharded_matches_serial(prepared_engine):
         "linked_products",
     ):
         assert sharded[key] > 0, (key, sharded)
-    # A serial (whole-dataset) pass now inserts and links nothing new: the shards covered it all.
+    # A serial (whole-dataset) pass now inserts and links nothing new: the shards
+    # covered it all.
     run_shard(None)
     assert counts() == sharded
 
@@ -305,8 +309,9 @@ def test_classify_sharded_covers_all(prepared_engine):
                     dataset.dataset_id, session, shard=(shard_index, num_shards)
                 )
     sharded = count()
-    # Shard 0 is a strict, non-empty subset: the fixture's ~80 reactions reliably hash into more
-    # than one of the 4 buckets, so this holds for it (a 1-reaction fixture would not).
+    # Shard 0 is a strict, non-empty subset: the fixture's ~80 reactions reliably hash
+    # into more than one of the 4 buckets, so this holds for it (a 1-reaction fixture
+    # would not).
     assert 0 < first < sharded, (first, sharded)
     # A whole-dataset pass now adds nothing: the shards classified every reaction.
     with Session(prepared_engine) as session, session.begin():
@@ -359,8 +364,9 @@ def test_compound_smiles_fallback_without_stored_smiles(prepared_engine):
     dataset = load_dataset(
         pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
     )
-    # Replace one compound's SMILES identifier with the equivalent InChI so only the fallback
-    # (structure reconstruction from a non-SMILES identifier) can derive its SMILES.
+    # Replace one compound's SMILES identifier with the equivalent InChI so only the
+    # fallback (structure reconstruction from a non-SMILES identifier) can derive its
+    # SMILES.
     compound = next(
         component
         for reaction in dataset.reactions
@@ -378,8 +384,8 @@ def test_compound_smiles_fallback_without_stored_smiles(prepared_engine):
             add_dataset(dataset, session)
         with session.begin():
             update_derived_tables(dataset.dataset_id, session)
-        # Exactly the modified compound lacks a SMILES identifier, so its derived row proves the
-        # fallback ran and produced the InChI-derived canonical SMILES.
+        # Exactly the modified compound lacks a SMILES identifier, so its derived row
+        # proves the fallback ran and produced the InChI-derived canonical SMILES.
         fallback_smiles = (
             session.execute(
                 text(
@@ -394,10 +400,11 @@ def test_compound_smiles_fallback_without_stored_smiles(prepared_engine):
     assert fallback_smiles == [expected], fallback_smiles
 
 
-# Counts every ord.compound by how it reaches its reaction, alongside how many of those rows made
-# it into derived.compound_smiles and how many of those are still missing an rdkit.mols link.
-# [Ti+5] structures are excluded from the unlinked tally because _update_rdkit_mols deliberately
-# keeps them out of rdkit.mols (see the NOT LIKE guard there, and issue #672).
+# Counts every ord.compound by how it reaches its reaction, alongside how many of
+# those rows made it into derived.compound_smiles and how many of those are still
+# missing an rdkit.mols link. [Ti+5] structures are excluded from the unlinked tally
+# because _update_rdkit_mols deliberately keeps them out of rdkit.mols (see the NOT
+# LIKE guard there, and issue #672).
 _COMPOUND_ATTACHMENT_COVERAGE = text("""
     SELECT CASE
              WHEN ord.reaction_input.reaction_id IS NOT NULL THEN 'reaction_input'
@@ -451,7 +458,8 @@ def test_derived_compound_smiles_covers_every_attachment(prepared_engine):
             row.attachment: row
             for row in session.execute(_COMPOUND_ATTACHMENT_COVERAGE)
         }
-    # Guard against the assertions below passing vacuously on an attachment the fixture lacks.
+    # Guard against the assertions below passing vacuously on an attachment the fixture
+    # lacks.
     assert set(coverage) == {
         "reaction_input",
         "workup_input",

--- a/ord_schema/orm/derived_mappers.py
+++ b/ord_schema/orm/derived_mappers.py
@@ -43,9 +43,10 @@ class ReactionSmiles(Base):
     rdkit_reaction = relationship("RDKitReactions")
 
     __table_args__ = (
-        # Partial index on the RDKit join key over not-yet-linked rows; the RDKit linking
-        # pass joins these to rdkit.reactions by reaction_smiles and filters unlinked, so
-        # this stays tiny once most rows are linked. See ord_schema/orm/README.md.
+        # Partial index on the RDKit join key over not-yet-linked rows; the RDKit
+        # linking pass joins these to rdkit.reactions by reaction_smiles and filters
+        # unlinked, so this stays tiny once most rows are linked. See
+        # ord_schema/orm/README.md.
         Index(
             "reaction_smiles_unlinked_index",
             "reaction_smiles",
@@ -73,7 +74,8 @@ class CompoundSmiles(Base):
     rdkit_mol = relationship("RDKitMols")
 
     __table_args__ = (
-        # Partial index on the RDKit join key (smiles) over not-yet-linked rows; see README.
+        # Partial index on the RDKit join key (smiles) over not-yet-linked rows; see
+        # README.
         Index(
             "compound_smiles_unlinked_index",
             "smiles",
@@ -102,7 +104,8 @@ class ProductCompoundSmiles(Base):
     rdkit_mol = relationship("RDKitMols")
 
     __table_args__ = (
-        # Partial index on the RDKit join key (smiles) over not-yet-linked rows; see README.
+        # Partial index on the RDKit join key (smiles) over not-yet-linked rows; see
+        # README.
         Index(
             "product_compound_smiles_unlinked_index",
             "smiles",
@@ -129,7 +132,8 @@ class ReactionClasses(Base):
     )
     # Coarse category (e.g. "C-C Coupling").
     reaction_class = Column(Text, index=True)
-    # Specific named reaction within the class (e.g. "Suzuki coupling with boronic acids").
+    # Specific named reaction within the class (e.g. "Suzuki coupling with boronic
+    # acids").
     reaction_name = Column(Text, index=True)
 
     __table_args__ = ({"schema": "derived"},)

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -53,14 +53,16 @@ logger = get_logger(__name__)
 
 STAGES = ("ingest", "derived")
 
-# SMILES derivation is sharded within a dataset so one large dataset does not pin a single worker
-# (the derived-stage analog of row-group sharding for ingest). A dataset is split into one shard
-# per this many reactions, capped, so small datasets stay a single shard.
+# SMILES derivation is sharded within a dataset so one large dataset does not pin a
+# single worker (the derived-stage analog of row-group sharding for ingest). A dataset
+# is split into one shard per this many reactions, capped, so small datasets stay a
+# single shard.
 _DERIVE_SHARD_SIZE = 50_000
 _DERIVE_SHARD_CAP = 32
 
-# Reaction classification loads a Rxn-INSIGHT/rxnmapper transformer model per worker, so its shard
-# pool is capped well below the ingest/SMILES n_jobs to keep the models within memory.
+# Reaction classification loads a Rxn-INSIGHT/rxnmapper transformer model per worker,
+# so its shard pool is capped well below the ingest/SMILES n_jobs to keep the models
+# within memory.
 _CLASSIFY_JOBS_CAP = 4
 
 
@@ -112,9 +114,11 @@ def ingest_dataset(filename: str, *, dsn: str, overwrite: bool) -> str:
         def insert(session: Session) -> None:
             database.add_dataset(dataset, session)
 
-    # NOTE(skearnes): Multiprocessing is hard to get right for shared connection pools, so we don't even try; see
+    # NOTE(skearnes): Multiprocessing is hard to get right for shared connection pools,
+    # so we don't even try; see
     # https://docs.sqlalchemy.org/en/20/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork.
-    # Each call owns its engine and disposes it so pooled connections don't accumulate in reused pool workers.
+    # Each call owns its engine and disposes it so pooled connections don't accumulate
+    # in reused pool workers.
     engine = create_engine(dsn)
     try:
         with Session(engine) as session:
@@ -161,7 +165,8 @@ def derive_dataset(dataset_id: str, *, dsn: str, classify_reactions: bool) -> st
             database.update_derived_data(
                 dataset_id,
                 session,
-                rdkit_cartridge=False,  # Done serially in add_rdkit() to avoid deadlocks.
+                # Done serially in add_rdkit() to avoid deadlocks.
+                rdkit_cartridge=False,
                 classify_reactions=classify_reactions,
             )
     finally:
@@ -187,8 +192,9 @@ def _derive_shard_items(
                     size = database.get_dataset_size(dataset_id, session)
                 except ValueError:
                     size = 0
-                # Ceiling division (-(-a // b)): a dataset just over a shard-size multiple still
-                # splits into an extra shard rather than staying single-worker.
+                # Ceiling division (-(-a // b)): a dataset just over a shard-size
+                # multiple still splits into an extra shard rather than staying
+                # single-worker.
                 num_shards = max(
                     1, min(_DERIVE_SHARD_CAP, -(-size // _DERIVE_SHARD_SIZE))
                 )
@@ -419,8 +425,9 @@ def _ingest_parquet_sharded(
     shard_items: list[tuple[str, uuid.UUID, int]] = []
     for plan in to_load:
         if plan.dataset_uuid is None:
-            # Prep sets dataset_uuid for every needs_load plan; enforce the contract explicitly
-            # (a bare assert is dropped under -O and would surface later as an obscure error).
+            # Prep sets dataset_uuid for every needs_load plan; enforce the contract
+            # explicitly (a bare assert is dropped under -O and would surface later as
+            # an obscure error).
             raise ValueError(
                 f"prep returned needs_load with no dataset_uuid: {plan.filename}"
             )
@@ -498,9 +505,9 @@ def load_datasets(
     if "ingest" in stages:
         logger.info("Ingesting datasets")
         dataset_ids: list[str] = []
-        # Parquet datasets are sharded by row group across the pool so one large dataset does not
-        # pin a single worker; the atomic single-process path handles n_jobs == 1 and non-parquet
-        # inputs (which cannot be sharded).
+        # Parquet datasets are sharded by row group across the pool so one large dataset
+        # does not pin a single worker; the atomic single-process path handles n_jobs ==
+        # 1 and non-parquet inputs (which cannot be sharded).
         if n_jobs > 1:
             parquet_files = [f for f in filenames if f.endswith(".parquet")]
             other_files = [f for f in filenames if not f.endswith(".parquet")]
@@ -526,8 +533,9 @@ def load_datasets(
 
     if "derived" in stages:
         logger.info("Deriving SMILES")
-        # Shard SMILES derivation within datasets so one large dataset does not pin a single
-        # worker; the pool sees a flat (dataset, shard) work list across all datasets.
+        # Shard SMILES derivation within datasets so one large dataset does not pin a
+        # single worker; the pool sees a flat (dataset, shard) work list across all
+        # datasets.
         shard_items = _derive_shard_items(dataset_ids, dsn)
         _, shard_failures = _run_parallel(
             partial(_derive_smiles_shard, dsn=dsn),
@@ -538,18 +546,19 @@ def load_datasets(
         failures.extend(sorted({dataset_id for dataset_id, _, _ in shard_failures}))
         if classify_reactions:
             logger.info("Classifying reactions")
-            # Shard classification within datasets by reaction-id hash, like SMILES, but through a
-            # smaller pool: each worker loads a Rxn-INSIGHT/rxnmapper model, so running n_jobs of
-            # them would multiply the model memory. Defaults to a capped fraction of n_jobs; the
-            # caller can override via classify_jobs once they know the models fit.
+            # Shard classification within datasets by reaction-id hash, like SMILES, but
+            # through a smaller pool: each worker loads a Rxn-INSIGHT/rxnmapper model,
+            # so running n_jobs of them would multiply the model memory. Defaults to a
+            # capped fraction of n_jobs; the caller can override via classify_jobs once
+            # they know the models fit.
             resolved_classify_jobs = (
                 max(1, min(n_jobs, _CLASSIFY_JOBS_CAP))
                 if classify_jobs is None
                 else max(1, classify_jobs)
             )
-            # Each shard reloads the transformer model, so sharding only pays off when the shards
-            # can run in parallel. With a single worker, keep one shard (one model load) per
-            # dataset, matching the pre-sharding behaviour.
+            # Each shard reloads the transformer model, so sharding only pays off when
+            # the shards can run in parallel. With a single worker, keep one shard (one
+            # model load) per dataset, matching the pre-sharding behaviour.
             if resolved_classify_jobs == 1:
                 classify_items = [(dataset_id, 0, 1) for dataset_id in dataset_ids]
             else:
@@ -564,10 +573,11 @@ def load_datasets(
                 sorted({dataset_id for dataset_id, _, _ in classify_failures})
             )
         logger.info("Adding RDKit functionality")
-        # Datasets are processed serially (the rdkit.* dedup tables are shared, so cross-dataset
-        # concurrency could collide on the same structure), but each dataset's pass is sharded by
-        # SMILES hash across the pool -- disjoint partitions keep concurrent inserts off each
-        # other's rdkit.* keys, so one large dataset no longer runs single-threaded.
+        # Datasets are processed serially (the rdkit.* dedup tables are shared, so
+        # cross-dataset concurrency could collide on the same structure), but each
+        # dataset's pass is sharded by SMILES hash across the pool -- disjoint
+        # partitions keep concurrent inserts off each other's rdkit.* keys, so one large
+        # dataset no longer runs single-threaded.
         engine = create_engine(dsn)
         try:
             for dataset_id in tqdm(dataset_ids, desc="RDKit"):
@@ -600,6 +610,6 @@ def load_datasets(
             engine.dispose()
 
     if failures:
-        # A dataset can fail in more than one pass (SMILES shards, classify, RDKit); report each
-        # failing file/dataset once, sorted for a deterministic message.
+        # A dataset can fail in more than one pass (SMILES shards, classify, RDKit);
+        # report each failing file/dataset once, sorted for a deterministic message.
         raise RuntimeError(sorted(set(failures)))

--- a/ord_schema/orm/loading_test.py
+++ b/ord_schema/orm/loading_test.py
@@ -74,9 +74,10 @@ def _content_digests(engine) -> dict[str, tuple[int, str | None]]:
             ).scalar()
             digest = None
             if content and count:
-                # json_build_array encodes NULL distinctly from any string and escapes the values,
-                # so there is no delimiter for a value to collide with (concat_ws instead drops
-                # NULLs, letting a NULL alias a value that contains the delimiter).
+                # json_build_array encodes NULL distinctly from any string and escapes
+                # the values, so there is no delimiter for a value to collide with
+                # (concat_ws instead drops NULLs, letting a NULL alias a value that
+                # contains the delimiter).
                 order = ", ".join(f'"{c}"' for c in content)
                 query = f"SELECT md5(string_agg(x, '|' ORDER BY x)) FROM (SELECT md5(json_build_array({order})::text) AS x FROM {table.fullname}) t"  # noqa: S608  (internal schema constants)
                 digest = session.execute(text(query)).scalar()
@@ -211,7 +212,8 @@ def test_parquet_sharded_ingest_recovers_from_partial_load(tmp_path):
         url = re.sub("postgresql://", "postgresql+psycopg://", postgres.url())
         engine = create_engine(url, future=True)
         database.prepare_database(engine)
-        # Prep inserts the ord.dataset row; load only the first row group; skip finalize.
+        # Prep inserts the ord.dataset row; load only the first row group; skip
+        # finalize.
         plan = loading._prep_parquet_dataset(parquet_path, dsn=url, overwrite=False)
         assert plan.needs_load
         assert plan.num_row_groups > 1
@@ -253,7 +255,8 @@ def test_load_datasets_parquet(prepared_engine, tmp_path):
         )
         assert mapped_dataset is not None
         assert len(mapped_dataset.reactions) == expected_count
-        # Spot-check that one reaction round-trips byte-identical through public.reactions.
+        # Spot-check that one reaction round-trips byte-identical through
+        # public.reactions.
         original = dataset.reactions[0]
         stored = next(
             r for r in mapped_dataset.reactions if r.reaction_id == original.reaction_id

--- a/ord_schema/orm/mappers.py
+++ b/ord_schema/orm/mappers.py
@@ -172,8 +172,9 @@ def build_mapper(
     assert msg_desc is not None  # Type hint.
     attrs: dict[str, Any] = {
         "__tablename__": underscore(msg_desc.name),
-        # UUIDv7 surrogate key: time-sortable (index locality) and client-generatable, so bulk
-        # loads can mint ids and wire foreign keys without a server round trip. See pyproject.
+        # UUIDv7 surrogate key: time-sortable (index locality) and client-generatable,
+        # so bulk loads can mint ids and wire foreign keys without a server round trip.
+        # See pyproject.
         "id": Column(Uuid, primary_key=True, default=uuid7),
         "ord_schema_context": Column(Text, nullable=False),
         "__table_args__": ({"schema": "ord"},),
@@ -223,16 +224,17 @@ def build_mapper(
     if message_type == dataset_pb2.Dataset:
         # Make dataset IDs globally unique.
         attrs["dataset_id"] = Column(Text, nullable=False, unique=True)
-        # Per-dataset metadata (md5, num_reactions, submitted_at) lives in public.datasets,
-        # populated at ingest so every dataset has its metadata row.
+        # Per-dataset metadata (md5, num_reactions, submitted_at) lives in
+        # public.datasets, populated at ingest so every dataset has its metadata row.
         attrs["metadata_row"] = relationship(
             "DatasetMetadata", uselist=False, cascade="all, delete-orphan"
         )
     elif message_type == reaction_pb2.Reaction:
         # Make reaction IDs globally unique.
         attrs["reaction_id"] = Column(Text, nullable=False, unique=True)
-        # The served proto lives in public.reactions; generated SMILES / RDKit links in the
-        # derived schema. See public_mappers.ReactionProto, derived_mappers.ReactionSmiles.
+        # The served proto lives in public.reactions; generated SMILES / RDKit links in
+        # the derived schema. See public_mappers.ReactionProto,
+        # derived_mappers.ReactionSmiles.
         attrs["proto_row"] = relationship(
             "ReactionProto", uselist=False, cascade="all, delete-orphan"
         )
@@ -270,7 +272,8 @@ def build_mapper(
             # Use get() to avoid column conflicts; see
             # https://docs.sqlalchemy.org/en/14/orm/inheritance.html#resolving-column-conflicts.
             #
-            # NOTE(skearnes): We are not enforcing unique constraints on this column; see the module docstring.
+            # NOTE(skearnes): We are not enforcing unique constraints on this column;
+            # see the module docstring.
             fk_name: table.c.get(
                 fk_name,
                 Column(Uuid, ForeignKey(foreign_key, ondelete="CASCADE")),
@@ -282,11 +285,12 @@ def build_mapper(
         child_class_name = f"_{parent_desc.name}{field_name.capitalize()}"
         logger.debug(f"Creating child mapper {child_class_name}: {child_attrs}")
         type(child_class_name, (mapper_class,), child_attrs)
-        # Partial index on the polymorphic foreign key. Under single-table inheritance this column
-        # is NULL for every row belonging to a sibling subclass, so indexing only the non-NULL rows
-        # keeps both the index and the per-insert index write proportional to the rows that actually
-        # reference this parent. A parent reused across fields shares one column and one index,
-        # created on first use. See derived_mappers for the same partial-index pattern.
+        # Partial index on the polymorphic foreign key. Under single-table inheritance
+        # this is NULL for every row belonging to a sibling subclass, so indexing only
+        # the non-NULL rows keeps both the index and the per-insert index write
+        # proportional to the rows that actually reference this parent. A parent reused
+        # across fields shares one column and one index, created on first use. See
+        # derived_mappers for the same partial-index pattern.
         index_name = f"ix_{table.name}_{fk_name}"
         if not any(index.name == index_name for index in table.indexes):
             Index(
@@ -302,8 +306,8 @@ _MAPPER_TO_MESSAGE: dict[type, type[Message]] = {
     value: key for key, value in _MESSAGE_TO_MAPPER.items()
 }
 
-# The generated SMILES and rdkit_*_id links, and the partial "unlinked" indexes that keep
-# incremental RDKit linking O(unlinked), live on the derived tables; see
+# The generated SMILES and rdkit_*_id links, and the partial "unlinked" indexes that
+# keep incremental RDKit linking O(unlinked), live on the derived tables; see
 # ord_schema.orm.derived_mappers and ord_schema/orm/README.md.
 
 
@@ -365,8 +369,9 @@ def from_proto(
             num_reactions=len(message.reactions) or len(message.reaction_ids),
         )
     elif isinstance(message, reaction_pb2.Reaction):
-        # Store the serialized proto (the served payload) in the public schema. The SMILES
-        # are computed from the search index afterward by database.update_derived_tables.
+        # Store the serialized proto (the served payload) in the public schema. The
+        # SMILES are computed from the search index afterward by
+        # database.update_derived_tables.
         kwargs["proto_row"] = ReactionProto(
             proto=message.SerializeToString(deterministic=True)
         )

--- a/ord_schema/orm/reaction_class.py
+++ b/ord_schema/orm/reaction_class.py
@@ -32,8 +32,9 @@ from ord_schema.orm.sharding import shard_predicate
 
 logger = get_logger(__name__)
 
-# Rxn-INSIGHT's "no named reaction" sentinel, normalized to NULL so reaction_name carries
-# no magic value. (The class catch-all "Miscellaneous" is a real category and is kept.)
+# Rxn-INSIGHT's "no named reaction" sentinel, normalized to NULL so reaction_name
+# carries no magic value. (The class catch-all "Miscellaneous" is a real category
+# and is kept.)
 _UNNAMED = "OtherReaction"
 
 
@@ -53,7 +54,8 @@ def classify_reaction_smiles(
     try:
         info = Reaction(reaction_smiles, rxn_mapper=rxn_mapper).get_reaction_info()
     except Exception as error:  # noqa: BLE001
-        # Best-effort: any Rxn-INSIGHT/rxnmapper failure leaves the reaction unclassified.
+        # Best-effort: any Rxn-INSIGHT/rxnmapper failure leaves the reaction
+        # unclassified.
         logger.debug(f"Could not classify {reaction_smiles!r}: {error}")
         return None, None
     reaction_class = info.get("CLASS") or None

--- a/ord_schema/parquet_test.py
+++ b/ord_schema/parquet_test.py
@@ -283,7 +283,8 @@ def test_writer_publishes_atomically(tmp_path):
 def test_writer_aborts_on_exception_in_context(tmp_path):
     """An exception in the with-body must leave neither destination nor temp behind."""
     path = tmp_path / "ds.parquet"
-    with (  # noqa: PT012  (abort-on-exception test: the multi-statement body in the context is under test)
+    # (abort-on-exception test: the multi-statement body in the context is under test)
+    with (  # noqa: PT012
         pytest.raises(RuntimeError, match="boom"),
         dataset.DatasetWriter(path, name="n", description="d") as writer,
     ):
@@ -295,7 +296,8 @@ def test_writer_aborts_on_exception_in_context(tmp_path):
 def test_writer_aborts_on_keyboard_interrupt_in_context(tmp_path):
     """KeyboardInterrupt in the with-body also triggers _abort and leaves no temp behind."""
     path = tmp_path / "ds.parquet"
-    with (  # noqa: PT012  (abort-on-exception test: the multi-statement body in the context is under test)
+    # (abort-on-exception test: the multi-statement body in the context is under test)
+    with (  # noqa: PT012
         pytest.raises(KeyboardInterrupt),
         dataset.DatasetWriter(path, name="n", description="d") as writer,
     ):
@@ -310,7 +312,8 @@ def test_writer_aborts_preserves_existing_destination(tmp_path):
     dataset.save_dataset(_make_dataset(n=2, name="old", description="old desc"), path)
     with path.open("rb") as f:
         original_bytes = f.read()
-    with (  # noqa: PT012  (abort-on-exception test: the multi-statement body in the context is under test)
+    # (abort-on-exception test: the multi-statement body in the context is under test)
+    with (  # noqa: PT012
         pytest.raises(RuntimeError, match="boom"),
         dataset.DatasetWriter(path, name="new", description="new desc") as writer,
     ):

--- a/ord_schema/scripts/parse_uspto.py
+++ b/ord_schema/scripts/parse_uspto.py
@@ -150,7 +150,8 @@ def resolve_units(value: str) -> ord_schema.UnitMessage:
 def get_component_map(root: ET.Element) -> dict[str, str]:
     """Builds a mapping of components to inputs."""
     reaction_inputs = {}
-    # NOTE(skearnes): ``ElementTree.Element.find`` returns ``None`` when no child matches.
+    # NOTE(skearnes): ``ElementTree.Element.find`` returns ``None`` when no child
+    # matches.
     # We treat a missing section as "no components" (via ``or []``) rather than raising;
     # CML files occasionally omit empty sections and we don't want to abort parsing
     # the whole reaction over it.

--- a/ord_schema/scripts/process_dataset.py
+++ b/ord_schema/scripts/process_dataset.py
@@ -122,7 +122,8 @@ def cleanup(filename: str, output_filename: str) -> None:
     else:
         args = ["git", "mv", filename, output_filename]
     logger.info("Running command: %s", " ".join(args))
-    subprocess.run(args, check=True)  # noqa: S603  (internal command, no untrusted input)
+    # (internal command, no untrusted input)
+    subprocess.run(args, check=True)  # noqa: S603
 
 
 def _get_reaction_ids(
@@ -159,7 +160,8 @@ def _load_base_dataset(
     else:
         git_args.append(f"{base}:{file_status.filename}")
     logger.info("Running command: %s", " ".join(git_args))
-    serialized = subprocess.run(git_args, capture_output=True, check=True, text=False)  # noqa: S603  (internal git command)
+    # (internal git command)
+    serialized = subprocess.run(git_args, capture_output=True, check=True, text=False)  # noqa: S603
     if serialized.stdout.startswith(b"version"):
         # Convert Git LFS pointers to real data.
         serialized = subprocess.run(
@@ -271,7 +273,8 @@ def _run_updates(
         # In-memory path: materialize a Parquet input if the requested output
         # format is not Parquet (so we can mutate via update_dataset).
         if isinstance(dataset, parquet.DatasetView):
-            dataset = parquet.load_dataset(input_filename)  # noqa: PLW2901  (materialize the view in place)
+            # (materialize the view in place)
+            dataset = parquet.load_dataset(input_filename)  # noqa: PLW2901
         updates.update_dataset(dataset)
         validations.validate_datasets(
             {input_filename: dataset}, write_errors, options=options

--- a/ord_schema/scripts/process_dataset_test.py
+++ b/ord_schema/scripts/process_dataset_test.py
@@ -200,7 +200,8 @@ class TestProcessParquetDataset:
             filename,
             "--root",
             tmp_path.as_posix(),
-            "--no-validate",  # Skip the pre-update validation so we hit the post-stream path.
+            # Skip the pre-update validation so we hit the post-stream path.
+            "--no-validate",
             "--update",
             "--output_format",
             ".parquet",

--- a/ord_schema/units_test.py
+++ b/ord_schema/units_test.py
@@ -287,7 +287,8 @@ def test_convert_precision(resolver, message, new_units, expected):
 
 def test_convert_wavelength_with_precision(resolver):
     # Expected per the implementation's documented formula:
-    # 10000000 / 2 * (1 / (value - precision) + 1 / (value + precision))  # noqa: ERA001  (documented formula)
+    # (documented formula)
+    # 10000000 / 2 * (1 / (value - precision) + 1 / (value + precision))  # noqa: ERA001
     # = 5e6 * (1/490 + 1/510) ≈ 20008.0032.
     converted = resolver.convert(
         reaction_pb2.Wavelength(

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -25,7 +25,8 @@ from typing import Any
 from dateutil import parser
 from rdkit import Chem
 from rdkit import (
-    __version__ as RDKIT_VERSION,  # noqa: N812  (RDKIT_VERSION reads better than rdkit_version)
+    # (RDKIT_VERSION reads better than rdkit_version)
+    __version__ as RDKIT_VERSION,  # noqa: N812
 )
 
 import ord_schema

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -24,7 +24,8 @@ from ord_schema.proto import dataset_pb2, reaction_pb2
 
 @pytest.fixture(autouse=True)
 def setup():
-    # Redirect warning messages to stdout so they can be filtered from the other test output.
+    # Redirect warning messages to stdout so they can be filtered from the other
+    # test output.
     original_showwarning = warnings.showwarning
 
     def _showwarning(message, category, filename, lineno, file=None, line=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,11 @@ ignore = [
     # (assert x is not None  # Type hint); not a security concern here.
     "S101",
     "FIX002",                # TODO comments are allowed
-    "E501",    # Line length is enforced by the formatter, not the linter.
+    # E501 (line too long): the formatter wraps code to `line-length`, but it does
+    # not reflow comments or string literals, so enforcing E501 would flag long
+    # comments/URLs the formatter can't fix. Left off; comments are kept in line by
+    # convention, not the linter.
+    "E501",
     # B028 (missing stacklevel= on warnings.warn): the ~103 sites in
     # validations.py are data-validation messages collected into ValidationOutput,
     # not deprecation/misuse warnings -- there is no caller location worth pointing


### PR DESCRIPTION
## What

Reflows ~108 code comments that exceeded the project's 88-character line-length limit, across 20 files, and corrects a misleading rationale in `pyproject.toml`.

## Why

`ruff format` wraps *code* to `line-length`, but it never reflows comments or string literals — and `E501` is disabled in this repo — so over-length comments accumulated with nothing to catch them. This is a one-time manual pass (the formatter can't do it, by design).

## Scope

- **Comment-only changes.** Verified mechanically: the non-comment token stream of every changed `.py` file is byte-for-byte identical to `main`. No code, strings, or docstrings were altered — only where line breaks fall inside comments.
- Full-line comments rewrapped at word boundaries; a few trailing comments lifted to their own line above the code. `# noqa` / `# ty: ignore` directives were kept on their code line (moving them would silently disable the suppression).
- **14 lines remain >88 by necessity** and can't be fixed without editing code: 3 bare documentation URLs longer than 88 chars on their own, and 11 code lines carrying a mandatory same-line `# noqa` / `# ty: ignore` directive where the code alone leaves no room.

## pyproject.toml

The old note said line length was "enforced by the formatter, not the linter" — but the formatter doesn't touch comments or strings, which is exactly why long comments slipped through. The `E501` comment now states that accurately and notes comments are kept in line by convention.

## Verification

- `ruff check .` (v0.15.10) — passes
- `ruff format --check .` (v0.15.10) — all formatted
- `ty check` — 43 diagnostics, unchanged from `main` (no new type issues)
- pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reflows long comments and clarifies the line-length lint note.

- Wrapped long Python comments across tests, ORM code, scripts, and helpers.
- Kept same-line `# noqa` and `# ty: ignore` directives on their code lines.
- Updated the `E501` explanation in `pyproject.toml` without changing the ignore entry.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pyproject.toml | The `E501` rationale was rewritten as comments while the ignore-list entry stays unchanged. |
| docs/conf.py | The Sphinx `copyright` explanation moved to a preceding comment while the assignment and suppression remain unchanged. |
| ord_schema/orm/database.py | Long ORM comments and suppression explanations were reflowed without changing SQL or Python tokens. |
| ord_schema/scripts/process_dataset.py | Suppression explanations were moved to comments above the unchanged subprocess and dataset-loading calls. |
| ord_schema/units_test.py | The documented formula comment was rewrapped while preserving the same-line `ERA001` suppression. |
| ord_schema/validations.py | The RDKit version alias explanation was reflowed while preserving the import and `N812` suppression. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Wrap over-length comments in ord-schema ..."](https://github.com/open-reaction-database/ord-schema/commit/33a3e5e736a38cc3c55e964e0f68e3c9e3e7fbc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43462601)</sub>

<!-- /greptile_comment -->