### PR TITLE
Cache CI setup with micromamba, and fix bugs found auditing the jobs

### DIFF
--- a/.github/conda-postgres.txt
+++ b/.github/conda-postgres.txt
@@ -1,0 +1,7 @@
+# Conda packages for the CI PostgreSQL used by the ORM tests, in requirements.txt format
+# (conda install --file). Conda is only used for postgres here, never for python.
+#
+# This lives in a file rather than inline in run_tests.yml so the workflow's package cache can
+# key on hashFiles() of it: the cache then refreshes exactly when this spec changes. Pin a
+# version here if CI ever needs to match a specific RDKit cartridge build.
+rdkit-postgresql

--- a/.github/conda-postgres.txt
+++ b/.github/conda-postgres.txt
@@ -1,7 +1,0 @@
-# Conda packages for the CI PostgreSQL used by the ORM tests, in requirements.txt format
-# (conda install --file). Conda is only used for postgres here, never for python.
-#
-# This lives in a file rather than inline in run_tests.yml so the workflow's package cache can
-# key on hashFiles() of it: the cache then refreshes exactly when this spec changes. Pin a
-# version here if CI ever needs to match a specific RDKit cartridge build.
-rdkit-postgresql

--- a/.github/conda-postgres.yml
+++ b/.github/conda-postgres.yml
@@ -1,0 +1,25 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Conda environment for the CI PostgreSQL the ORM tests run against. Conda is only used for
+# postgres here, never for python -- the interpreter under test comes from uv.
+#
+# setup-micromamba installs this and derives its cache key from a hash of this file, so the
+# cached environment refreshes exactly when the spec below changes. Pin a version here if CI
+# ever needs to match a specific RDKit cartridge build.
+name: ci-postgres
+channels:
+  - conda-forge
+dependencies:
+  - rdkit-postgresql

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -20,6 +20,14 @@ on:
     branches:
       - main
 
+# See run_tests.yml: cancel superseded PR runs, never cancel a main run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   check_licenses:
     runs-on: ubuntu-latest
@@ -80,4 +88,9 @@ jobs:
           node-version: '24'
       - name: markdownlint-cli2
         # Pinned to the same version as the pre-commit hook so CI and local runs agree.
-        run: npx --yes markdownlint-cli2@0.23.1 "**/*.md"
+        #
+        # Feed the file list from git rather than a `**/*.md` glob. The glob is expanded by
+        # globby, which does not match dotfiles by default, so everything under .claude/ and
+        # .github/ was silently unlinted here while the pre-commit hook -- which receives
+        # explicit filenames -- checked it. Tracked files also exclude .venv/ for free.
+        run: git ls-files -z '*.md' | xargs -0 npx --yes markdownlint-cli2@0.23.1

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -33,29 +33,33 @@ permissions:
 jobs:
   test_ord_schema:
     strategy:
-      # One job per OS covers every Python version, so a failure on one OS should not
-      # cancel the other and take three more interpreters' results with it.
-      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     env:
       # Only ${{ }} is expanded in env values, so $GITHUB_WORKSPACE here would stay a literal
       # and initdb would create a directory named after the variable.
       PGDATA: ${{ github.workspace }}/rdkit-postgres
