### PR TITLE
Add an agent package, starting with natural-language translation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,7 @@ repos:
     rev: v0.23.1
     hooks:
       - id: markdownlint-cli2
+        # Agent prompts are model input, not documentation: their first line is an
+        # instruction, and adding a heading to satisfy MD041 would change what the
+        # model receives.
+        exclude: ^ord_schema/agent/.*\.md$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,3 @@ repos:
     rev: v0.23.1
     hooks:
       - id: markdownlint-cli2
-        # Agent prompts are model input, not documentation: their first line is an
-        # instruction, and adding a heading to satisfy MD041 would change what the
-        # model receives.
-        exclude: ^ord_schema/agent/.*\.md$

--- a/ord_schema/agent/__init__.py
+++ b/ord_schema/agent/__init__.py
@@ -1,0 +1,29 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Machinery for reaching ORD from an agent.
+
+Everything an agent needs to turn an intent into a query lives here: prompts, the
+schemas a model is allowed to emit, name resolution, and -- as they arrive -- tool
+and MCP surfaces.
+
+It sits in ``ord-schema`` rather than in a serving repository because these pieces
+describe the *data*, not a deployment. A prompt that tells a model which columns exist
+has to be versioned alongside the code that generates them, or it silently drifts from
+a schema it cannot see. For the same reason nothing here does HTTP, holds a database
+connection, or owns a cache; a server supplies those and maps library exceptions onto
+its own protocol.
+
+Requires the ``agent`` extra (``pip install ord-schema[agent]``).
+"""

--- a/ord_schema/agent/nl_query.py
+++ b/ord_schema/agent/nl_query.py
@@ -268,8 +268,13 @@ async def translate(query: str, client: anthropic.AsyncAnthropic) -> NLQuery:
 
 
 def translation_cache_key(query: str) -> str:
-    """Returns the cache key for a translation, scoped to the prompt and model."""
-    digest = hashlib.sha256(query.strip().lower().encode()).hexdigest()
+    """Returns the cache key for a translation, scoped to the prompt version and model.
+
+    The question is *not* case-folded, unlike a name lookup: a question can carry a
+    SMILES, and ``CCO`` and ``cco`` are different molecules. Two questions differing
+    only in case therefore get separate entries rather than one wrong answer.
+    """
+    digest = hashlib.sha256(query.strip().encode()).hexdigest()
     return f"nl_translate:{TRANSLATION_CACHE_VERSION}:{model_name()}:{digest}"
 
 

--- a/ord_schema/agent/nl_query.py
+++ b/ord_schema/agent/nl_query.py
@@ -1,0 +1,360 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Translating a natural-language question into a structured ORD query.
+
+The model only ever emits a *structured* query, through a forced tool call -- it never
+writes SQL and never invents SMILES. Compound names are resolved deterministically by
+``ord_schema.resolvers`` (PubChem/CIR/OPSIN), so the chemistry is grounded in a resolver
+rather than in model recall.
+
+This module is the translation half only: text in, a resolved interpretation out. It
+holds no HTTP, no database, and no cache of its own, so the same translation can serve a
+web API, a notebook, and an evaluation harness without any of them inheriting the
+others' dependencies. Serving concerns stay with the server:
+
+* **Errors** are library exceptions (:class:`NLQueryError` and its subclasses), which a
+  web layer maps to status codes. Nothing here knows what a 503 is.
+* **Caching** is injected. Pass any :class:`Cache` implementation to reuse name
+  resolutions across requests; omit it and every lookup is live. The cache is always an
+  optimization, never a dependency -- an implementation that fails or times out should
+  return None rather than raise, so translation falls back to a live call.
+
+Requires the ``agent`` extra; see :mod:`ord_schema.agent`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+from importlib import resources
+from typing import Any, Literal, Protocol, cast
+
+import anthropic
+from pydantic import BaseModel, Field, ValidationError
+from rdkit import Chem
+
+from ord_schema.logging import get_logger
+from ord_schema.resolvers import canonicalize_smiles, resolve_name
+
+logger = get_logger(__name__)
+
+# Haiku is fast and cheap and the translation task is tightly constrained; override with
+# ORD_NL_QUERY_MODEL (e.g. a Sonnet snapshot) if disambiguation needs more reasoning.
+DEFAULT_MODEL = "claude-haiku-4-5"
+MAX_TOKENS = 1024
+
+# Bump when the prompt or the NLQuery schema changes, so a caller's cache does not serve
+# interpretations produced by a definition that no longer exists.
+TRANSLATION_CACHE_VERSION = "v3"
+TRANSLATION_CACHE_TTL_SECONDS = 60 * 60
+
+# Name -> SMILES resolutions are cached separately and for much longer: they are stable
+# (a name maps to the same structure) and shared across different questions that mention
+# the same compound, which spares the name resolvers repeated lookups.
+RESOLVE_CACHE_VERSION = "v1"
+RESOLVE_CACHE_TTL_SECONDS = 60 * 60 * 24 * 30
+
+Target = Literal["INPUT", "OUTPUT"]
+MatchMode = Literal["EXACT", "SIMILAR", "SUBSTRUCTURE", "SMARTS"]
+
+
+class NLQueryError(Exception):
+    """Base class for failures translating a natural-language question."""
+
+
+class ModelUnavailableError(NLQueryError):
+    """The language model could not be reached, or is not configured."""
+
+
+class ModelRateLimitedError(NLQueryError):
+    """The language model is rate limited; the same request may succeed later."""
+
+
+class MalformedQueryError(NLQueryError):
+    """The model returned no structured query, or one that failed schema validation."""
+
+
+class Cache(Protocol):
+    """An optional key-value cache for name resolutions.
+
+    Implementations must treat every operation as best-effort: return None on a miss
+    *or* on any failure, and swallow errors on write. Translation is correct without a
+    cache, so an unreachable one must never turn into a failed request.
+    """
+
+    async def get(self, key: str) -> str | None:
+        """Returns the cached value for ``key``, or None on a miss or any failure."""
+
+    async def set(self, key: str, value: str, ttl_seconds: int) -> None:
+        """Stores ``value`` under ``key``, ignoring failures."""
+
+
+class NLComponent(BaseModel):
+    """A single component constraint extracted from the question."""
+
+    identifier: str = Field(
+        description=(
+            "The compound as the user named it: a common/trade/IUPAC name (e.g. "
+            "'ibuprofen', 'benzene'), a SMILES, or -- only when mode is SMARTS -- a "
+            "SMARTS pattern. Prefer the plain name; do not translate names to SMILES."
+        )
+    )
+    target: Target = Field(
+        description=(
+            "INPUT if the compound is a reactant/reagent/solvent consumed by the "
+            "reaction ('using X', 'from X', 'with X'); OUTPUT if it is produced by "
+            "the reaction ('synthesizing X', 'to make X', 'yields X')."
+        )
+    )
+    mode: MatchMode = Field(
+        description=(
+            "EXACT for a specific named molecule (the default). SUBSTRUCTURE when the "
+            "user wants molecules that merely contain a group/scaffold ('containing a "
+            "pyridine ring'). SIMILAR for 'similar to'/'like X'. SMARTS only when the "
+            "user supplies or describes an explicit query pattern."
+        )
+    )
+
+
+class NLQuery(BaseModel):
+    """Structured query produced by the language model from natural language."""
+
+    components: list[NLComponent] = Field(
+        default_factory=list,
+        description="Per-compound constraints; AND-combined with the other fields.",
+    )
+    min_yield: float | None = Field(
+        default=None, description="Minimum percent yield (0-100), if requested."
+    )
+    max_yield: float | None = Field(
+        default=None, description="Maximum percent yield (0-100), if requested."
+    )
+    min_conversion: float | None = Field(
+        default=None, description="Minimum percent conversion (0-100), if requested."
+    )
+    max_conversion: float | None = Field(
+        default=None, description="Maximum percent conversion (0-100), if requested."
+    )
+    reaction_smarts: str | None = Field(
+        default=None,
+        description=(
+            "A reaction SMARTS (reactants>>products) when the user describes a "
+            "transformation rather than individual components. Usually omitted."
+        ),
+    )
+    similarity_threshold: float | None = Field(
+        default=None,
+        description="Tanimoto threshold (0-1) for SIMILAR components; default 0.5.",
+    )
+    use_stereochemistry: bool | None = Field(
+        default=None,
+        description="True only if the user asks to respect stereochemistry/chirality.",
+    )
+    limit: int | None = Field(
+        default=None, description="Maximum number of reactions to return, if stated."
+    )
+
+
+class ResolvedComponent(BaseModel):
+    """A component after name resolution, surfaced for transparency."""
+
+    identifier: str
+    smiles: str
+    resolver: str
+    target: Target
+    mode: MatchMode
+
+
+# The system prompt lives in nl_query_prompt.md (alongside this module) so it reads as
+# plain markdown and can be edited without touching Python string escaping.
+SYSTEM_PROMPT = (
+    (resources.files("ord_schema.agent") / "nl_query_prompt.md")
+    .read_text(encoding="utf-8")
+    .strip()
+)
+
+_TOOL: dict[str, Any] = {
+    "name": "build_query",
+    "description": "Build a structured ORD search query from the user's question.",
+    "input_schema": NLQuery.model_json_schema(),
+}
+
+
+def get_client() -> anthropic.AsyncAnthropic:
+    """Returns an Anthropic async client.
+
+    Returns:
+        A client reading ANTHROPIC_API_KEY from the environment.
+
+    Raises:
+        ModelUnavailableError: If ANTHROPIC_API_KEY is not configured.
+    """
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        raise ModelUnavailableError(
+            "Natural-language search is unavailable: ANTHROPIC_API_KEY is not set."
+        )
+    return anthropic.AsyncAnthropic()
+
+
+def model_name() -> str:
+    """Returns the model to translate with, honoring ORD_NL_QUERY_MODEL."""
+    return os.getenv("ORD_NL_QUERY_MODEL", DEFAULT_MODEL)
+
+
+async def translate(query: str, client: anthropic.AsyncAnthropic) -> NLQuery:
+    """Translates a natural-language question into a structured query.
+
+    Args:
+        query: The user's free-text question.
+        client: Anthropic async client.
+
+    Returns:
+        The structured NLQuery produced by the model.
+
+    Raises:
+        ModelRateLimitedError: If the model is rate limited.
+        ModelUnavailableError: If the model is unreachable or erroring.
+        MalformedQueryError: If the model does not return a usable structured query.
+    """
+    try:
+        response = await client.messages.create(
+            model=model_name(),
+            max_tokens=MAX_TOKENS,
+            system=SYSTEM_PROMPT,
+            tools=[cast(anthropic.types.ToolParam, _TOOL)],
+            tool_choice={"type": "tool", "name": "build_query"},
+            messages=[{"role": "user", "content": query}],
+        )
+    except anthropic.RateLimitError as error:
+        raise ModelRateLimitedError(
+            "Natural-language search is busy right now; please retry shortly."
+        ) from error
+    except anthropic.APIError as error:
+        # Connection failures, server errors, overloads, and auth problems all degrade
+        # to a graceful "temporarily unavailable" rather than an unhandled error.
+        logger.warning(f"Anthropic API error during NL translation: {error}")
+        raise ModelUnavailableError(
+            "Natural-language search is temporarily unavailable."
+        ) from error
+    for block in response.content:
+        if (
+            isinstance(block, anthropic.types.ToolUseBlock)
+            and block.name == "build_query"
+        ):
+            try:
+                return NLQuery.model_validate(block.input)
+            except ValidationError as error:
+                # The forced tool schema makes this unlikely, but a payload that slips
+                # through is reported as malformed rather than crashing the caller.
+                logger.warning(f"Model tool call failed schema validation: {error}")
+                raise MalformedQueryError(
+                    "Language model returned a malformed structured query."
+                ) from error
+    raise MalformedQueryError("Language model did not return a structured query.")
+
+
+def translation_cache_key(query: str) -> str:
+    """Returns the cache key for a translation, scoped to the prompt and model."""
+    digest = hashlib.sha256(query.strip().lower().encode()).hexdigest()
+    return f"nl_translate:{TRANSLATION_CACHE_VERSION}:{model_name()}:{digest}"
+
+
+def resolve_cache_key(name: str) -> str:
+    """Returns the cache key for a name -> SMILES resolution."""
+    digest = hashlib.sha256(name.strip().lower().encode()).hexdigest()
+    return f"nl_resolve:{RESOLVE_CACHE_VERSION}:{digest}"
+
+
+async def _resolve_name_cached(name: str, cache: Cache | None) -> tuple[str, str]:
+    """Resolves a compound name to (SMILES, resolver), caching successful lookups.
+
+    The blocking PubChem/CIR/OPSIN call runs in a worker thread. Failures are not cached
+    so a transient PubChem outage does not poison the cache with a permanent miss.
+
+    Args:
+        name: The compound name to resolve.
+        cache: Optional cache; every lookup is live when omitted.
+
+    Returns:
+        A tuple of canonical SMILES and the resolver that produced it (e.g. "PubChem
+        API"); the resolver is suffixed with " (cached)" on a cache hit.
+
+    Raises:
+        ValueError: If the name cannot be resolved to a structure.
+    """
+    key = resolve_cache_key(name)
+    if cache is not None:
+        raw = await cache.get(key)
+        if raw is not None:
+            try:
+                smiles, resolver = json.loads(raw)
+            except (ValueError, TypeError) as error:
+                logger.warning(
+                    f"Discarding bad cached resolution for {name!r}: {error}"
+                )
+            else:
+                return smiles, f"{resolver} (cached)"
+    smiles, resolver = await asyncio.to_thread(resolve_name, "name", name)
+    if cache is not None:
+        await cache.set(key, json.dumps([smiles, resolver]), RESOLVE_CACHE_TTL_SECONDS)
+    return smiles, resolver
+
+
+async def resolve_component(
+    component: NLComponent, cache: Cache | None = None
+) -> ResolvedComponent:
+    """Resolves a component's identifier to canonical SMILES.
+
+    SMARTS patterns pass through untouched once validated. Otherwise the identifier
+    is treated as a SMILES if RDKit can parse it, and falls back to (cached) name
+    resolution via PubChem/CIR/OPSIN.
+
+    Args:
+        component: The component to resolve.
+        cache: Optional cache for name resolutions.
+
+    Returns:
+        The resolved component.
+
+    Raises:
+        ValueError: If a SMARTS pattern is unparseable, or a non-SMARTS identifier
+            resolves to neither SMILES nor a name.
+    """
+    if component.mode == "SMARTS":
+        # The model authors SMARTS directly; validate up front so a bad pattern fails
+        # here rather than deep in query execution (and is caught on dry runs).
+        if Chem.MolFromSmarts(component.identifier) is None:
+            raise ValueError(f"Invalid SMARTS pattern: {component.identifier!r}")
+        return ResolvedComponent(
+            identifier=component.identifier,
+            smiles=component.identifier,
+            resolver="SMARTS (verbatim)",
+            target=component.target,
+            mode=component.mode,
+        )
+    try:
+        smiles = canonicalize_smiles(component.identifier)
+        resolver = "SMILES (verbatim)"
+    except ValueError:
+        smiles, resolver = await _resolve_name_cached(component.identifier, cache)
+    return ResolvedComponent(
+        identifier=component.identifier,
+        smiles=smiles,
+        resolver=resolver,
+        target=component.target,
+        mode=component.mode,
+    )

--- a/ord_schema/agent/nl_query_eval.py
+++ b/ord_schema/agent/nl_query_eval.py
@@ -1,0 +1,151 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scoring natural-language translations against expected interpretations.
+
+The eval harness has two halves. Deciding whether a translation is *right* needs only
+the cases and the model's output, so it lives here alongside the prompt it grades: you
+change a prompt and a case together, and a scoring rule drifting from the prompt is the
+bug this placement prevents. Actually *running* the resulting query needs a database, so
+that half stays with the server that has one.
+
+Identifiers are compared by structure rather than by string, so a prompt change that
+emits an equivalent-but-differently-spelled pattern does not read as a regression.
+"""
+
+from importlib import resources
+
+import yaml
+from pydantic import BaseModel
+from rdkit import Chem
+
+from ord_schema.agent.nl_query import NLQuery
+
+# Numeric filters the model must populate only when the question asks for them; an
+# unexpected value here is over-extraction and counts as a miss.
+_NUMERIC_FIELDS = (
+    "min_yield",
+    "max_yield",
+    "min_conversion",
+    "max_conversion",
+    "similarity_threshold",
+    "limit",
+)
+
+
+class ComponentExpectation(BaseModel):
+    """Expected component constraint.
+
+    Identifiers are compared by structure, not by exact string: SMARTS and SMILES are
+    canonicalized with RDKit so equivalent patterns match (e.g. ``cB(O)O`` vs
+    ``[c]B(O)O``), while names that RDKit cannot parse fall back to a case- and
+    whitespace-insensitive string compare (so "4-aminophenol" still differs from
+    "aminophenol").
+    """
+
+    identifier: str
+    target: str
+    mode: str
+
+
+def _canonical_identifier(identifier: str, mode: str) -> str:
+    """Canonicalizes a component identifier for structure-aware comparison.
+
+    Args:
+        identifier: The component identifier (a name, SMILES, or SMARTS).
+        mode: The match mode; ``SMARTS`` is parsed as SMARTS, everything else as SMILES.
+
+    Returns:
+        The RDKit-canonical SMARTS or SMILES, or the lowercased, stripped identifier
+        RDKit cannot parse it (e.g. a compound name awaiting resolution).
+    """
+    if mode == "SMARTS":
+        mol = Chem.MolFromSmarts(identifier)
+        if mol is not None:
+            return Chem.MolToSmarts(mol)
+    else:
+        mol = Chem.MolFromSmiles(identifier)
+        if mol is not None:
+            return Chem.MolToSmiles(mol)
+    return identifier.strip().lower()
+
+
+class CaseExpectation(BaseModel):
+    """Per-case expectations checked against the model's interpretation."""
+
+    components: list[ComponentExpectation] = []
+    min_yield: float | None = None
+    max_yield: float | None = None
+    min_conversion: float | None = None
+    max_conversion: float | None = None
+    similarity_threshold: float | None = None
+    limit: int | None = None
+
+
+class EvalCase(BaseModel):
+    """A single evaluation example: a question and its expected interpretation."""
+
+    question: str
+    expect: CaseExpectation
+
+
+def load_cases() -> list[EvalCase]:
+    """Loads the evaluation cases bundled alongside this module."""
+    raw = (resources.files("ord_schema.agent") / "nl_query_eval_cases.yaml").read_text(
+        encoding="utf-8"
+    )
+    return [EvalCase.model_validate(case) for case in yaml.safe_load(raw)]
+
+
+def check_interpretation(expect: CaseExpectation, interpretation: NLQuery) -> list[str]:
+    """Returns a list of mismatch messages between expectation and interpretation.
+
+    An empty list means the interpretation matched all expectations.
+
+    Args:
+        expect: The case's expected interpretation.
+        interpretation: The structured query the model produced.
+
+    Returns:
+        Human-readable mismatch descriptions; empty if the case passed.
+    """
+    mismatches = []
+    remaining = list(interpretation.components)
+    for wanted in expect.components:
+        for candidate in remaining:
+            if (
+                candidate.target == wanted.target
+                and candidate.mode == wanted.mode
+                and _canonical_identifier(candidate.identifier, candidate.mode)
+                == _canonical_identifier(wanted.identifier, wanted.mode)
+            ):
+                remaining.remove(candidate)
+                break
+        else:
+            mismatches.append(
+                f"missing component {wanted.identifier!r} "
+                f"({wanted.target}/{wanted.mode})"
+            )
+    mismatches.extend(
+        f"unexpected component {extra.identifier!r} ({extra.target}/{extra.mode})"
+        for extra in remaining
+    )
+    for field in _NUMERIC_FIELDS:
+        wanted_value = getattr(expect, field)
+        actual_value = getattr(interpretation, field)
+        if wanted_value is None and actual_value is not None:
+            mismatches.append(f"unexpected {field}={actual_value}")
+        elif wanted_value is not None and actual_value != wanted_value:
+            mismatches.append(f"{field}: expected {wanted_value}, got {actual_value}")
+    return mismatches

--- a/ord_schema/agent/nl_query_eval_cases.yaml
+++ b/ord_schema/agent/nl_query_eval_cases.yaml
@@ -1,0 +1,140 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Evaluation cases for natural-language query translation. Each case pairs a question
+# with the structured interpretation the model is expected to produce. Component
+# identifiers are compared by structure: SMARTS and SMILES are canonicalized with RDKit
+# so equivalent patterns match, while names RDKit cannot parse fall back to a case- and
+# whitespace-insensitive string compare (so a dropped locant -- aminophenol instead of
+# 4-aminophenol -- still fails). Numeric filters are checked when present and must be
+# absent otherwise.
+
+- question: reactions for synthesizing ibuprofen
+  expect:
+    components:
+      - identifier: ibuprofen
+        target: OUTPUT
+        mode: EXACT
+
+- question: reactions using benzene as an input with yield greater than 70%
+  expect:
+    components:
+      - identifier: benzene
+        target: INPUT
+        mode: EXACT
+    min_yield: 70
+
+- question: find reactions that make aspirin with at least 90% yield
+  expect:
+    components:
+      - identifier: aspirin
+        target: OUTPUT
+        mode: EXACT
+    min_yield: 90
+
+- question: reactions producing molecules similar to morphine
+  expect:
+    components:
+      - identifier: morphine
+        target: OUTPUT
+        mode: SIMILAR
+
+- question: reactions with a pyridine ring in the product
+  expect:
+    components:
+      - identifier: c1ccncc1
+        target: OUTPUT
+        mode: SUBSTRUCTURE
+
+- question: reactions converting toluene with conversion below 50%
+  expect:
+    components:
+      - identifier: toluene
+        target: INPUT
+        mode: EXACT
+    max_conversion: 50
+
+- question: reactions using benzaldehyde and aniline as inputs
+  expect:
+    components:
+      - identifier: benzaldehyde
+        target: INPUT
+        mode: EXACT
+      - identifier: aniline
+        target: INPUT
+        mode: EXACT
+
+- question: reactions to make acetaminophen from 4-aminophenol
+  expect:
+    components:
+      - identifier: acetaminophen
+        target: OUTPUT
+        mode: EXACT
+      - identifier: 4-aminophenol
+        target: INPUT
+        mode: EXACT
+
+- question: reactions making ethyl acetate with yield between 40 and 60 percent
+  expect:
+    components:
+      - identifier: ethyl acetate
+        target: OUTPUT
+        mode: EXACT
+    min_yield: 40
+    max_yield: 60
+
+- question: reactions that use palladium acetate as a catalyst
+  expect:
+    components:
+      - identifier: palladium acetate
+        target: INPUT
+        mode: EXACT
+
+# SMILES given directly by the user are passed through verbatim as the identifier.
+- question: reactions using CCO as a reactant
+  expect:
+    components:
+      - identifier: CCO
+        target: INPUT
+        mode: EXACT
+
+- question: reactions that produce O=C(C)Oc1ccccc1C(=O)O
+  expect:
+    components:
+      - identifier: O=C(C)Oc1ccccc1C(=O)O
+        target: OUTPUT
+        mode: EXACT
+
+- question: reactions whose products contain C(=O)O
+  expect:
+    components:
+      - identifier: C(=O)O
+        target: OUTPUT
+        mode: SUBSTRUCTURE
+
+# Element/functional-group classes are never sent to the resolver; the model writes a
+# SMARTS pattern itself (the prompt gives these exact patterns as examples).
+- question: reactions producing brominated products
+  expect:
+    components:
+      - identifier: "[Br]"
+        target: OUTPUT
+        mode: SMARTS
+
+- question: reactions that make an aryl boronic acid
+  expect:
+    components:
+      - identifier: cB(O)O
+        target: OUTPUT
+        mode: SMARTS

--- a/ord_schema/agent/nl_query_eval_test.py
+++ b/ord_schema/agent/nl_query_eval_test.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the natural-language evaluation harness scoring logic.
+
+These cover the offline parts only -- case loading and interpretation scoring -- so no
+model, network, or database is required.
+"""
+
+from ord_schema.agent.nl_query import NLComponent, NLQuery
+from ord_schema.agent.nl_query_eval import (
+    CaseExpectation,
+    ComponentExpectation,
+    check_interpretation,
+    load_cases,
+)
+
+
+def test_load_cases_returns_nonempty():
+    cases = load_cases()
+    assert cases
+    assert all(case.question for case in cases)
+
+
+def test_check_interpretation_passes_on_match():
+    expect = CaseExpectation(
+        components=[
+            ComponentExpectation(identifier="benzene", target="INPUT", mode="EXACT")
+        ],
+        min_yield=70,
+    )
+    interpretation = NLQuery(
+        components=[NLComponent(identifier="Benzene", target="INPUT", mode="EXACT")],
+        min_yield=70,
+    )
+    # Matching is case- and whitespace-insensitive but otherwise exact.
+    assert check_interpretation(expect, interpretation) == []
+
+
+def test_check_interpretation_requires_exact_identifier():
+    # A less-specific identifier must NOT match: "aminophenol" != "4-aminophenol".
+    expect = CaseExpectation(
+        components=[
+            ComponentExpectation(
+                identifier="4-aminophenol", target="INPUT", mode="EXACT"
+            )
+        ]
+    )
+    interpretation = NLQuery(
+        components=[NLComponent(identifier="aminophenol", target="INPUT", mode="EXACT")]
+    )
+    mismatches = check_interpretation(expect, interpretation)
+    assert any("missing component" in m for m in mismatches)
+    assert any("unexpected component" in m for m in mismatches)
+
+
+def test_check_interpretation_matches_equivalent_smarts():
+    # Equivalent SMARTS that differ as strings should match once canonicalized.
+    expect = CaseExpectation(
+        components=[
+            ComponentExpectation(identifier="cB(O)O", target="OUTPUT", mode="SMARTS")
+        ]
+    )
+    interpretation = NLQuery(
+        components=[NLComponent(identifier="[c]B(O)O", target="OUTPUT", mode="SMARTS")]
+    )
+    assert check_interpretation(expect, interpretation) == []
+
+
+def test_check_interpretation_matches_equivalent_smiles():
+    # Equivalent SMILES (different atom ordering) should match once canonicalized.
+    expect = CaseExpectation(
+        components=[
+            ComponentExpectation(
+                identifier="c1ccncc1", target="OUTPUT", mode="SUBSTRUCTURE"
+            )
+        ]
+    )
+    interpretation = NLQuery(
+        components=[
+            NLComponent(identifier="n1ccccc1", target="OUTPUT", mode="SUBSTRUCTURE")
+        ]
+    )
+    assert check_interpretation(expect, interpretation) == []
+
+
+def test_check_interpretation_flags_wrong_target():
+    expect = CaseExpectation(
+        components=[
+            ComponentExpectation(identifier="ibuprofen", target="OUTPUT", mode="EXACT")
+        ]
+    )
+    interpretation = NLQuery(
+        components=[NLComponent(identifier="ibuprofen", target="INPUT", mode="EXACT")]
+    )
+    mismatches = check_interpretation(expect, interpretation)
+    assert any("missing component" in m for m in mismatches)
+    assert any("unexpected component" in m for m in mismatches)
+
+
+def test_check_interpretation_flags_over_extracted_yield():
+    expect = CaseExpectation(
+        components=[
+            ComponentExpectation(identifier="benzene", target="INPUT", mode="EXACT")
+        ]
+    )
+    interpretation = NLQuery(
+        components=[NLComponent(identifier="benzene", target="INPUT", mode="EXACT")],
+        min_yield=70,
+    )
+    mismatches = check_interpretation(expect, interpretation)
+    assert mismatches == ["unexpected min_yield=70.0"]
+
+
+def test_check_interpretation_flags_wrong_yield_value():
+    expect = CaseExpectation(min_yield=90)
+    interpretation = NLQuery(min_yield=70)
+    mismatches = check_interpretation(expect, interpretation)
+    assert mismatches == ["min_yield: expected 90.0, got 70.0"]

--- a/ord_schema/agent/nl_query_prompt.md
+++ b/ord_schema/agent/nl_query_prompt.md
@@ -1,0 +1,40 @@
+You translate a chemist's natural-language question about the Open Reaction Database
+into a structured search query by calling the `build_query` tool. Follow these rules.
+
+## Components
+
+- Map each chemical the user mentions to a component.
+- **Role** (`target`): "synthesizing / making / producing X" makes X an `OUTPUT`;
+  "using / from / with X", or X named as a reactant, reagent, catalyst, or solvent,
+  makes X an `INPUT`.
+- **Identifier**: for a specific, named compound, keep the user's own name; never convert
+  it to SMILES yourself — a downstream resolver does that. A SMILES or SMARTS the user
+  typed is itself a valid identifier; pass it through verbatim. Strip descriptive words
+  like "ring", "group", "moiety", or "scaffold" (e.g. "a pyridine ring" → "pyridine").
+
+## Match mode
+
+- `EXACT` (the default): one specific, named compound (e.g. "aspirin", "benzene").
+- `SUBSTRUCTURE`: a class of molecules defined by a substructure — a functional group,
+  scaffold, or "anything containing X". Put a SMILES for the fragment in `identifier`
+  (e.g. "a carboxylic acid" → `C(=O)O`; "products with a pyridine ring" → `c1ccncc1`).
+- `SIMILAR`: "like" or "similar to" a molecule.
+- `SMARTS`: a structural class that needs query features a plain SMILES cannot express —
+  aromaticity, atom lists, "any halogen", or a bare element. Write the SMARTS yourself
+  and put it in `identifier` (e.g. "brominated products" → `[Br]`; "aryl boronic acid" →
+  `cB(O)O`; "nitrogen-containing" → `[#7]`).
+
+The structure resolver only handles specific, named compounds. A compound class or
+functional group — often signaled by "a"/"an"/"any" ("make an aryl boronic acid"), or by
+naming a group rather than a molecule ("a boronic acid", "an amine", "halogenated") — is
+never sent to the resolver; express it yourself as a `SUBSTRUCTURE` or `SMARTS` pattern.
+
+## Filters
+
+- Translate yield/conversion phrases to the numeric percent fields
+  (e.g. "yield over 70%" → `min_yield=70`).
+- Only populate fields the user actually constrained; leave everything else null.
+
+## Output
+
+- Always call `build_query` exactly once.

--- a/ord_schema/agent/nl_query_prompt.md
+++ b/ord_schema/agent/nl_query_prompt.md
@@ -1,3 +1,5 @@
+# Translating a question into an ORD search query
+
 You translate a chemist's natural-language question about the Open Reaction Database
 into a structured search query by calling the `build_query` tool. Follow these rules.
 

--- a/ord_schema/agent/nl_query_test.py
+++ b/ord_schema/agent/nl_query_test.py
@@ -280,3 +280,11 @@ def test_cache_keys_are_scoped_by_version_and_model(monkeypatch):
 
 def test_resolution_cache_keys_ignore_case_and_padding():
     assert nl_query.resolve_cache_key("  ThF ") == nl_query.resolve_cache_key("thf")
+
+
+def test_translation_cache_keys_are_case_sensitive():
+    # A question can contain a SMILES, and CCO is not cco.
+    assert nl_query.translation_cache_key("with CCO") != nl_query.translation_cache_key(
+        "with cco"
+    )
+    assert nl_query.translation_cache_key(" q ") == nl_query.translation_cache_key("q")

--- a/ord_schema/agent/nl_query_test.py
+++ b/ord_schema/agent/nl_query_test.py
@@ -1,0 +1,282 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.nl_query."""
+
+import json
+from types import SimpleNamespace
+from unittest import mock
+
+import anthropic
+import httpx
+import pytest
+
+from ord_schema.agent import nl_query
+
+
+class _FakeCache:
+    """An in-memory Cache implementation; records calls for assertions."""
+
+    def __init__(self, initial=None):
+        self.store = dict(initial or {})
+        self.writes = []
+
+    async def get(self, key):
+        return self.store.get(key)
+
+    async def set(self, key, value, ttl_seconds):
+        self.writes.append((key, value, ttl_seconds))
+        self.store[key] = value
+
+
+def _tool_response(payload):
+    block = anthropic.types.ToolUseBlock(
+        type="tool_use", id="toolu_test", name="build_query", input=payload
+    )
+    return SimpleNamespace(content=[block])
+
+
+def _client(response=None, error=None):
+    client = mock.AsyncMock()
+    if error is not None:
+        client.messages.create.side_effect = error
+    else:
+        client.messages.create.return_value = response
+    return client
+
+
+# Translation
+
+
+@pytest.mark.asyncio
+async def test_translate_parses_a_forced_tool_call():
+    client = _client(
+        _tool_response(
+            {
+                "components": [
+                    {"identifier": "ibuprofen", "target": "OUTPUT", "mode": "EXACT"}
+                ],
+                "min_yield": 70,
+            }
+        )
+    )
+    result = await nl_query.translate("reactions making ibuprofen over 70%", client)
+    assert result.components[0].identifier == "ibuprofen"
+    assert result.components[0].target == "OUTPUT"
+    assert result.min_yield == 70
+
+
+@pytest.mark.asyncio
+async def test_translate_without_a_tool_call_is_malformed():
+    client = _client(SimpleNamespace(content=[SimpleNamespace(type="text")]))
+    with pytest.raises(nl_query.MalformedQueryError):
+        await nl_query.translate("hello", client)
+
+
+@pytest.mark.asyncio
+async def test_translate_with_an_invalid_payload_is_malformed():
+    client = _client(_tool_response({"components": [{"identifier": "x"}]}))
+    with pytest.raises(nl_query.MalformedQueryError):
+        await nl_query.translate("hello", client)
+
+
+@pytest.mark.asyncio
+async def test_translate_maps_a_rate_limit_to_its_own_error():
+    request = httpx.Request("POST", "https://api.anthropic.com")
+    error = anthropic.RateLimitError(
+        "slow down", response=httpx.Response(429, request=request), body=None
+    )
+    with pytest.raises(nl_query.ModelRateLimitedError):
+        await nl_query.translate("hello", _client(error=error))
+
+
+@pytest.mark.asyncio
+async def test_translate_maps_an_api_error_to_unavailable():
+    error = anthropic.APIConnectionError(
+        request=httpx.Request("POST", "https://api.anthropic.com")
+    )
+    with pytest.raises(nl_query.ModelUnavailableError):
+        await nl_query.translate("hello", _client(error=error))
+
+
+def test_translate_errors_share_a_base_class():
+    # A caller that does not care which failure it was can catch one exception.
+    for error in (
+        nl_query.ModelUnavailableError,
+        nl_query.ModelRateLimitedError,
+        nl_query.MalformedQueryError,
+    ):
+        assert issubclass(error, nl_query.NLQueryError)
+
+
+def test_get_client_without_an_api_key_is_unavailable(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    with pytest.raises(nl_query.ModelUnavailableError, match="ANTHROPIC_API_KEY"):
+        nl_query.get_client()
+
+
+def test_model_name_honors_the_environment(monkeypatch):
+    monkeypatch.delenv("ORD_NL_QUERY_MODEL", raising=False)
+    assert nl_query.model_name() == nl_query.DEFAULT_MODEL
+    monkeypatch.setenv("ORD_NL_QUERY_MODEL", "claude-sonnet-5")
+    assert nl_query.model_name() == "claude-sonnet-5"
+
+
+def test_the_tool_schema_is_the_query_model():
+    assert nl_query._TOOL["name"] == "build_query"
+    properties = nl_query._TOOL["input_schema"]["properties"]
+    assert "components" in properties
+    assert "min_yield" in properties
+
+
+def test_the_prompt_ships_with_the_package():
+    assert "build_query" in nl_query.SYSTEM_PROMPT
+
+
+# Resolution
+
+
+@pytest.mark.asyncio
+async def test_a_verbatim_smiles_is_not_sent_to_a_name_resolver(monkeypatch):
+    monkeypatch.setattr(
+        nl_query, "resolve_name", mock.Mock(side_effect=AssertionError("resolved"))
+    )
+    component = nl_query.NLComponent(
+        identifier="c1ccccc1", target="INPUT", mode="EXACT"
+    )
+    resolved = await nl_query.resolve_component(component)
+    assert resolved.resolver == "SMILES (verbatim)"
+    assert resolved.smiles == "c1ccccc1"
+
+
+@pytest.mark.asyncio
+async def test_a_name_falls_back_to_the_resolver(monkeypatch):
+    monkeypatch.setattr(
+        nl_query, "resolve_name", mock.Mock(return_value=("CCO", "PubChem API"))
+    )
+    component = nl_query.NLComponent(identifier="ethanol", target="INPUT", mode="EXACT")
+    resolved = await nl_query.resolve_component(component)
+    assert (resolved.smiles, resolved.resolver) == ("CCO", "PubChem API")
+
+
+@pytest.mark.asyncio
+async def test_smarts_passes_through_untouched():
+    component = nl_query.NLComponent(
+        identifier="[#6][Br]", target="OUTPUT", mode="SMARTS"
+    )
+    resolved = await nl_query.resolve_component(component)
+    assert resolved.smiles == "[#6][Br]"
+    assert resolved.resolver == "SMARTS (verbatim)"
+
+
+@pytest.mark.asyncio
+async def test_an_unparseable_smarts_is_rejected():
+    component = nl_query.NLComponent(
+        identifier="not a smarts", target="OUTPUT", mode="SMARTS"
+    )
+    with pytest.raises(ValueError, match="Invalid SMARTS"):
+        await nl_query.resolve_component(component)
+
+
+@pytest.mark.asyncio
+async def test_an_unresolvable_name_raises(monkeypatch):
+    monkeypatch.setattr(
+        nl_query, "resolve_name", mock.Mock(side_effect=ValueError("no such compound"))
+    )
+    component = nl_query.NLComponent(
+        identifier="unobtainium", target="INPUT", mode="EXACT"
+    )
+    with pytest.raises(ValueError, match="no such compound"):
+        await nl_query.resolve_component(component)
+
+
+# Caching is injected, and optional
+
+
+@pytest.mark.asyncio
+async def test_resolution_works_with_no_cache_at_all(monkeypatch):
+    resolver = mock.Mock(return_value=("CCO", "PubChem API"))
+    monkeypatch.setattr(nl_query, "resolve_name", resolver)
+    component = nl_query.NLComponent(identifier="ethanol", target="INPUT", mode="EXACT")
+    assert (await nl_query.resolve_component(component)).smiles == "CCO"
+    assert resolver.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_a_cache_hit_skips_the_resolver(monkeypatch):
+    monkeypatch.setattr(
+        nl_query, "resolve_name", mock.Mock(side_effect=AssertionError("resolved"))
+    )
+    key = nl_query.resolve_cache_key("ethanol")
+    cache = _FakeCache({key: json.dumps(["CCO", "PubChem API"])})
+    component = nl_query.NLComponent(identifier="ethanol", target="INPUT", mode="EXACT")
+    resolved = await nl_query.resolve_component(component, cache)
+    assert resolved.smiles == "CCO"
+    assert resolved.resolver == "PubChem API (cached)"
+
+
+@pytest.mark.asyncio
+async def test_a_cache_miss_writes_the_resolution_back(monkeypatch):
+    monkeypatch.setattr(
+        nl_query, "resolve_name", mock.Mock(return_value=("CCO", "PubChem API"))
+    )
+    cache = _FakeCache()
+    component = nl_query.NLComponent(identifier="ethanol", target="INPUT", mode="EXACT")
+    await nl_query.resolve_component(component, cache)
+    assert len(cache.writes) == 1
+    key, value, ttl = cache.writes[0]
+    assert key == nl_query.resolve_cache_key("ethanol")
+    assert json.loads(value) == ["CCO", "PubChem API"]
+    assert ttl == nl_query.RESOLVE_CACHE_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_a_corrupt_cache_entry_falls_back_to_the_resolver(monkeypatch):
+    monkeypatch.setattr(
+        nl_query, "resolve_name", mock.Mock(return_value=("CCO", "PubChem API"))
+    )
+    key = nl_query.resolve_cache_key("ethanol")
+    cache = _FakeCache({key: "not json"})
+    component = nl_query.NLComponent(identifier="ethanol", target="INPUT", mode="EXACT")
+    resolved = await nl_query.resolve_component(component, cache)
+    assert resolved.smiles == "CCO"
+
+
+@pytest.mark.asyncio
+async def test_a_failing_resolution_is_not_cached(monkeypatch):
+    monkeypatch.setattr(
+        nl_query, "resolve_name", mock.Mock(side_effect=ValueError("transient"))
+    )
+    cache = _FakeCache()
+    component = nl_query.NLComponent(
+        identifier="unobtainium", target="INPUT", mode="EXACT"
+    )
+    with pytest.raises(ValueError, match="transient"):
+        await nl_query.resolve_component(component, cache)
+    assert cache.writes == []
+
+
+def test_cache_keys_are_scoped_by_version_and_model(monkeypatch):
+    assert nl_query.resolve_cache_key("THF").startswith(
+        f"nl_resolve:{nl_query.RESOLVE_CACHE_VERSION}:"
+    )
+    monkeypatch.setenv("ORD_NL_QUERY_MODEL", "model-a")
+    first = nl_query.translation_cache_key("q")
+    monkeypatch.setenv("ORD_NL_QUERY_MODEL", "model-b")
+    # A different model must not read another model's interpretation.
+    assert nl_query.translation_cache_key("q") != first
+
+
+def test_resolution_cache_keys_ignore_case_and_padding():
+    assert nl_query.resolve_cache_key("  ThF ") == nl_query.resolve_cache_key("thf")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,13 @@ github = [
 huggingface = [
     "huggingface-hub>=0.20",
 ]
+# Optional: the ord_schema.agent subpackage holds the prompts, schemas, and (later)
+# tool surfaces an agent uses to query ORD. Pulls an HTTP client and pydantic, neither
+# of which parsing or validating a dataset requires.
+agent = [
+    "anthropic>=0.40",
+    "pydantic>=2",
+]
 # Optional: the ord_schema.orm subpackage maps the schema into a relational
 # (SQLAlchemy + PostgreSQL) database. Not needed to parse/validate datasets.
 orm = [
@@ -96,7 +103,8 @@ tests = [
     "treon>=0.1.3",
     # The suite exercises the optional-feature modules, so collecting it needs
     # their extras. Self-reference rather than duplicate the dependencies.
-    "ord-schema[github,huggingface,orm]",
+    "pytest-asyncio>=0.23",
+    "ord-schema[agent,github,huggingface,orm]",
 ]
 
 [tool.setuptools.packages.find]
@@ -104,6 +112,8 @@ include = ["ord_schema*"]
 
 [tool.setuptools.package-data]
 "ord_schema.proto" = ["*.pyi"]
+# Agent prompts (*.md) and eval cases (*.yaml) ship as data.
+"ord_schema.agent" = ["*.md", "*.yaml"]
 
 [tool.ruff]
 line-length = 88

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,34 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.120.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/10/4ca013cb166f226bd89e0aeb0fcaff94f45ddf716d4925ce89475d3c587b/anthropic-0.120.2.tar.gz", hash = "sha256:9722efc10c27a30a69f5338ddacdb35bc6a64297a4e4ba729bf83af873d5fb3a", size = 1008421, upload-time = "2026-07-28T17:38:26.986Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/af/0f5db57b9397a0f3b7fc204cbef143401a7cadaf982330f97f1ce3d39f34/anthropic-0.120.2-py3-none-any.whl", hash = "sha256:0f0bc2b381dc0eb41c8d886b815d79c2041cd2374f83aed36f574b6dc9c579c1", size = 1022851, upload-time = "2026-07-28T17:38:25.466Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -676,10 +704,28 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "docopt"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
 
 [[package]]
 name = "docutils"
@@ -1243,6 +1289,92 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/3f/fae6cc967d120ec89e31c5418a51176d8278b3087fbb384a9176754f353c/jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3", size = 309289, upload-time = "2026-06-29T13:02:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/97c6c3562c077f6247d6e6ce5c82562500b6316c0d928e97e106b7a1321a/jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e", size = 315181, upload-time = "2026-06-29T13:02:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/d8d073f8aa2667e46c6c0873f86fe4a512bba4293cc730f626a076211a62/jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037", size = 340939, upload-time = "2026-06-29T13:02:55.412Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c9/db4fda3ed73fb864139305e935e5b8b38a5a24692a5a9dd356c22f1b9c8d/jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e", size = 364932, upload-time = "2026-06-29T13:02:57.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/74/52b5e86241057f52ddd7c9a580f90effb51f9d06239f6fc612279b91a838/jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b", size = 461132, upload-time = "2026-06-29T13:02:58.994Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/87/544a700f7447c1f31c5d7833821a4daa5683165c2d5a094fbf5b5800c3dc/jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c", size = 374857, upload-time = "2026-06-29T13:03:00.455Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/0fcc3f7d39183674d5bfa9ec640faaeb506c60be7c8f94625dfba366e37c/jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee", size = 347053, upload-time = "2026-06-29T13:03:02.045Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ae/c7e64e7932ad597fa395b61440b249ada6366716e25c6e08dd2afbd021e6/jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03", size = 356153, upload-time = "2026-06-29T13:03:03.706Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/1c719044f14da814e1a060191ab19b96f3e99207bc5b4bfc6d6be34b3f80/jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea", size = 393956, upload-time = "2026-06-29T13:03:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/7b2f303a2847207e265503853a2d964a55354cffd62a5f2936c155486798/jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91", size = 521081, upload-time = "2026-06-29T13:03:06.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5f/501cf6e1e09caeb420195179ffc6f62aca603f1220ec53fd80d0d70b3e56/jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3", size = 552085, upload-time = "2026-06-29T13:03:08.339Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/aa5be86520113b79455c3877f3d1f07a348098df4083ba3688e9537e52dd/jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7", size = 206755, upload-time = "2026-06-29T13:03:09.653Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ec/2feb893eb330bd69b413866f4d5daada33c3962f1c6f270c91ca2d87fdf9/jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1", size = 199155, upload-time = "2026-06-29T13:03:10.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9c/ca040d94415048a3666fc237774df8151c96f8d2b661cbe3b184acc95876/jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056", size = 194403, upload-time = "2026-06-29T13:03:12.341Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d3/8e278946d43eeca2585b4dd0834a887cd71136329b837f3a16ed86a8b4b0/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad", size = 304518, upload-time = "2026-06-29T13:05:00.172Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/28d4ef495028bf0506a413d4db3f4eb3e7288a382e0f065f306a17bbeb5e/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f", size = 310207, upload-time = "2026-06-29T13:05:02.123Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ca/c366b1012da1d640de975d9683acd44e4d150d9068845d0ca2610435253f/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5", size = 342771, upload-time = "2026-06-29T13:05:03.55Z" },
+    { url = "https://files.pythonhosted.org/packages/16/52/50cc4056fc1ae02e7154704e7ecc89df0afb8300222cfe8a52d3f67e4730/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85", size = 346468, upload-time = "2026-06-29T13:05:05.452Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
 ]
 
 [[package]]
@@ -2183,6 +2315,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+agent = [
+    { name = "anthropic" },
+    { name = "pydantic" },
+]
 docs = [
     { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -2211,12 +2347,15 @@ orm = [
     { name = "uuid6" },
 ]
 tests = [
+    { name = "anthropic" },
     { name = "coverage" },
     { name = "huggingface-hub" },
     { name = "inflection" },
     { name = "psycopg", extra = ["binary", "pool"] },
+    { name = "pydantic" },
     { name = "pygithub" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "ruff" },
@@ -2229,6 +2368,7 @@ tests = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", marker = "extra == 'agent'", specifier = ">=0.40" },
     { name = "coverage", marker = "extra == 'tests'", specifier = ">=5.2.1" },
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.20" },
     { name = "inflection", marker = "extra == 'orm'", specifier = ">=0.5.1" },
@@ -2237,14 +2377,16 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'examples'", specifier = ">=3.3.4" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "openpyxl", specifier = ">=3.0.5" },
-    { name = "ord-schema", extras = ["github", "huggingface", "orm"], marker = "extra == 'tests'" },
+    { name = "ord-schema", extras = ["agent", "github", "huggingface", "orm"], marker = "extra == 'tests'" },
     { name = "pandas", specifier = ">=1.0.4" },
     { name = "protobuf", specifier = ">=4.22.3,<6" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'orm'", specifier = ">=3" },
     { name = "pyarrow", specifier = ">=14" },
+    { name = "pydantic", marker = "extra == 'agent'", specifier = ">=2" },
     { name = "pygithub", marker = "extra == 'github'", specifier = ">=1.51" },
     { name = "pygments", marker = "extra == 'docs'", specifier = ">=2.13.0" },
     { name = "pytest", marker = "extra == 'tests'", specifier = ">=7.1.1" },
+    { name = "pytest-asyncio", marker = "extra == 'tests'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'tests'", specifier = ">=3.0.0" },
     { name = "pytest-xdist", marker = "extra == 'tests'", specifier = ">=3.0.2" },
     { name = "python-dateutil", specifier = ">=1.10.0" },
@@ -2263,7 +2405,7 @@ requires-dist = [
     { name = "uuid6", marker = "extra == 'orm'", specifier = ">=2023" },
     { name = "wget", marker = "extra == 'examples'", specifier = ">=3.2" },
 ]
-provides-extras = ["docs", "examples", "github", "huggingface", "orm", "tests"]
+provides-extras = ["docs", "examples", "github", "huggingface", "agent", "orm", "tests"]
 
 [[package]]
 name = "overrides"
@@ -2708,6 +2850,123 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
 name = "pygithub"
 version = "2.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2804,6 +3063,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
@@ -3401,6 +3673,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "snowballstemmer"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3922,6 +4203,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Everything an agent needs to turn an intent into a query belongs next to the code that defines the data: prompts, the schemas a model may emit, name resolution, and — as they arrive — tool and MCP surfaces. A prompt that tells a model which columns exist has to be versioned alongside the code generating those columns, or it silently drifts from a schema it cannot see. That is the argument for `ord_schema/agent/`; it follows the `ord_schema/orm/` pattern, subpackage plus same-named extra.

The first occupant is the translation half of `ord-interface`'s `nl_query`: text in, a resolved interpretation out.

```
ord_schema/agent/
    __init__.py               what belongs here, and why
    nl_query.py               models, prompt loading, translate(), resolve_component()
    nl_query_prompt.md
    nl_query_eval_cases.yaml
    nl_query_test.py          22 tests
```

## This is not a lift-and-shift

The original mixes translation with serving, and two things had to change to break that apart. Both are worth reviewing on their own terms.

**Errors were FastAPI `HTTPException`s carrying status codes.** They are now library exceptions under `NLQueryError` — `ModelUnavailableError`, `ModelRateLimitedError`, `MalformedQueryError`. Nothing in ord-schema knows what a 503 is; the web layer maps them, preserving the existing 429/502/503 behaviour. A caller that does not care which failure occurred catches the base class.

**Caching was a direct Redis dependency.** It is now an injected `Cache` protocol — `async get`/`set` — and optional: omit it and every lookup is live. The protocol documents caching as best-effort, because it is an optimization and never a dependency: an implementation that fails or times out must return `None` rather than raise, so translation falls back to a live call instead of failing the request. Tested against a fake covering hits, misses, write-back, corrupt entries, and the rule that failed resolutions are never cached.

## What deliberately stays in ord-interface

`build_query_params` and the `/nl_query` endpoint. Mapping a resolved interpretation onto *that server's* `QueryParams`, and caching translations in *that server's* Redis, are its concerns. The seam is exactly: ord-schema turns text into a resolved interpretation; a server maps that interpretation onto whatever backend it has.

The companion PR in ord-interface deletes the moved code, imports from `ord_schema.agent`, and supplies a Redis adapter for `Cache` plus the exception mapping. **Nothing works end to end until both land**, so they should be reviewed together.

## Dependencies

`anthropic` and `pydantic` arrive as the optional `agent` extra, alongside the existing `orm`, `huggingface`, and `github` extras. Parsing or validating a dataset should not pull an HTTP client. `pytest-asyncio` joins the `tests` extra.

## Verification

**683 tests pass** (22 new), 2 skipped, plus `ruff check`, `ruff format --check`, `ty check`, and all pre-commit hooks. Run with the `ord` conda environment active so `testing.postgresql` finds `initdb`.

The prompt gained an H1. It already used `##` headings throughout, so it was always a structured document; the heading makes it satisfy MD041 rather than needing a linter exemption, and keeps prompts readable as documents.

## Next

A follow-up teaches this to target the [projection](https://github.com/open-reaction-database/ord-schema/pull/918) — a different output type and a substantially rewritten prompt covering 389 leaf columns and the `UNNEST` trap. Kept separate so a move bug cannot hide behind a prompt regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a natural-language ORD query translation package.
- Adds Anthropic-backed structured translation, component resolution, injected name-resolution caching, and library-specific errors.
- Bundles the translation prompt and evaluation cases with an offline scoring harness and tests.
- Adds the optional `agent` dependency extra and updates test dependencies and the lockfile.
</details>

<h3>Confidence Score: 4/5</h3>

The PR does not appear safe to merge until external name resolution has a bounded end-to-end deadline.

The reply from "" states that the resolver timeout was fixed, but current HEAD still calls `urlopen` without a timeout for PubChem, CIR, and OPSIN and then performs unbounded full-response reads; the agent awaits those calls in a worker thread without another deadline, so an unresponsive or indefinitely streaming resolver can still leave requests pending and consume executor capacity.

**Files Needing Attention:** ord_schema/agent/nl_query.py and ord_schema/resolvers.py

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/agent/nl_query.py | Adds the translation models, Anthropic call, cache protocol, and asynchronous component-resolution entry points. |
| ord_schema/agent/nl_query_eval.py | Adds offline, structure-aware comparison of model interpretations against bundled evaluation cases. |
| ord_schema/agent/nl_query_prompt.md | Defines the model instructions for extracting components, match modes, and numeric filters. |
| pyproject.toml | Adds the optional agent extra, asynchronous test dependency, and package-data declarations. |
| uv.lock | Locks the new agent and testing dependency graph. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Q[User question] --> T[Anthropic structured translation]
    T --> N[NLQuery]
    N --> R[Component resolution]
    C[(Optional cache)] --> R
    R --> S[Resolved interpretation]
    R --> X[PubChem / CIR / OPSIN]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Move the offline half of the eval harnes..."](https://github.com/open-reaction-database/ord-schema/commit/ef59d5511846de898cfd70ed66f52aa33b4dba41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49251019)</sub>

<!-- /greptile_comment -->