### PR TITLE
Gate derived-SMILES coverage on a tolerance, not the first missing row

### DIFF
--- a/.claude/skills/orm-database-load/SKILL.md
+++ b/.claude/skills/orm-database-load/SKILL.md
@@ -140,15 +140,18 @@ gate on process status. What it checks:
     unparseable rows it also carries, and `min_scope_size` (default 50) absorbs a hypothetical
     tiny all-unparseable cell. Catches the single-dataset × single-path omission a corpus-wide
     or reaction-keyed count would dilute.
-  - **Partial** (completeness): SMILES derivation is **sharded** (one hash partition of a
-    >50k-reaction dataset's compound ids per worker, capped at 32). The loader raises on a
-    failed shard, but this gate does not trust that exit status: a failed shard leaves a cell
-    with `derived > 0` yet ~1/`num_shards` of it underived — tens of thousands of compounds at
-    ≥ ~3% of the cell, dwarfing the residue. A cell is flagged when its underived count clears
-    **both** an absolute floor (`max_cell_missing`, default 10000 — above any per-cell residue)
-    **and** a fraction (`min_gap_pct`, default 1 — below the smallest 1/32 shard hole).
-    Requiring both spares a small organometallic cell (high fraction, tiny absolute) and a huge
-    cell holding a little residue (large absolute, tiny fraction).
+  - **Partial** (completeness, **per dataset**): SMILES derivation is **sharded** (one
+    `hashtextextended` partition of a >50k-reaction dataset's compound ids per worker, capped at
+    32). The loader raises on a failed shard, but this gate does not trust that exit status. A
+    shard partitions the *whole dataset's* ids, so a failed shard removes ~1/`num_shards` of
+    **every** scope at once — a small scope's slice can be tiny in absolute terms while the
+    dataset-wide hole is enormous. So completeness rolls the cells up to the dataset: any shard
+    hole underives tens of thousands of a dataset's compounds (≥ 1/32 ≈ 3%), dwarfing the
+    whole-dataset residue (at most the corpus total). A dataset is flagged when its total
+    underived clears **both** an absolute floor (`max_dataset_missing`, default 10000 — above
+    any one dataset's residue) **and** a fraction (`min_gap_pct`, default 1 — below the smallest
+    1/32 hole). Requiring both spares an organometallic-heavy dataset (high fraction, small
+    absolute) and a huge dataset holding a little residue (large absolute, tiny fraction).
 
   Name-only compounds are excluded, so the printed `compounds > derived` gap does not count.
   Override any threshold with `-v NAME=N`.

--- a/.claude/skills/orm-database-load/SKILL.md
+++ b/.claude/skills/orm-database-load/SKILL.md
@@ -146,15 +146,17 @@ gate on process status. What it checks:
     at all. The loader raises on a failed shard, but this gate does not trust that exit status.
     A failed shard leaves **exactly one hash bucket wholly underived** — parseable compounds
     included — while the unparseable residue spreads uniformly across every bucket (parseability
-    is uncorrelated with the id hash) and so can never empty one. The check recomputes each
-    dataset's `num_shards`, buckets its structural compounds by the same hash, and judges an
-    empty bucket against its **sibling buckets**: they measure how often this dataset's
-    identifiers legitimately fail to derive, so the bucket is flagged when the siblings make
-    "every one of mine missed by chance" implausible (probability < `max_false_positive`,
-    default `1e-6`). Judging by **shape** against siblings rather than by size needs no
-    residue-calibrated tolerance and keeps a *sparse* hole visible — a dataset shards on its
-    reaction count, so a name-heavy one just over the threshold may hold only a handful of
-    structural compounds per bucket, which any absolute floor would ignore. `shard_size` /
+    is uncorrelated with the id hash) and so can never empty one. The same shard writes that
+    dataset's **reaction** SMILES in the same transaction under the same hash, so its reaction
+    bucket is empty too. The check recomputes each dataset's `num_shards`, buckets both tables by
+    that hash, and judges an empty bucket against its **sibling buckets**: they measure how often
+    this dataset's rows legitimately fail to derive, so the bucket is flagged when the siblings
+    make "every one of mine missed by chance" implausible (combined probability <
+    `max_false_positive`, default `1e-6`). Using **both** tables is what keeps a *sparse* hole
+    visible: sharding is chosen by **reaction** count, so every bucket of a sharded dataset holds
+    thousands of reactions even when a name-heavy one leaves only a handful of structural
+    compounds there — the reaction evidence is strongest exactly where the compound evidence is
+    weakest, and no absolute floor over either table alone spans both. `shard_size` /
     `shard_cap` mirror the loader's constants — keep them in step if those change.
 
   Name-only compounds are excluded, so the printed `compounds > derived` gap does not count.

--- a/.claude/skills/orm-database-load/SKILL.md
+++ b/.claude/skills/orm-database-load/SKILL.md
@@ -124,23 +124,27 @@ Run `scripts/verify_coverage.sql` against the candidate database. Under
 `psql -v ON_ERROR_STOP=1` a violated invariant exits non-zero, so a cutover wrapper can
 gate on process status. What it checks:
 
-- **Coverage** (enforced per scope): every compound carrying a structural identifier
-  (SMILES/InChI/MolBlock) should have a derived SMILES row. Checked **per attachment scope** —
-  `ord.compound` split by reaction input, **workup** input, and **product measurement** (three
-  attachments easy to lose to a join that only follows `reaction_input.reaction_id`), plus
-  `ord.product_compound` (reaction products) — so a low-volume path omitted from derivation
-  fails on its own ~100% miss rate rather than being diluted by a corpus-wide count. Each scope
-  fails only above a small tolerance (default 0.1%), tolerating the RDKit-unparseable residual
-  every real load carries (~0.02%: organometallics, charged-N rings — a structural identifier
-  the load-time RDKit cannot parse or reconstruct). Name-only compounds are excluded, so the
-  printed `compounds > derived` gap does not count. Lower the tolerance to tighten the gate.
-- **Per-dataset derivation** (enforced): the per-scope check still spreads a single dataset's
-  rows across each path, so a small dataset omitted from the derive pass entirely could stay
-  under the tolerance in every path (parity only proves its reactions were *ingested*, and the
-  unlinked check can't see rows that were never derived). The derive pass writes compound and
-  reaction SMILES together per dataset, so a separate check flags any dataset with fewer than
-  half its reactions derived — a full omission is ~100%, while the reaction residual stays well
-  under half.
+- **Coverage** (enforced per dataset × scope): every compound carrying a structural identifier
+  (SMILES/InChI/MolBlock) should have a derived SMILES row. Checked **per (dataset, attachment
+  scope) cell** — `ord.compound` split by reaction input, **workup** input, and **product
+  measurement** (three attachments easy to lose to a join that only follows
+  `reaction_input.reaction_id`), plus `ord.product_compound` (reaction products), each grouped
+  by the reaction's dataset. `_update_compound_smiles` derives a dataset's compounds across all
+  attachment paths in one unsegmented pass, so a cell it visited keeps at least one derived row
+  (its parseable compounds) while a cell it skipped has **exactly zero** — the invariant is
+  simply that any cell holding a meaningful number of structural-identifier compounds has a
+  derived row. No percentage tolerance: a healthy cell keeps its parseable derivations however
+  many RDKit-unparseable organometallics or charged-N rings it also carries (the residual every
+  real load leaves — a structural identifier the load-time RDKit cannot parse or reconstruct),
+  and `min_scope_size` (default 50, `-v min_scope_size=N`) absorbs a hypothetical tiny
+  all-unparseable cell. This catches the single-dataset × single-path omission a corpus-wide or
+  reaction-keyed count would dilute. Name-only compounds are excluded, so the printed
+  `compounds > derived` gap does not count.
+- **Per-dataset reaction derivation** (enforced): an independent guard on
+  `derived.reaction_smiles`, the separate table the compound gate never touches. `reaction_smiles`
+  carries the reaction's `dataset_id`, so it is a cheap hash aggregate over `ord.reaction` (no
+  compound→reaction join) — flag any dataset with fewer than half its reactions derived. A dataset
+  omitted from the derive pass has ~none; the reaction residual stays well under half.
 - **No stray unlinked rows** (enforced): the only unlinked derived rows are `[Ti+5]`
   structures, which `_update_rdkit_mols` deliberately keeps out of `rdkit.mols`. Any other
   unlinked row fails the script.

--- a/.claude/skills/orm-database-load/SKILL.md
+++ b/.claude/skills/orm-database-load/SKILL.md
@@ -124,22 +124,23 @@ Run `scripts/verify_coverage.sql` against the candidate database. Under
 `psql -v ON_ERROR_STOP=1` a violated invariant exits non-zero, so a cutover wrapper can
 gate on process status. What it checks:
 
