### PR TITLE
Add markdown linting and a load_message Parquet guard

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -24,9 +25,10 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -70,3 +70,14 @@ jobs:
         run: |
           sudo apt update && sudo apt install clang-format --yes
           find . -name '*.proto' -exec clang-format -n -Werror --style=file {} +
+
+  check_markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+      - name: markdownlint-cli2
+        # Pinned to the same version as the pre-commit hook so CI and local runs agree.
+        run: npx --yes markdownlint-cli2@0.23.1 "**/*.md"

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# markdownlint-cli2 configuration. Rule reference:
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+config:
+  # Prose is hand-wrapped at varying widths and tables/links routinely exceed any
+  # fixed column; a line-length cap would be churn with no readability gain.
+  MD013: false
+  # `$ ` prompts in shell blocks are an intentional convention in the READMEs.
+  MD014: false
+  # House style: dash bullets, asterisk emphasis/strong. Pin the styles so the
+  # linter enforces them rather than inferring from whichever file it sees first.
+  MD004:
+    style: dash
+  MD049:
+    style: asterisk
+  MD050:
+    style: asterisk

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -14,6 +14,9 @@
 
 # markdownlint-cli2 configuration. Rule reference:
 # https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+# Skip anything git ignores (e.g. vendored Markdown under node_modules).
+gitignore: true
 config:
   # Prose is hand-wrapped at varying widths and tables/links routinely exceed any
   # fixed column; a line-length cap would be churn with no readability gain.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,8 @@ repos:
     hooks:
       - id: clang-format
         types_or: [proto]
+
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.23.1
+    hooks:
+      - id: markdownlint-cli2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Excellent! There are a few steps you'll need to follow to get ready to submit ch
        pre-commit install
        ```
 
-       Hooks run `addlicense`, Ruff (`ruff-check` with fixes + `ruff-format`), `ty check ord_schema` (same scope as CI Lint), and `clang-format` on `.proto` files. Example notebooks under `examples/` are not type-checked by `ty`; they are covered by the notebook test job (`treon`).
+       Hooks run `addlicense`, Ruff (`ruff-check` with fixes + `ruff-format`), `ty check ord_schema` (same scope as CI Lint), `clang-format` on `.proto` files, and `markdownlint-cli2` on Markdown. Example notebooks under `examples/` are not type-checked by `ty`; they are covered by the notebook test job (`treon`).
 
        If you'd rather not use pre-commit, you can run the same checks by hand:
 
@@ -66,6 +66,8 @@ Excellent! There are a few steps you'll need to follow to get ready to submit ch
        uv run ty check ord_schema
        # License headers (requires Go + github.com/google/addlicense@v1.2.0):
        addlicense -c "Open Reaction Database Project Authors" -l apache .
+       # Markdown (requires Node; matches the markdownlint-cli2 pre-commit hook and CI):
+       npx --yes markdownlint-cli2@0.23.1 "**/*.md"
        ```
 
     1. Create a new branch and make your changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,9 @@
 
 Thanks for helping out! What would you like to do?
 
