### PR TITLE
Handle CXSMILES extensions and padded values in identifier validation

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -32,16 +32,18 @@ from google.protobuf import (
 from google.protobuf.descriptor import Descriptor
 from google.protobuf.message import DecodeError
 from rdkit import Chem
-from rdkit.Chem import rdChemReactions
+from rdkit.Chem import rdChemReactions, rdmolfiles
 
 import ord_schema
 from ord_schema import atomic_io, units
 from ord_schema.proto import reaction_pb2
 
+# Enhanced stereochemistry is structural; atom labels and coordinates are not.
+_CX_ENHANCED_STEREO = rdmolfiles.CXSmilesFields.CX_ENHANCEDSTEREO
+
 _COMPOUND_IDENTIFIER_LOADERS = {
     reaction_pb2.CompoundIdentifier.SMILES: Chem.MolFromSmiles,
-    # MolFromSmiles reads CXSMILES, so a compound identified that way is as structural
-    # as one identified by SMILES.
+    # MolFromSmiles reads CXSMILES, so it is as structural as SMILES.
     reaction_pb2.CompoundIdentifier.CXSMILES: Chem.MolFromSmiles,
     reaction_pb2.CompoundIdentifier.INCHI: Chem.MolFromInchi,
     reaction_pb2.CompoundIdentifier.MOLBLOCK: Chem.MolFromMolBlock,
@@ -295,19 +297,21 @@ def smiles_from_compound(
         canonical: If True, returns a canonicalized SMILES.
 
     Returns:
-        Text SMILES.
+        Text SMILES, carrying an enhanced-stereochemistry block where the structure has
+        one (see :func:`canonical_smiles`).
 
     Raises:
         ValueError: if no structural identifiers are defined.
     """
-    smiles = get_compound_smiles(compound) or Chem.MolToSmiles(
-        mol_from_compound(compound)
-    )
+    smiles = get_compound_smiles(compound)
+    if not smiles:
+        # Deferred: mol_from_compound raises for compounds with no structure at all.
+        smiles = canonical_smiles(cast("Chem.Mol", mol_from_compound(compound)))
     if canonical:
         mol = Chem.MolFromSmiles(smiles)
         if mol is None:
             raise ValueError(f"Cannot parse SMILES: {smiles}")
-        smiles = Chem.MolToSmiles(mol)
+        smiles = canonical_smiles(mol)
     return smiles
 
 
@@ -330,13 +334,29 @@ def molblock_from_compound(
     )
 
 
+def canonical_smiles(mol: Chem.Mol) -> str:
+    """Returns a canonical SMILES, keeping enhanced stereochemistry if present.
+
+    Plain SMILES cannot express AND/OR stereo groups, so writing one would silently
+    assert a more specific structure than the source recorded. Only that field is
+    emitted; atom labels and coordinates are presentation, not structure.
+
+    Args:
+        mol: RDKit Mol.
+
+    Returns:
+        Canonical SMILES, with a ``|a:...|``/``|o...|`` block only for molecules that
+        have enhanced stereochemistry; others match ``Chem.MolToSmiles`` exactly.
+    """
+    return Chem.MolToCXSmiles(mol, Chem.SmilesWriteParams(), _CX_ENHANCED_STEREO)
+
+
 def split_cxsmiles_extension(value: str) -> tuple[str, str | None]:
     """Splits a CXSMILES extension block off a value, if it has one.
 
-    CXSMILES appends the block after whitespace, introduced by ``|``. Whitespace alone
-    does not identify one -- records exist whose SMILES carry trailing non-breaking
-    spaces -- so a value whose remainder is not a block is returned intact rather than
-    truncated at the space.
+    The block follows whitespace and is introduced by ``|``. Whitespace alone does not
+    identify one -- records exist whose SMILES carry trailing non-breaking spaces -- so
+    anything else is returned intact rather than truncated at the space.
 
     Args:
         value: A SMILES or CXSMILES string.

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -408,6 +408,10 @@ def check_compound_identifiers(
 ) -> None:
     """Verifies that structural compound identifiers are consistent.
 
+    Compared through :func:`canonical_smiles`, so identifiers that disagree about
+    enhanced stereochemistry are inconsistent: they assert different things about the
+    molecule even though they share a skeleton.
+
     Args:
         compound: reaction_pb2.Compound message.
 
@@ -424,7 +428,7 @@ def check_compound_identifiers(
             raise ValueError(
                 f"invalid structural identifier for Compound: {identifier}"
             )
-        smiles.add(Chem.MolToSmiles(mol))
+        smiles.add(canonical_smiles(mol))
     if len(smiles) > 1:
         raise ValueError(f"structural identifiers are inconsistent: {smiles}")
 
@@ -436,8 +440,14 @@ def get_reaction_smiles(
     allow_unspecified_roles: bool = True,
     validate: bool = False,
     canonical: bool = True,
+    strip_extension: bool = False,
 ) -> str | None:
     """Fetches or generates a reaction SMILES.
+
+    A stored REACTION_CXSMILES identifier is returned whole, extension block and all, so
+    the result is not necessarily parseable as plain SMILES. Pass ``strip_extension`` to
+    get the SMILES half; ``split_cxsmiles_extension`` returns both parts if the block
+    itself is wanted.
 
     Args:
         message: reaction_pb2.Reaction message.
@@ -452,6 +462,8 @@ def get_reaction_smiles(
         validate: Boolean whether to validate the reaction SMILES with rdkit.
             Only used if allow_incomplete is False.
         canonical: Boolean whether to return a canonicalized reaction SMILES.
+        strip_extension: If True, drop a CXSMILES extension block from the result so it
+            is plain SMILES. Generated SMILES never carry one.
 
     Returns:
         Text reaction SMILES, or None.
@@ -465,6 +477,8 @@ def get_reaction_smiles(
     ]
     for identifier in message.identifiers:
         if identifier.type in types:
+            if strip_extension:
+                return split_cxsmiles_extension(identifier.value)[0]
             return identifier.value
     if not generate_if_missing:
         return None

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -40,6 +40,9 @@ from ord_schema.proto import reaction_pb2
 
 _COMPOUND_IDENTIFIER_LOADERS = {
     reaction_pb2.CompoundIdentifier.SMILES: Chem.MolFromSmiles,
+    # MolFromSmiles reads CXSMILES, so a compound identified that way is as structural
+    # as one identified by SMILES.
+    reaction_pb2.CompoundIdentifier.CXSMILES: Chem.MolFromSmiles,
     reaction_pb2.CompoundIdentifier.INCHI: Chem.MolFromInchi,
     reaction_pb2.CompoundIdentifier.MOLBLOCK: Chem.MolFromMolBlock,
 }
@@ -325,6 +328,26 @@ def molblock_from_compound(
     return get_compound_molblock(compound) or Chem.MolToMolBlock(
         mol_from_compound(compound)
     )
+
+
+def split_cxsmiles_extension(value: str) -> tuple[str, str | None]:
+    """Splits a CXSMILES extension block off a value, if it has one.
+
+    CXSMILES appends the block after whitespace, introduced by ``|``. Whitespace alone
+    does not identify one -- records exist whose SMILES carry trailing non-breaking
+    spaces -- so a value whose remainder is not a block is returned intact rather than
+    truncated at the space.
+
+    Args:
+        value: A SMILES or CXSMILES string.
+
+    Returns:
+        ``(smiles, extension)``, where extension is None when there is no block.
+    """
+    tokens = value.split(maxsplit=1)
+    if len(tokens) == 2 and tokens[1].lstrip().startswith("|"):
+        return tokens[0], tokens[1]
+    return value, None
 
 
 def mol_from_compound(

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -59,6 +59,7 @@ def test_structural_identifier_types():
     """STRUCTURAL_IDENTIFIER_TYPES mirrors _COMPOUND_IDENTIFIER_LOADERS exactly."""
     assert {
         "SMILES",
+        "CXSMILES",
         "INCHI",
         "MOLBLOCK",
     } == message_helpers.STRUCTURAL_IDENTIFIER_TYPES
@@ -764,3 +765,25 @@ class TestMessagesToDataFrame:
             expected,
             check_like=True,
         )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("c1ccccc1 |f:0.1|", ("c1ccccc1", "|f:0.1|")),
+        ("c1ccccc1", ("c1ccccc1", None)),
+        # Trailing non-breaking spaces occur in real records; splitting there would
+        # truncate a valid SMILES and report a block that is not present.
+        ("c1ccccc1\xa0\xa0", ("c1ccccc1\xa0\xa0", None)),
+        ("c1ccccc1 benzene", ("c1ccccc1 benzene", None)),
+        ("", ("", None)),
+    ],
+)
+def test_split_cxsmiles_extension(value, expected):
+    assert message_helpers.split_cxsmiles_extension(value) == expected
+
+
+def test_cxsmiles_is_a_structural_identifier():
+    compound = reaction_pb2.Compound()
+    compound.identifiers.add(type="CXSMILES", value="c1ccccc1 |f:0.1|")
+    assert message_helpers.smiles_from_compound(compound) == "c1ccccc1"

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -787,3 +787,29 @@ def test_cxsmiles_is_a_structural_identifier():
     compound = reaction_pb2.Compound()
     compound.identifiers.add(type="CXSMILES", value="c1ccccc1 |f:0.1|")
     assert message_helpers.smiles_from_compound(compound) == "c1ccccc1"
+
+
+@pytest.mark.parametrize(
+    ("smiles", "expected"),
+    [
+        # Nothing to preserve: byte-identical to MolToSmiles.
+        ("c1ccccc1", "c1ccccc1"),
+        ("C[C@H](N)O", "C[C@H](N)O"),
+        # Enhanced stereochemistry cannot be written as plain SMILES, so it stays.
+        ("C[C@H](N)O |a:1|", "C[C@H](N)O |a:1|"),
+        ("C[C@H](N)O |o1:1|", "C[C@H](N)O |o1:1|"),
+        # Presentation and provenance fields are dropped.
+        ("c1ccccc1 |$_R1;;;;;$|", "c1ccccc1"),
+        ("CC |(0,0,;1,0,)|", "CC"),
+    ],
+)
+def test_canonical_smiles_keeps_only_enhanced_stereochemistry(smiles, expected):
+    assert message_helpers.canonical_smiles(Chem.MolFromSmiles(smiles)) == expected
+
+
+def test_enhanced_stereochemistry_survives_smiles_from_compound():
+    compound = reaction_pb2.Compound()
+    compound.identifiers.add(type="CXSMILES", value="C[C@H](N)O |o1:1|")
+    smiles = message_helpers.smiles_from_compound(compound)
+    assert smiles == "C[C@H](N)O |o1:1|"
+    assert Chem.MolFromSmiles(smiles) is not None

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -813,3 +813,36 @@ def test_enhanced_stereochemistry_survives_smiles_from_compound():
     smiles = message_helpers.smiles_from_compound(compound)
     assert smiles == "C[C@H](N)O |o1:1|"
     assert Chem.MolFromSmiles(smiles) is not None
+
+
+@pytest.mark.parametrize(
+    ("value", "identifier_type", "strip", "expected"),
+    [
+        ("CCO>>CCO |f:0.1|", "REACTION_CXSMILES", False, "CCO>>CCO |f:0.1|"),
+        ("CCO>>CCO |f:0.1|", "REACTION_CXSMILES", True, "CCO>>CCO"),
+        # Padding is not an extension block, so nothing is dropped.
+        ("CCO>>CCO\xa0", "REACTION_SMILES", True, "CCO>>CCO\xa0"),
+        ("CCO>>CCO", "REACTION_SMILES", True, "CCO>>CCO"),
+    ],
+)
+def test_get_reaction_smiles_strip_extension(value, identifier_type, strip, expected):
+    reaction = reaction_pb2.Reaction()
+    reaction.identifiers.add(type=identifier_type, value=value)
+    actual = message_helpers.get_reaction_smiles(reaction, strip_extension=strip)
+    assert actual == expected
+
+
+def test_check_compound_identifiers_compares_enhanced_stereochemistry():
+    """Identifiers that disagree about stereo are not the same assertion."""
+    compound = reaction_pb2.Compound()
+    compound.identifiers.add(type="SMILES", value="C[C@H](N)O")
+    compound.identifiers.add(type="CXSMILES", value="C[C@H](N)O |o1:1|")
+    with pytest.raises(ValueError, match="inconsistent"):
+        message_helpers.check_compound_identifiers(compound)
+
+
+def test_check_compound_identifiers_accepts_matching_stereo_groups():
+    compound = reaction_pb2.Compound()
+    compound.identifiers.add(type="CXSMILES", value="C[C@H](N)O |o1:1|")
+    compound.identifiers.add(type="SMILES", value="C[C@H](N)O |o1:1|")
+    message_helpers.check_compound_identifiers(compound)

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -858,14 +858,33 @@ def validate_compound_identifier(message: reaction_pb2.CompoundIdentifier) -> No
     check_type_and_details(message)
     if not message.value:
         warnings.warn("value must be set", ValidationError)
-    if message.type in (message.SMILES, message.INCHI, message.MOLBLOCK):
+    if message.type in (
+        message.SMILES,
+        message.CXSMILES,
+        message.INCHI,
+        message.MOLBLOCK,
+    ):
         parse_func, identifier_type = {
+            # MolFromSmiles reads CXSMILES too, so a CXSMILES identifier is validated
+            # whole -- extension included -- while a SMILES one is validated without
+            # the extension it should not be carrying.
             message.SMILES: (Chem.MolFromSmiles, "SMILES"),
+            message.CXSMILES: (Chem.MolFromSmiles, "CXSMILES"),
             message.INCHI: (Chem.MolFromInchi, "InChI"),
             message.MOLBLOCK: (Chem.MolFromMolBlock, "MolBlock"),
         }[message.type]
-        if parse_func(message.value) is None:
-            if parse_func(message.value, sanitize=False) is None:
+        value = message.value
+        if message.type == message.SMILES:
+            tokens = message.value.split(maxsplit=1)
+            value = tokens[0] if tokens else ""
+            if len(tokens) > 1:
+                warnings.warn(
+                    "CompoundIdentifier is typed SMILES but its value carries a "
+                    "CXSMILES extension block; use CXSMILES",
+                    ValidationWarning,
+                )
+        if parse_func(value) is None:
+            if parse_func(value, sanitize=False) is None:
                 warnings.warn(
                     f"RDKit {RDKIT_VERSION} could not validate {identifier_type} "
                     f"identifier {message.value}",

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -681,21 +681,48 @@ def validate_reaction(
             warnings.warn("Reaction requires provenance", ValidationError)
 
 
+# Block formats whose leading and trailing newlines are part of the format.
+_WHITESPACE_EXEMPT_TYPES = frozenset(
+    {
+        reaction_pb2.CompoundIdentifier.MOLBLOCK,
+        reaction_pb2.CompoundIdentifier.XYZ,
+        reaction_pb2.ReactionIdentifier.RDFILE,
+    }
+)
+
+
+def _check_surrounding_whitespace(
+    message: reaction_pb2.CompoundIdentifier | reaction_pb2.ReactionIdentifier,
+) -> None:
+    """Warns when an identifier value is padded with whitespace.
+
+    Padding is invisible in most tooling and silently defeats the exact-match lookups
+    and joins these values exist for; non-breaking spaces in particular survive a
+    careless copy-paste.
+    """
+    if message.type in _WHITESPACE_EXEMPT_TYPES:
+        return
+    if message.value and message.value != message.value.strip():
+        warnings.warn("value has leading or trailing whitespace", ValidationWarning)
+
+
 def validate_reaction_identifier(message: reaction_pb2.ReactionIdentifier) -> None:
     """Validates a ReactionIdentifier's SMILES and atom-mapping consistency."""
     check_type_and_details(message)
+    _check_surrounding_whitespace(message)
     if message.type in [message.REACTION_SMILES, message.REACTION_CXSMILES]:
-        # CXSMILES writes an extension block after a space. Validate the SMILES half
-        # whichever type it arrives under: RDKit parses the extension without
-        # complaint, so the type alone does not establish that there is none.
-        tokens = message.value.split(maxsplit=1)
-        smiles = tokens[0] if tokens else ""
-        if len(tokens) > 1 and message.type == message.REACTION_SMILES:
-            warnings.warn(
-                "ReactionIdentifier is typed REACTION_SMILES but its value carries a "
-                "CXSMILES extension block; use REACTION_CXSMILES",
-                ValidationWarning,
-            )
+        if message.type == message.REACTION_CXSMILES:
+            smiles = message_helpers.split_cxsmiles_extension(message.value)[0]
+        else:
+            # RDKit parses an extension block without complaint, so a value carrying
+            # one under this type would otherwise validate silently.
+            smiles, extension = message_helpers.split_cxsmiles_extension(message.value)
+            if extension is not None:
+                warnings.warn(
+                    "ReactionIdentifier is typed REACTION_SMILES but its value carries "
+                    "a CXSMILES extension block; use REACTION_CXSMILES",
+                    ValidationWarning,
+                )
         try:
             message_helpers.validate_reaction_smiles(smiles)
         except ValueError as error:
@@ -856,6 +883,7 @@ def validate_compound_preparation(message: reaction_pb2.CompoundPreparation) -> 
 def validate_compound_identifier(message: reaction_pb2.CompoundIdentifier) -> None:
     """Validates a CompoundIdentifier's value and type-specific format."""
     check_type_and_details(message)
+    _check_surrounding_whitespace(message)
     if not message.value:
         warnings.warn("value must be set", ValidationError)
     if message.type in (
@@ -875,9 +903,8 @@ def validate_compound_identifier(message: reaction_pb2.CompoundIdentifier) -> No
         }[message.type]
         value = message.value
         if message.type == message.SMILES:
-            tokens = message.value.split(maxsplit=1)
-            value = tokens[0] if tokens else ""
-            if len(tokens) > 1:
+            value, extension = message_helpers.split_cxsmiles_extension(message.value)
+            if extension is not None:
                 warnings.warn(
                     "CompoundIdentifier is typed SMILES but its value carries a "
                     "CXSMILES extension block; use CXSMILES",

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -685,10 +685,17 @@ def validate_reaction_identifier(message: reaction_pb2.ReactionIdentifier) -> No
     """Validates a ReactionIdentifier's SMILES and atom-mapping consistency."""
     check_type_and_details(message)
     if message.type in [message.REACTION_SMILES, message.REACTION_CXSMILES]:
-        if message.type == message.REACTION_CXSMILES:
-            smiles = message.value.split()[0]
-        else:
-            smiles = message.value
+        # CXSMILES writes an extension block after a space. Validate the SMILES half
+        # whichever type it arrives under: RDKit parses the extension without
+        # complaint, so the type alone does not establish that there is none.
+        tokens = message.value.split(maxsplit=1)
+        smiles = tokens[0] if tokens else ""
+        if len(tokens) > 1 and message.type == message.REACTION_SMILES:
+            warnings.warn(
+                "ReactionIdentifier is typed REACTION_SMILES but its value carries a "
+                "CXSMILES extension block; use REACTION_CXSMILES",
+                ValidationWarning,
+            )
         try:
             message_helpers.validate_reaction_smiles(smiles)
         except ValueError as error:

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -694,16 +694,26 @@ _WHITESPACE_EXEMPT_TYPES = frozenset(
 def _check_surrounding_whitespace(
     message: reaction_pb2.CompoundIdentifier | reaction_pb2.ReactionIdentifier,
 ) -> None:
-    """Warns when an identifier value is padded with whitespace.
-
-    Padding is invisible in most tooling and silently defeats the exact-match lookups
-    and joins these values exist for; non-breaking spaces in particular survive a
-    careless copy-paste.
-    """
+    """Warns when an identifier value is padded, which defeats exact-match lookups."""
     if message.type in _WHITESPACE_EXEMPT_TYPES:
         return
     if message.value and message.value != message.value.strip():
         warnings.warn("value has leading or trailing whitespace", ValidationWarning)
+
+
+def _smiles_without_extension(value: str, cxsmiles_type: str) -> str:
+    """Returns the SMILES half of a value, warning if it carries a CXSMILES block.
+
+    RDKit parses the block, so one recorded under a plain SMILES type would otherwise
+    validate silently.
+    """
+    smiles, extension = message_helpers.split_cxsmiles_extension(value)
+    if extension is not None:
+        warnings.warn(
+            f"value carries a CXSMILES extension block; use {cxsmiles_type}",
+            ValidationWarning,
+        )
+    return smiles
 
 
 def validate_reaction_identifier(message: reaction_pb2.ReactionIdentifier) -> None:
@@ -714,15 +724,7 @@ def validate_reaction_identifier(message: reaction_pb2.ReactionIdentifier) -> No
         if message.type == message.REACTION_CXSMILES:
             smiles = message_helpers.split_cxsmiles_extension(message.value)[0]
         else:
-            # RDKit parses an extension block without complaint, so a value carrying
-            # one under this type would otherwise validate silently.
-            smiles, extension = message_helpers.split_cxsmiles_extension(message.value)
-            if extension is not None:
-                warnings.warn(
-                    "ReactionIdentifier is typed REACTION_SMILES but its value carries "
-                    "a CXSMILES extension block; use REACTION_CXSMILES",
-                    ValidationWarning,
-                )
+            smiles = _smiles_without_extension(message.value, "REACTION_CXSMILES")
         try:
             message_helpers.validate_reaction_smiles(smiles)
         except ValueError as error:
@@ -892,10 +894,9 @@ def validate_compound_identifier(message: reaction_pb2.CompoundIdentifier) -> No
         message.INCHI,
         message.MOLBLOCK,
     ):
+        # MolFromSmiles reads CXSMILES, so a CXSMILES identifier validates whole while
+        # a SMILES one validates without the extension it should not be carrying.
         parse_func, identifier_type = {
-            # MolFromSmiles reads CXSMILES too, so a CXSMILES identifier is validated
-            # whole -- extension included -- while a SMILES one is validated without
-            # the extension it should not be carrying.
             message.SMILES: (Chem.MolFromSmiles, "SMILES"),
             message.CXSMILES: (Chem.MolFromSmiles, "CXSMILES"),
             message.INCHI: (Chem.MolFromInchi, "InChI"),
@@ -903,13 +904,7 @@ def validate_compound_identifier(message: reaction_pb2.CompoundIdentifier) -> No
         }[message.type]
         value = message.value
         if message.type == message.SMILES:
-            value, extension = message_helpers.split_cxsmiles_extension(message.value)
-            if extension is not None:
-                warnings.warn(
-                    "CompoundIdentifier is typed SMILES but its value carries a "
-                    "CXSMILES extension block; use CXSMILES",
-                    ValidationWarning,
-                )
+            value = _smiles_without_extension(message.value, "CXSMILES")
         if parse_func(value) is None:
             if parse_func(value, sanitize=False) is None:
                 warnings.warn(

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -701,19 +701,17 @@ def _check_surrounding_whitespace(
         warnings.warn("value has leading or trailing whitespace", ValidationWarning)
 
 
-def _smiles_without_extension(value: str, cxsmiles_type: str) -> str:
-    """Returns the SMILES half of a value, warning if it carries a CXSMILES block.
+def _check_cxsmiles_type(value: str, cxsmiles_type: str) -> None:
+    """Warns when a plain-SMILES identifier carries a CXSMILES extension block.
 
-    RDKit parses the block, so one recorded under a plain SMILES type would otherwise
-    validate silently.
+    RDKit parses the block, so one recorded under the wrong type is otherwise silent.
+    The value is still validated as recorded, since a malformed block is an error.
     """
-    smiles, extension = message_helpers.split_cxsmiles_extension(value)
-    if extension is not None:
+    if message_helpers.split_cxsmiles_extension(value)[1] is not None:
         warnings.warn(
             f"value carries a CXSMILES extension block; use {cxsmiles_type}",
             ValidationWarning,
         )
-    return smiles
 
 
 def validate_reaction_identifier(message: reaction_pb2.ReactionIdentifier) -> None:
@@ -721,15 +719,18 @@ def validate_reaction_identifier(message: reaction_pb2.ReactionIdentifier) -> No
     check_type_and_details(message)
     _check_surrounding_whitespace(message)
     if message.type in [message.REACTION_SMILES, message.REACTION_CXSMILES]:
+        bare, _ = message_helpers.split_cxsmiles_extension(message.value)
         if message.type == message.REACTION_CXSMILES:
-            smiles = message_helpers.split_cxsmiles_extension(message.value)[0]
+            # The extension is not validated here, matching CXSMILES handling before.
+            checked = bare
         else:
-            smiles = _smiles_without_extension(message.value, "REACTION_CXSMILES")
+            _check_cxsmiles_type(message.value, "REACTION_CXSMILES")
+            checked = message.value
         try:
-            message_helpers.validate_reaction_smiles(smiles)
+            message_helpers.validate_reaction_smiles(checked)
         except ValueError as error:
             warnings.warn(str(error), ValidationError)
-        has_mapping = has_atom_mapping(smiles)
+        has_mapping = has_atom_mapping(bare)
         if message.is_mapped and not has_mapping:
             warnings.warn(
                 "ReactionIdentifier is marked is_mapped but the SMILES "
@@ -894,19 +895,17 @@ def validate_compound_identifier(message: reaction_pb2.CompoundIdentifier) -> No
         message.INCHI,
         message.MOLBLOCK,
     ):
-        # MolFromSmiles reads CXSMILES, so a CXSMILES identifier validates whole while
-        # a SMILES one validates without the extension it should not be carrying.
+        # MolFromSmiles reads CXSMILES, so both types validate as recorded.
         parse_func, identifier_type = {
             message.SMILES: (Chem.MolFromSmiles, "SMILES"),
             message.CXSMILES: (Chem.MolFromSmiles, "CXSMILES"),
             message.INCHI: (Chem.MolFromInchi, "InChI"),
             message.MOLBLOCK: (Chem.MolFromMolBlock, "MolBlock"),
         }[message.type]
-        value = message.value
         if message.type == message.SMILES:
-            value = _smiles_without_extension(message.value, "CXSMILES")
-        if parse_func(value) is None:
-            if parse_func(value, sanitize=False) is None:
+            _check_cxsmiles_type(message.value, "CXSMILES")
+        if parse_func(message.value) is None:
+            if parse_func(message.value, sanitize=False) is None:
                 warnings.warn(
                     f"RDKit {RDKIT_VERSION} could not validate {identifier_type} "
                     f"identifier {message.value}",

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -719,17 +719,16 @@ def validate_reaction_identifier(message: reaction_pb2.ReactionIdentifier) -> No
     check_type_and_details(message)
     _check_surrounding_whitespace(message)
     if message.type in [message.REACTION_SMILES, message.REACTION_CXSMILES]:
-        bare, _ = message_helpers.split_cxsmiles_extension(message.value)
-        if message.type == message.REACTION_CXSMILES:
-            # The extension is not validated here, matching CXSMILES handling before.
-            checked = bare
-        else:
+        # Parsed as recorded under either type: RDKit reads CXSMILES, and a malformed
+        # extension block is an error rather than something to strip and ignore.
+        if message.type == message.REACTION_SMILES:
             _check_cxsmiles_type(message.value, "REACTION_CXSMILES")
-            checked = message.value
         try:
-            message_helpers.validate_reaction_smiles(checked)
+            message_helpers.validate_reaction_smiles(message.value)
         except ValueError as error:
             warnings.warn(str(error), ValidationError)
+        # Atom maps live in the SMILES half, never in the extension block.
+        bare, _ = message_helpers.split_cxsmiles_extension(message.value)
         has_mapping = has_atom_mapping(bare)
         if message.is_mapped and not has_mapping:
             warnings.warn(

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -511,15 +511,26 @@ def test_cxsmiles_under_its_own_type_is_not_flagged():
     assert not output.errors
 
 
-def test_reaction_smiles_is_validated_without_its_extension():
-    # Only the SMILES half is checked; the extension is not a reaction SMILES and
-    # validating the whole string would test something that is not one.
-    message = reaction_pb2.ReactionIdentifier(
-        type="REACTION_SMILES", value="notareaction |f:0.1|"
-    )
+@pytest.mark.parametrize(
+    ("identifier_type", "value"),
+    [
+        ("REACTION_SMILES", "CCO>>CCO |garbage|"),
+        ("REACTION_SMILES", "notareaction |f:0.1|"),
+    ],
+)
+def test_reaction_identifier_is_validated_as_recorded(identifier_type, value):
+    # Stripping the block before parsing would let a malformed one through with only
+    # an advisory warning.
+    message = reaction_pb2.ReactionIdentifier(type=identifier_type, value=value)
     output = _run_validation(message, raise_on_error=False)
     assert any("bad reaction SMILES" in error for error in output.errors)
-    assert not any("|f:0.1|" in error for error in output.errors)
+
+
+@pytest.mark.parametrize("value", ["c1ccccc1 |garbage|", "c1ccccc1 |$|"])
+def test_compound_identifier_is_validated_as_recorded(value):
+    message = reaction_pb2.CompoundIdentifier(type="SMILES", value=value)
+    output = _run_validation(message, raise_on_error=False)
+    assert any("could not validate SMILES" in error for error in output.errors)
 
 
 @pytest.mark.parametrize("identifier_type", ["REACTION_SMILES", "REACTION_CXSMILES"])

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -494,6 +494,42 @@ def test_reaction_identifier_atom_mapping(value, is_mapped, expected):
     assert expected in output.warnings[0]
 
 
+_CXSMILES = "CC(=O)O.CCO>>CC(=O)OCC |f:0.1|"
+
+
+def test_reaction_smiles_carrying_a_cxsmiles_extension_warns():
+    message = reaction_pb2.ReactionIdentifier(type="REACTION_SMILES", value=_CXSMILES)
+    output = _run_validation(message)
+    assert len(output.warnings) == 1
+    assert "use REACTION_CXSMILES" in output.warnings[0]
+
+
+def test_cxsmiles_under_its_own_type_is_not_flagged():
+    message = reaction_pb2.ReactionIdentifier(type="REACTION_CXSMILES", value=_CXSMILES)
+    output = _run_validation(message)
+    assert not output.warnings
+    assert not output.errors
+
+
+def test_reaction_smiles_is_validated_without_its_extension():
+    # Only the SMILES half is checked; the extension is not a reaction SMILES and
+    # validating the whole string would test something that is not one.
+    message = reaction_pb2.ReactionIdentifier(
+        type="REACTION_SMILES", value="notareaction |f:0.1|"
+    )
+    output = _run_validation(message, raise_on_error=False)
+    assert any("bad reaction SMILES" in error for error in output.errors)
+    assert not any("|f:0.1|" in error for error in output.errors)
+
+
+@pytest.mark.parametrize("identifier_type", ["REACTION_SMILES", "REACTION_CXSMILES"])
+def test_empty_reaction_identifier_reports_rather_than_raises(identifier_type):
+    # An empty CXSMILES value used to index off the end of an empty token list.
+    message = reaction_pb2.ReactionIdentifier(type=identifier_type, value="")
+    output = _run_validation(message, raise_on_error=False)
+    assert any("value must be set" in error for error in output.errors)
+
+
 def test_data_bad_url():
     message = reaction_pb2.Data(url="not a url")
     output = _run_validation(message)

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -18,7 +18,7 @@ import warnings
 
 import pytest
 
-from ord_schema import message_helpers, validations
+from ord_schema import validations
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 
@@ -560,22 +560,6 @@ def test_compound_smiles_is_validated_without_its_extension():
     )
     output = _run_validation(message, raise_on_error=False)
     assert any("could not validate SMILES" in error for error in output.errors)
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        ("c1ccccc1 |f:0.1|", ("c1ccccc1", "|f:0.1|")),
-        ("c1ccccc1", ("c1ccccc1", None)),
-        # Trailing non-breaking spaces appear in real records; splitting there would
-        # truncate a valid SMILES and report a block that is not present.
-        ("c1ccccc1\xa0\xa0", ("c1ccccc1\xa0\xa0", None)),
-        ("c1ccccc1 benzene", ("c1ccccc1 benzene", None)),
-        ("", ("", None)),
-    ],
-)
-def test_split_cxsmiles_extension(value, expected):
-    assert message_helpers.split_cxsmiles_extension(value) == expected
 
 
 @pytest.mark.parametrize("identifier_type", ["SMILES", "CXSMILES"])

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -516,6 +516,9 @@ def test_cxsmiles_under_its_own_type_is_not_flagged():
     [
         ("REACTION_SMILES", "CCO>>CCO |garbage|"),
         ("REACTION_SMILES", "notareaction |f:0.1|"),
+        # A malformed block is an error under its own type too.
+        ("REACTION_CXSMILES", "CCO>>CCO |garbage|"),
+        ("REACTION_CXSMILES", "notareaction |f:0.1|"),
     ],
 )
 def test_reaction_identifier_is_validated_as_recorded(identifier_type, value):

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -18,7 +18,7 @@ import warnings
 
 import pytest
 
-from ord_schema import validations
+from ord_schema import message_helpers, validations
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 
@@ -560,6 +560,60 @@ def test_compound_smiles_is_validated_without_its_extension():
     )
     output = _run_validation(message, raise_on_error=False)
     assert any("could not validate SMILES" in error for error in output.errors)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("c1ccccc1 |f:0.1|", ("c1ccccc1", "|f:0.1|")),
+        ("c1ccccc1", ("c1ccccc1", None)),
+        # Trailing non-breaking spaces appear in real records; splitting there would
+        # truncate a valid SMILES and report a block that is not present.
+        ("c1ccccc1\xa0\xa0", ("c1ccccc1\xa0\xa0", None)),
+        ("c1ccccc1 benzene", ("c1ccccc1 benzene", None)),
+        ("", ("", None)),
+    ],
+)
+def test_split_cxsmiles_extension(value, expected):
+    assert message_helpers.split_cxsmiles_extension(value) == expected
+
+
+@pytest.mark.parametrize("identifier_type", ["SMILES", "CXSMILES"])
+def test_trailing_whitespace_is_not_treated_as_an_extension(identifier_type):
+    # Parsing only up to the whitespace would strip a stray byte off the SMILES and
+    # turn these into errors. It is still worth a warning, but not a parse failure.
+    message = reaction_pb2.CompoundIdentifier(
+        type=identifier_type, value="CCC(C)(C)[O-].[K+]\xc2\xa0\xc2\xa0"
+    )
+    output = _run_validation(message, raise_on_error=False)
+    assert not output.errors
+    assert output.warnings == [
+        "CompoundIdentifier: value has leading or trailing whitespace"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_warning"),
+    [
+        ("c1ccccc1 ", True),
+        (" c1ccccc1", True),
+        ("c1ccccc1\xa0", True),
+        ("c1ccccc1\n", True),
+        ("c1ccccc1", False),
+        ("", False),
+    ],
+)
+def test_compound_identifier_surrounding_whitespace(value, expected_warning):
+    message = reaction_pb2.CompoundIdentifier(type="SMILES", value=value)
+    output = _run_validation(message, raise_on_error=False)
+    warned = any("whitespace" in warning for warning in output.warnings)
+    assert warned is expected_warning
+
+
+def test_reaction_identifier_surrounding_whitespace():
+    message = reaction_pb2.ReactionIdentifier(type="REACTION_SMILES", value=" CO>>CC ")
+    output = _run_validation(message, raise_on_error=False)
+    assert any("whitespace" in warning for warning in output.warnings)
 
 
 def test_data_bad_url():

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -530,6 +530,38 @@ def test_empty_reaction_identifier_reports_rather_than_raises(identifier_type):
     assert any("value must be set" in error for error in output.errors)
 
 
+_COMPOUND_CXSMILES = "c1ccccc1 |f:0.1|"
+
+
+def test_compound_smiles_carrying_a_cxsmiles_extension_warns():
+    message = reaction_pb2.CompoundIdentifier(type="SMILES", value=_COMPOUND_CXSMILES)
+    output = _run_validation(message)
+    assert len(output.warnings) == 1
+    assert "use CXSMILES" in output.warnings[0]
+
+
+def test_compound_cxsmiles_under_its_own_type_is_not_flagged():
+    message = reaction_pb2.CompoundIdentifier(type="CXSMILES", value=_COMPOUND_CXSMILES)
+    output = _run_validation(message)
+    assert not output.warnings
+    assert not output.errors
+
+
+def test_compound_cxsmiles_is_validated():
+    # CXSMILES identifiers were parsed by nothing, so an unparseable one passed.
+    message = reaction_pb2.CompoundIdentifier(type="CXSMILES", value="notamolecule")
+    output = _run_validation(message, raise_on_error=False)
+    assert any("could not validate CXSMILES" in error for error in output.errors)
+
+
+def test_compound_smiles_is_validated_without_its_extension():
+    message = reaction_pb2.CompoundIdentifier(
+        type="SMILES", value="notamolecule |f:0.1|"
+    )
+    output = _run_validation(message, raise_on_error=False)
+    assert any("could not validate SMILES" in error for error in output.errors)
+
+
 def test_data_bad_url():
     message = reaction_pb2.Data(url="not a url")
     output = _run_validation(message)


### PR DESCRIPTION
CXSMILES appends an extension block after whitespace. `validate_reaction_identifier` split it off only for `REACTION_CXSMILES`, and `validate_compound_identifier` did not know about CXSMILES at all — so RDKit parsed the block without complaint and a mistyped identifier validated silently:

```python
>>> validate_reaction_identifier(ReactionIdentifier(
...     type="REACTION_SMILES", value="CC(=O)O.CCO>>CC(=O)OCC |f:0.1|"))
# warnings: none
```

Now a plain-SMILES type carrying a block warns and names the type it belongs under, and **every value is parsed exactly as recorded**. That second part matters: RDKit rejects a malformed block (`c1ccccc1 |garbage|`) but accepts its leading token, so stripping before parsing would downgrade a hard error to an advisory warning. The old code stripped for `REACTION_CXSMILES`, which is why a malformed block under that type was never checked at all. `CXSMILES` also joins the structurally validated compound types — previously an unparseable CXSMILES compound value was checked by nothing.

## Whitespace alone does not mark a block

This is the part worth reviewing. The obvious implementation — split on whitespace — is wrong on real data. **4,477 compound identifiers in ord-data carry a SMILES value padded with mis-encoded non-breaking spaces** (`"CCC(C)(C)[O-].[K+]Â Â "`), and on 959 of them the leading token keeps a stray `Â` that does not parse. Splitting there would have converted currently-valid records into validation **errors**, in a repository that validates its whole corpus on every merge to `main`.

`split_cxsmiles_extension` therefore requires the remainder to introduce a block with `|`, and returns anything else intact. It lives in `message_helpers`, so validation and the views work in #914 share one definition rather than each guessing.

The padding is itself worth reporting, so both validators warn when a value differs from its stripped form. `MOLBLOCK`, `XYZ`, and `RDFILE` are exempt — their leading and trailing newlines are part of the format.

## Enhanced stereochemistry survives canonicalization

`MolToSmiles` cannot express AND/OR stereo groups, so canonicalizing a structure that has them silently asserted a *more specific* molecule than the source recorded. `canonical_smiles` writes CXSMILES with only the enhanced-stereo field:

| input | output |
| --- | --- |
| `c1ccccc1` | `c1ccccc1` (byte-identical to `MolToSmiles`) |
| `C[C@H](N)O \|a:1\|` | `C[C@H](N)O \|a:1\|` |
| `c1ccccc1 \|$_R1;;;;;$\|` | `c1ccccc1` (labels dropped) |
| `CC \|(0,0,;1,0,)\|` | `CC` (coordinates dropped) |

`CXSMILES` also joins `_COMPOUND_IDENTIFIER_LOADERS`, so `smiles_from_compound` no longer refuses a compound identified that way. That widens `STRUCTURAL_IDENTIFIER_TYPES`, which the ORM's derived-SMILES pass shares.

## Measured against the whole corpus

Not sampled — every reaction in all 53 datasets:

| | |
| --- | --- |
| reaction identifiers scanned | 3,137,187 |
| compound identifiers scanned | 37,317,905 |
| **identifiers whose parse target changes** | **0** |
| mistyped CXSMILES blocks found | 0 |
| padded values (new warning) | 16,802, across 7 datasets |
| `REACTION_CXSMILES` identifiers | 1,771,032 |
| of those, carrying an extension block | 967,841 |
| **failing whole-value validation** | **0** |
| compounds with 2+ structural identifiers | 9,494,519 |
| **whose consistency verdict changes** | **0** |

**No existing identifier changes how it is parsed**, so this adds no errors anywhere. The CXSMILES checks are a pure guard against future submissions. The 16,802 padded values raise `ValidationWarning`, which is not a subclass of `ValidationError` and is filtered out by `validate_datasets` — ord-data's corpus validation stays green while the dirt becomes visible.

## Two smaller changes from sweeping the rest of the codebase

`get_reaction_smiles` returned a stored `REACTION_CXSMILES` whole, so every caller wanting plain SMILES had to know to split — three of them each solved it separately, and anyone who did not know got a CX string and found out at runtime. `strip_extension=True` makes that one flag; the default is unchanged, and the docstring now says the result is not necessarily plain SMILES.

`check_compound_identifiers` compares through `canonical_smiles` rather than `MolToSmiles`. A `SMILES` of `C[C@H](N)O` and a `CXSMILES` of `C[C@H](N)O |o1:1|` previously compared equal — same skeleton, different assertion about the molecule.

## An IndexError falls out too

`message.value.split()[0]` indexed off an empty list, so an empty `REACTION_CXSMILES` value raised `IndexError` instead of reporting the "value must be set" error waiting below it. There is a parametrized test over both identifier types.

605 tests pass, plus `ruff check`, `ruff format --check`, `ty check`, and the pre-commit hooks.

Found while splitting `reaction_smiles` from `reaction_cxsmiles` in #914, which stacks on this and shares the splitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR strengthens CXSMILES handling and identifier validation.
- Validates reaction and compound identifier values exactly as recorded, including CXSMILES extension blocks.
- Detects CXSMILES blocks stored under plain-SMILES identifier types and warns about surrounding whitespace.
- Preserves enhanced stereochemistry during canonicalization and treats compound CXSMILES as structural identifiers.
- Adds regression coverage for malformed extensions, padded values, empty reaction identifiers, and canonicalization behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the current code validates full reaction and compound identifier values without retaining the previously reported suffix bypasses.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/validations.py | Validates complete SMILES/CXSMILES values, adds type and whitespace warnings, and closes the previously reported suffix-validation bypasses. |
| ord_schema/message_helpers.py | Adds shared CXSMILES splitting and stereo-preserving canonicalization while extending structural identifier support. |
| ord_schema/validations_test.py | Covers malformed whole-value extensions, padded identifiers, type warnings, and empty reaction identifier handling. |
| ord_schema/message_helpers_test.py | Covers CXSMILES splitting, structural loading, enhanced-stereo preservation, and extension stripping. |

</details>

<sub>Reviews (7): Last reviewed commit: ["Give get\_reaction\_smiles a way to return..."](https://github.com/open-reaction-database/ord-schema/commit/29822efb98cb5c65b0d3d94221e657043f5e9744) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48560307)</sub>

<!-- /greptile_comment -->
