### PR TITLE
Teach units about torr and mmHg

### DIFF
--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -93,6 +93,8 @@ _UNIT_SYNONYMS: dict[type[ord_schema.UnitMessage], dict[ProtoEnumMember, list[st
         reaction_pb2.Pressure.KPSI: ["kpsi"],
         reaction_pb2.Pressure.PASCAL: ["Pa", "pascal", "pascals", "pas"],
         reaction_pb2.Pressure.KILOPASCAL: ["kPa", "kilopascals", "kPas"],
+        reaction_pb2.Pressure.TORR: ["torr"],
+        reaction_pb2.Pressure.MM_HG: ["mmHg", "mm Hg"],
     },
     reaction_pb2.Temperature: {
         reaction_pb2.Temperature.CELSIUS: [
@@ -199,6 +201,12 @@ _UNIT_CONVERSIONS: dict[
         reaction_pb2.Pressure.KPSI: 1000 / 14.69595,
         reaction_pb2.Pressure.PASCAL: 1 / 101325,
         reaction_pb2.Pressure.KILOPASCAL: 1000 / 101325,
+        # Torr and mmHg differ by ~2e-7 relative (mmHg is defined from the density of
+        # mercury, torr as exactly 1/760 atm); the schema keeps them as separate units
+        # because sources report both, and 1/760 is correct for either at any precision
+        # reaction data carries.
+        reaction_pb2.Pressure.TORR: 1 / 760,
+        reaction_pb2.Pressure.MM_HG: 1 / 760,
     },
     reaction_pb2.Current: {
         reaction_pb2.Current.AMPERE: 1,

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -163,6 +163,14 @@ _WAVENUMBER_NM_CM = 1e7
 _UNIT_CONVERSIONS: dict[
     type[ord_schema.UnitMessage], dict[ProtoEnumMember, int | float]
 ] = {
+    # Concentration spellings live in CONCENTRATION_UNIT_SYNONYMS because "M" and
+    # "molar" collide with mass and mole spellings, but conversion is keyed by message
+    # type, so there is nothing to keep apart here.
+    reaction_pb2.Concentration: {
+        reaction_pb2.Concentration.MOLAR: 1,
+        reaction_pb2.Concentration.MILLIMOLAR: 0.001,
+        reaction_pb2.Concentration.MICROMOLAR: 0.000001,
+    },
     reaction_pb2.Time: {
         reaction_pb2.Time.DAY: 24,
         reaction_pb2.Time.HOUR: 1,

--- a/ord_schema/units_test.py
+++ b/ord_schema/units_test.py
@@ -415,7 +415,7 @@ def test_every_unit_resolves_from_its_spellings(message_type):
     "message_type", _UNITED_MESSAGE_TYPES, ids=lambda t: t.__name__
 )
 def test_every_unit_converts_to_every_other(resolver, message_type):
-    """Every pair of units within a message type converts; two types once could not."""
+    """Every pair of units within a message type converts."""
     unit_values = list(_unit_enum_values(message_type))
     for source in unit_values:
         message = message_type(value=1.0, units=source)

--- a/ord_schema/units_test.py
+++ b/ord_schema/units_test.py
@@ -319,3 +319,71 @@ def test_format_message(message, expected):
 def test_format_message_unspecified_returns_none():
     # Default-constructed message has UNSPECIFIED units.
     assert units.format_message(reaction_pb2.Mass()) is None
+
+
+@pytest.mark.parametrize(
+    ("string", "expected"),
+    [
+        (
+            "760 torr",
+            reaction_pb2.Pressure(value=760, units=reaction_pb2.Pressure.TORR),
+        ),
+        (
+            "760 Torr",
+            reaction_pb2.Pressure(value=760, units=reaction_pb2.Pressure.TORR),
+        ),
+        (
+            "760 mmHg",
+            reaction_pb2.Pressure(value=760, units=reaction_pb2.Pressure.MM_HG),
+        ),
+        (
+            "760 mm Hg",
+            reaction_pb2.Pressure(value=760, units=reaction_pb2.Pressure.MM_HG),
+        ),
+    ],
+)
+def test_resolve_mercury_pressure_units(resolver, string, expected):
+    assert resolver.resolve(string) == expected
+
+
+@pytest.mark.parametrize(
+    "units_enum", [reaction_pb2.Pressure.TORR, reaction_pb2.Pressure.MM_HG]
+)
+def test_convert_mercury_pressure_units(resolver, units_enum):
+    # 1 atm is 760 torr and, to the precision reaction data carries, 760 mmHg.
+    message = reaction_pb2.Pressure(value=760, units=units_enum)
+    assert resolver.convert(message, "atm").value == pytest.approx(1.0)
+    assert resolver.convert(message, "kPa").value == pytest.approx(101.325, rel=1e-6)
+
+
+def _unit_enum_values(message_type):
+    """Returns {enum value: name} for a united message, minus UNSPECIFIED."""
+    descriptor = message_type.DESCRIPTOR
+    return {
+        value.number: value.name
+        for enum_type in descriptor.enum_types
+        for value in enum_type.values
+        if value.name != "UNSPECIFIED"
+    }
+
+
+@pytest.mark.parametrize("message_type", list(units._UNIT_CONVERSIONS))
+def test_every_unit_is_convertible(message_type):
+    """Every unit in the schema must be convertible; Pressure once was not."""
+    missing = {
+        name
+        for value, name in _unit_enum_values(message_type).items()
+        if value not in units._UNIT_CONVERSIONS[message_type]
+    }
+    assert not missing
+
+
+@pytest.mark.parametrize("message_type", list(units._UNIT_SYNONYMS))
+def test_every_unit_is_resolvable(message_type):
+    """Every unit in the schema must have at least one spelling to parse from."""
+    missing = {
+        name
+        for value, name in _unit_enum_values(message_type).items()
+        if value not in units._UNIT_SYNONYMS[message_type]
+    }
+    assert not missing

--- a/ord_schema/units_test.py
+++ b/ord_schema/units_test.py
@@ -16,6 +16,7 @@
 import typing
 
 import pytest
+from google.protobuf import descriptor
 
 import ord_schema
 from ord_schema import units
@@ -369,13 +370,37 @@ def _unit_enum_values(message_type):
     }
 
 
-# Parametrized from the schema rather than from the tables under test: driving these
-# from _UNIT_CONVERSIONS or _UNIT_SYNONYMS would generate no case at all for a message
-# type missing from them, which is the failure they exist to catch. Both assert on
-# behavior, so it does not matter which mechanism implements a conversion -- Temperature
-# goes through Celsius and Wavelength through a wavenumber reciprocal, neither of which
-# appears in _UNIT_CONVERSIONS.
-_UNITED_MESSAGE_TYPES = typing.get_args(ord_schema.UnitMessage)
+def _united_message_types():
+    """Returns every message in the schema carrying a value and a units enum.
+
+    Read from the proto descriptor rather than from any hand-maintained list, so that a
+    united message added to the schema is covered without a second edit here.
+    """
+    types = []
+    for message_descriptor in reaction_pb2.DESCRIPTOR.message_types_by_name.values():
+        fields = {field.name: field for field in message_descriptor.fields}
+        units_field = fields.get("units")
+        if (
+            units_field is not None
+            and units_field.type == descriptor.FieldDescriptor.TYPE_ENUM
+            and "value" in fields
+        ):
+            types.append(getattr(reaction_pb2, message_descriptor.name))
+    return types
+
+
+# The checks below are parametrized from the schema, not from the tables under test:
+# driving them from _UNIT_CONVERSIONS or _UNIT_SYNONYMS would generate no case at all
+# for a message type missing from those, which is the failure they exist to catch. They
+# assert on behavior, so it also does not matter which mechanism implements a
+# conversion -- Temperature goes through Celsius and Wavelength through a wavenumber
+# reciprocal, neither of which appears in _UNIT_CONVERSIONS.
+_UNITED_MESSAGE_TYPES = _united_message_types()
+
+
+def test_unit_message_alias_covers_the_schema():
+    """``ord_schema.UnitMessage`` lists exactly the schema's united messages."""
+    assert set(typing.get_args(ord_schema.UnitMessage)) == set(_UNITED_MESSAGE_TYPES)
 
 
 def _synonyms_for(message_type):

--- a/ord_schema/units_test.py
+++ b/ord_schema/units_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """Tests for ord_schema.units."""
 
+import typing
+
 import pytest
 
 import ord_schema
@@ -367,23 +369,55 @@ def _unit_enum_values(message_type):
     }
 
 
-@pytest.mark.parametrize("message_type", list(units._UNIT_CONVERSIONS))
-def test_every_unit_is_convertible(message_type):
-    """Every unit in the schema must be convertible; Pressure once was not."""
-    missing = {
-        name
-        for value, name in _unit_enum_values(message_type).items()
-        if value not in units._UNIT_CONVERSIONS[message_type]
-    }
-    assert not missing
+# Parametrized from the schema rather than from the tables under test: driving these
+# from _UNIT_CONVERSIONS or _UNIT_SYNONYMS would generate no case at all for a message
+# type missing from them, which is the failure they exist to catch. Both assert on
+# behavior, so it does not matter which mechanism implements a conversion -- Temperature
+# goes through Celsius and Wavelength through a wavenumber reciprocal, neither of which
+# appears in _UNIT_CONVERSIONS.
+_UNITED_MESSAGE_TYPES = typing.get_args(ord_schema.UnitMessage)
 
 
-@pytest.mark.parametrize("message_type", list(units._UNIT_SYNONYMS))
-def test_every_unit_is_resolvable(message_type):
-    """Every unit in the schema must have at least one spelling to parse from."""
-    missing = {
-        name
-        for value, name in _unit_enum_values(message_type).items()
-        if value not in units._UNIT_SYNONYMS[message_type]
-    }
-    assert not missing
+def _synonyms_for(message_type):
+    """Returns the synonym table covering a united message type.
+
+    Concentration spellings ("M", "molar") are ambiguous with mass and mole spellings,
+    so they live in a separate table used by a separate resolver.
+    """
+    if message_type in units.CONCENTRATION_UNIT_SYNONYMS:
+        return units.CONCENTRATION_UNIT_SYNONYMS
+    return units._UNIT_SYNONYMS
+
+
+@pytest.mark.parametrize(
+    "message_type", _UNITED_MESSAGE_TYPES, ids=lambda t: t.__name__
+)
+def test_every_unit_resolves_from_its_spellings(message_type):
+    """Every unit in the schema has at least one usable spelling that maps back to it.
+
+    Checked through ``resolve_unit`` rather than ``resolve``: a few spellings ("ul/s",
+    "cm^-1") carry characters the value-plus-unit pattern does not accept, so they are
+    reachable only when the unit is supplied on its own.
+    """
+    synonyms = _synonyms_for(message_type)
+    resolver = units.UnitResolver(unit_synonyms=synonyms)
+    for value, name in _unit_enum_values(message_type).items():
+        spellings = synonyms.get(message_type, {}).get(value)
+        assert spellings, f"{message_type.__name__}.{name} has no spelling"
+        # "M" for molar collides with meter/minute and is forbidden outright.
+        usable = [s for s in spellings if s.lower() not in units._FORBIDDEN_UNITS]
+        assert usable, f"{message_type.__name__}.{name} has no usable spelling"
+        for spelling in usable:
+            assert resolver.resolve_unit(spelling) == (message_type, value)
+
+
+@pytest.mark.parametrize(
+    "message_type", _UNITED_MESSAGE_TYPES, ids=lambda t: t.__name__
+)
+def test_every_unit_converts_to_every_other(resolver, message_type):
+    """Every pair of units within a message type converts; two types once could not."""
+    unit_values = list(_unit_enum_values(message_type))
+    for source in unit_values:
+        message = message_type(value=1.0, units=source)
+        for target in unit_values:
+            assert resolver.convert(message, target).units == target


### PR DESCRIPTION
`Pressure.TORR` and `Pressure.MM_HG` are members of the schema's pressure enum, but they appear in neither `_UNIT_SYNONYMS` nor `_UNIT_CONVERSIONS`. The result is that a pressure the schema is perfectly happy to store cannot be parsed or converted:

```python
>>> resolver.resolve("760 torr")
KeyError: 'unrecognized units: torr'
>>> resolver.convert(Pressure(value=760, units=Pressure.TORR), "kPa")
KeyError: 7
```

Reaction data records pressures in both units, so this is reachable rather than theoretical. Both convert as `1/760` atm: torr is defined as exactly 1/760 atm and mmHg from the density of mercury, and they differ by about 2e-7 relative — orders of magnitude below any precision reaction data carries.

## Concentration could not be converted at all

Found by the coverage tests below, once they were parametrized correctly: `Concentration` appeared in no conversion table, so all nine of its unit pairs raised `KeyError`. Its *spellings* live in `CONCENTRATION_UNIT_SYNONYMS` because "M" and "molar" collide with mass and mole spellings and need their own resolver — but conversion is keyed by message type, where there is nothing to keep apart, so the omission followed from the synonym split rather than from a decision.

## The tests are the point

`test_every_unit_resolves_from_its_spellings` and `test_every_unit_converts_to_every_other` parametrize over `typing.get_args(ord_schema.UnitMessage)` — the schema's own list of united types — rather than over the tables under test, and assert behavior rather than table membership. Driving them from `_UNIT_CONVERSIONS` would generate no case at all for a type missing from it, which is exactly the bug they exist to catch (thanks @greptile-apps). Asserting behavior also keeps them agnostic to mechanism: `Temperature` converts through Celsius and `Wavelength` through a wavenumber reciprocal, so a membership check would have reported two false failures.

Resolvability goes through `resolve_unit`, not `resolve`: `"ul/s"` and `"cm^-1"` contain characters the value-plus-unit pattern does not accept, and `"M"` is blocked outright as ambiguous with meter/minute. The asserted invariant is that every unit has at least one usable spelling and that each usable spelling maps back to it.

I found this while writing the derived-views work, which converts pressures to a single canonical unit and would have silently dropped every torr and mmHg reading. That PR stacks on this one.

Verified: 605 tests pass, `ruff check`, `ruff format --check`, `ty check`, and all pre-commit hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds torr, mmHg, and concentration unit conversions, with schema-driven tests ensuring every united message type can resolve and convert all declared units.
- Registers torr and mmHg spellings and pressure conversion factors.
- Adds multiplier-based conversions for molar concentration units.
- Replaces table-driven completeness checks with protobuf descriptor-driven behavioral coverage.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previous completeness issue is fixed by deriving united message types from the protobuf schema and checking conversion behavior for every declared unit.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/units.py | Adds the missing pressure synonyms and conversion factors, along with concentration conversion multipliers. |
| ord_schema/units_test.py | Adds focused pressure tests and schema-driven resolution and conversion completeness checks that address the prior self-referential coverage issue. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Read the united message types from the p..."](https://github.com/open-reaction-database/ord-schema/commit/d04240f270357c85e63ab592c61205a3a0c7be06) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48523527)</sub>

<!-- /greptile_comment -->