-* [Report an issue](#report-an-issue)
-* [Suggest an improvement](#suggest-an-improvement)
-* [Make a change](#make-a-change)
+- [Report an issue](#report-an-issue)
+- [Suggest an improvement](#suggest-an-improvement)
+- [Make a change](#make-a-change)
 
 ## Report an issue
 
@@ -49,14 +49,17 @@ Excellent! There are a few steps you'll need to follow to get ready to submit ch
     1. Create a fork of `ord-schema` (click "Fork" at the top-right of this page) and clone it to your local machine
        ([instructions](https://help.github.com/en/github/getting-started-with-github/fork-a-repo)).
     1. Sync the dev environment (needed for the `ty` hook) and install [pre-commit](https://pre-commit.com/):
+
        ```shell
        uv sync --extra tests
        pip install pre-commit
        pre-commit install
        ```
+
        Hooks run `addlicense`, Ruff (`ruff-check` with fixes + `ruff-format`), `ty check ord_schema` (same scope as CI Lint), and `clang-format` on `.proto` files. Example notebooks under `examples/` are not type-checked by `ty`; they are covered by the notebook test job (`treon`).
 
        If you'd rather not use pre-commit, you can run the same checks by hand:
+
        ```shell
        uv run ruff check --fix .
        uv run ruff format .
@@ -64,6 +67,7 @@ Excellent! There are a few steps you'll need to follow to get ready to submit ch
        # License headers (requires Go + github.com/google/addlicense@v1.2.0):
        addlicense -c "Open Reaction Database Project Authors" -l apache .
        ```
+
     1. Create a new branch and make your changes.
     1. Test your changes by syncing the environment and running the test suite, for example:
        `uv sync --extra tests` then `uv run pytest` (or `pytest` after activating the `.venv` that `uv` creates).
@@ -96,7 +100,8 @@ and tag to `main`, and creates a GitHub release with generated notes.
 By submitting Contributions (as defined below) to this project, you agree that
 You (as defined below) and your Contributions are bound to the following terms.
 
-<p align="center">Open Reaction Database Project License Agreement</p> 
+<!-- markdownlint-disable-next-line MD033 -- centered title; markdown has no equivalent -->
+<p align="center">Open Reaction Database Project License Agreement</p>
 
 In order to clarify the intellectual property license granted with Contributions
 to the Open Access Reaction Database from any person or entity, You must

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PyPI version](https://badge.fury.io/py/ord-schema.svg)](https://badge.fury.io/py/ord-schema)
 
 This repository contains the schema for the Open Reaction Database initiative; please see the documentation
-at https://docs.open-reaction-database.org.
+at <https://docs.open-reaction-database.org>.
 
 This repository does not contain the database itself; that is stored
 in [ord-data](https://github.com/open-reaction-database/ord-data). Rather, `ord-schema` is
@@ -21,7 +21,7 @@ message/Parquet I/O). Heavier, single-purpose features live behind optional
 extras so the default install stays lightweight:
 
 | Extra | Enables | Install |
-|-------|---------|---------|
+| ------- | --------- | --------- |
 | `huggingface` | `ord_schema.huggingface.fetch_dataset`: download datasets from the Hugging Face [ord-data](https://huggingface.co/datasets/open-reaction-database/ord-data) mirror | `pip install "ord-schema[huggingface]"` |
 | `orm` | `ord_schema.orm`: map the schema into a relational (SQLAlchemy + PostgreSQL) database | `pip install "ord-schema[orm]"` |
 | `github` | the GitHub-issue submission flow in `ord_schema.scripts.process_dataset` | `pip install "ord-schema[github]"` |
@@ -68,16 +68,18 @@ and run `./compile_proto_wrappers.sh` to rebuild the wrappers.
 
 ### 1. convention: compound stoichiometry
 
-##### Created: 2023.07.04
+#### Created: 2023.07.04
 
-##### Last updated: 2023.07.04
+#### Last updated: 2023.07.04
 
-##### Description: 
+#### Description
+
 1. The preferred field for compound stoichiometry is the map `Compound.features` or `ProductCompound.features`.
 2. The key should be "stoichiometric_coefficient" or "stoichiometric_ratio".
-3. The value should be a `Data` message with its `float_value` representing the compound's stoichiometric 
+3. The value should be a `Data` message with its `float_value` representing the compound's stoichiometric
 coefficient or ratio.
 
-##### Related links: 
-[#683](https://github.com/open-reaction-database/ord-schema/issues/683) 
+#### Related links
+
+[#683](https://github.com/open-reaction-database/ord-schema/issues/683)
 [#684](https://github.com/open-reaction-database/ord-schema/pull/684)

--- a/js/ord-schema-protobufjs/README.md
+++ b/js/ord-schema-protobufjs/README.md
@@ -1,3 +1,3 @@
 # JavaScript wrappers for the Open Reaction Database schema
 
-See https://open-reaction-database.org for more information.
+See <https://open-reaction-database.org> for more information.

--- a/js/ord-schema/README.md
+++ b/js/ord-schema/README.md
@@ -1,3 +1,3 @@
 # JavaScript wrappers for the Open Reaction Database schema
 
-See https://open-reaction-database.org for more information.
+See <https://open-reaction-database.org> for more information.

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -831,10 +831,16 @@ def load_message(
         Message object.
 
     Raises:
-        ValueError: if the message cannot be parsed, or if `input_format` is not
-            supported.
+        ValueError: if the message cannot be parsed, if ``filename`` is a Parquet
+            dataset (use ``datasets.load_dataset``), or if the format is unsupported.
     """
     path = pathlib.Path(filename)
+    if path.suffix == ".parquet":
+        raise ValueError(
+            f"{path} is a Parquet dataset; load_message reads a single serialized "
+            "message. Use ord_schema.datasets.load_dataset for the whole Dataset, or "
+            "ord_schema.parquet.DatasetView / iter_reactions to stream large ones."
+        )
     this_open = gzip.open if path.suffix == ".gz" else open
     input_format = _message_format(path)
     mode = "rb" if input_format in _BINARY_FORMATS else "rt"

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -593,6 +593,11 @@ class TestLoadAndSaveMessage:
             with pytest.raises(ValueError, match='no field named "values"'):
                 message_helpers.load_message(f.name, test_pb2.Nested)
 
+    def test_load_message_parquet_points_to_load_dataset(self):
+        """load_message rejects a Parquet dataset and names the dataset-level loader."""
+        with pytest.raises(ValueError, match="load_dataset"):
+            message_helpers.load_message("dataset.parquet", test_pb2.Scalar)
+
     def test_bad_suffix(self):
         message = test_pb2.RepeatedScalar(values=[1.2, 3.4])
         with pytest.raises(ValueError, match="not a valid MessageFormat"):

--- a/ord_schema/orm/README.md
+++ b/ord_schema/orm/README.md
@@ -10,7 +10,7 @@ relational database.
 ## Overview
 
 Conceptually, an ORM is an abstraction on top of a relational database that allows data to be manipulated using
-object-oriented programming techniques. In our case, every protocol buffer message has an associated _mapper_ that wraps
+object-oriented programming techniques. In our case, every protocol buffer message has an associated *mapper* that wraps
 a table in a relational database. For example, here is the definition of the `Mass` message in the [protocol buffer
 schema](https://github.com/open-reaction-database/ord-schema/blob/main/ord_schema/proto/reaction.proto), which is
 used as a subfield in the `Amount` message:
@@ -67,17 +67,17 @@ table.
 
 ### Database structure
 
-* Every message in the schema has an associated table in the database. `Mass` messages appear in the `mass` table,
+- Every message in the schema has an associated table in the database. `Mass` messages appear in the `mass` table,
   `ReactionInput` messages appear in the `reaction_input` table, etc.
-* Some message types appear in more than one context in the schema. For instance, `ReactionInput` appears as a field
+- Some message types appear in more than one context in the schema. For instance, `ReactionInput` appears as a field
   in both `Reaction` (as `Reaction.inputs`) and `ReactionWorkup` (as `ReactionWorkup.input`) messages. Every table in
   the database contains an `ord_schema_context` column that indicates the context of each message in the ORD schema.
-* Every database table has a unique `id` column that is used as the primary key and as the foreign key when defining
+- Every database table has a unique `id` column that is used as the primary key and as the foreign key when defining
   relationships between tables. This database-specific ID should not be confused with the `dataset_id` and `reaction_id`
   fields of `Dataset` and `Reaction`, respectively. Notably, the `CompoundPreparation` and `CrudeComponent` messages
-  refer to ORD reaction IDs (`reaction.reaction_id`, _not_ `reaction.id`); these are explicit ORD-level relationships
+  refer to ORD reaction IDs (`reaction.reaction_id`, *not* `reaction.id`); these are explicit ORD-level relationships
   that are not part of the database-specific relationship structure.
-* The ORM uses four schemas. `ord` holds the decomposed message tables — the search index, i.e. only the proto fields
+- The ORM uses four schemas. `ord` holds the decomposed message tables — the search index, i.e. only the proto fields
   plus the structural columns (`id`, the `ord_schema_context` discriminator, map `key`, and parent foreign keys).
   `public` holds API-facing data: `public.reactions` is the serialized `Reaction` proto keyed by `reaction_id`, and
   `public.datasets` holds per-dataset metadata (`md5` for change detection, `num_reactions` and `submitted_at` for
@@ -90,7 +90,7 @@ table.
   direct lookup into its RDKit object), while `rdkit.*` is deduplicated by SMILES because the parsed structures and
   fingerprints are expensive to recompute and store — i.e. deduplicate where the payload is expensive, store per-entity
   where it is cheap.
-* Partial indexes over not-yet-linked rows (`reaction_smiles_unlinked_index`, `compound_smiles_unlinked_index`, and
+- Partial indexes over not-yet-linked rows (`reaction_smiles_unlinked_index`, `compound_smiles_unlinked_index`, and
   `product_compound_smiles_unlinked_index`, on the `derived` SMILES tables) keep incremental RDKit linking fast. They
   index only the rows whose `rdkit_*_id` is still `NULL`, so the repeated "which of this dataset's rows still need
   linking?" queries stay proportional to the in-flight backlog rather than the full table. `prepare_database` creates
@@ -106,7 +106,7 @@ is required** — the derived/RDKit passes use `AS MATERIALIZED` common table ex
 introduced in PostgreSQL 12. There are a couple convenient installation methods (this list is not
 an endorsement of any particular provider):
 
-* Conda: [rdkit-postgresql](
+- Conda: [rdkit-postgresql](
   https://www.rdkit.org/docs/Install.html#installing-and-using-postgresql-and-the-rdkit-postgresql-cartridge-from-a-conda-environment)
 
 ```shell
@@ -124,7 +124,7 @@ pg_ctl -l "${HOME}/rdkit-postgresql-logfile" start
 psql -U <username> postgres -c 'CREATE DATABASE <database>;'
 ```
 
-* AWS: [Amazon Aurora PostgreSQL](
+- AWS: [Amazon Aurora PostgreSQL](
   https://aws.amazon.com/about-aws/whats-new/2020/09/amazon-aurora-postgresql-supports-rdkit-extension/)
 
 ### Initialize the database and tables


### PR DESCRIPTION
Two independent quality-of-life changes.

## Markdown linting

Adds a [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) pre-commit hook (`v0.23.1`) plus a `.markdownlint-cli2.yaml` config, and brings the tracked Markdown into conformance.

The config keeps the repo's intentional conventions rather than fighting them:

- **MD013** (line length) and **MD014** (`$ ` shell prompts) disabled — both are deliberate in the READMEs.
- House style pinned so the linter enforces one style instead of inferring it per file: dash bullets (**MD004**), asterisk emphasis/strong (**MD049**/**MD050**). The repo was previously mixed (`-` vs `*`, `_x_` vs `*x*`).

Conformance fixes across the 7 tracked `.md` files: blank lines around lists/headings/fenced code, consistent bullet and emphasis characters, wrapped bare URLs (`<https://…>`), padded table pipes, stripped trailing whitespace and heading punctuation, single trailing newline, and README's convention sub-labels demoted from `h5` to `h4` so heading levels increment by one. The one intentional inline HTML — a centered license-agreement title in `CONTRIBUTING.md` — keeps a scoped inline `MD033` disable rather than dropping the rule repo-wide.

`markdownlint-cli2` runs as a Node pre-commit hook (pre-commit bootstraps its own Node; no system dependency). It is also enforced in CI by a `check_markdown` job in the Lint workflow, pinned to the same version so CI and local runs agree, and both the hook and its by-hand equivalent are documented in `CONTRIBUTING.md` — so violations are caught even on the no-pre-commit path. Config lives in `.markdownlint-cli2.yaml` because markdownlint-cli2 does not read `pyproject.toml`.

## `load_message` Parquet guard

Calling `message_helpers.load_message(path, Dataset)` on a new-style `.parquet` dataset previously failed with a cryptic `'.parquet' is not a valid MessageFormat` from `_message_format`. Parquet holds a whole `Dataset`, not a single serialized message, so `load_message` legitimately can't read it.

It now detects the `.parquet` suffix up front and raises a `ValueError` naming the right entry point — `ord_schema.datasets.load_dataset` for the whole `Dataset`, or streaming `ord_schema.parquet.DatasetView` / `iter_reactions` for large ones. (No warning for `load_message(..., Dataset)` on other suffixes: `datasets.load_dataset` delegates there for non-parquet files, so it would fire on the supported path.)

## Verification

- `pre-commit run markdownlint-cli2 --all-files` passes; all pre-commit hooks pass on every commit. The `check_markdown` CI job runs the same linter (`npx markdownlint-cli2@0.23.1 "**/*.md"`).
- `pytest ord_schema/message_helpers_test.py` — 105 passed, including a new `test_load_message_parquet_points_to_load_dataset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds Markdown linting across pre-commit, CI, and contributor documentation, reformats tracked Markdown for compliance, and gives `load_message` callers explicit guidance when passed a Parquet dataset.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain, and the previously reported Markdown-check omission has been addressed in both CI and contributor documentation.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/cleanup.yml | Adds the CI Markdown lint job omitted by the earlier implementation. |
| .pre-commit-config.yaml | Registers the pinned markdownlint-cli2 pre-commit hook. |
| CONTRIBUTING.md | Documents the Markdown hook and its equivalent manual command, completing the previous review fix. |
| .markdownlint-cli2.yaml | Defines repository-wide Markdown lint rules and intentional style exceptions. |
| ord_schema/message_helpers.py | Rejects Parquet paths before message-format parsing and directs callers to dataset-level APIs. |
| ord_schema/message_helpers_test.py | Tests that Parquet inputs produce guidance toward the appropriate dataset loader. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Enforce markdown linting in CI and docum..."](https://github.com/open-reaction-database/ord-schema/commit/06409e5de19a0252218c21d58cbd54395da5020b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46880639)</sub>

<!-- /greptile_comment -->