### PR TITLE
Publish to PyPI with uv instead of a third-party action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,16 +73,14 @@ jobs:
           # Fail before the upload (and before the version bump is pushed) rather than taking a
           # 400 from PyPI: twine check does not reject direct (URL) dependencies.
           python .github/scripts/check_direct_dependencies.py dist/*
-      # The one action here not pinned to a commit SHA. It is a container action
-      # resolved as ghcr.io/pypa/gh-action-pypi-publish:<ref>, so the ref must have a
-      # matching GHCR image -- a SHA has none, and even v1.14.0 had no manifest at
-      # publish time. release/v1 is what PyPA documents. This job holds id-token: write
-      # for Trusted Publishing, so revisit if PyPA starts publishing SHA-tagged images.
+      # uv does the OIDC exchange itself and uploads PEP 740 attestations by default,
+      # so no third-party action runs in this job -- which matters here, because
+      # id-token: write lets any step in it mint a token and publish a release.
+      # --trusted-publishing always fails loudly rather than falling back to looking
+      # for an API token that does not exist. Metadata is already checked above by
+      # twine check and check_direct_dependencies.py.
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
-          verify-metadata: false
+        run: uv publish --trusted-publishing always dist/*
       - name: Build and upload to NPM
         run: |
           cd js/ord-schema


### PR DESCRIPTION
```diff
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
-          verify-metadata: false
+      - name: Publish package distributions to PyPI
+        run: uv publish --trusted-publishing always dist/*
```

`pypa/gh-action-pypi-publish` was the last thing in `publish.yml` that could not be pinned to a commit SHA — it is a container action resolved as `ghcr.io/pypa/gh-action-pypi-publish:<ref>`, so the ref needs a matching GHCR image and a SHA has none. #910 documented that as a deliberate exception. This removes the exception instead.

It matters here more than anywhere else in the org: the job runs with `id-token: write` for Trusted Publishing, so any step in it can mint an OIDC token and publish an `ord-schema` release. With this change every step in that job is either a SHA-pinned action or a `run:` block.

## Nothing is lost

`uv publish` does the trusted-publishing OIDC exchange itself, and it uploads PEP 740 attestations **by default** — `--no-attestations` is the opt-out, so provenance is unchanged. uv is already in the job via `setup-uv`, which the base branch pins.

`--trusted-publishing always` rather than the default `automatic`: it fails loudly instead of quietly falling back to looking for an API token that does not exist.

`verify-metadata: false` is moot. The step above already runs `twine check dist/*` and `check_direct_dependencies.py dist/*`, and the `test_publish` job in `run_tests.yml` exercises that same pre-upload sequence on every run.

## What is and is not verified

I ran the exact invocation locally against a stub `dist/`:

```
Publishing 1 file to https://upload.pypi.org/legacy/
error: Failed to obtain token for trusted publishing
  Caused by: No OIDC token discovered: are you in a supported trusted publishing environment?
```

So the arguments parse, the target URL is right, and it reaches the OIDC exchange before stopping for want of a token — which also demonstrates the fail-loudly behavior.

**The upload itself cannot be exercised without cutting a real release**, which was equally true of the action it replaces. If you want a rehearsal first, `--publish-url` against TestPyPI would drive the full OIDC exchange end to end.

Stacked on #910; retargets to `main` when that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Replaces the third-party PyPI publishing action with a direct, fail-loudly `uv publish` invocation.
- Retains Trusted Publishing through the workflow’s existing OIDC permission.
- Publishes the distributions already built and validated from `dist/`.
- Removes the final action in the privileged publishing job that could not be pinned to a commit SHA.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no identified publishing regression.

The existing pinned setup-uv step provides the publisher, the same validated dist artifacts are passed to the new command, and Trusted Publishing remains explicitly required through OIDC.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish.yml | The workflow now publishes validated Python distributions directly with uv while retaining the existing OIDC and artifact flow; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Publish to PyPI with uv instead of a thi..."](https://github.com/open-reaction-database/ord-schema/commit/ca6a4d2bf3b26fe95e7be8b454862505fa7adbeb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48151132)</sub>

<!-- /greptile_comment -->