-- **Coverage** (enforced above a tolerance): every compound carrying a structural identifier
-  (SMILES/InChI/MolBlock) should have a derived SMILES row — across `ord.compound` (reaction
-  input, **workup** input, or **product measurement**, three attachments easy to lose to a join
-  that only follows `reaction_input.reaction_id`) and `ord.product_compound` (reaction products).
-  The count of structural-identifier compounds without a derived row is printed, and the script
-  fails only when it exceeds a small tolerance (default 0.1% of derived rows), tolerating the
-  RDKit-unparseable residual that every real load carries (~0.02%: organometallics, charged-N
-  rings — a structural identifier the load-time RDKit cannot parse or reconstruct). Name-only
-  compounds are excluded, so the printed `compounds > derived` gap does not count. Lower the
-  tolerance to tighten the gate.
-- **Per-dataset derivation** (enforced): because that tolerance is global, a small dataset
-  omitted from the derive pass entirely would slip under it (parity only proves its reactions
-  were *ingested*, and the unlinked check can't see rows that were never derived). The derive
-  pass writes compound and reaction SMILES together per dataset, so a separate check flags any
-  dataset with fewer than half its reactions derived — a full omission is ~100%, while the
-  reaction residual stays well under half.
+- **Coverage** (enforced per scope): every compound carrying a structural identifier
+  (SMILES/InChI/MolBlock) should have a derived SMILES row. Checked **per attachment scope** —
+  `ord.compound` split by reaction input, **workup** input, and **product measurement** (three
+  attachments easy to lose to a join that only follows `reaction_input.reaction_id`), plus
+  `ord.product_compound` (reaction products) — so a low-volume path omitted from derivation
+  fails on its own ~100% miss rate rather than being diluted by a corpus-wide count. Each scope
+  fails only above a small tolerance (default 0.1%), tolerating the RDKit-unparseable residual
+  every real load carries (~0.02%: organometallics, charged-N rings — a structural identifier
+  the load-time RDKit cannot parse or reconstruct). Name-only compounds are excluded, so the
+  printed `compounds > derived` gap does not count. Lower the tolerance to tighten the gate.
+- **Per-dataset derivation** (enforced): the per-scope check still spreads a single dataset's
+  rows across each path, so a small dataset omitted from the derive pass entirely could stay
+  under the tolerance in every path (parity only proves its reactions were *ingested*, and the
+  unlinked check can't see rows that were never derived). The derive pass writes compound and
+  reaction SMILES together per dataset, so a separate check flags any dataset with fewer than
+  half its reactions derived — a full omission is ~100%, while the reaction residual stays well
+  under half.
 - **No stray unlinked rows** (enforced): the only unlinked derived rows are `[Ti+5]`
   structures, which `_update_rdkit_mols` deliberately keeps out of `rdkit.mols`. Any other
   unlinked row fails the script.

--- a/.claude/skills/orm-database-load/SKILL.md
+++ b/.claude/skills/orm-database-load/SKILL.md
@@ -129,17 +129,29 @@ gate on process status. What it checks:
   scope) cell** — `ord.compound` split by reaction input, **workup** input, and **product
   measurement** (three attachments easy to lose to a join that only follows
   `reaction_input.reaction_id`), plus `ord.product_compound` (reaction products), each grouped
-  by the reaction's dataset. `_update_compound_smiles` derives a dataset's compounds across all
-  attachment paths in one unsegmented pass, so a cell it visited keeps at least one derived row
-  (its parseable compounds) while a cell it skipped has **exactly zero** — the invariant is
-  simply that any cell holding a meaningful number of structural-identifier compounds has a
-  derived row. No percentage tolerance: a healthy cell keeps its parseable derivations however
-  many RDKit-unparseable organometallics or charged-N rings it also carries (the residual every
-  real load leaves — a structural identifier the load-time RDKit cannot parse or reconstruct),
-  and `min_scope_size` (default 50, `-v min_scope_size=N`) absorbs a hypothetical tiny
-  all-unparseable cell. This catches the single-dataset × single-path omission a corpus-wide or
-  reaction-keyed count would dilute. Name-only compounds are excluded, so the printed
-  `compounds > derived` gap does not count.
+  by the reaction's dataset. Two gates, both robust to the RDKit-unparseable residue every real
+  load carries (organometallics, charged-N rings — a structural identifier the load-time RDKit
+  cannot parse or reconstruct; ~3.2k across ~18.8M derived rows on a full load):
+  - **Omission** (existence): `_update_compound_smiles` derives a dataset's compounds across
+    all attachment paths in one unsegmented pass, so a cell it visited keeps at least one
+    derived row (its parseable compounds) while a cell it skipped has **exactly zero**. Any
+    cell holding ≥ `min_scope_size` structural compounds must have a derived row. No
+    percentage tolerance — a healthy cell keeps its parseable derivations however many
+    unparseable rows it also carries, and `min_scope_size` (default 50) absorbs a hypothetical
+    tiny all-unparseable cell. Catches the single-dataset × single-path omission a corpus-wide
+    or reaction-keyed count would dilute.
+  - **Partial** (completeness): SMILES derivation is **sharded** (one hash partition of a
+    >50k-reaction dataset's compound ids per worker, capped at 32). The loader raises on a
+    failed shard, but this gate does not trust that exit status: a failed shard leaves a cell
+    with `derived > 0` yet ~1/`num_shards` of it underived — tens of thousands of compounds at
+    ≥ ~3% of the cell, dwarfing the residue. A cell is flagged when its underived count clears
+    **both** an absolute floor (`max_cell_missing`, default 10000 — above any per-cell residue)
+    **and** a fraction (`min_gap_pct`, default 1 — below the smallest 1/32 shard hole).
+    Requiring both spares a small organometallic cell (high fraction, tiny absolute) and a huge
+    cell holding a little residue (large absolute, tiny fraction).
+
+  Name-only compounds are excluded, so the printed `compounds > derived` gap does not count.
+  Override any threshold with `-v NAME=N`.
 - **Per-dataset reaction derivation** (enforced): an independent guard on
   `derived.reaction_smiles`, the separate table the compound gate never touches. `reaction_smiles`
   carries the reaction's `dataset_id`, so it is a cheap hash aggregate over `ord.reaction` (no

--- a/.claude/skills/orm-database-load/SKILL.md
+++ b/.claude/skills/orm-database-load/SKILL.md
@@ -129,11 +129,17 @@ gate on process status. What it checks:
   input, **workup** input, or **product measurement**, three attachments easy to lose to a join
   that only follows `reaction_input.reaction_id`) and `ord.product_compound` (reaction products).
   The count of structural-identifier compounds without a derived row is printed, and the script
-  fails only when it exceeds a small tolerance (default 0.1% of derived rows) — enough to catch a
-  skipped compound, dataset, or attachment path, while tolerating the RDKit-unparseable residual
-  that every real load carries (~0.02%: organometallics, charged-N rings — a structural
-  identifier the load-time RDKit cannot parse or reconstruct). Name-only compounds are excluded,
-  so the printed `compounds > derived` gap does not count. Lower the tolerance to tighten the gate.
+  fails only when it exceeds a small tolerance (default 0.1% of derived rows), tolerating the
+  RDKit-unparseable residual that every real load carries (~0.02%: organometallics, charged-N
+  rings — a structural identifier the load-time RDKit cannot parse or reconstruct). Name-only
+  compounds are excluded, so the printed `compounds > derived` gap does not count. Lower the
+  tolerance to tighten the gate.
+- **Per-dataset derivation** (enforced): because that tolerance is global, a small dataset
+  omitted from the derive pass entirely would slip under it (parity only proves its reactions
+  were *ingested*, and the unlinked check can't see rows that were never derived). The derive
+  pass writes compound and reaction SMILES together per dataset, so a separate check flags any
+  dataset with fewer than half its reactions derived — a full omission is ~100%, while the
+  reaction residual stays well under half.
 - **No stray unlinked rows** (enforced): the only unlinked derived rows are `[Ti+5]`
   structures, which `_update_rdkit_mols` deliberately keeps out of `rdkit.mols`. Any other
   unlinked row fails the script.

--- a/.claude/skills/orm-database-load/SKILL.md
+++ b/.claude/skills/orm-database-load/SKILL.md
@@ -140,18 +140,19 @@ gate on process status. What it checks:
     unparseable rows it also carries, and `min_scope_size` (default 50) absorbs a hypothetical
     tiny all-unparseable cell. Catches the single-dataset × single-path omission a corpus-wide
     or reaction-keyed count would dilute.
-  - **Partial** (completeness, **per dataset**): SMILES derivation is **sharded** (one
-    `hashtextextended` partition of a >50k-reaction dataset's compound ids per worker, capped at
-    32). The loader raises on a failed shard, but this gate does not trust that exit status. A
-    shard partitions the *whole dataset's* ids, so a failed shard removes ~1/`num_shards` of
-    **every** scope at once — a small scope's slice can be tiny in absolute terms while the
-    dataset-wide hole is enormous. So completeness rolls the cells up to the dataset: any shard
-    hole underives tens of thousands of a dataset's compounds (≥ 1/32 ≈ 3%), dwarfing the
-    whole-dataset residue (at most the corpus total). A dataset is flagged when its total
-    underived clears **both** an absolute floor (`max_dataset_missing`, default 10000 — above
-    any one dataset's residue) **and** a fraction (`min_gap_pct`, default 1 — below the smallest
-    1/32 hole). Requiring both spares an organometallic-heavy dataset (high fraction, small
-    absolute) and a huge dataset holding a little residue (large absolute, tiny fraction).
+  - **Failed shard** (completeness, per **shard-hash bucket**): SMILES derivation is **sharded**
+    — one `hashtextextended(id)` partition of a dataset's compound ids per worker, with
+    `num_shards = min(32, ceil(reactions / 50000))`, so only datasets over ~50k reactions shard
+    at all. The loader raises on a failed shard, but this gate does not trust that exit status.
+    A failed shard leaves **exactly one hash bucket wholly underived** — parseable compounds
+    included — while the unparseable residue spreads uniformly across every bucket (parseability
+    is uncorrelated with the id hash) and so can never empty one. The check recomputes each
+    dataset's `num_shards` from its reaction count, buckets its structural compounds by the same
+    hash, and flags any bucket of a sharded dataset holding ≥ `min_bucket_size` (default 50)
+    structural compounds with no derived row. Detecting the hole by its **shape** (a wholly
+    empty hash class) rather than its size needs no residue-calibrated tolerance, so it catches
+    the failure however small or name-heavy the dataset is. `shard_size`/`shard_cap` mirror the
+    loader's constants — keep them in step if those change.
 
   Name-only compounds are excluded, so the printed `compounds > derived` gap does not count.
   Override any threshold with `-v NAME=N`.

--- a/.claude/skills/orm-database-load/SKILL.md
+++ b/.claude/skills/orm-database-load/SKILL.md
@@ -147,12 +147,15 @@ gate on process status. What it checks:
     A failed shard leaves **exactly one hash bucket wholly underived** — parseable compounds
     included — while the unparseable residue spreads uniformly across every bucket (parseability
     is uncorrelated with the id hash) and so can never empty one. The check recomputes each
-    dataset's `num_shards` from its reaction count, buckets its structural compounds by the same
-    hash, and flags any bucket of a sharded dataset holding ≥ `min_bucket_size` (default 50)
-    structural compounds with no derived row. Detecting the hole by its **shape** (a wholly
-    empty hash class) rather than its size needs no residue-calibrated tolerance, so it catches
-    the failure however small or name-heavy the dataset is. `shard_size`/`shard_cap` mirror the
-    loader's constants — keep them in step if those change.
+    dataset's `num_shards`, buckets its structural compounds by the same hash, and judges an
+    empty bucket against its **sibling buckets**: they measure how often this dataset's
+    identifiers legitimately fail to derive, so the bucket is flagged when the siblings make
+    "every one of mine missed by chance" implausible (probability < `max_false_positive`,
+    default `1e-6`). Judging by **shape** against siblings rather than by size needs no
+    residue-calibrated tolerance and keeps a *sparse* hole visible — a dataset shards on its
+    reaction count, so a name-heavy one just over the threshold may hold only a handful of
+    structural compounds per bucket, which any absolute floor would ignore. `shard_size` /
+    `shard_cap` mirror the loader's constants — keep them in step if those change.
 
   Name-only compounds are excluded, so the printed `compounds > derived` gap does not count.
   Override any threshold with `-v NAME=N`.

--- a/.claude/skills/orm-database-load/SKILL.md
+++ b/.claude/skills/orm-database-load/SKILL.md
@@ -124,15 +124,16 @@ Run `scripts/verify_coverage.sql` against the candidate database. Under
 `psql -v ON_ERROR_STOP=1` a violated invariant exits non-zero, so a cutover wrapper can
 gate on process status. What it checks:
 
-- **Coverage** (enforced): every compound carrying a structural identifier (SMILES/InChI/
-  MolBlock) has a derived SMILES row — across `ord.compound` (reaction input, **workup** input,
-  or **product measurement**, three attachments easy to lose to a join that only follows
-  `reaction_input.reaction_id`) and `ord.product_compound` (reaction products). A load that skips
-  a compound or an entire attachment path fails the script. Name-only compounds are excluded, so
-  the printed `compounds > derived` gap does not trip it; the per-attachment counts are still
-  shown for inspection. The residual is a structural identifier the load-time RDKit cannot
-  parse or reconstruct — itself coverage loss worth surfacing, and another reason the RDKit
-  version must match.
+- **Coverage** (enforced above a tolerance): every compound carrying a structural identifier
+  (SMILES/InChI/MolBlock) should have a derived SMILES row — across `ord.compound` (reaction
+  input, **workup** input, or **product measurement**, three attachments easy to lose to a join
+  that only follows `reaction_input.reaction_id`) and `ord.product_compound` (reaction products).
+  The count of structural-identifier compounds without a derived row is printed, and the script
+  fails only when it exceeds a small tolerance (default 0.1% of derived rows) — enough to catch a
+  skipped compound, dataset, or attachment path, while tolerating the RDKit-unparseable residual
+  that every real load carries (~0.02%: organometallics, charged-N rings — a structural
+  identifier the load-time RDKit cannot parse or reconstruct). Name-only compounds are excluded,
+  so the printed `compounds > derived` gap does not count. Lower the tolerance to tighten the gate.
 - **No stray unlinked rows** (enforced): the only unlinked derived rows are `[Ti+5]`
   structures, which `_update_rdkit_mols` deliberately keeps out of `rdkit.mols`. Any other
   unlinked row fails the script.

--- a/.claude/skills/orm-database-load/scripts/verify_coverage.sql
+++ b/.claude/skills/orm-database-load/scripts/verify_coverage.sql
@@ -104,71 +104,84 @@ BEGIN
 END $$;
 
 -- Every compound carrying a structural identifier should derive a SMILES; a load that
--- skipped a compound -- or an entire attachment path (workup input, product measurement,
--- reaction product) -- leaves it with a structural identifier but no derived row. Covers
--- both ord.compound and ord.product_compound. NAME-only compounds are excluded, so the
--- documented `compounds > derived` gap does not trip this. The type list mirrors
+-- skipped a compound -- or an entire attachment path -- leaves it with a structural
+-- identifier but no derived row. NAME-only compounds are excluded, so the documented
+-- `compounds > derived` gap does not trip this. The type list mirrors
 -- message_helpers.STRUCTURAL_IDENTIFIER_TYPES.
 --
--- This does not raise on the first missing row. Even on a load whose RDKit matches the
--- writer, a small residue of structural identifiers is unparseable/unreconstructable by
--- RDKit (organometallics such as Ir photocatalysts or C[Al](C)(C)([Li])..., charged-N
--- ring systems) and legitimately derives no row -- on the order of 0.02% of the full ORD
--- corpus. Raising on any miss would fail every real load. Instead it raises only when the
--- miss rate exceeds `tolerance_pct` of derived rows, which still catches a systematic gap
--- (a skipped dataset or attachment path, orders of magnitude larger) while tolerating that
--- residue. The count is always printed; lower the tolerance to tighten the gate.
+-- Checked PER SCOPE, not against one global count: ord.compound split by its three
+-- attachment paths (reaction input, workup input, product measurement) plus
+-- ord.product_compound. A low-volume path omitted from derivation has a ~100% miss rate
+-- *within its own scope*, so it fails even though its rows would stay under a corpus-wide
+-- tolerance (and a reaction-keyed check would miss it, since reaction SMILES can still
+-- derive). Within each scope the tolerance absorbs the RDKit-unparseable residue every real
+-- load carries (~0.02%: organometallics such as Ir photocatalysts or C[Al](C)(C)([Li])...,
+-- charged-N ring systems -- identifiers the load-time RDKit cannot parse or reconstruct).
+-- The total is printed; lower the tolerance to tighten the gate.
 DO $$
 DECLARE
-    missing bigint;
-    derived_total bigint;
+    total_missing bigint;
+    bad_scopes bigint;
     tolerance_pct numeric := 0.1;
 BEGIN
-    SELECT count(*) INTO missing
-    FROM (
-        SELECT c.id
-        FROM ord.compound c
-        WHERE EXISTS (
+    WITH scoped AS (
+        SELECT
+            CASE WHEN ri.reaction_id IS NOT NULL THEN 'reaction_input'
+                 WHEN c.reaction_input_id IS NOT NULL THEN 'workup_input'
+                 ELSE 'product_measurement' END AS scope,
+            EXISTS (
                 SELECT 1 FROM ord.compound_identifier ci
                 WHERE ci.compound_id = c.id
-                  AND ci.type IN ('SMILES', 'INCHI', 'MOLBLOCK')
-                  AND ci.value <> ''
-            )
-          AND NOT EXISTS (
+                  AND ci.type IN ('SMILES', 'INCHI', 'MOLBLOCK') AND ci.value <> ''
+            ) AS structural,
+            NOT EXISTS (
                 SELECT 1 FROM derived.compound_smiles d WHERE d.compound_id = c.id
-            )
+            ) AS underived
+        FROM ord.compound c
+        LEFT JOIN ord.reaction_input ri ON c.reaction_input_id = ri.id
         UNION ALL
-        SELECT pc.id
-        FROM ord.product_compound pc
-        WHERE EXISTS (
+        SELECT
+            'product_compound',
+            EXISTS (
                 SELECT 1 FROM ord.compound_identifier ci
                 WHERE ci.product_compound_id = pc.id
-                  AND ci.type IN ('SMILES', 'INCHI', 'MOLBLOCK')
-                  AND ci.value <> ''
-            )
-          AND NOT EXISTS (
+                  AND ci.type IN ('SMILES', 'INCHI', 'MOLBLOCK') AND ci.value <> ''
+            ),
+            NOT EXISTS (
                 SELECT 1 FROM derived.product_compound_smiles d
                 WHERE d.product_compound_id = pc.id
             )
-    ) t;
-    SELECT (SELECT count(*) FROM derived.compound_smiles)
-         + (SELECT count(*) FROM derived.product_compound_smiles)
-      INTO derived_total;
-    RAISE INFO 'coverage: % structural-identifier compound(s) of % derived rows lack a derived row (tolerance % percent)', missing, derived_total, tolerance_pct;
-    IF missing::numeric > tolerance_pct / 100 * derived_total THEN
-        RAISE EXCEPTION 'coverage: % structural-identifier compounds lack a derived row, above the tolerance of % percent of % derived rows -- likely a systematic miss, not the RDKit-unparseable residual', missing, tolerance_pct, derived_total;
+        FROM ord.product_compound pc
+    ),
+    per_scope AS (
+        SELECT scope,
+               count(*) FILTER (WHERE structural) AS structural,
+               count(*) FILTER (WHERE structural AND underived) AS missing
+        FROM scoped
+        GROUP BY scope
+    )
+    SELECT coalesce(sum(missing), 0),
+           count(*) FILTER (
+               WHERE structural > 0
+                 AND missing::numeric > tolerance_pct / 100 * structural
+           )
+      INTO total_missing, bad_scopes
+    FROM per_scope;
+    RAISE INFO 'coverage: % structural-identifier compound(s) lack a derived row across attachment scopes (tolerance % percent per scope)', total_missing, tolerance_pct;
+    IF bad_scopes > 0 THEN
+        RAISE EXCEPTION 'coverage: % attachment scope(s) have structural-identifier compounds underived beyond the % percent tolerance -- a scope omitted from the derive pass that a corpus-wide count would dilute', bad_scopes, tolerance_pct;
     END IF;
 END $$;
 
--- Per-dataset derivation completeness. The tolerance above is global, so a small scope
--- (one dataset) omitted from the derive pass entirely can slip under it while parity still
--- passes (parity only proves the reactions were ingested) and the unlinked check stays
--- silent (it cannot see rows that were never derived). The derive pass runs per dataset and
--- writes both compound and reaction SMILES together, so an omitted dataset has ~none of
--- either. reaction_smiles carries the reaction's dataset_id, making a per-dataset check
--- cheap: flag any dataset with fewer than half its reactions derived. A full omission is
--- ~100% underived; the ~0.4% unparseable reaction residual and normal variation stay well
--- under half.
+-- Per-dataset derivation completeness. The per-scope compound check above still spreads a
+-- single dataset's rows across each attachment path, so one small dataset omitted entirely
+-- can stay under the tolerance in every path while parity passes (it only proves the
+-- reactions were ingested) and the unlinked check stays silent (it cannot see rows that
+-- were never derived). The derive pass runs per dataset and writes both compound and
+-- reaction SMILES together, so an omitted dataset has ~none of either. reaction_smiles
+-- carries the reaction's dataset_id, making a per-dataset check cheap: flag any dataset with
+-- fewer than half its reactions derived. A full omission is ~100% underived; the ~0.4%
+-- unparseable reaction residual and normal variation stay well under half.
 DO $$
 DECLARE
     omitted bigint;

--- a/.claude/skills/orm-database-load/scripts/verify_coverage.sql
+++ b/.claude/skills/orm-database-load/scripts/verify_coverage.sql
@@ -160,6 +160,32 @@ BEGIN
     END IF;
 END $$;
 
+-- Per-dataset derivation completeness. The tolerance above is global, so a small scope
+-- (one dataset) omitted from the derive pass entirely can slip under it while parity still
+-- passes (parity only proves the reactions were ingested) and the unlinked check stays
+-- silent (it cannot see rows that were never derived). The derive pass runs per dataset and
+-- writes both compound and reaction SMILES together, so an omitted dataset has ~none of
+-- either. reaction_smiles carries the reaction's dataset_id, making a per-dataset check
+-- cheap: flag any dataset with fewer than half its reactions derived. A full omission is
+-- ~100% underived; the ~0.4% unparseable reaction residual and normal variation stay well
+-- under half.
+DO $$
+DECLARE
+    omitted bigint;
+BEGIN
+    SELECT count(*) INTO omitted
+    FROM (
+        SELECT r.dataset_id, count(*) AS reactions, count(rs.reaction_id) AS derived
+        FROM ord.reaction r
+        LEFT JOIN derived.reaction_smiles rs ON rs.reaction_id = r.id
+        GROUP BY r.dataset_id
+    ) t
+    WHERE derived * 2 < reactions;
+    IF omitted > 0 THEN
+        RAISE EXCEPTION 'coverage: % dataset(s) have fewer than half their reactions derived -- a scope omitted from the derive pass that the global tolerance would hide', omitted;
+    END IF;
+END $$;
+
 DO $$
 DECLARE
     index_rows bigint := (SELECT count(*) FROM ord.reaction);

--- a/.claude/skills/orm-database-load/scripts/verify_coverage.sql
+++ b/.claude/skills/orm-database-load/scripts/verify_coverage.sql
@@ -108,12 +108,21 @@ END $$;
 -- reaction product) -- leaves it with a structural identifier but no derived row. Covers
 -- both ord.compound and ord.product_compound. NAME-only compounds are excluded, so the
 -- documented `compounds > derived` gap does not trip this. The type list mirrors
--- message_helpers.STRUCTURAL_IDENTIFIER_TYPES; on a load whose RDKit matches the writer
--- (the skill's premise) every such compound derives, so the only residual is an identifier
--- the load-time RDKit cannot parse or reconstruct -- itself coverage loss worth surfacing.
+-- message_helpers.STRUCTURAL_IDENTIFIER_TYPES.
+--
+-- This does not raise on the first missing row. Even on a load whose RDKit matches the
+-- writer, a small residue of structural identifiers is unparseable/unreconstructable by
+-- RDKit (organometallics such as Ir photocatalysts or C[Al](C)(C)([Li])..., charged-N
+-- ring systems) and legitimately derives no row -- on the order of 0.02% of the full ORD
+-- corpus. Raising on any miss would fail every real load. Instead it raises only when the
+-- miss rate exceeds `tolerance_pct` of derived rows, which still catches a systematic gap
+-- (a skipped dataset or attachment path, orders of magnitude larger) while tolerating that
+-- residue. The count is always printed; lower the tolerance to tighten the gate.
 DO $$
 DECLARE
     missing bigint;
+    derived_total bigint;
+    tolerance_pct numeric := 0.1;
 BEGIN
     SELECT count(*) INTO missing
     FROM (
@@ -142,10 +151,12 @@ BEGIN
                 WHERE d.product_compound_id = pc.id
             )
     ) t;
-    IF missing > 0 THEN
-        RAISE EXCEPTION
-            'coverage: % compound(s) with a structural identifier lack a derived row',
-            missing;
+    SELECT (SELECT count(*) FROM derived.compound_smiles)
+         + (SELECT count(*) FROM derived.product_compound_smiles)
+      INTO derived_total;
+    RAISE INFO 'coverage: % structural-identifier compound(s) of % derived rows lack a derived row (tolerance % percent)', missing, derived_total, tolerance_pct;
+    IF missing::numeric > tolerance_pct / 100 * derived_total THEN
+        RAISE EXCEPTION 'coverage: % structural-identifier compounds lack a derived row, above the tolerance of % percent of % derived rows -- likely a systematic miss, not the RDKit-unparseable residual', missing, tolerance_pct, derived_total;
     END IF;
 END $$;
 

--- a/.claude/skills/orm-database-load/scripts/verify_coverage.sql
+++ b/.claude/skills/orm-database-load/scripts/verify_coverage.sql
@@ -135,16 +135,19 @@ END $$;
 --      hash) and so never empties one. So recompute each dataset's num_shards from its reaction
 --      count, bucket its structural compounds by the same ((h % n) + n) % n hash, and flag any
 --      bucket of a sharded dataset with >= min_bucket_size structural compounds but no derived
---      row. Whether that outcome is really a hole is judged against the bucket's SIBLING buckets,
---      not an absolute size floor: the hash spreads a dataset's compounds uniformly, so the
---      siblings measure how often this dataset's structural identifiers legitimately fail to
---      derive, and the bucket is flagged when they make "every one of mine missed by chance"
---      implausible (probability < max_false_positive). That keeps a sparse hole visible -- a
---      dataset shards on its reaction count, so a name-heavy one just over the threshold may hold
---      only a handful of structural compounds per bucket -- while never flagging a small
---      all-unparseable bucket in a dataset whose siblings show a high miss rate. A healthy
---      database populates every bucket whatever num_shards is, so an inaccurate recomputation can
---      only miss a hole, never invent one.
+--      row -- and, because the shard derives that dataset's reaction SMILES in the same
+--      transaction under the same hash, an empty reaction bucket alongside it. Whether that
+--      outcome is really a hole is judged against the bucket's SIBLING buckets, not an absolute
+--      size floor: the hash spreads a dataset's rows uniformly, so the siblings measure how often
+--      this dataset's compounds and reactions legitimately fail to derive, and the bucket is
+--      flagged when they make "every one of mine missed by chance" implausible (combined
+--      probability < max_false_positive). Using both tables is what keeps a SPARSE hole visible:
+--      sharding is chosen by reaction count, so every bucket of a sharded dataset holds thousands
+--      of reactions even when a name-heavy one leaves only a handful of structural compounds
+--      there -- the reaction evidence is strongest exactly where the compound evidence is weakest,
+--      and no absolute floor over either table alone can span both. A dataset whose siblings show
+--      a high miss rate still convicts nothing. A healthy database populates every bucket whatever
+--      num_shards is, so an inaccurate recomputation can only miss a hole, never invent one.
 --
 -- The total underived count is printed. Defaults: min_scope_size 50, min_bucket_size 2,
 -- max_false_positive 1e-6, and shard_size/shard_cap mirroring
@@ -288,30 +291,70 @@ BEGIN
         ) b
         GROUP BY dataset_id, num_shards, bucket
     ),