-      # The interpreters to test, oldest first. uv fetches whichever are not already
-      # present, so no separate setup-python step is needed.
-      PYTHON_VERSIONS: "3.11 3.12 3.13 3.14"
-      # Exercise the live PubChem/OPSIN resolver smoke tests on a single interpreter and
-      # OS only; running them everywhere at once trips PubChem's per-IP throttling (503
-      # ServerBusy). Every other run skips them (see resolvers_test).
-      LIVE_RESOLVER_PYTHON: "3.12"
-      LIVE_RESOLVER_OS: ${{ matrix.os == 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4
         with:
           miniconda-version: 'latest'
+      # Point conda at a cacheable package directory before anything installs, so the
+      # rdkit-postgresql tarballs below are restored rather than re-downloaded by all eight
+      # matrix jobs on every run.
+      - name: Use a cacheable conda package directory
+        shell: bash -l {0}
+        run: |
+          set -eo pipefail
+          conda config --add pkgs_dirs "${HOME}/conda_pkgs_dir"
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/conda_pkgs_dir
+          # Only rdkit-postgresql is installed, so the spec is the whole key. Bump the suffix
+          # to discard the cache deliberately.
+          key: conda-pkgs-${{ runner.os }}-rdkit-postgresql-v1
       - name: Setup PostgreSQL
         shell: bash -l {0}
         run: |
@@ -65,78 +69,65 @@ jobs:
           # NOTE(skearnes): conda is only used for postgres (not python).
           conda install -c conda-forge rdkit-postgresql
           initdb
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
-      - name: Run tests on every supported Python
-        # bash -l picks up the conda profile so initdb/postgres are on PATH. It also means
-        # no -e (see above), so every failure below is captured explicitly -- the loop must
-        # outlive one bad interpreter to report the rest.
+          python-version: ${{ matrix.python-version }}
+          # Key the wheel cache on the lockfile so a dependency bump, and only a dependency
+          # bump, misses.
+          cache-dependency-glob: "uv.lock"
+      - name: Install ord_schema
+        run: uv sync --extra tests --locked
+      - name: Run tests
         shell: bash -l {0}
+        # Exercise the live PubChem/OPSIN resolver smoke tests on a single matrix
+        # entry only; running them on all 8 jobs at once trips PubChem's per-IP
+        # throttling (503 ServerBusy). Other entries skip them (see resolvers_test).
+        env:
+          ORD_LIVE_RESOLVERS: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         run: |
-          set -o pipefail
-          failed=""
-          for version in ${PYTHON_VERSIONS}; do
-            echo "::group::Python ${version}"
-            if [[ "${LIVE_RESOLVER_OS}" == "true" && "${version}" == "${LIVE_RESOLVER_PYTHON}" ]]; then
-              export ORD_LIVE_RESOLVERS=true
-            else
-              export ORD_LIVE_RESOLVERS=false
-            fi
-            if uv sync --extra tests --locked --python "${version}"; then
-              uv run coverage erase
-              # -n auto: each ORM test spins up its own testing.postgresql instance, so the suite is
-              # parallel-safe; pytest-cov aggregates coverage across xdist workers.
-              # -ra: summarize all non-passing outcomes (failures, errors, and skip reasons) at the end of the run --
-              # e.g. live resolver tests gated off this interpreter vs. skipped on a PubChem 503.
-              uv run pytest -n auto -vv -ra --cov=ord_schema --durations=20 \
-                || failed="${failed} ${version}"
-              # Print the coverage summary in the job log (no external upload).
-              uv run coverage report || true
-            else
-              failed="${failed} ${version}"
-            fi
-            echo "::endgroup::"
-          done
-          if [[ -n "${failed}" ]]; then
-            echo "::error::tests failed on Python:${failed}"
-            exit 1
-          fi
+          # A bare `shell:` string is used verbatim, so -e is not applied. Without this a failing
+          # pytest is masked by the coverage report below, whose exit code becomes the step's.
+          set -eo pipefail
+          uv run coverage erase
+          # -n auto: each ORM test spins up its own testing.postgresql instance, so the suite is
+          # parallel-safe; pytest-cov aggregates coverage across xdist workers.
+          # -ra: summarize all non-passing outcomes (failures, errors, and skip reasons) at the end of the run --
+          # e.g. live resolver tests gated off this matrix entry vs. skipped on a PubChem 503.
+          uv run pytest -n auto -vv -ra --cov=ord_schema --durations=20
+          # Print the coverage summary in the job log (no external upload).
+          uv run coverage report
 
   test_notebooks:
     strategy:
-      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14"]
+        # examples extra requires TensorFlow, which only ships wheels through cp313 as of 2.20.0.
+        python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     env:
       # CPU-only runners: avoid TensorFlow probing CUDA (noise + unstable kernels).
       CUDA_VISIBLE_DEVICES: "-1"
       TF_CPP_MIN_LOG_LEVEL: "2"
-      # examples extra requires TensorFlow, which only ships wheels through cp313 as of 2.20.0.
-      PYTHON_VERSIONS: "3.11 3.12 3.13"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
-      - name: Test notebooks on every supported Python
-        run: |
-          failed=""
-          for version in ${PYTHON_VERSIONS}; do
-            echo "::group::Python ${version}"
-            if uv sync --extra examples --extra tests --locked --python "${version}"; then
-              # Single-threaded: default treon parallelism loads TensorFlow in multiple kernels and OOMs on CI.
-              uv run treon --threads=1 || failed="${failed} ${version}"
-            else
-              failed="${failed} ${version}"
-            fi
-            echo "::endgroup::"
-          done
-          if [[ -n "${failed}" ]]; then
-            echo "::error::notebooks failed on Python:${failed}"
-            exit 1
-          fi
+          python-version: ${{ matrix.python-version }}
+          # TensorFlow is the bulk of this extra; key its wheel cache on the lockfile.
+          cache-dependency-glob: "uv.lock"
+      - name: Install ord_schema
+        run: uv sync --extra examples --extra tests --locked
+      - name: Test notebooks
+        # Single-threaded: default treon parallelism loads TensorFlow in multiple kernels and OOMs on CI.
+        run: uv run treon --threads=1
 
   test_proto_wrappers:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,15 +20,37 @@ on:
     branches:
       - main
 
+# Superseded PR runs are pointless work: a push replaces the commit under test. Cancel them
+# rather than letting a stale full matrix run to completion. Never cancel on main, where each
+# push's result is the record for that commit.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
 jobs:
   test_ord_schema:
     strategy:
+      # One job per OS covers every Python version, so a failure on one OS should not
+      # cancel the other and take three more interpreters' results with it.
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14"]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     env:
-      PGDATA: $GITHUB_WORKSPACE/rdkit-postgres
+      # Only ${{ }} is expanded in env values, so $GITHUB_WORKSPACE here would stay a literal
+      # and initdb would create a directory named after the variable.
+      PGDATA: ${{ github.workspace }}/rdkit-postgres
+      # The interpreters to test, oldest first. uv fetches whichever are not already
+      # present, so no separate setup-python step is needed.
+      PYTHON_VERSIONS: "3.11 3.12 3.13 3.14"
+      # Exercise the live PubChem/OPSIN resolver smoke tests on a single interpreter and
+      # OS only; running them everywhere at once trips PubChem's per-IP throttling (503
+      # ServerBusy). Every other run skips them (see resolvers_test).
+      LIVE_RESOLVER_PYTHON: "3.12"
+      LIVE_RESOLVER_OS: ${{ matrix.os == 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4
@@ -37,60 +59,84 @@ jobs:
       - name: Setup PostgreSQL
         shell: bash -l {0}
         run: |
+          # A bare `shell:` string is used verbatim, so -e is not applied; set it here or a
+          # failed conda install would be masked by whatever runs next.
+          set -eo pipefail
           # NOTE(skearnes): conda is only used for postgres (not python).
           conda install -c conda-forge rdkit-postgresql
           initdb
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
-          python-version: ${{ matrix.python-version }}
-      - name: Install ord_schema
-        run: uv sync --extra tests --locked
-      - name: Run tests
+      - name: Run tests on every supported Python
+        # bash -l picks up the conda profile so initdb/postgres are on PATH. It also means
+        # no -e (see above), so every failure below is captured explicitly -- the loop must
+        # outlive one bad interpreter to report the rest.
         shell: bash -l {0}
-        # Exercise the live PubChem/OPSIN resolver smoke tests on a single matrix
-        # entry only; running them on all 8 jobs at once trips PubChem's per-IP
-        # throttling (503 ServerBusy). Other entries skip them (see resolvers_test).
-        env:
-          ORD_LIVE_RESOLVERS: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         run: |
-          uv run coverage erase
-          # -n auto: each ORM test spins up its own testing.postgresql instance, so the suite is
-          # parallel-safe; pytest-cov aggregates coverage across xdist workers.
-          # -ra: summarize all non-passing outcomes (failures, errors, and skip reasons) at the end of the run --
-          # e.g. live resolver tests gated off this matrix entry vs. skipped on a PubChem 503.
-          uv run pytest -n auto -vv -ra --cov=ord_schema --durations=20
-          # Print the coverage summary in the job log (no external upload).
-          uv run coverage report
+          set -o pipefail
+          failed=""
+          for version in ${PYTHON_VERSIONS}; do
+            echo "::group::Python ${version}"
+            if [[ "${LIVE_RESOLVER_OS}" == "true" && "${version}" == "${LIVE_RESOLVER_PYTHON}" ]]; then
+              export ORD_LIVE_RESOLVERS=true
+            else
+              export ORD_LIVE_RESOLVERS=false
+            fi
+            if uv sync --extra tests --locked --python "${version}"; then
+              uv run coverage erase
+              # -n auto: each ORM test spins up its own testing.postgresql instance, so the suite is
+              # parallel-safe; pytest-cov aggregates coverage across xdist workers.
+              # -ra: summarize all non-passing outcomes (failures, errors, and skip reasons) at the end of the run --
+              # e.g. live resolver tests gated off this interpreter vs. skipped on a PubChem 503.
+              uv run pytest -n auto -vv -ra --cov=ord_schema --durations=20 \
+                || failed="${failed} ${version}"
+              # Print the coverage summary in the job log (no external upload).
+              uv run coverage report || true
+            else
+              failed="${failed} ${version}"
+            fi
+            echo "::endgroup::"
+          done
+          if [[ -n "${failed}" ]]; then
+            echo "::error::tests failed on Python:${failed}"
+            exit 1
+          fi
 
   test_notebooks:
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-14"]
-        # examples extra requires TensorFlow, which only ships wheels through cp313 as of 2.20.0.
-        python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     env:
       # CPU-only runners: avoid TensorFlow probing CUDA (noise + unstable kernels).
       CUDA_VISIBLE_DEVICES: "-1"
       TF_CPP_MIN_LOG_LEVEL: "2"
+      # examples extra requires TensorFlow, which only ships wheels through cp313 as of 2.20.0.
+      PYTHON_VERSIONS: "3.11 3.12 3.13"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: ${{ matrix.python-version }}
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: true
-          python-version: ${{ matrix.python-version }}
-      - name: Install ord_schema
-        run: uv sync --extra examples --extra tests --locked
-      - name: Test notebooks
-        # Single-threaded: default treon parallelism loads TensorFlow in multiple kernels and OOMs on CI.
-        run: uv run treon --threads=1
+      - name: Test notebooks on every supported Python
+        run: |
+          failed=""
+          for version in ${PYTHON_VERSIONS}; do
+            echo "::group::Python ${version}"
+            if uv sync --extra examples --extra tests --locked --python "${version}"; then
+              # Single-threaded: default treon parallelism loads TensorFlow in multiple kernels and OOMs on CI.
+              uv run treon --threads=1 || failed="${failed} ${version}"
+            else
+              failed="${failed} ${version}"
+            fi
+            echo "::endgroup::"
+          done
+          if [[ -n "${failed}" ]]; then
+            echo "::error::notebooks failed on Python:${failed}"
+            exit 1
+          fi
 
   test_proto_wrappers:
     runs-on: ubuntu-latest
@@ -103,9 +149,11 @@ jobs:
         with:
           node-version: '24'
       - name: Install protoc
+        # Unpack outside the checkout. These binaries are not gitignored, so in the workspace
+        # they pollute the drift check below and `addlicense .` rewrites their headers.
         run: |
-          mkdir protoc
-          cd protoc
+          mkdir "${RUNNER_TEMP}/protoc"
+          cd "${RUNNER_TEMP}/protoc"
           wget https://github.com/protocolbuffers/protobuf/releases/download/v22.3/protoc-22.3-linux-x86_64.zip
           echo "0f8070d762eb8a2f5a13a47713a553f989f9d9b556e7e3ebfa2bd6464e2ecaeb  protoc-22.3-linux-x86_64.zip" | sha256sum -c -
           unzip protoc-22.3-linux-x86_64.zip
@@ -113,20 +161,29 @@ jobs:
           echo "075ed6163fea314c415f67a4af68d1b6dbddc8fa8be35addf74e4c81812a9148  protobuf-javascript-3.21.2-linux-x86_64.zip" | sha256sum -c -
           unzip protobuf-javascript-3.21.2-linux-x86_64.zip
           npm i -g ts-protoc-gen@0.15.0 protobufjs@7.4.0 protobufjs-cli@1.1.3
-          PATH=$GITHUB_WORKSPACE/protoc/bin:$PATH protoc --version
+          PATH="${RUNNER_TEMP}/protoc/bin:$PATH" protoc --version
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '>=1.16'
       - name: Install addlicense
-        run: go install github.com/google/addlicense@latest
+        # Same pin as the check_licenses job in cleanup.yml: this job writes the headers that
+        # one checks, so a floating version could make them disagree.
+        run: go install github.com/google/addlicense@v1.2.0
       - name: Run protoc
         run: |
-          PATH=$GITHUB_WORKSPACE/protoc/bin:$PATH ./compile_proto_wrappers.sh
+          PATH="${RUNNER_TEMP}/protoc/bin:$PATH" ./compile_proto_wrappers.sh
           "${HOME}/go/bin/addlicense" -c "Open Reaction Database Project Authors" -l apache .
       - name: Check for drift
         run: |
-          # Ignore the copyright line in the diff so the year can change.
-          [[ -z $(git diff -I "^(#| \*) Copyright") ]] || { echo "proto wrappers do not match:\n$(git diff)"; exit 1; }
+          # Stage everything first: git diff reports only tracked modifications, so a wrapper
+          # generated for a brand-new .proto is untracked and would register as no drift at all.
+          git add -A
+          # -I ignores the copyright line so the year can change without failing.
+          if ! git diff --cached --quiet -I "^(#| \*) Copyright"; then
+            printf 'proto wrappers do not match:\n'
+            git diff --cached -I "^(#| \*) Copyright"
+            exit 1
+          fi
 
   test_js:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -45,7 +45,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4
         with:
-          miniconda-version: 'latest'
+          # Miniforge, not Miniconda: everything here comes from conda-forge, and Miniconda
+          # implicitly adds Anaconda's `defaults` channel (which the runs warned about) with
+          # its own terms of use attached. Miniforge defaults to conda-forge alone, matching
+          # both the install below and the miniforge environments these tests run in locally.
+          miniforge-version: 'latest'
           # setup-miniconda has no cache input of its own, so put the package directory
           # somewhere predictable and cache it below.
           pkgs-dirs: ~/conda_pkgs_dir

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -46,20 +46,25 @@ jobs:
       - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4
         with:
           miniconda-version: 'latest'
-      # Point conda at a cacheable package directory before anything installs, so the
-      # rdkit-postgresql tarballs below are restored rather than re-downloaded by all eight
-      # matrix jobs on every run.
-      - name: Use a cacheable conda package directory
-        shell: bash -l {0}
-        run: |
-          set -eo pipefail
-          conda config --add pkgs_dirs "${HOME}/conda_pkgs_dir"
+          # setup-miniconda has no cache input of its own, so put the package directory
+          # somewhere predictable and cache it below.
+          pkgs-dirs: ~/conda_pkgs_dir
+      # Rotates weekly. hashFiles below pins the cache to our spec, but nothing in this repo
+      # changes when conda-forge publishes a newer rdkit-postgresql, and actions/cache does not
+      # re-save on an exact key hit -- so without a rotating component the entry would be frozen
+      # at the first version ever cached and quietly stop matching what conda resolves.
+      - name: Compute weekly cache epoch
+        id: cache-epoch
+        run: echo "value=$(date -u +%Y-%V)" >> "$GITHUB_OUTPUT"
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/conda_pkgs_dir
-          # Only rdkit-postgresql is installed, so the spec is the whole key. Bump the suffix
-          # to discard the cache deliberately.
-          key: conda-pkgs-${{ runner.os }}-rdkit-postgresql-v1
+          key: conda-pkgs-${{ runner.os }}-${{ hashFiles('.github/conda-postgres.txt') }}-${{ steps.cache-epoch.outputs.value }}
+          # A rotated or respecified key still warm-starts from the nearest previous entry
+          # instead of downloading everything again.
+          restore-keys: |
+            conda-pkgs-${{ runner.os }}-${{ hashFiles('.github/conda-postgres.txt') }}-
+            conda-pkgs-${{ runner.os }}-
       - name: Setup PostgreSQL
         shell: bash -l {0}
         run: |
@@ -67,7 +72,7 @@ jobs:
           # failed conda install would be masked by whatever runs next.
           set -eo pipefail
           # NOTE(skearnes): conda is only used for postgres (not python).
-          conda install -c conda-forge rdkit-postgresql
+          conda install -c conda-forge --file .github/conda-postgres.txt
           initdb
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -43,41 +43,32 @@ jobs:
       PGDATA: ${{ github.workspace }}/rdkit-postgres
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4
-        with:
-          # Miniforge, not Miniconda: everything here comes from conda-forge, and Miniconda
-          # implicitly adds Anaconda's `defaults` channel (which the runs warned about) with
-          # its own terms of use attached. Miniforge defaults to conda-forge alone, matching
-          # both the install below and the miniforge environments these tests run in locally.
-          miniforge-version: 'latest'
-          # setup-miniconda has no cache input of its own, so put the package directory
-          # somewhere predictable and cache it below.
-          pkgs-dirs: ~/conda_pkgs_dir
-      # Rotates weekly. hashFiles below pins the cache to our spec, but nothing in this repo
-      # changes when conda-forge publishes a newer rdkit-postgresql, and actions/cache does not
-      # re-save on an exact key hit -- so without a rotating component the entry would be frozen
-      # at the first version ever cached and quietly stop matching what conda resolves.
+      # Rotates the cache weekly. The action already appends a hash of the environment file to
+      # the key, so a spec change invalidates on its own -- but nothing in this repo changes
+      # when conda-forge publishes a newer rdkit-postgresql, and a cache entry is not re-saved
+      # once its key hits exactly. Without a rotating component the entry would stay pinned to
+      # the first build ever cached.
       - name: Compute weekly cache epoch
         id: cache-epoch
         run: echo "value=$(date -u +%Y-%V)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
         with:
-          path: ~/conda_pkgs_dir
-          key: conda-pkgs-${{ runner.os }}-${{ hashFiles('.github/conda-postgres.txt') }}-${{ steps.cache-epoch.outputs.value }}
-          # A rotated or respecified key still warm-starts from the nearest previous entry
-          # instead of downloading everything again.
-          restore-keys: |
-            conda-pkgs-${{ runner.os }}-${{ hashFiles('.github/conda-postgres.txt') }}-
-            conda-pkgs-${{ runner.os }}-
-      - name: Setup PostgreSQL
-        shell: bash -l {0}
-        run: |
-          # A bare `shell:` string is used verbatim, so -e is not applied; set it here or a
-          # failed conda install would be masked by whatever runs next.
-          set -eo pipefail
-          # NOTE(skearnes): conda is only used for postgres (not python).
-          conda install -c conda-forge --file .github/conda-postgres.txt
-          initdb
+          # micromamba over conda: the environment and download caches are built into the
+          # action -- keyed on a hash of this file plus the environment name and OS -- so there
+          # is no cache wiring to hand-roll, and conda-forge is the only channel by
+          # construction. Mambaforge, which used to be the way to get that, is retired; its
+          # configuration and Miniforge3's are identical now.
+          environment-file: .github/conda-postgres.yml
+          init-shell: bash
+          cache-environment: true
+          cache-downloads: true
+          cache-environment-key: conda-postgres-${{ steps.cache-epoch.outputs.value }}
+          cache-downloads-key: conda-postgres-downloads-${{ steps.cache-epoch.outputs.value }}
+      - name: Initialize the PostgreSQL data directory
+        # -l activates the environment installed above (so initdb resolves); -eo pipefail
+        # because a bare `shell:` string is used verbatim and would otherwise drop them.
+        shell: bash -leo pipefail {0}
+        run: initdb
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -91,16 +82,16 @@ jobs:
       - name: Install ord_schema
         run: uv sync --extra tests --locked
       - name: Run tests
-        shell: bash -l {0}
+        # -l activates the conda environment so testing.postgresql finds initdb; -eo pipefail
+        # because a bare `shell:` string is used verbatim, and without -e a failing pytest is
+        # masked by the coverage report below, whose exit code would become the step's.
+        shell: bash -leo pipefail {0}
         # Exercise the live PubChem/OPSIN resolver smoke tests on a single matrix
         # entry only; running them on all 8 jobs at once trips PubChem's per-IP
         # throttling (503 ServerBusy). Other entries skip them (see resolvers_test).
         env:
           ORD_LIVE_RESOLVERS: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         run: |
-          # A bare `shell:` string is used verbatim, so -e is not applied. Without this a failing
-          # pytest is masked by the coverage report below, whose exit code becomes the step's.
-          set -eo pipefail
           uv run coverage erase
           # -n auto: each ORM test spins up its own testing.postgresql instance, so the suite is
           # parallel-safe; pytest-cov aggregates coverage across xdist workers.


### PR DESCRIPTION
## Why

Reducing the CI job count looked attractive: the Python dimension fans out to 14 jobs (8 `test_ord_schema` + 6 `test_notebooks`), each repeating the conda `rdkit-postgresql` install and a `uv sync`. Measured on `main`: **21 jobs, 47 runner-minutes, 6.2 min wall clock.**

I tried collapsing the matrix into one job per OS. **It is the wrong trade, and this PR does not do it.** What it does instead is cache the expensive setup properly and fix the bugs the attempt uncovered.

## Why not collapse the matrix

`uv sync --python X` does recreate the environment correctly, but a following bare `uv run` resolves the *project's default* interpreter, decides the environment does not match, and rebuilds it **without the extras**:

```
Using CPython 3.11.15
Removed virtual environment at: .venv     <- the synced 3.12 env
Installed 15 packages in 42ms             <- default deps only, extras gone
error: Failed to spawn: `treon`
```

3.11 passed (versions matched, nothing destroyed) while 3.12 and 3.13 failed. Fixable by passing `--python` and `--extra` to every `uv run`, but that discipline has to hold forever, and the payoff was ~19 runner-minutes on a **public repo where Actions minutes are free** — bought with ~2 minutes of extra wall clock from serializing. Not worth it.

## Install postgres with micromamba instead

The real waste is `rdkit-postgresql` being installed from scratch in all eight jobs on every run. `setup-micromamba` caches both the environment and the downloads **natively**, keying on a hash of the environment file plus the environment name and OS — so there is no `actions/cache` wiring to hand-roll, and the spec moves into `.github/conda-postgres.yml` where a version pin belongs.

It also fixes a channel problem: Miniconda implicitly adds Anaconda's `defaults` channel — the runs were warning about exactly that — while everything here comes from conda-forge. micromamba is conda-forge-only by construction. (Mambaforge used to be how you got that and is **retired**; its configuration and Miniforge3's are identical now.)

One thing the file hash cannot see is conda-forge publishing a *newer* `rdkit-postgresql`, and a cache entry is not re-saved once its key hits exactly — so the keys carry a weekly epoch and the entry refreshes on its own.

The matrix stays parallel with `fail-fast` intact, so none of this costs wall clock. The uv wheel cache is now keyed on `uv.lock`, so a dependency bump is the only thing that misses.

**`concurrency`** is the bigger saving and is independent of matrix shape: a superseded PR run is cancelled instead of running a full stale matrix to completion. `main` is never cancelled, since each push's result is the record for that commit. Plus `permissions: contents: read` at the workflow level.

## Bugs found while auditing the jobs

Each verified rather than assumed:

- **`test_ord_schema` reported success when tests failed.** A bare `shell:` string is used verbatim, so GitHub does not add `-eo pipefail`; `uv run coverage report` ran last and set the step's exit code. Reproduced: `bash -l -c 'true; false; true'` exits **0**. The most consequential item here — failing tests were showing green. Steps now declare `shell: bash -leo pipefail {0}`.
- **The proto-wrapper drift check could not see a wrapper generated for a new `.proto`.** `git diff` reports only tracked modifications, so a newly generated (untracked) file read as *no drift*. Now stages first and diffs `--cached`; confirmed `-I` still ignores copyright-year-only changes under `--quiet`. Staging in turn required unpacking protoc into `RUNNER_TEMP` rather than the workspace, where it is not gitignored — and where `addlicense .` had been rewriting headers inside the unpacked archives, invisibly, because the old tracked-only diff never looked.
- **`check_markdown` never linted `.claude/` or `.github/`.** `**/*.md` is expanded by globby, which skips dotfiles by default, so `SKILL.md` and both issue templates were unchecked in CI while the pre-commit hook (which gets explicit filenames) checked them. Now takes the list from `git ls-files`, which also excludes `.venv/` for free — bringing 3 previously-invisible files under CI.
- **`addlicense` floated on `@latest`** in `test_proto_wrappers` while `cleanup.yml` pins `v1.2.0` — in the job that *writes* the headers `cleanup.yml` *checks*. Now pinned to match.
- **`PGDATA` was a literal `$GITHUB_WORKSPACE/...`**, since `env:` values expand only `${{ }}`. `initdb` was creating a directory named after the variable.

`check_proto` was suspect for the same reason (`find -exec … {} +`) but is **sound**: the `+` form propagates a non-zero exit; only the `\;` form swallows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
