### PR TITLE
Pin GitHub Actions to commit SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Actions in .github/workflows are pinned to commit SHAs. Dependabot rewrites
+# both the SHA and its trailing version comment, which is what keeps a pinned
+# workflow from freezing on whatever was current the day it was written.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      # One pull request per month for all actions rather than one per action.
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -24,8 +24,8 @@ jobs:
   check_licenses:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '>=1.16'
       - name: Install dependencies
@@ -38,11 +38,11 @@ jobs:
   check_python:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           python-version: '3.11'
@@ -65,7 +65,7 @@ jobs:
   check_proto:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: clang-format
         run: |
           sudo apt update && sudo apt install clang-format --yes
@@ -74,8 +74,8 @@ jobs:
   check_markdown:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
       - name: markdownlint-cli2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,16 +42,16 @@ jobs:
       contents: write
       id-token: write  # PyPI + npm trusted publishing (OIDC).
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           token: ${{ secrets.ACTIONS_PUSH }}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: '3.11'
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           # Trusted publishing requires Node >= 22.14 and npm >= 11.5.1 (https://docs.npmjs.com/trusted-publishers)
           node-version: '24'
@@ -73,8 +73,11 @@ jobs:
           # Fail before the upload (and before the version bump is pushed) rather than taking a
           # 400 from PyPI: twine check does not reject direct (URL) dependencies.
           python .github/scripts/check_direct_dependencies.py dist/*
-      # Use release/v1 (not a bare v1.x.x tag): each tag must have a matching GHCR image
-      # (ghcr.io/pypa/gh-action-pypi-publish:<ref>); v1.14.0 had no manifest at publish time.
+      # The one action here not pinned to a commit SHA. It is a container action
+      # resolved as ghcr.io/pypa/gh-action-pypi-publish:<ref>, so the ref must have a
+      # matching GHCR image -- a SHA has none, and even v1.14.0 had no manifest at
+      # publish time. release/v1 is what PyPA documents. This job holds id-token: write
+      # for Trusted Publishing, so revisit if PyPA starts publishing SHA-tagged images.
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,16 +73,14 @@ jobs:
           # Fail before the upload (and before the version bump is pushed) rather than taking a
           # 400 from PyPI: twine check does not reject direct (URL) dependencies.
           python .github/scripts/check_direct_dependencies.py dist/*
-      # The one action here not pinned to a commit SHA. It is a container action
-      # resolved as ghcr.io/pypa/gh-action-pypi-publish:<ref>, so the ref must have a
-      # matching GHCR image -- a SHA has none, and even v1.14.0 had no manifest at
-      # publish time. release/v1 is what PyPA documents. This job holds id-token: write
-      # for Trusted Publishing, so revisit if PyPA starts publishing SHA-tagged images.
+      # uv does the OIDC exchange itself and uploads PEP 740 attestations by default,
+      # so no third-party action runs in this job -- which matters here, because
+      # id-token: write lets any step in it mint a token and publish a release.
+      # --trusted-publishing always fails loudly rather than falling back to looking
+      # for an API token that does not exist. Metadata is already checked above by
+      # twine check and check_direct_dependencies.py.
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
-          verify-metadata: false
+        run: uv publish --trusted-publishing always dist/*
       - name: Build and upload to NPM
         run: |
           cd js/ord-schema

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -30,8 +30,8 @@ jobs:
     env:
       PGDATA: $GITHUB_WORKSPACE/rdkit-postgres
     steps:
-      - uses: actions/checkout@v7
-      - uses: conda-incubator/setup-miniconda@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4
         with:
           miniconda-version: 'latest'
       - name: Setup PostgreSQL
@@ -40,10 +40,10 @@ jobs:
           # NOTE(skearnes): conda is only used for postgres (not python).
           conda install -c conda-forge rdkit-postgresql
           initdb
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -78,11 +78,11 @@ jobs:
       CUDA_VISIBLE_DEVICES: "-1"
       TF_CPP_MIN_LOG_LEVEL: "2"
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -95,11 +95,11 @@ jobs:
   test_proto_wrappers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
       - name: Install protoc
@@ -114,7 +114,7 @@ jobs:
           unzip protobuf-javascript-3.21.2-linux-x86_64.zip
           npm i -g ts-protoc-gen@0.15.0 protobufjs@7.4.0 protobufjs-cli@1.1.3
           PATH=$GITHUB_WORKSPACE/protoc/bin:$PATH protoc --version
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: '>=1.16'
       - name: Install addlicense
@@ -131,8 +131,8 @@ jobs:
   test_js:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: '24'
       - name: Test NPM package
@@ -143,14 +143,14 @@ jobs:
   test_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           python-version: '3.11'
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           # Trusted publishing requires Node >= 22.14 and npm >= 11.5.1 (https://docs.npmjs.com/trusted-publishers)
           node-version: '24'


### PR DESCRIPTION
Version tags are mutable. The `tj-actions/changed-files` compromise in March 2025 repointed every version tag at a commit that dumped runner secrets into build logs, hitting roughly 23,000 repositories; tag pinning offered no protection and SHA pinning offered complete protection.

This repository is the highest-value target in the org. `publish.yml` runs with `id-token: write` for PyPI Trusted Publishing, so any action step in that job can mint an OIDC token and publish an `ord-schema` release. It also publishes to npm and pushes tags with `secrets.ACTIONS_PUSH`.

## No exceptions left

`pypa/gh-action-pypi-publish` could not be SHA-pinned — it is a container action resolved as `ghcr.io/pypa/gh-action-pypi-publish:<ref>`, and a commit SHA has no matching GHCR image (the workflow's own comment records that even `v1.14.0` had no manifest at publish time). Rather than carry it as a documented exception, #911 replaced it with `uv publish --trusted-publishing always`, which is now merged into this branch.

uv performs the OIDC exchange itself and uploads PEP 740 attestations by default, so the release path lost nothing. **Every `uses:` in this repository now resolves to a commit SHA**, and every step in the `id-token: write` job is either a SHA-pinned action or a `run:` block.

## Dependabot is the other half

Dependabot understands SHA-pinned actions and rewrites the SHA together with its trailing `# vN` comment, so pinned workflows keep tracking upstream. Without it, pinning freezes the workflows on whatever was current the day they were written.

That failure mode is already live in this org: ord-app and ord-infrastructure are fully SHA-pinned with no update mechanism, and both sit on `astral-sh/setup-uv` **v5.4.2** while this repository runs **v7**. ord-app's `actions/checkout` pin is stale even within v4. Companion Dependabot PRs for those repositories, and the matching change in ord-data ([#264](https://github.com/open-reaction-database/ord-data/pull/264)), follow.

Updates are grouped so this arrives as one pull request a month rather than one per action.

Every pin resolves the tag that was already in use — `checkout@v7`, `setup-python@v6`, `setup-node@v6`, `setup-go@v6`, `setup-uv@v7`, `setup-miniconda@v4` — so the pinning commit changes no behavior; the PyPI publisher swap in #911 is the one behavioral change on this branch. Resolved through the git refs API, dereferencing annotated tags to their commits. All pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Pins GitHub Actions to immutable commit SHAs and modernizes release maintenance.
- Adds monthly grouped Dependabot updates for GitHub Actions.
- Replaces mutable action tags across CI and release workflows with SHA pins.
- Replaces the third-party PyPI publishing action with `uv publish` using trusted publishing.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | Adds a valid monthly updater that groups all GitHub Actions updates into one pull request. |
| .github/workflows/cleanup.yml | Replaces mutable action version tags with immutable SHAs without changing workflow inputs. |
| .github/workflows/publish.yml | Pins setup actions and moves PyPI trusted publishing from a third-party action to the installed uv CLI. |
| .github/workflows/run_tests.yml | Pins all test-workflow actions to immutable SHAs while retaining their existing configuration. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    D[Dependabot monthly update] --> P[Update pinned action SHAs]
    P --> W[CI and release workflows]
    W --> B[Build and validate distributions]
    B --> U[uv trusted publishing]
    U --> PYPI[PyPI]
    B --> NPM[npm]
    PYPI --> G[Push version bump and tag]
    NPM --> G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Publish to PyPI with uv instead of a thi..."](https://github.com/open-reaction-database/ord-schema/commit/df63c09e4249e9236cb6758a9cf9916d4919f1ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48150024)</sub>

<!-- /greptile_comment -->