-    -- Judge each bucket against its SIBLING buckets in the same dataset rather than an absolute
-    -- size floor. The hash spreads a dataset's compounds uniformly, so the siblings measure the
-    -- rate at which this dataset's structural identifiers legitimately fail to derive; a bucket
-    -- that derived nothing is a shard hole exactly when the siblings say that outcome is
-    -- implausible. An absolute floor would ignore a sparse hole -- a dataset shards on its
-    -- reaction count, so a name-heavy one over the threshold can hold only a handful of
-    -- structural compounds per bucket and still lose a whole shard.
-    bucket_stats AS (
-        SELECT dataset_id, num_shards, bucket, structural, derived,
-               sum(structural) OVER (PARTITION BY dataset_id) - structural AS structural_other,
-               sum(derived) OVER (PARTITION BY dataset_id) - derived AS derived_other
-        FROM per_bucket
+    -- The same shard derives a dataset's reaction SMILES in the same transaction, partitioned by
+    -- the same hash over ord.reaction.id, so a failed shard empties its reaction bucket too. That
+    -- second signal is what makes a sparse hole visible: a dataset shards on its REACTION count,
+    -- so every bucket of a sharded dataset holds thousands of reactions even when a name-heavy
+    -- one leaves only a handful of structural compounds there. The reaction evidence is strongest
+    -- exactly where the compound evidence is weakest.
+    reaction_buckets AS (
+        SELECT r.dataset_id,
+               ((hashtextextended(r.id::text, 0) % ds.num_shards) + ds.num_shards)
+                   % ds.num_shards AS bucket,
+               count(*) AS reactions,
+               count(rs.reaction_id) AS derived
+        FROM ord.reaction r
+        JOIN dataset_shards ds ON ds.dataset_id = r.dataset_id
+        LEFT JOIN derived.reaction_smiles rs ON rs.reaction_id = r.id
+        GROUP BY 1, 2
     ),
-    -- Laplace-smoothed miss rate from the siblings (the +1s keep an all-derived sibling set from
-    -- claiming a zero miss rate, which would flag a lone unparseable compound). The exponent is
-    -- capped because a bucket only has to be a handful of compounds deep before the probability
-    -- is negligible, and an uncapped numeric power over a large bucket would underflow.
+    -- Judge each bucket against its SIBLING buckets in the same dataset rather than an absolute
+    -- size floor. The hash spreads a dataset's rows uniformly, so the siblings measure the rate at
+    -- which this dataset's compounds and reactions legitimately fail to derive; a bucket that
+    -- derived nothing is a shard hole exactly when the siblings say that outcome is implausible.
+    -- An absolute floor cannot do this: sharding is chosen by reaction count while the floor would
+    -- count structural compounds, so a name-heavy dataset over the threshold slips under it.
+    bucket_stats AS (
+        SELECT coalesce(c.dataset_id, x.dataset_id) AS dataset_id,
+               coalesce(c.bucket, x.bucket) AS bucket,
+               coalesce(c.num_shards, ds.num_shards) AS num_shards,
+               coalesce(c.structural, 0) AS structural,
+               coalesce(c.derived, 0) AS derived,
+               coalesce(x.reactions, 0) AS reactions,
+               coalesce(x.derived, 0) AS reactions_derived
+        FROM per_bucket c
+        FULL OUTER JOIN reaction_buckets x
+            ON x.dataset_id = c.dataset_id AND x.bucket = c.bucket
+        JOIN dataset_shards ds ON ds.dataset_id = coalesce(c.dataset_id, x.dataset_id)
+    ),
+    bucket_siblings AS (
+        SELECT *,
+               sum(structural) OVER w - structural AS structural_other,
+               sum(derived) OVER w - derived AS derived_other,
+               sum(reactions) OVER w - reactions AS reactions_other,
+               sum(reactions_derived) OVER w - reactions_derived AS reactions_derived_other
+        FROM bucket_stats
+        WINDOW w AS (PARTITION BY dataset_id)
+    ),
+    -- Chance the siblings' miss rate alone explains an empty bucket, compounds and reactions
+    -- multiplied as independent evidence (a table that did derive contributes no evidence, i.e. a
+    -- factor of 1). Each rate is Laplace-smoothed, so an all-derived sibling set cannot claim a
+    -- zero miss rate and convict a lone unparseable row; an empty sibling set gives a rate of 1
+    -- and so proves nothing. Exponents are capped because a bucket only has to be a few rows deep
+    -- before the probability is negligible, and an uncapped numeric power would underflow.
     bucket_verdict AS (
         SELECT *,
-               power((structural_other - derived_other + 1)::numeric / (structural_other + 1),
-                     least(structural, 50)) AS chance_all_missed
-        FROM bucket_stats
-        WHERE num_shards > 1 AND derived = 0 AND structural >= min_bucket_size
-          AND structural_other > 0
+               CASE WHEN derived = 0 THEN
+                   power((structural_other - derived_other + 1)::numeric
+                             / (structural_other + 1), least(structural, 50))
+               ELSE 1 END
+               * CASE WHEN reactions_derived = 0 THEN
+                   power((reactions_other - reactions_derived_other + 1)::numeric
+                             / (reactions_other + 1), least(reactions, 50))
+               ELSE 1 END AS chance_all_missed
+        FROM bucket_siblings
+        WHERE num_shards > 1 AND derived = 0 AND reactions_derived = 0
+          AND structural + reactions >= min_bucket_size
     )
     -- Scalar subqueries over the shared CTEs; scoped (hence the UNION) materializes once.
     SELECT
@@ -322,8 +365,10 @@ BEGIN
              WHERE structural >= min_scope_size AND derived = 0),
         (SELECT count(*) FROM bucket_verdict WHERE chance_all_missed < max_false_positive),
         (SELECT min('shard ' || bucket || '/' || num_shards || ' of dataset ' || dataset_id
-                    || ' (' || structural || ' structural compounds, 0 derived; sibling shards '
-                    || 'derived ' || derived_other || '/' || structural_other || ')')
+                    || ' (' || structural || ' structural compounds and ' || reactions
+                    || ' reactions, none derived; sibling shards derived '
+                    || derived_other || '/' || structural_other || ' and '
+                    || reactions_derived_other || '/' || reactions_other || ')')
              FROM bucket_verdict WHERE chance_all_missed < max_false_positive)
       INTO total_missing, bad_omitted, example_omitted, bad_shard, example_shard;
     RAISE INFO 'coverage: % structural-identifier compound(s) lack a derived row (existence gate per (dataset, scope), min scope size %; shard-hole gate per hash bucket vs siblings, min bucket size %, max false positive %)', total_missing, min_scope_size, min_bucket_size, max_false_positive;
