### PR TITLE
Skip reconstruction for underivable compounds in derived-SMILES pass

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -43,6 +43,13 @@ _COMPOUND_IDENTIFIER_LOADERS = {
     reaction_pb2.CompoundIdentifier.INCHI: Chem.MolFromInchi,
     reaction_pb2.CompoundIdentifier.MOLBLOCK: Chem.MolFromMolBlock,
 }
+# Enum names of the identifier types a Mol can be built from, keyed off the loaders above
+# so callers (e.g. the derived-SMILES pass) share this module's single source of truth for
+# what "structural" means. These match the values stored in ord.compound_identifier.type.
+STRUCTURAL_IDENTIFIER_TYPES = frozenset(
+    reaction_pb2.CompoundIdentifier.CompoundIdentifierType.Name(identifier_type)
+    for identifier_type in _COMPOUND_IDENTIFIER_LOADERS
+)
 MessageType = TypeVar("MessageType")  # Generic for setting return types
 
 

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -55,6 +55,20 @@ _BENZENE_MOLBLOCK = """241
 M  END"""
 
 
+def test_structural_identifier_types():
+    """STRUCTURAL_IDENTIFIER_TYPES names exactly the types _COMPOUND_IDENTIFIER_LOADERS can load."""
+    assert {
+        "SMILES",
+        "INCHI",
+        "MOLBLOCK",
+    } == message_helpers.STRUCTURAL_IDENTIFIER_TYPES
+    expected = {
+        reaction_pb2.CompoundIdentifier.CompoundIdentifierType.Name(identifier_type)
+        for identifier_type in message_helpers._COMPOUND_IDENTIFIER_LOADERS
+    }
+    assert expected == message_helpers.STRUCTURAL_IDENTIFIER_TYPES
+
+
 class TestMessageHelpers:
     @pytest.mark.parametrize(
         ("filename", "expected"),

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -755,10 +755,14 @@ def _update_compound_smiles(
     The common case -- a compound with a stored SMILES identifier -- is served set-based: the
     first SMILES identifier for each compound in the batch is fetched from ord.compound_identifier
     in a single query and canonicalized with RDKit, avoiding a per-compound ORM load. Compounds
-    without a stored SMILES fall back to reconstructing the message via to_proto and computing the
-    SMILES from its other identifiers. Ids are resolved up front and processed in batches of
-    _DERIVED_BATCH so memory stays bounded. ``shard`` (index, num_shards) restricts to one disjoint
-    hash-partition of this table's ids so large datasets can be split across workers.
+    without a stored SMILES but with some other structural identifier (INCHI/MOLBLOCK) fall back to
+    reconstructing the message via to_proto and computing the SMILES from those identifiers; a second
+    set-based query flags which batch ids carry any structural identifier at all, so a compound with
+    only non-structural identifiers (e.g. NAME) -- which never yields a derived row and is therefore
+    re-selected every run -- is skipped without the ORM load plus to_proto that is certain to raise.
+    Ids are resolved up front and processed in batches of _DERIVED_BATCH so memory stays bounded.
+    ``shard`` (index, num_shards) restricts to one disjoint hash-partition of this table's ids so
+    large datasets can be split across workers.
 
     ``reaction_joins`` are the disjoint join paths from ``compound_table`` to ord.reaction; one id
     query runs per path and the results are concatenated. See _COMPOUND_REACTION_JOINS.
@@ -800,6 +804,19 @@ def _update_compound_smiles(
           AND ord.compound_identifier.type = 'SMILES'
         ORDER BY ord.compound_identifier.{derived_id}, ord.compound_identifier.id
         """).bindparams(bindparam("ids", expanding=True))  # noqa: S608
+    # Ids in the batch that carry a non-empty structural identifier, i.e. one of the
+    # types smiles_from_compound can build a Mol from (see _COMPOUND_IDENTIFIER_LOADERS).
+    # A compound with only non-structural identifiers (e.g. NAME) can never yield a SMILES,
+    # so the reconstruction fallback below is skipped for it -- keeping the re-attempt of a
+    # permanently underivable compound (no derived row is ever inserted, so it is re-selected
+    # every run) cheap instead of paying an ORM load plus to_proto that is certain to raise.
+    select_structural = text(f"""
+        SELECT DISTINCT ord.compound_identifier.{derived_id}
+        FROM ord.compound_identifier
+        WHERE ord.compound_identifier.{derived_id} IN :ids
+          AND ord.compound_identifier.type IN ('SMILES', 'INCHI', 'MOLBLOCK')
+          AND ord.compound_identifier.value <> ''
+        """).bindparams(bindparam("ids", expanding=True))  # noqa: S608
     insert_smiles = text(
         f"INSERT INTO {derived_table} ({derived_id}, smiles) "  # noqa: S608
         f"VALUES (:{derived_id}, :smiles)"
@@ -813,6 +830,9 @@ def _update_compound_smiles(
         batch_ids = compound_ids[batch_start : batch_start + _DERIVED_BATCH]
         stored_smiles = {
             row[0]: row[1] for row in session.execute(select_smiles, {"ids": batch_ids})
+        }
+        derivable = {
+            row[0] for row in session.execute(select_structural, {"ids": batch_ids})
         }
         inserts = []
         for compound_id in batch_ids:
@@ -831,6 +851,10 @@ def _update_compound_smiles(
                     )
                     continue
                 smiles = Chem.MolToSmiles(mol)
+            elif compound_id not in derivable:
+                # Only non-structural identifiers: smiles_from_compound would raise, so
+                # skip the reconstruction (see select_structural).
+                continue
             else:
                 # No stored SMILES: reconstruct the message and derive from other
                 # identifiers.

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -805,18 +805,23 @@ def _update_compound_smiles(
         ORDER BY ord.compound_identifier.{derived_id}, ord.compound_identifier.id
         """).bindparams(bindparam("ids", expanding=True))  # noqa: S608
     # Ids in the batch that carry a non-empty structural identifier, i.e. one of the
-    # types smiles_from_compound can build a Mol from (see _COMPOUND_IDENTIFIER_LOADERS).
-    # A compound with only non-structural identifiers (e.g. NAME) can never yield a SMILES,
-    # so the reconstruction fallback below is skipped for it -- keeping the re-attempt of a
-    # permanently underivable compound (no derived row is ever inserted, so it is re-selected
-    # every run) cheap instead of paying an ORM load plus to_proto that is certain to raise.
+    # types smiles_from_compound can build a Mol from. A compound with only non-structural
+    # identifiers (e.g. NAME) can never yield a SMILES, so the reconstruction fallback below
+    # is skipped for it -- keeping the re-attempt of a permanently underivable compound (no
+    # derived row is ever inserted, so it is re-selected every run) cheap instead of paying an
+    # ORM load plus to_proto that is certain to raise. The type list is bound from
+    # message_helpers.STRUCTURAL_IDENTIFIER_TYPES so it tracks the loaders that back the
+    # reconstruction, rather than a hand-maintained literal that could drift from them.
     select_structural = text(f"""
         SELECT DISTINCT ord.compound_identifier.{derived_id}
         FROM ord.compound_identifier
         WHERE ord.compound_identifier.{derived_id} IN :ids
-          AND ord.compound_identifier.type IN ('SMILES', 'INCHI', 'MOLBLOCK')
+          AND ord.compound_identifier.type IN :structural_types
           AND ord.compound_identifier.value <> ''
-        """).bindparams(bindparam("ids", expanding=True))  # noqa: S608
+        """).bindparams(  # noqa: S608
+        bindparam("ids", expanding=True),
+        bindparam("structural_types", expanding=True),
+    )
     insert_smiles = text(
         f"INSERT INTO {derived_table} ({derived_id}, smiles) "  # noqa: S608
         f"VALUES (:{derived_id}, :smiles)"
@@ -832,7 +837,16 @@ def _update_compound_smiles(
             row[0]: row[1] for row in session.execute(select_smiles, {"ids": batch_ids})
         }
         derivable = {
-            row[0] for row in session.execute(select_structural, {"ids": batch_ids})
+            row[0]
+            for row in session.execute(
+                select_structural,
+                {
+                    "ids": batch_ids,
+                    "structural_types": list(
+                        message_helpers.STRUCTURAL_IDENTIFIER_TYPES
+                    ),
+                },
+            )
         }
         inserts = []
         for compound_id in batch_ids:

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -400,6 +400,62 @@ def test_compound_smiles_fallback_without_stored_smiles(prepared_engine):
     assert fallback_smiles == [expected], fallback_smiles
 
 
+def test_underivable_compound_skips_reconstruction(prepared_engine, monkeypatch):
+    """A compound with only non-structural identifiers is not reconstructed each run.
+
+    Such a compound never yields a derived row, so the NOT EXISTS guard re-selects it on every
+    derived pass. The set-based structural pre-filter must skip it before the expensive
+    session.get + to_proto fallback (which would raise ValueError anyway); otherwise a database of
+    underivable compounds pays a full reconstruction pass for zero new rows on every re-run.
+    """
+    dataset = load_dataset(
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+    )
+    # Strip one compound down to a NAME-only identifier so it has no structural identifier
+    # to derive a SMILES from; every other compound keeps its SMILES fast path.
+    compound = next(
+        component
+        for reaction in dataset.reactions
+        for reaction_input in reaction.inputs.values()
+        for component in reaction_input.components
+    )
+    del compound.identifiers[:]
+    compound.identifiers.add(
+        type=reaction_pb2.CompoundIdentifier.NAME, value="mystery reagent"
+    )
+    to_proto_calls = []
+    real_to_proto = _orm_database.to_proto
+
+    def _spy_to_proto(mapper):
+        to_proto_calls.append(mapper)
+        return real_to_proto(mapper)
+
+    monkeypatch.setattr(_orm_database, "to_proto", _spy_to_proto)
+    with Session(prepared_engine) as session:
+        with session.begin():
+            add_dataset(dataset, session)
+        with session.begin():
+            update_derived_tables(dataset.dataset_id, session)
+        underivable = (
+            session.execute(
+                text(
+                    "SELECT count(*) FROM ord.compound c "
+                    "WHERE NOT EXISTS (SELECT 1 FROM ord.compound_identifier ci "
+                    "WHERE ci.compound_id = c.id AND ci.type != 'NAME') "
+                    "AND NOT EXISTS (SELECT 1 FROM derived.compound_smiles cs "
+                    "WHERE cs.compound_id = c.id)"
+                )
+            )
+            .scalars()
+            .one()
+        )
+    # The NAME-only compound derives nothing (no derived row) ...
+    assert underivable == 1, underivable
+    # ... and the every-compound-has-SMILES fixture plus the pre-filter mean the
+    # reconstruction fallback never runs, so to_proto is not called at all.
+    assert to_proto_calls == [], to_proto_calls
+
+
 # Counts every ord.compound by how it reaches its reaction, alongside how many of
 # those rows made it into derived.compound_smiles and how many of those are still
 # missing an rdkit.mols link. [Ti+5] structures are excluded from the unlinked tally


### PR DESCRIPTION
## Problem

`_update_compound_smiles` re-selects every compound lacking a derived row on each `--stages derived` run (the `NOT EXISTS` guard). A compound with only non-structural identifiers (e.g. only `NAME`) never yields a derived row, so it is re-attempted *forever* through the expensive fallback: `session.get` → `to_proto` → `smiles_from_compound`, which is certain to raise `ValueError` and insert nothing.

On production data (`ord_20260702`) that is ~800k `ord.compound` + ~68k `ord.product_compound` reconstructed for **zero new rows** on every re-run — the derive phase spent 25+ minutes doing exactly this with nothing changing.

## Fix (option 1 from the issue — cheap pre-filter)

Add a set-based structural pre-filter alongside the existing SMILES query: a second per-batch query flags which batch ids carry a non-empty `SMILES`/`INCHI`/`MOLBLOCK` identifier — exactly the types in `_COMPOUND_IDENTIFIER_LOADERS` that `smiles_from_compound` can build a `Mol` from. An id without one skips the reconstruction fallback, turning each wasted re-attempt from an ORM load + proto rebuild into a set-membership check (one extra indexed query per 1000-compound batch).

Properties:
- **Conservative:** only compounds with *zero* structural identifiers are skipped, so nothing potentially derivable is ever dropped. Value parity of the fast/fallback paths is unchanged (`test_compound_smiles_match_reference` / `..._fallback_without_stored_smiles` still pass).
- **Persists nothing** (not the option-2 tombstone): the derivability check is recomputed from `ord.compound_identifier` every run, so a later resolver/backfill that adds a structural identifier (picked up next run) or writes straight into `derived.compound_smiles` (excluded by the existing `NOT EXISTS`) works without interference.

Covers the `compound` and `product_compound` paths. The reaction-SMILES pass (~9.7k re-attempts) reconstructs the full reaction proto regardless and is small enough to leave as-is.

## Test

`test_underivable_compound_skips_reconstruction` strips one fixture compound to a `NAME`-only identifier and asserts (a) it produces no derived row and (b) `to_proto` is never called — the regression guard for the reconstruction skip.

Closes #899

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR skips wasted compound-SMILES reconstruction for compounds that cannot be structurally derived. The main changes are:

- Adds a shared structural identifier type set from the molecule loaders.
- Queries each batch for compounds with SMILES, INCHI, or MOLBLOCK identifiers.
- Skips fallback reconstruction for compounds with only non-structural identifiers.
- Adds tests for the shared type set and the NAME-only skip behavior.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/message_helpers.py | Adds a shared set of structural identifier names derived from the existing molecule loader map. |
| ord_schema/orm/database.py | Adds a batch-level structural identifier check before running the compound reconstruction fallback. |
| ord_schema/message_helpers_test.py | Adds coverage that the structural identifier set matches the loader-backed identifier types. |
| ord_schema/orm/database_test.py | Adds coverage that NAME-only compounds produce no derived row and skip reconstruction. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Derive structural identifier types from ..."](https://github.com/open-reaction-database/ord-schema/commit/ff42f18d377e803b25961de284b0774890b4b1ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43465467)</sub>

<!-- /greptile_comment -->