@@ -331,7 +376,7 @@ BEGIN
         RAISE EXCEPTION 'coverage: % (dataset, attachment scope) cell(s) hold >= % structural-identifier compounds but no derived row (e.g. %) -- a dataset or attachment path omitted from the derive pass', bad_omitted, min_scope_size, example_omitted;
     END IF;
     IF bad_shard > 0 THEN
-        RAISE EXCEPTION 'coverage: % shard-hash bucket(s) hold >= % structural-identifier compounds but no derived row (e.g. %) -- a failed derivation shard leaves exactly one bucket wholly underived', bad_shard, min_bucket_size, example_shard;
+        RAISE EXCEPTION 'coverage: % shard-hash bucket(s) derived nothing, compounds or reactions, beyond what their sibling shards make plausible (e.g. %) -- a failed derivation shard leaves exactly one bucket wholly underived', bad_shard, example_shard;
     END IF;
 END $$;
 

--- a/.claude/skills/orm-database-load/scripts/verify_coverage.sql
+++ b/.claude/skills/orm-database-load/scripts/verify_coverage.sql
@@ -125,51 +125,58 @@ END $$;
 --      reagent/product cells always contain parseable organics). Catches the single dataset x
 --      single path omission a corpus-wide or reaction-keyed count would dilute.
 --
---   2. PARTIAL derivation (completeness), checked PER DATASET. SMILES derivation is sharded
---      (loading.py: one hashtextextended partition of a >50k-reaction dataset's compound ids per
---      worker, capped at 32), and the loader raises on a failed shard -- but a defence-in-depth
---      gate should not trust that exit status. A shard partitions the *whole dataset's* compound
---      ids, so a failed shard removes ~1/num_shards of every scope at once; a small scope's slice
---      can be under an absolute floor even though the dataset-wide hole is enormous. So this gate
---      aggregates to the dataset: the smallest sharded dataset still has >50k reactions and >=2
---      structural compounds each over <=32 shards, so any shard hole underives tens of thousands
---      of the dataset's compounds (>= 1/32 ~= 3%), dwarfing the whole-dataset residue (at most the
---      corpus total, a few thousand). A dataset is flagged when its total underived clears BOTH an
---      absolute floor (max_dataset_missing, above any one dataset's residue) AND a fraction
---      (min_gap_pct, below the smallest 1/32 hole). Requiring both keeps an organometallic-heavy
---      dataset (high fraction, small absolute) and a huge dataset holding a little residue (large
---      absolute, tiny fraction) from tripping, while a shard hole clears both.
+--   2. PARTIAL derivation (completeness), detected by SHARD SHAPE. SMILES derivation is sharded
+--      (loading.py / ord_schema.orm.sharding: one hashtextextended(id) partition of a dataset's
+--      compound ids per worker; num_shards = min(32, ceil(reactions / 50000)), so only datasets
+--      over ~50k reactions shard at all). The loader raises on a failed shard, but a
+--      defence-in-depth gate should not trust that exit status. A failed shard leaves exactly one
+--      hash bucket entirely underived -- parseable compounds included -- while the unparseable
+--      residue spreads uniformly across all buckets (unparseability is uncorrelated with the id
+--      hash) and so never empties one. So recompute each dataset's num_shards from its reaction
+--      count, bucket its structural compounds by the same ((h % n) + n) % n hash, and flag any
+--      bucket of a sharded dataset with >= min_bucket_size structural compounds but no derived
+--      row. Detecting the hole by its shape (a wholly-empty hash class) rather than its size needs
+--      no residue-calibrated tolerance and catches the failure however small or name-heavy the
+--      dataset is. Keep min_bucket_size in step with the loader's shard constants if they change.
 --
--- The total underived count is printed. Defaults: min_scope_size 50, max_dataset_missing 10000,
--- min_gap_pct 1 (override with -v NAME=N).
+-- The total underived count is printed. Defaults: min_scope_size 50, min_bucket_size 50, and
+-- shard_size/shard_cap mirroring loading._DERIVE_SHARD_SIZE/_DERIVE_SHARD_CAP -- keep those two
+-- in step with the loader if its constants change (override any with -v NAME=N).
 \if :{?min_scope_size}
 \else
   \set min_scope_size 50
 \endif
-\if :{?max_dataset_missing}
+\if :{?min_bucket_size}
 \else
-  \set max_dataset_missing 10000
+  \set min_bucket_size 50
 \endif
-\if :{?min_gap_pct}
+\if :{?shard_size}
 \else
-  \set min_gap_pct 1
+  \set shard_size 50000
+\endif
+\if :{?shard_cap}
+\else
+  \set shard_cap 32
 \endif
 SELECT set_config('ord.verify_min_scope_size', :'min_scope_size', false) AS min_scope_size,
-       set_config('ord.verify_max_dataset_missing', :'max_dataset_missing', false) AS max_dataset_missing,
-       set_config('ord.verify_min_gap_pct', :'min_gap_pct', false) AS min_gap_pct;
+       set_config('ord.verify_min_bucket_size', :'min_bucket_size', false) AS min_bucket_size,
+       set_config('ord.verify_shard_size', :'shard_size', false) AS shard_size,
+       set_config('ord.verify_shard_cap', :'shard_cap', false) AS shard_cap;
 DO $$
 DECLARE
     total_missing bigint;
     bad_omitted bigint;
     example_omitted text;
-    bad_partial bigint;
-    example_partial text;
+    bad_shard bigint;
+    example_shard text;
     min_scope_size int := current_setting('ord.verify_min_scope_size')::int;
-    max_dataset_missing int := current_setting('ord.verify_max_dataset_missing')::int;
-    min_gap_pct numeric := current_setting('ord.verify_min_gap_pct')::numeric;
+    min_bucket_size int := current_setting('ord.verify_min_bucket_size')::int;
+    shard_size int := current_setting('ord.verify_shard_size')::int;
+    shard_cap int := current_setting('ord.verify_shard_cap')::int;
 BEGIN
     WITH scoped AS (
         SELECT r.dataset_id AS dataset_id, 'reaction_input' AS scope,
+               hashtextextended(c.id::text, 0) AS id_hash,
                EXISTS (
                    SELECT 1 FROM ord.compound_identifier ci
                    WHERE ci.compound_id = c.id
@@ -183,6 +190,7 @@ BEGIN
         JOIN ord.reaction r ON ri.reaction_id = r.id
         UNION ALL
         SELECT r.dataset_id, 'workup_input',
+               hashtextextended(c.id::text, 0),
                EXISTS (
                    SELECT 1 FROM ord.compound_identifier ci
                    WHERE ci.compound_id = c.id
@@ -197,6 +205,7 @@ BEGIN
         JOIN ord.reaction r ON rw.reaction_id = r.id
         UNION ALL
         SELECT r.dataset_id, 'product_measurement',
+               hashtextextended(c.id::text, 0),
                EXISTS (
                    SELECT 1 FROM ord.compound_identifier ci
                    WHERE ci.compound_id = c.id
@@ -212,6 +221,7 @@ BEGIN
         JOIN ord.reaction r ON ro.reaction_id = r.id
         UNION ALL
         SELECT r.dataset_id, 'product_compound',
+               hashtextextended(pc.id::text, 0),
                EXISTS (
                    SELECT 1 FROM ord.compound_identifier ci
                    WHERE ci.product_compound_id = pc.id
@@ -232,40 +242,53 @@ BEGIN
         FROM scoped
         GROUP BY dataset_id, scope
     ),
-    -- Completeness rolls the cells up to the dataset, because a failed shard's hole is
-    -- dataset-wide (it partitions all scopes' ids at once); a small scope's slice may be
-    -- tiny in absolute terms while the dataset-wide hole is not.
-    per_dataset AS (
+    -- num_shards the loader used for each dataset's SMILES derivation, recomputed from its
+    -- reaction count: min(shard_cap, ceil(reactions / shard_size)), at least 1. Mirrors
+    -- loading._derive_shard_items.
+    dataset_shards AS (
         SELECT dataset_id,
-               sum(structural) AS structural,
-               sum(derived) AS derived
-        FROM per_cell
+               greatest(1, least(shard_cap, ceil(count(*)::numeric / shard_size)::int))
+                   AS num_shards
+        FROM ord.reaction
         GROUP BY dataset_id
+    ),
+    -- Bucket each dataset's structural compounds by the loader's shard hash, so a failed shard
+    -- shows up as a bucket with structural rows but no derived row (the residue spreads across
+    -- every bucket and cannot empty one). num_shards = 1 datasets never sharded, so their lone
+    -- bucket only restates the omission gate and is excluded below.
+    per_bucket AS (
+        SELECT dataset_id, num_shards, bucket,
+               count(*) FILTER (WHERE structural) AS structural,
+               count(*) FILTER (WHERE structural AND derived) AS derived
+        FROM (
+            SELECT s.dataset_id, ds.num_shards,
+                   ((s.id_hash % ds.num_shards) + ds.num_shards) % ds.num_shards AS bucket,
+                   s.structural, s.derived
+            FROM scoped s
+            JOIN dataset_shards ds ON ds.dataset_id = s.dataset_id
+        ) b
+        GROUP BY dataset_id, num_shards, bucket
     )
-    -- Scalar subqueries over the shared CTEs; per_cell (hence the UNION) materializes once.
+    -- Scalar subqueries over the shared CTEs; scoped (hence the UNION) materializes once.
     SELECT
         (SELECT coalesce(sum(structural - derived), 0) FROM per_cell),
         (SELECT count(*) FROM per_cell
              WHERE structural >= min_scope_size AND derived = 0),
         (SELECT min(scope || ' in dataset ' || dataset_id) FROM per_cell
              WHERE structural >= min_scope_size AND derived = 0),
-        (SELECT count(*) FROM per_dataset
-             WHERE derived > 0
-               AND structural - derived >= max_dataset_missing
-               AND (structural - derived)::numeric >= min_gap_pct / 100 * structural),
-        (SELECT min('dataset ' || dataset_id
-                    || ' (' || (structural - derived) || ' of ' || structural || ' missing)')
-             FROM per_dataset
-             WHERE derived > 0
-               AND structural - derived >= max_dataset_missing
-               AND (structural - derived)::numeric >= min_gap_pct / 100 * structural)
-      INTO total_missing, bad_omitted, example_omitted, bad_partial, example_partial;
-    RAISE INFO 'coverage: % structural-identifier compound(s) lack a derived row (existence gate per (dataset, scope), min scope size %; completeness gate per dataset, max % missing and >= % pct)', total_missing, min_scope_size, max_dataset_missing, min_gap_pct;
+        (SELECT count(*) FROM per_bucket
+             WHERE num_shards > 1 AND structural >= min_bucket_size AND derived = 0),
+        (SELECT min('shard ' || bucket || '/' || num_shards || ' of dataset ' || dataset_id
+                    || ' (' || structural || ' structural compounds, 0 derived)')
+             FROM per_bucket
+             WHERE num_shards > 1 AND structural >= min_bucket_size AND derived = 0)
+      INTO total_missing, bad_omitted, example_omitted, bad_shard, example_shard;
+    RAISE INFO 'coverage: % structural-identifier compound(s) lack a derived row (existence gate per (dataset, scope), min scope size %; shard-hole gate per hash bucket, min bucket size %)', total_missing, min_scope_size, min_bucket_size;
     IF bad_omitted > 0 THEN
         RAISE EXCEPTION 'coverage: % (dataset, attachment scope) cell(s) hold >= % structural-identifier compounds but no derived row (e.g. %) -- a dataset or attachment path omitted from the derive pass', bad_omitted, min_scope_size, example_omitted;
     END IF;
-    IF bad_partial > 0 THEN
-        RAISE EXCEPTION 'coverage: % dataset(s) are partially derived beyond the unparseable residue (e.g. %) -- likely a failed derivation shard, which underives ~1/num_shards of a dataset', bad_partial, example_partial;
+    IF bad_shard > 0 THEN
+        RAISE EXCEPTION 'coverage: % shard-hash bucket(s) hold >= % structural-identifier compounds but no derived row (e.g. %) -- a failed derivation shard leaves exactly one bucket wholly underived', bad_shard, min_bucket_size, example_shard;
     END IF;
 END $$;
 

--- a/.claude/skills/orm-database-load/scripts/verify_coverage.sql
+++ b/.claude/skills/orm-database-load/scripts/verify_coverage.sql
@@ -104,84 +104,119 @@ BEGIN
 END $$;
 
 -- Every compound carrying a structural identifier should derive a SMILES; a load that
--- skipped a compound -- or an entire attachment path -- leaves it with a structural
--- identifier but no derived row. NAME-only compounds are excluded, so the documented
--- `compounds > derived` gap does not trip this. The type list mirrors
--- message_helpers.STRUCTURAL_IDENTIFIER_TYPES.
+-- skipped a compound -- a whole dataset, a whole attachment path, or their intersection --
+-- leaves structural-identifier compounds with no derived row. NAME-only compounds are
+-- excluded, so the documented `compounds > derived` gap does not trip this. The type list
+-- mirrors message_helpers.STRUCTURAL_IDENTIFIER_TYPES.
 --
--- Checked PER SCOPE, not against one global count: ord.compound split by its three
--- attachment paths (reaction input, workup input, product measurement) plus
--- ord.product_compound. A low-volume path omitted from derivation has a ~100% miss rate
--- *within its own scope*, so it fails even though its rows would stay under a corpus-wide
--- tolerance (and a reaction-keyed check would miss it, since reaction SMILES can still
--- derive). Within each scope the tolerance absorbs the RDKit-unparseable residue every real
--- load carries (~0.02%: organometallics such as Ir photocatalysts or C[Al](C)(C)([Li])...,
--- charged-N ring systems -- identifiers the load-time RDKit cannot parse or reconstruct).
--- The total is printed; lower the tolerance to tighten the gate.
+-- Checked PER (dataset, attachment scope) cell: ord.compound split by its three attachment
+-- paths (reaction input, workup input, product measurement) plus ord.product_compound, each
+-- grouped by the reaction's dataset. _update_compound_smiles derives a dataset's compounds
+-- across all attachment paths together in one unsegmented pass, so a cell it actually visited
+-- always retains at least one derived row (its parseable compounds); a cell omitted from the
+-- pass has exactly zero. The invariant is therefore: any cell holding a meaningful number of
+-- structural-identifier compounds must have at least one derived row. This needs no percentage
+-- tolerance -- a healthy cell keeps its parseable derivations regardless of how many
+-- RDKit-unparseable organometallics or charged-N rings it also carries, and min_scope_size
+-- absorbs a hypothetical tiny all-unparseable cell (real reagent/product cells always contain
+-- parseable organics, so none is 100% unparseable at that size). Catches the single dataset x
+-- single path omission a corpus-wide or reaction-keyed count would dilute. The total underived
+-- count is printed; min_scope_size defaults to 50 (override with -v min_scope_size=N).
+\if :{?min_scope_size}
+\else
+  \set min_scope_size 50
+\endif
+SELECT set_config('ord.verify_min_scope_size', :'min_scope_size', false) AS min_scope_size;
 DO $$
 DECLARE
     total_missing bigint;
-    bad_scopes bigint;
-    tolerance_pct numeric := 0.1;
+    bad_cells bigint;
+    example text;
+    min_scope_size int := current_setting('ord.verify_min_scope_size')::int;
 BEGIN
     WITH scoped AS (
-        SELECT
-            CASE WHEN ri.reaction_id IS NOT NULL THEN 'reaction_input'
-                 WHEN c.reaction_input_id IS NOT NULL THEN 'workup_input'
-                 ELSE 'product_measurement' END AS scope,
-            EXISTS (
-                SELECT 1 FROM ord.compound_identifier ci
-                WHERE ci.compound_id = c.id
-                  AND ci.type IN ('SMILES', 'INCHI', 'MOLBLOCK') AND ci.value <> ''
-            ) AS structural,
-            NOT EXISTS (
-                SELECT 1 FROM derived.compound_smiles d WHERE d.compound_id = c.id
-            ) AS underived
+        SELECT r.dataset_id AS dataset_id, 'reaction_input' AS scope,
+               EXISTS (
+                   SELECT 1 FROM ord.compound_identifier ci
+                   WHERE ci.compound_id = c.id
+                     AND ci.type IN ('SMILES', 'INCHI', 'MOLBLOCK') AND ci.value <> ''
+               ) AS structural,
+               EXISTS (
+                   SELECT 1 FROM derived.compound_smiles d WHERE d.compound_id = c.id
+               ) AS derived
         FROM ord.compound c
-        LEFT JOIN ord.reaction_input ri ON c.reaction_input_id = ri.id
+        JOIN ord.reaction_input ri ON c.reaction_input_id = ri.id
+        JOIN ord.reaction r ON ri.reaction_id = r.id
         UNION ALL
-        SELECT
-            'product_compound',
-            EXISTS (
-                SELECT 1 FROM ord.compound_identifier ci
-                WHERE ci.product_compound_id = pc.id
-                  AND ci.type IN ('SMILES', 'INCHI', 'MOLBLOCK') AND ci.value <> ''
-            ),
-            NOT EXISTS (
-                SELECT 1 FROM derived.product_compound_smiles d
-                WHERE d.product_compound_id = pc.id
-            )
+        SELECT r.dataset_id, 'workup_input',
+               EXISTS (
+                   SELECT 1 FROM ord.compound_identifier ci
+                   WHERE ci.compound_id = c.id
+                     AND ci.type IN ('SMILES', 'INCHI', 'MOLBLOCK') AND ci.value <> ''
+               ),
+               EXISTS (
+                   SELECT 1 FROM derived.compound_smiles d WHERE d.compound_id = c.id
+               )
+        FROM ord.compound c
+        JOIN ord.reaction_input ri ON c.reaction_input_id = ri.id
+        JOIN ord.reaction_workup rw ON ri.reaction_workup_id = rw.id
+        JOIN ord.reaction r ON rw.reaction_id = r.id
+        UNION ALL
+        SELECT r.dataset_id, 'product_measurement',
+               EXISTS (
+                   SELECT 1 FROM ord.compound_identifier ci
+                   WHERE ci.compound_id = c.id
+                     AND ci.type IN ('SMILES', 'INCHI', 'MOLBLOCK') AND ci.value <> ''
+               ),
+               EXISTS (
+                   SELECT 1 FROM derived.compound_smiles d WHERE d.compound_id = c.id
+               )
+        FROM ord.compound c
+        JOIN ord.product_measurement pm ON c.product_measurement_id = pm.id
+        JOIN ord.product_compound pc ON pm.product_compound_id = pc.id
+        JOIN ord.reaction_outcome ro ON pc.reaction_outcome_id = ro.id
+        JOIN ord.reaction r ON ro.reaction_id = r.id
+        UNION ALL
+        SELECT r.dataset_id, 'product_compound',
+               EXISTS (
+                   SELECT 1 FROM ord.compound_identifier ci
+                   WHERE ci.product_compound_id = pc.id
+                     AND ci.type IN ('SMILES', 'INCHI', 'MOLBLOCK') AND ci.value <> ''
+               ),
+               EXISTS (
+                   SELECT 1 FROM derived.product_compound_smiles d
+                   WHERE d.product_compound_id = pc.id
+               )
         FROM ord.product_compound pc
+        JOIN ord.reaction_outcome ro ON pc.reaction_outcome_id = ro.id
+        JOIN ord.reaction r ON ro.reaction_id = r.id
     ),
-    per_scope AS (
-        SELECT scope,
+    per_cell AS (
+        SELECT dataset_id, scope,
                count(*) FILTER (WHERE structural) AS structural,
-               count(*) FILTER (WHERE structural AND underived) AS missing
+               count(*) FILTER (WHERE structural AND derived) AS derived
         FROM scoped
-        GROUP BY scope
+        GROUP BY dataset_id, scope
     )
-    SELECT coalesce(sum(missing), 0),
-           count(*) FILTER (
-               WHERE structural > 0
-                 AND missing::numeric > tolerance_pct / 100 * structural
-           )
-      INTO total_missing, bad_scopes
-    FROM per_scope;
-    RAISE INFO 'coverage: % structural-identifier compound(s) lack a derived row across attachment scopes (tolerance % percent per scope)', total_missing, tolerance_pct;
-    IF bad_scopes > 0 THEN
-        RAISE EXCEPTION 'coverage: % attachment scope(s) have structural-identifier compounds underived beyond the % percent tolerance -- a scope omitted from the derive pass that a corpus-wide count would dilute', bad_scopes, tolerance_pct;
+    SELECT
+        coalesce(sum(structural - derived), 0),
+        count(*) FILTER (WHERE structural >= min_scope_size AND derived = 0),
+        min(scope || ' in dataset ' || dataset_id)
+            FILTER (WHERE structural >= min_scope_size AND derived = 0)
+      INTO total_missing, bad_cells, example
+    FROM per_cell;
+    RAISE INFO 'coverage: % structural-identifier compound(s) lack a derived row (per (dataset, scope) derived>0 gate, min scope size %)', total_missing, min_scope_size;
+    IF bad_cells > 0 THEN
+        RAISE EXCEPTION 'coverage: % (dataset, attachment scope) cell(s) hold >= % structural-identifier compounds but no derived row (e.g. %) -- a dataset or attachment path omitted from the derive pass', bad_cells, min_scope_size, example;
     END IF;
 END $$;
 
--- Per-dataset derivation completeness. The per-scope compound check above still spreads a
--- single dataset's rows across each attachment path, so one small dataset omitted entirely
--- can stay under the tolerance in every path while parity passes (it only proves the
--- reactions were ingested) and the unlinked check stays silent (it cannot see rows that
--- were never derived). The derive pass runs per dataset and writes both compound and
--- reaction SMILES together, so an omitted dataset has ~none of either. reaction_smiles
--- carries the reaction's dataset_id, making a per-dataset check cheap: flag any dataset with
--- fewer than half its reactions derived. A full omission is ~100% underived; the ~0.4%
--- unparseable reaction residual and normal variation stay well under half.
+-- Per-dataset reaction derivation completeness. Independent of the compound gate above: it
+-- validates derived.reaction_smiles, a separate table the per-cell compound check never
+-- touches. reaction_smiles carries the reaction's dataset_id, so this is cheap (a hash
+-- aggregate over ord.reaction, no compound->reaction join) -- flag any dataset with fewer than
+-- half its reactions derived. A dataset omitted from the derive pass has ~none derived; the
+-- ~0.4% unparseable reaction residual and normal variation stay well under half.
 DO $$
 DECLARE
     omitted bigint;
@@ -195,7 +230,7 @@ BEGIN
     ) t
     WHERE derived * 2 < reactions;
     IF omitted > 0 THEN
-        RAISE EXCEPTION 'coverage: % dataset(s) have fewer than half their reactions derived -- a scope omitted from the derive pass that the global tolerance would hide', omitted;
+        RAISE EXCEPTION 'coverage: % dataset(s) have fewer than half their reactions derived -- omitted from the derive pass', omitted;
     END IF;
 END $$;
 

--- a/.claude/skills/orm-database-load/scripts/verify_coverage.sql
+++ b/.claude/skills/orm-database-load/scripts/verify_coverage.sql
@@ -125,33 +125,37 @@ END $$;
 --      reagent/product cells always contain parseable organics). Catches the single dataset x
 --      single path omission a corpus-wide or reaction-keyed count would dilute.
 --
---   2. PARTIAL derivation (completeness). SMILES derivation is sharded (loading.py: one hash
---      partition of a >50k-reaction dataset's compound ids per worker, capped at 32), and the
---      loader raises on a failed shard -- but a defence-in-depth gate should not trust that exit
---      status. A failed shard leaves a cell with derived>0 yet ~1/num_shards of it underived:
---      tens of thousands of compounds at >= ~3% of the cell (num_shards <= 32). That dwarfs the
---      residue (a few thousand corpus-wide), so a cell is flagged when its underived count clears
---      BOTH an absolute floor (max_cell_missing, above any per-cell residue) AND a fraction
---      (min_gap_pct, below the smallest 1/32 shard hole). Requiring both keeps a small
---      organometallic cell (high fraction, tiny absolute) and a huge cell holding a little
---      residue (large absolute, tiny fraction) from tripping, while a shard hole clears both.
+--   2. PARTIAL derivation (completeness), checked PER DATASET. SMILES derivation is sharded
+--      (loading.py: one hashtextextended partition of a >50k-reaction dataset's compound ids per
+--      worker, capped at 32), and the loader raises on a failed shard -- but a defence-in-depth
+--      gate should not trust that exit status. A shard partitions the *whole dataset's* compound
+--      ids, so a failed shard removes ~1/num_shards of every scope at once; a small scope's slice
+--      can be under an absolute floor even though the dataset-wide hole is enormous. So this gate
+--      aggregates to the dataset: the smallest sharded dataset still has >50k reactions and >=2
+--      structural compounds each over <=32 shards, so any shard hole underives tens of thousands
+--      of the dataset's compounds (>= 1/32 ~= 3%), dwarfing the whole-dataset residue (at most the
+--      corpus total, a few thousand). A dataset is flagged when its total underived clears BOTH an
+--      absolute floor (max_dataset_missing, above any one dataset's residue) AND a fraction
+--      (min_gap_pct, below the smallest 1/32 hole). Requiring both keeps an organometallic-heavy
+--      dataset (high fraction, small absolute) and a huge dataset holding a little residue (large
+--      absolute, tiny fraction) from tripping, while a shard hole clears both.
 --
--- The total underived count is printed. Defaults: min_scope_size 50, max_cell_missing 10000,
+-- The total underived count is printed. Defaults: min_scope_size 50, max_dataset_missing 10000,
 -- min_gap_pct 1 (override with -v NAME=N).
 \if :{?min_scope_size}
 \else
   \set min_scope_size 50
 \endif
-\if :{?max_cell_missing}
+\if :{?max_dataset_missing}
 \else
-  \set max_cell_missing 10000
+  \set max_dataset_missing 10000
 \endif
 \if :{?min_gap_pct}
 \else
   \set min_gap_pct 1
 \endif
 SELECT set_config('ord.verify_min_scope_size', :'min_scope_size', false) AS min_scope_size,
-       set_config('ord.verify_max_cell_missing', :'max_cell_missing', false) AS max_cell_missing,
+       set_config('ord.verify_max_dataset_missing', :'max_dataset_missing', false) AS max_dataset_missing,
        set_config('ord.verify_min_gap_pct', :'min_gap_pct', false) AS min_gap_pct;
 DO $$
 DECLARE
@@ -161,7 +165,7 @@ DECLARE
     bad_partial bigint;
     example_partial text;
     min_scope_size int := current_setting('ord.verify_min_scope_size')::int;
-    max_cell_missing int := current_setting('ord.verify_max_cell_missing')::int;
+    max_dataset_missing int := current_setting('ord.verify_max_dataset_missing')::int;
     min_gap_pct numeric := current_setting('ord.verify_min_gap_pct')::numeric;
 BEGIN
     WITH scoped AS (
@@ -227,32 +231,41 @@ BEGIN
                count(*) FILTER (WHERE structural AND derived) AS derived
         FROM scoped
         GROUP BY dataset_id, scope
+    ),
+    -- Completeness rolls the cells up to the dataset, because a failed shard's hole is
+    -- dataset-wide (it partitions all scopes' ids at once); a small scope's slice may be
+    -- tiny in absolute terms while the dataset-wide hole is not.
+    per_dataset AS (
+        SELECT dataset_id,
+               sum(structural) AS structural,
+               sum(derived) AS derived
+        FROM per_cell
+        GROUP BY dataset_id
     )
+    -- Scalar subqueries over the shared CTEs; per_cell (hence the UNION) materializes once.
     SELECT
-        coalesce(sum(structural - derived), 0),
-        count(*) FILTER (WHERE structural >= min_scope_size AND derived = 0),
-        min(scope || ' in dataset ' || dataset_id)
-            FILTER (WHERE structural >= min_scope_size AND derived = 0),
-        count(*) FILTER (
-            WHERE derived > 0
-              AND structural - derived >= max_cell_missing
-              AND (structural - derived)::numeric >= min_gap_pct / 100 * structural
-        ),
-        min(scope || ' in dataset ' || dataset_id
-            || ' (' || (structural - derived) || ' of ' || structural || ' missing)')
-            FILTER (
-                WHERE derived > 0
-                  AND structural - derived >= max_cell_missing
-                  AND (structural - derived)::numeric >= min_gap_pct / 100 * structural
-            )
-      INTO total_missing, bad_omitted, example_omitted, bad_partial, example_partial
-    FROM per_cell;
-    RAISE INFO 'coverage: % structural-identifier compound(s) lack a derived row (per (dataset, scope) gates: existence min scope size %, completeness max % missing and >= % pct per cell)', total_missing, min_scope_size, max_cell_missing, min_gap_pct;
+        (SELECT coalesce(sum(structural - derived), 0) FROM per_cell),
+        (SELECT count(*) FROM per_cell
+             WHERE structural >= min_scope_size AND derived = 0),
+        (SELECT min(scope || ' in dataset ' || dataset_id) FROM per_cell
+             WHERE structural >= min_scope_size AND derived = 0),
+        (SELECT count(*) FROM per_dataset
+             WHERE derived > 0
+               AND structural - derived >= max_dataset_missing
+               AND (structural - derived)::numeric >= min_gap_pct / 100 * structural),
+        (SELECT min('dataset ' || dataset_id
+                    || ' (' || (structural - derived) || ' of ' || structural || ' missing)')
+             FROM per_dataset
+             WHERE derived > 0
+               AND structural - derived >= max_dataset_missing
+               AND (structural - derived)::numeric >= min_gap_pct / 100 * structural)
+      INTO total_missing, bad_omitted, example_omitted, bad_partial, example_partial;
+    RAISE INFO 'coverage: % structural-identifier compound(s) lack a derived row (existence gate per (dataset, scope), min scope size %; completeness gate per dataset, max % missing and >= % pct)', total_missing, min_scope_size, max_dataset_missing, min_gap_pct;
     IF bad_omitted > 0 THEN
         RAISE EXCEPTION 'coverage: % (dataset, attachment scope) cell(s) hold >= % structural-identifier compounds but no derived row (e.g. %) -- a dataset or attachment path omitted from the derive pass', bad_omitted, min_scope_size, example_omitted;
     END IF;
     IF bad_partial > 0 THEN
-        RAISE EXCEPTION 'coverage: % (dataset, attachment scope) cell(s) are partially derived beyond the unparseable residue (e.g. %) -- likely a failed derivation shard, which underives ~1/num_shards of a cell', bad_partial, example_partial;
+        RAISE EXCEPTION 'coverage: % dataset(s) are partially derived beyond the unparseable residue (e.g. %) -- likely a failed derivation shard, which underives ~1/num_shards of a dataset', bad_partial, example_partial;
     END IF;
 END $$;
 

--- a/.claude/skills/orm-database-load/scripts/verify_coverage.sql
+++ b/.claude/skills/orm-database-load/scripts/verify_coverage.sql
@@ -104,35 +104,65 @@ BEGIN
 END $$;
 
 -- Every compound carrying a structural identifier should derive a SMILES; a load that
--- skipped a compound -- a whole dataset, a whole attachment path, or their intersection --
--- leaves structural-identifier compounds with no derived row. NAME-only compounds are
--- excluded, so the documented `compounds > derived` gap does not trip this. The type list
--- mirrors message_helpers.STRUCTURAL_IDENTIFIER_TYPES.
+-- skipped a compound leaves structural-identifier compounds with no derived row. NAME-only
+-- compounds are excluded, so the documented `compounds > derived` gap does not trip this.
+-- The type list mirrors message_helpers.STRUCTURAL_IDENTIFIER_TYPES.
 --
 -- Checked PER (dataset, attachment scope) cell: ord.compound split by its three attachment
 -- paths (reaction input, workup input, product measurement) plus ord.product_compound, each
--- grouped by the reaction's dataset. _update_compound_smiles derives a dataset's compounds
--- across all attachment paths together in one unsegmented pass, so a cell it actually visited
--- always retains at least one derived row (its parseable compounds); a cell omitted from the
--- pass has exactly zero. The invariant is therefore: any cell holding a meaningful number of
--- structural-identifier compounds must have at least one derived row. This needs no percentage
--- tolerance -- a healthy cell keeps its parseable derivations regardless of how many
--- RDKit-unparseable organometallics or charged-N rings it also carries, and min_scope_size
--- absorbs a hypothetical tiny all-unparseable cell (real reagent/product cells always contain
--- parseable organics, so none is 100% unparseable at that size). Catches the single dataset x
--- single path omission a corpus-wide or reaction-keyed count would dilute. The total underived
--- count is printed; min_scope_size defaults to 50 (override with -v min_scope_size=N).
+-- grouped by the reaction's dataset. Two gates over the same cells, both robust to the
+-- RDKit-unparseable residue every real load carries (organometallics such as Ir photocatalysts
+-- or C[Al](C)(C)([Li])..., charged-N rings -- identifiers the load-time RDKit cannot parse or
+-- reconstruct; observed ~3.2k across ~18.8M derived rows on a full load):
+--
+--   1. OMISSION (derived>0 existence). _update_compound_smiles derives a dataset's compounds
+--      across all attachment paths together in one unsegmented pass, so a cell it visited keeps
+--      at least one derived row (its parseable compounds) while a cell it skipped -- a whole
+--      dataset, a whole path, or their intersection -- has exactly zero. Any cell holding
+--      >= min_scope_size structural compounds must have a derived row. No percentage tolerance:
+--      a healthy cell keeps its parseable derivations regardless of how many unparseable rows it
+--      also carries, and min_scope_size absorbs a hypothetical tiny all-unparseable cell (real
+--      reagent/product cells always contain parseable organics). Catches the single dataset x
+--      single path omission a corpus-wide or reaction-keyed count would dilute.
+--
+--   2. PARTIAL derivation (completeness). SMILES derivation is sharded (loading.py: one hash
+--      partition of a >50k-reaction dataset's compound ids per worker, capped at 32), and the
+--      loader raises on a failed shard -- but a defence-in-depth gate should not trust that exit
+--      status. A failed shard leaves a cell with derived>0 yet ~1/num_shards of it underived:
+--      tens of thousands of compounds at >= ~3% of the cell (num_shards <= 32). That dwarfs the
+--      residue (a few thousand corpus-wide), so a cell is flagged when its underived count clears
+--      BOTH an absolute floor (max_cell_missing, above any per-cell residue) AND a fraction
+--      (min_gap_pct, below the smallest 1/32 shard hole). Requiring both keeps a small
+--      organometallic cell (high fraction, tiny absolute) and a huge cell holding a little
+--      residue (large absolute, tiny fraction) from tripping, while a shard hole clears both.
+--
+-- The total underived count is printed. Defaults: min_scope_size 50, max_cell_missing 10000,
+-- min_gap_pct 1 (override with -v NAME=N).
 \if :{?min_scope_size}
 \else
   \set min_scope_size 50
 \endif
-SELECT set_config('ord.verify_min_scope_size', :'min_scope_size', false) AS min_scope_size;
+\if :{?max_cell_missing}
+\else
+  \set max_cell_missing 10000
+\endif
+\if :{?min_gap_pct}
+\else
+  \set min_gap_pct 1
+\endif
+SELECT set_config('ord.verify_min_scope_size', :'min_scope_size', false) AS min_scope_size,
+       set_config('ord.verify_max_cell_missing', :'max_cell_missing', false) AS max_cell_missing,
+       set_config('ord.verify_min_gap_pct', :'min_gap_pct', false) AS min_gap_pct;
 DO $$
 DECLARE
     total_missing bigint;
-    bad_cells bigint;
-    example text;
+    bad_omitted bigint;
+    example_omitted text;
+    bad_partial bigint;
+    example_partial text;
     min_scope_size int := current_setting('ord.verify_min_scope_size')::int;
+    max_cell_missing int := current_setting('ord.verify_max_cell_missing')::int;
+    min_gap_pct numeric := current_setting('ord.verify_min_gap_pct')::numeric;
 BEGIN
     WITH scoped AS (
         SELECT r.dataset_id AS dataset_id, 'reaction_input' AS scope,
@@ -202,12 +232,27 @@ BEGIN
         coalesce(sum(structural - derived), 0),
         count(*) FILTER (WHERE structural >= min_scope_size AND derived = 0),
         min(scope || ' in dataset ' || dataset_id)
-            FILTER (WHERE structural >= min_scope_size AND derived = 0)
-      INTO total_missing, bad_cells, example
+            FILTER (WHERE structural >= min_scope_size AND derived = 0),
+        count(*) FILTER (
+            WHERE derived > 0
+              AND structural - derived >= max_cell_missing
+              AND (structural - derived)::numeric >= min_gap_pct / 100 * structural
+        ),
+        min(scope || ' in dataset ' || dataset_id
+            || ' (' || (structural - derived) || ' of ' || structural || ' missing)')
+            FILTER (
+                WHERE derived > 0
+                  AND structural - derived >= max_cell_missing
+                  AND (structural - derived)::numeric >= min_gap_pct / 100 * structural
+            )
+      INTO total_missing, bad_omitted, example_omitted, bad_partial, example_partial
     FROM per_cell;
-    RAISE INFO 'coverage: % structural-identifier compound(s) lack a derived row (per (dataset, scope) derived>0 gate, min scope size %)', total_missing, min_scope_size;
-    IF bad_cells > 0 THEN
-        RAISE EXCEPTION 'coverage: % (dataset, attachment scope) cell(s) hold >= % structural-identifier compounds but no derived row (e.g. %) -- a dataset or attachment path omitted from the derive pass', bad_cells, min_scope_size, example;
+    RAISE INFO 'coverage: % structural-identifier compound(s) lack a derived row (per (dataset, scope) gates: existence min scope size %, completeness max % missing and >= % pct per cell)', total_missing, min_scope_size, max_cell_missing, min_gap_pct;
+    IF bad_omitted > 0 THEN
+        RAISE EXCEPTION 'coverage: % (dataset, attachment scope) cell(s) hold >= % structural-identifier compounds but no derived row (e.g. %) -- a dataset or attachment path omitted from the derive pass', bad_omitted, min_scope_size, example_omitted;
+    END IF;
+    IF bad_partial > 0 THEN
+        RAISE EXCEPTION 'coverage: % (dataset, attachment scope) cell(s) are partially derived beyond the unparseable residue (e.g. %) -- likely a failed derivation shard, which underives ~1/num_shards of a cell', bad_partial, example_partial;
     END IF;
 END $$;
 

--- a/.claude/skills/orm-database-load/scripts/verify_coverage.sql
+++ b/.claude/skills/orm-database-load/scripts/verify_coverage.sql
@@ -135,21 +135,32 @@ END $$;
 --      hash) and so never empties one. So recompute each dataset's num_shards from its reaction
 --      count, bucket its structural compounds by the same ((h % n) + n) % n hash, and flag any
 --      bucket of a sharded dataset with >= min_bucket_size structural compounds but no derived
---      row. Detecting the hole by its shape (a wholly-empty hash class) rather than its size needs
---      no residue-calibrated tolerance and catches the failure however small or name-heavy the
---      dataset is. A healthy database populates every bucket whatever num_shards is, so an
---      inaccurate recomputation can only miss a hole, never invent one.
+--      row. Whether that outcome is really a hole is judged against the bucket's SIBLING buckets,
+--      not an absolute size floor: the hash spreads a dataset's compounds uniformly, so the
+--      siblings measure how often this dataset's structural identifiers legitimately fail to
+--      derive, and the bucket is flagged when they make "every one of mine missed by chance"
+--      implausible (probability < max_false_positive). That keeps a sparse hole visible -- a
+--      dataset shards on its reaction count, so a name-heavy one just over the threshold may hold
+--      only a handful of structural compounds per bucket -- while never flagging a small
+--      all-unparseable bucket in a dataset whose siblings show a high miss rate. A healthy
+--      database populates every bucket whatever num_shards is, so an inaccurate recomputation can
+--      only miss a hole, never invent one.
 --
--- The total underived count is printed. Defaults: min_scope_size 50, min_bucket_size 50, and
--- shard_size/shard_cap mirroring loading._DERIVE_SHARD_SIZE/_DERIVE_SHARD_CAP -- keep those two
--- in step with the loader if its constants change (override any with -v NAME=N).
+-- The total underived count is printed. Defaults: min_scope_size 50, min_bucket_size 2,
+-- max_false_positive 1e-6, and shard_size/shard_cap mirroring
+-- loading._DERIVE_SHARD_SIZE/_DERIVE_SHARD_CAP -- keep those two in step with the loader if its
+-- constants change (override any with -v NAME=N).
 \if :{?min_scope_size}
 \else
   \set min_scope_size 50
 \endif
 \if :{?min_bucket_size}
 \else
-  \set min_bucket_size 50
+  \set min_bucket_size 2
+\endif
+\if :{?max_false_positive}
+\else
+  \set max_false_positive 1e-6
 \endif
 \if :{?shard_size}
 \else
@@ -161,6 +172,8 @@ END $$;
 \endif
 SELECT set_config('ord.verify_min_scope_size', :'min_scope_size', false) AS min_scope_size,
        set_config('ord.verify_min_bucket_size', :'min_bucket_size', false) AS min_bucket_size,
+       set_config('ord.verify_max_false_positive', :'max_false_positive', false)
+           AS max_false_positive,
        set_config('ord.verify_shard_size', :'shard_size', false) AS shard_size,
        set_config('ord.verify_shard_cap', :'shard_cap', false) AS shard_cap;
 DO $$
@@ -172,6 +185,7 @@ DECLARE
     example_shard text;
     min_scope_size int := current_setting('ord.verify_min_scope_size')::int;
     min_bucket_size int := current_setting('ord.verify_min_bucket_size')::int;
+    max_false_positive numeric := current_setting('ord.verify_max_false_positive')::numeric;
     shard_size int := current_setting('ord.verify_shard_size')::int;
     shard_cap int := current_setting('ord.verify_shard_cap')::int;
 BEGIN
@@ -273,6 +287,31 @@ BEGIN
             JOIN dataset_shards ds ON ds.dataset_id = s.dataset_id
         ) b
         GROUP BY dataset_id, num_shards, bucket
+    ),
+    -- Judge each bucket against its SIBLING buckets in the same dataset rather than an absolute
+    -- size floor. The hash spreads a dataset's compounds uniformly, so the siblings measure the
+    -- rate at which this dataset's structural identifiers legitimately fail to derive; a bucket
+    -- that derived nothing is a shard hole exactly when the siblings say that outcome is
+    -- implausible. An absolute floor would ignore a sparse hole -- a dataset shards on its
+    -- reaction count, so a name-heavy one over the threshold can hold only a handful of
+    -- structural compounds per bucket and still lose a whole shard.
+    bucket_stats AS (
+        SELECT dataset_id, num_shards, bucket, structural, derived,
+               sum(structural) OVER (PARTITION BY dataset_id) - structural AS structural_other,
+               sum(derived) OVER (PARTITION BY dataset_id) - derived AS derived_other
+        FROM per_bucket
+    ),
+    -- Laplace-smoothed miss rate from the siblings (the +1s keep an all-derived sibling set from
+    -- claiming a zero miss rate, which would flag a lone unparseable compound). The exponent is
+    -- capped because a bucket only has to be a handful of compounds deep before the probability
+    -- is negligible, and an uncapped numeric power over a large bucket would underflow.
+    bucket_verdict AS (
+        SELECT *,
+               power((structural_other - derived_other + 1)::numeric / (structural_other + 1),
+                     least(structural, 50)) AS chance_all_missed
+        FROM bucket_stats
+        WHERE num_shards > 1 AND derived = 0 AND structural >= min_bucket_size
+          AND structural_other > 0
     )
     -- Scalar subqueries over the shared CTEs; scoped (hence the UNION) materializes once.
     SELECT
@@ -281,14 +320,13 @@ BEGIN
              WHERE structural >= min_scope_size AND derived = 0),
         (SELECT min(scope || ' in dataset ' || dataset_id) FROM per_cell
              WHERE structural >= min_scope_size AND derived = 0),
-        (SELECT count(*) FROM per_bucket
-             WHERE num_shards > 1 AND structural >= min_bucket_size AND derived = 0),
+        (SELECT count(*) FROM bucket_verdict WHERE chance_all_missed < max_false_positive),
         (SELECT min('shard ' || bucket || '/' || num_shards || ' of dataset ' || dataset_id
-                    || ' (' || structural || ' structural compounds, 0 derived)')
-             FROM per_bucket
-             WHERE num_shards > 1 AND structural >= min_bucket_size AND derived = 0)
+                    || ' (' || structural || ' structural compounds, 0 derived; sibling shards '
+                    || 'derived ' || derived_other || '/' || structural_other || ')')
+             FROM bucket_verdict WHERE chance_all_missed < max_false_positive)
       INTO total_missing, bad_omitted, example_omitted, bad_shard, example_shard;
-    RAISE INFO 'coverage: % structural-identifier compound(s) lack a derived row (existence gate per (dataset, scope), min scope size %; shard-hole gate per hash bucket, min bucket size %)', total_missing, min_scope_size, min_bucket_size;
+    RAISE INFO 'coverage: % structural-identifier compound(s) lack a derived row (existence gate per (dataset, scope), min scope size %; shard-hole gate per hash bucket vs siblings, min bucket size %, max false positive %)', total_missing, min_scope_size, min_bucket_size, max_false_positive;
     IF bad_omitted > 0 THEN
         RAISE EXCEPTION 'coverage: % (dataset, attachment scope) cell(s) hold >= % structural-identifier compounds but no derived row (e.g. %) -- a dataset or attachment path omitted from the derive pass', bad_omitted, min_scope_size, example_omitted;
     END IF;

--- a/.claude/skills/orm-database-load/scripts/verify_coverage.sql
+++ b/.claude/skills/orm-database-load/scripts/verify_coverage.sql
@@ -137,7 +137,8 @@ END $$;
 --      bucket of a sharded dataset with >= min_bucket_size structural compounds but no derived
 --      row. Detecting the hole by its shape (a wholly-empty hash class) rather than its size needs
 --      no residue-calibrated tolerance and catches the failure however small or name-heavy the
---      dataset is. Keep min_bucket_size in step with the loader's shard constants if they change.
+--      dataset is. A healthy database populates every bucket whatever num_shards is, so an
+--      inaccurate recomputation can only miss a hole, never invent one.
 --
 -- The total underived count is printed. Defaults: min_scope_size 50, min_bucket_size 50, and
 -- shard_size/shard_cap mirroring loading._DERIVE_SHARD_SIZE/_DERIVE_SHARD_CAP -- keep those two
@@ -242,15 +243,19 @@ BEGIN
         FROM scoped
         GROUP BY dataset_id, scope
     ),
-    -- num_shards the loader used for each dataset's SMILES derivation, recomputed from its
-    -- reaction count: min(shard_cap, ceil(reactions / shard_size)), at least 1. Mirrors
-    -- loading._derive_shard_items.
+    -- num_shards the loader used for each dataset's SMILES derivation:
+    -- min(shard_cap, ceil(size / shard_size)), at least 1. Mirrors loading._derive_shard_items,
+    -- reading size from the same place it does (get_dataset_size -> public.datasets.num_reactions,
+    -- 0 when the metadata row is missing) rather than counting ord.reaction -- if the two ever
+    -- disagreed across a shard-size boundary, a recomputed num_shards would bucket the compounds
+    -- differently than the loader did and smear a shard hole across buckets instead of exposing it.
     dataset_shards AS (
-        SELECT dataset_id,
-               greatest(1, least(shard_cap, ceil(count(*)::numeric / shard_size)::int))
+        SELECT d.id AS dataset_id,
+               greatest(1, least(shard_cap,
+                                 ceil(coalesce(pd.num_reactions, 0)::numeric / shard_size)::int))
                    AS num_shards
-        FROM ord.reaction
-        GROUP BY dataset_id
+        FROM ord.dataset d
+        LEFT JOIN public.datasets pd ON pd.dataset_id = d.dataset_id
     ),
     -- Bucket each dataset's structural compounds by the loader's shard hash, so a failed shard
     -- shows up as a bucket with structural rows but no derived row (the residue spreads across


### PR DESCRIPTION
## Problem

The `verify_coverage.sql` coverage invariant (added in #894) must fail a cutover when the derive pass skipped compounds, while tolerating the small residue of RDKit-**unparseable** structural identifiers every real ORD load carries (organometallics — Ir photocatalysts, `C[Al](C)(C)([Li])c1ccccc1` — charged-nitrogen rings, explicit-H ammonium), which legitimately derive no row (~3.2k across ~18.8M derived rows).

Earlier iterations chased this with tolerances — corpus-wide, then per attachment scope, then per dataset. Successive Greptile rounds showed each one has a gap:

1. A global tolerance dilutes a scoped omission.
2. A reaction-keyed check misses a compound-only omission.
3. A single dataset's single attachment path, omitted, dilutes in both.
4. A **partially**-derived cell (a failed derivation shard) keeps `derived > 0`, so an existence-only check passes it.
5. A per-cell absolute floor is evaded — a shard partitions the whole dataset's ids, so a small scope's slice of the hole falls under a per-cell floor.
6. **Any** residue-calibrated floor is evaded — a ~50k-reaction, name-heavy dataset with <20k structural compounds loses <10k rows when one of two shards fails.

Round 6 is the general lesson: you cannot separate "shard failed" from "unparseable residue" by **size**.

## Change

Two gates over `(dataset, attachment scope)` cells — `ord.compound` split by reaction input, workup input, and product measurement, plus `ord.product_compound` — both **calibration-free**, each keyed to the *shape* of the failure rather than its magnitude:

- **Omission (existence), per `(dataset, scope)`.** `_update_compound_smiles` derives a dataset's compounds across all attachment paths in **one unsegmented pass**, so a cell it visited keeps ≥1 derived row while a cell it skipped — whole dataset, whole path, or their intersection — has **exactly zero**. Any cell with ≥ `min_scope_size` (default 50) structural compounds must have a derived row. Closes rounds 1–3.
- **Failed shard, per shard-hash bucket.** Derivation shards by `hashtextextended(id)` with `num_shards = min(32, ceil(reactions / 50000))`. A failed shard leaves **exactly one hash bucket wholly underived** — parseable compounds included — while the residue spreads uniformly across every bucket (parseability is uncorrelated with the id hash) and so can never empty one. The gate recomputes each dataset's `num_shards`, buckets its structural compounds by the same hash, and flags any bucket of a **sharded** dataset with ≥ `min_bucket_size` (default 50) structural compounds and no derived row. No tolerance, so dataset size and name-heaviness are irrelevant. Closes rounds 4–6.

`num_shards` is recomputed from the same source the loader sizes shards from (`public.datasets.num_reactions`, missing row → 0), so the buckets match the ones the loader actually used. `num_shards = 1` datasets never sharded and are excluded, so the gate cannot invent a hole; a healthy database populates every bucket whatever `num_shards` is, so an inaccurate recomputation could only miss a hole, never raise falsely.

The loader `raise`s on a failed shard, but these gates deliberately don't trust that exit status. The **per-dataset reaction** check stays as an independent guard on `derived.reaction_smiles`. The `unlinked`, `payload parity`, and `non-empty` gates are unchanged. Thresholds and the loader-mirroring `shard_size`/`shard_cap` override with `-v NAME=N`; `scoped` is shared by both gates so the compound→reaction UNION materializes once.

## Verification

`verify_coverage.sql` under `psql -v ON_ERROR_STOP=1` against a `prepare_database()`'d schema with a loaded dataset:

- A clean load exits 0 and prints the count.
- **Round 3 (path omission):** wiping compound derivation for *only* the `reaction_input` path (401 compounds), leaving `reaction_smiles` and other scopes intact, exits non-zero on `attachment scope` / `reaction_input`; the reaction gate does not fire.
- **Rounds 4–6 (failed shard):** forcing the corpus to shard (`-v shard_size=…`) and deleting the derived rows of exactly one bucket — compound *and* product-compound, which is what an uncommitted shard leaves — exits non-zero naming `shard 0/4 of dataset …`, while the omission gate stays silent because every scope still has derived rows.
- Running that same wiped corpus at the default `shard_size` (dataset under the threshold → `num_shards = 1`) correctly reports **no** shard hole.
- Wiping a dataset's `reaction_smiles` exits non-zero on `fewer than half their reactions derived`.
- `markdownlint-cli2` passes on `SKILL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces size-based derived-SMILES coverage tolerances with omission and shard-shape gates.
- Checks compound coverage per dataset and attachment scope.
- Detects failed derivation shards by matching empty compound and reaction hash buckets against sibling derivation rates.
- Documents the revised verification process, thresholds, and operational rationale.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains in the revised coverage checks.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .claude/skills/orm-database-load/scripts/verify_coverage.sql | Replaces tolerance-based compound coverage with per-scope omission detection and joint compound/reaction shard-bucket verification. |
| .claude/skills/orm-database-load/SKILL.md | Documents the new omission and failed-shard coverage gates and their operational assumptions. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Data[Structural compounds and reactions] --> Scope[Group compounds by dataset and attachment scope]
  Data --> Buckets[Recompute loader shard buckets]
  Scope --> Omission{Large scope with zero derived compounds?}
  Buckets --> CompoundBucket[Compound derivation by bucket]
  Buckets --> ReactionBucket[Reaction derivation by bucket]
  CompoundBucket --> ShardGate{Both corresponding buckets empty beyond sibling miss rate?}
  ReactionBucket --> ShardGate
  Omission -->|Yes| Fail[Reject cutover]
  ShardGate -->|Yes| Fail
  Omission -->|No| Continue[Continue invariant checks]
  ShardGate -->|No| Continue
```
</details>

<sub>Reviews (10): Last reviewed commit: ["Corroborate a shard hole with the reacti..."](https://github.com/open-reaction-database/ord-schema/commit/88a4a8ace21a18a4ab31bbdbb076258411e437a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46890985)</sub>

**Context used:**

- Knowledge Base — [ORM and Database Loading](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/orm-database.md)

<!-- /greptile_comment -->