### PR TITLE
Bound each name-resolver request with a timeout

### DIFF
--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -28,11 +28,16 @@ from ord_schema.proto import reaction_pb2
 
 logger = get_logger(__name__)
 
-# Wall-clock budget for one resolver request, covering connect and body together. An
-# upstream that accepts the connection and then stalls -- or drip-feeds a byte at a time
-# to stay under a per-socket timeout -- would otherwise block the calling thread for
-# good; callers that dispatch resolution to a worker pool lose a worker per hung lookup.
-_RESOLVER_TIMEOUT_SECONDS = 10
+# Hard wall-clock ceiling on one resolver request, covering connect and body together.
+# An upstream that accepts the connection and then stalls -- or drip-feeds a byte at a
+# time to stay under a per-socket timeout -- would otherwise block the calling thread
+# for good; a caller dispatching to a worker pool loses a worker per hung lookup.
+_REQUEST_TIMEOUT_SECONDS = 10
+
+# How long the socket may go silent, during connect or mid-body. Must stay below
+# _REQUEST_TIMEOUT_SECONDS: the read loop only begins a read it can finish inside the
+# request budget, so a stall tolerance at or above it leaves no room to read at all.
+_STALL_TIMEOUT_SECONDS = 5
 
 # Resolvers answer with a single SMILES, so a response this large means the upstream is
 # misbehaving (an error page, a redirect loop) and is not worth buffering.
@@ -123,11 +128,13 @@ def resolve_names(message: ord_schema.Message) -> bool:
 def _fetch_text(url: str) -> str:
     """Fetches ``url`` as stripped text under a wall-clock deadline and a size cap.
 
-    The socket timeout alone bounds each read, not the request: an upstream that sends a
-    little data just often enough resets it forever. The body is therefore consumed with
-    ``read1``, which returns as soon as any bytes arrive, so the deadline is rechecked
-    between them rather than after a read that never returns. A single read may still
-    block for the socket timeout, so the true worst case is about twice the budget.
+    The socket timeout bounds a single read, not the request: an upstream sending a
+    little data just often enough to reset it would stream forever. Two rules together
+    make the ceiling hard. The body is consumed with ``read1``, which returns as soon as
+    any bytes arrive, so control comes back between chunks rather than being held inside
+    one read that never returns; and a read is only begun when the stall tolerance still
+    fits inside the deadline, so the last read cannot run past it. Total time is
+    therefore at most ``_REQUEST_TIMEOUT_SECONDS``, not that plus a trailing read.
 
     Args:
         url: The URL to fetch.
@@ -136,19 +143,19 @@ def _fetch_text(url: str) -> str:
         The decoded response body with surrounding whitespace removed.
 
     Raises:
-        TimeoutError: If the deadline passes before the body is fully read.
+        TimeoutError: If the body cannot be finished within the request budget.
         urllib.error.URLError: If the response exceeds ``_MAX_RESPONSE_BYTES``.
     """
-    deadline = time.monotonic() + _RESOLVER_TIMEOUT_SECONDS
+    deadline = time.monotonic() + _REQUEST_TIMEOUT_SECONDS
     chunks: list[bytes] = []
     size = 0
     # S310: every caller builds an https literal here, interpolating only a quoted path
     # segment, so no caller-supplied scheme can reach urlopen.
     with urllib.request.urlopen(  # noqa: S310
-        url, timeout=_RESOLVER_TIMEOUT_SECONDS
+        url, timeout=_STALL_TIMEOUT_SECONDS
     ) as response:
         while True:
-            if time.monotonic() >= deadline:
+            if time.monotonic() + _STALL_TIMEOUT_SECONDS > deadline:
                 raise TimeoutError(f"Timed out reading a response from {url}")
             chunk = response.read1(_MAX_RESPONSE_BYTES)
             if not chunk:

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -46,12 +46,27 @@ _MAX_RESPONSE_BYTES = 1 << 20
 # allocate the whole cap to receive a few dozen bytes.
 _READ_CHUNK_BYTES = 1 << 16
 
+# Statuses that say the service, not the identifier, is the problem: PubChem answers 503
+# both under load and when it has blocked the caller's IP. Repeating the request for
+# every remaining compound would deepen a rate limit rather than resolve anything.
+_BACK_OFF_STATUSES = frozenset({429, 503})
 
-class _ResolverUnavailableError(Exception):
-    """A resolver could not be reached, or did not answer usefully.
 
-    Resolvers signal failure with this alone, so the fallback chain does not have to
-    enumerate the transport library's exception types on their behalf.
+class _ResolverError(Exception):
+    """A resolver did not produce a structure.
+
+    Resolvers signal failure with this hierarchy alone, so the fallback chain does not
+    have to enumerate the transport library's exception types on their behalf.
+    """
+
+
+class _ResolverUnavailableError(_ResolverError):
+    """A resolver could not be reached at all.
+
+    Separate from the base class because no response arrived, which distinguishes the
+    failures that cost a full timeout from an HTTP status that comes back promptly.
+    A resolver that is unreachable for one lookup is unreachable for the next, so
+    :func:`resolve_names` stops asking it for the rest of a traversal.
     """
 
 
@@ -82,6 +97,37 @@ def canonicalize_smiles(smiles: str) -> str:
     return Chem.MolToSmiles(mol)
 
 
+def _resolve_name(
+    value_type: str, value: str, unavailable: set[str]
+) -> tuple[str, str]:
+    """Resolves one identifier, skipping and recording resolvers that are unreachable.
+
+    Args:
+        value_type: The kind of identifier being resolved, e.g. "name".
+        value: The identifier to resolve.
+        unavailable: Names of resolvers already found unreachable, added to in place.
+            Callers resolving a single identifier pass an empty set and discard it.
+
+    Returns:
+        A tuple of SMILES and the name of the resolver that produced it.
+
+    Raises:
+        ValueError: If every resolver is skipped or fails.
+    """
+    for resolver, resolver_func in _NAME_RESOLVERS.items():
+        if resolver in unavailable:
+            continue
+        try:
+            smiles = resolver_func(value_type, value)
+            if smiles is not None:
+                return smiles, resolver
+        except _ResolverError as error:
+            if isinstance(error, _ResolverUnavailableError):
+                unavailable.add(resolver)
+            logger.info(f"{resolver} could not resolve {value_type} {value}: {error}")
+    raise ValueError(f"Could not resolve {value_type} {value} to SMILES")
+
+
 def resolve_name(value_type: str, value: str) -> tuple[str, str]:
     """Resolves compound identifiers to SMILES via multiple APIs.
 
@@ -90,14 +136,7 @@ def resolve_name(value_type: str, value: str) -> tuple[str, str]:
     separately, which puts the worst case at the length of the chain times
     ``_REQUEST_TIMEOUT_SECONDS``.
     """
-    for resolver, resolver_func in _NAME_RESOLVERS.items():
-        try:
-            smiles = resolver_func(value_type, value)
-            if smiles is not None:
-                return smiles, resolver
-        except _ResolverUnavailableError as error:
-            logger.info(f"{resolver} could not resolve {value_type} {value}: {error}")
-    raise ValueError(f"Could not resolve {value_type} {value} to SMILES")
+    return _resolve_name(value_type, value, set())
 
 
 def resolve_names(message: ord_schema.Message) -> bool:
@@ -107,6 +146,12 @@ def resolve_names(message: ord_schema.Message) -> bool:
     of identifiers for that compound. Note that this function moves on to the
     next Compound after the first successful name resolution.
 
+    A resolver found unreachable is not tried again for the rest of this message.
+    Without that, an outage costs the full request budget once per compound, so a
+    message carrying dozens of names would spend minutes re-confirming the same
+    dead service. The cost is that a resolver which recovers mid-traversal stays
+    unused until the next call.
+
     Args:
         message: Protocol buffer tree containing Compound submessages (e.g. Reaction
             or ReactionInput).
@@ -115,6 +160,7 @@ def resolve_names(message: ord_schema.Message) -> bool:
         Boolean whether `message` was modified.
     """
     modified = False
+    unavailable: set[str] = set()
     compounds = message_helpers.find_submessages(message, reaction_pb2.Compound)
     for compound in compounds:
         if any(
@@ -125,7 +171,9 @@ def resolve_names(message: ord_schema.Message) -> bool:
         for identifier in compound.identifiers:
             if identifier.type == identifier.NAME:
                 try:
-                    smiles, resolver = resolve_name("name", identifier.value)
+                    smiles, resolver = _resolve_name(
+                        "name", identifier.value, unavailable
+                    )
                     new_identifier = compound.identifiers.add()
                     new_identifier.type = new_identifier.SMILES
                     new_identifier.value = smiles
@@ -154,8 +202,12 @@ def _fetch_text(url: str) -> str:
         The decoded response body with surrounding whitespace removed.
 
     Raises:
-        _ResolverUnavailableError: If the request fails, cannot be finished within the
-            request budget, or returns more than ``_MAX_RESPONSE_BYTES``.
+        _ResolverError: If the resolver answers with an HTTP error status other than a
+            back-off. The service is up and the status describes this identifier, so it
+            is asked again for the next one.
+        _ResolverUnavailableError: If no response arrives, the status asks us to back
+            off, the body cannot be finished within the request budget, or it exceeds
+            ``_MAX_RESPONSE_BYTES``.
     """
     deadline = time.monotonic() + _REQUEST_TIMEOUT_SECONDS
     body = bytearray()
@@ -174,8 +226,18 @@ def _fetch_text(url: str) -> str:
                 body += chunk
                 if len(body) > _MAX_RESPONSE_BYTES:
                     raise _ResolverUnavailableError(f"{url} sent too much data")
+    except urllib.error.HTTPError as error:
+        if error.code in _BACK_OFF_STATUSES:
+            raise _ResolverUnavailableError(
+                f"{url} returned {error.code}; backing off"
+            ) from error
+        # Any other status describes the identifier rather than the service -- notably
+        # CIR, which answers 500 for a name it does not know -- so keep asking.
+        raise _ResolverError(f"{url} returned {error.code}") from error
     except (urllib.error.URLError, TimeoutError) as error:
-        raise _ResolverUnavailableError(f"{url} could not be read: {error}") from error
+        raise _ResolverUnavailableError(
+            f"{url} could not be reached: {error}"
+        ) from error
     return body.decode().strip()
 
 

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -27,6 +27,12 @@ from ord_schema.proto import reaction_pb2
 
 logger = get_logger(__name__)
 
+# Applied to each resolver request separately, so a name that falls through all three
+# resolvers is bounded by the sum. Without it, an upstream that accepts the connection
+# and then stops responding blocks the calling thread forever; callers that dispatch
+# resolution to a worker pool would lose a worker per hung lookup.
+_RESOLVER_TIMEOUT_SECONDS = 10
+
 _COMPOUND_STRUCTURAL_IDENTIFIERS = [
     reaction_pb2.CompoundIdentifier.SMILES,
     reaction_pb2.CompoundIdentifier.INCHI,
@@ -55,13 +61,19 @@ def canonicalize_smiles(smiles: str) -> str:
 
 
 def resolve_name(value_type: str, value: str) -> tuple[str, str]:
-    """Resolves compound identifiers to SMILES via multiple APIs."""
+    """Resolves compound identifiers to SMILES via multiple APIs.
+
+    Any single resolver being unreachable, erroring, or timing out falls through to the
+    next one; only an exhausted chain is a failure. ``URLError`` covers ``HTTPError``
+    and connect-time timeouts, while a stall part-way through a response body surfaces
+    as a bare ``TimeoutError``.
+    """
     for resolver, resolver_func in _NAME_RESOLVERS.items():
         try:
             smiles = resolver_func(value_type, value)
             if smiles is not None:
                 return smiles, resolver
-        except urllib.error.HTTPError as error:
+        except (urllib.error.URLError, TimeoutError) as error:
             logger.info(f"{resolver} could not resolve {value_type} {value}: {error}")
     raise ValueError(f"Could not resolve {value_type} {value} to SMILES")
 
@@ -111,7 +123,8 @@ def _pubchem_resolve(value_type: str, value: str) -> str:
     """
     with urllib.request.urlopen(
         f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/{value_type}/"
-        f"{urllib.parse.quote(value)}/property/IsomericSMILES/txt"
+        f"{urllib.parse.quote(value)}/property/IsomericSMILES/txt",
+        timeout=_RESOLVER_TIMEOUT_SECONDS,
     ) as response:
         return response.read().decode().strip()
 
@@ -126,7 +139,8 @@ def _cactus_resolve(value_type: str, value: str) -> str:
     """
     del value_type  # CIR infers the identifier type from the string.
     with urllib.request.urlopen(
-        f"https://cactus.nci.nih.gov/chemical/structure/{urllib.parse.quote(value)}/smiles"
+        f"https://cactus.nci.nih.gov/chemical/structure/{urllib.parse.quote(value)}/smiles",
+        timeout=_RESOLVER_TIMEOUT_SECONDS,
     ) as response:
         # CIR can return several representations newline-separated; take the first.
         return response.read().decode().strip().split("\n", 1)[0]
@@ -141,7 +155,8 @@ def _opsin_resolve(value_type: str, value: str) -> str:
     """
     del value_type  # OPSIN only supports names.
     with urllib.request.urlopen(
-        f"https://www.ebi.ac.uk/opsin/ws/{urllib.parse.quote(value)}.smi"
+        f"https://www.ebi.ac.uk/opsin/ws/{urllib.parse.quote(value)}.smi",
+        timeout=_RESOLVER_TIMEOUT_SECONDS,
     ) as response:
         return response.read().decode().strip()
 

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -14,6 +14,7 @@
 """Name/string resolution to structured messages or identifiers."""
 
 import re
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -27,11 +28,15 @@ from ord_schema.proto import reaction_pb2
 
 logger = get_logger(__name__)
 
-# Applied to each resolver request separately, so a name that falls through all three
-# resolvers is bounded by the sum. Without it, an upstream that accepts the connection
-# and then stops responding blocks the calling thread forever; callers that dispatch
-# resolution to a worker pool would lose a worker per hung lookup.
+# Wall-clock budget for one resolver request, covering connect and body together. An
+# upstream that accepts the connection and then stalls -- or drip-feeds a byte at a time
+# to stay under a per-socket timeout -- would otherwise block the calling thread for
+# good; callers that dispatch resolution to a worker pool lose a worker per hung lookup.
 _RESOLVER_TIMEOUT_SECONDS = 10
+
+# Resolvers answer with a single SMILES, so a response this large means the upstream is
+# misbehaving (an error page, a redirect loop) and is not worth buffering.
+_MAX_RESPONSE_BYTES = 1 << 20
 
 _COMPOUND_STRUCTURAL_IDENTIFIERS = [
     reaction_pb2.CompoundIdentifier.SMILES,
@@ -115,18 +120,56 @@ def resolve_names(message: ord_schema.Message) -> bool:
     return modified
 
 
+def _fetch_text(url: str) -> str:
+    """Fetches ``url`` as stripped text under a wall-clock deadline and a size cap.
+
+    The socket timeout alone bounds each read, not the request: an upstream that sends a
+    little data just often enough resets it forever. The body is therefore consumed with
+    ``read1``, which returns as soon as any bytes arrive, so the deadline is rechecked
+    between them rather than after a read that never returns. A single read may still
+    block for the socket timeout, so the true worst case is about twice the budget.
+
+    Args:
+        url: The URL to fetch.
+
+    Returns:
+        The decoded response body with surrounding whitespace removed.
+
+    Raises:
+        TimeoutError: If the deadline passes before the body is fully read.
+        urllib.error.URLError: If the response exceeds ``_MAX_RESPONSE_BYTES``.
+    """
+    deadline = time.monotonic() + _RESOLVER_TIMEOUT_SECONDS
+    chunks: list[bytes] = []
+    size = 0
+    # S310: every caller builds an https literal here, interpolating only a quoted path
+    # segment, so no caller-supplied scheme can reach urlopen.
+    with urllib.request.urlopen(  # noqa: S310
+        url, timeout=_RESOLVER_TIMEOUT_SECONDS
+    ) as response:
+        while True:
+            if time.monotonic() >= deadline:
+                raise TimeoutError(f"Timed out reading a response from {url}")
+            chunk = response.read1(_MAX_RESPONSE_BYTES)
+            if not chunk:
+                break
+            size += len(chunk)
+            if size > _MAX_RESPONSE_BYTES:
+                raise urllib.error.URLError(f"Response from {url} is too large")
+            chunks.append(chunk)
+    return b"".join(chunks).decode().strip()
+
+
 def _pubchem_resolve(value_type: str, value: str) -> str:
     """Resolves compound identifiers to SMILES via the PubChem REST API.
 
     A 503 (genuine service load or an IP-level block) propagates to ``resolve_name``,
     which falls through to the next resolver instead of retrying.
     """
-    with urllib.request.urlopen(
+    return _fetch_text(
         f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/{value_type}/"
-        f"{urllib.parse.quote(value)}/property/IsomericSMILES/txt",
-        timeout=_RESOLVER_TIMEOUT_SECONDS,
-    ) as response:
-        return response.read().decode().strip()
+        f"{urllib.parse.quote(value)}/property/IsomericSMILES/txt"
+    )
 
 
 def _cactus_resolve(value_type: str, value: str) -> str:
@@ -138,12 +181,11 @@ def _cactus_resolve(value_type: str, value: str) -> str:
     through.
     """
     del value_type  # CIR infers the identifier type from the string.
-    with urllib.request.urlopen(
-        f"https://cactus.nci.nih.gov/chemical/structure/{urllib.parse.quote(value)}/smiles",
-        timeout=_RESOLVER_TIMEOUT_SECONDS,
-    ) as response:
-        # CIR can return several representations newline-separated; take the first.
-        return response.read().decode().strip().split("\n", 1)[0]
+    body = _fetch_text(
+        f"https://cactus.nci.nih.gov/chemical/structure/{urllib.parse.quote(value)}/smiles"
+    )
+    # CIR can return several representations newline-separated; take the first.
+    return body.split("\n", 1)[0]
 
 
 def _opsin_resolve(value_type: str, value: str) -> str:
@@ -154,11 +196,9 @@ def _opsin_resolve(value_type: str, value: str) -> str:
     HTTP 404. Treat it strictly as a complement to PubChem.
     """
     del value_type  # OPSIN only supports names.
-    with urllib.request.urlopen(
-        f"https://www.ebi.ac.uk/opsin/ws/{urllib.parse.quote(value)}.smi",
-        timeout=_RESOLVER_TIMEOUT_SECONDS,
-    ) as response:
-        return response.read().decode().strip()
+    return _fetch_text(
+        f"https://www.ebi.ac.uk/opsin/ws/{urllib.parse.quote(value)}.smi"
+    )
 
 
 def resolve_input(input_string: str) -> reaction_pb2.ReactionInput:

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -165,6 +165,13 @@ def _fetch_text(url: str) -> str:
         # value can reach urlopen as a scheme.
         with urllib.request.urlopen(url, timeout=_TIMEOUT_SECONDS) as response:  # noqa: S310
             body = response.read(_MAX_RESPONSE_BYTES + 1)
+            # Passing a size means EOF ends the read quietly, where the no-argument
+            # form would raise: a connection dropped mid-body leaves a short answer
+            # that is not detectably broken, since a truncated SMILES usually parses
+            # as a different molecule. ``length`` is what a declared body still owes,
+            # and is None for a chunked one, which raises IncompleteRead instead.
+            if response.length:
+                raise _ResolverError(f"{url} ended early")
     except (OSError, http.client.HTTPException) as error:
         raise _ResolverError(f"{url} could not be read: {error}") from error
     if len(body) > _MAX_RESPONSE_BYTES:

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -15,7 +15,6 @@
 
 import http.client
 import re
-import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -29,45 +28,21 @@ from ord_schema.proto import reaction_pb2
 
 logger = get_logger(__name__)
 
-# Hard wall-clock ceiling on one resolver request, covering connect and body together.
-# A caller dispatching these to a worker pool loses a worker for as long as a hung
-# lookup runs, so the ceiling is what stops an upstream outage from draining the pool.
-_REQUEST_TIMEOUT_SECONDS = 10
-
-# How long the socket may go silent, during connect or mid-body. Must stay below
-# _REQUEST_TIMEOUT_SECONDS; see _fetch_text for how the two combine.
-_STALL_TIMEOUT_SECONDS = 5
+# Applied to each socket operation. Without it a resolver that accepts the connection
+# and then goes quiet blocks its caller forever, which costs a worker per hung lookup
+# when resolution is dispatched to a thread pool.
+_TIMEOUT_SECONDS = 10
 
 # Resolvers answer with a single SMILES, so a response this large means the upstream is
 # misbehaving (an error page, a redirect loop) and is not worth buffering.
 _MAX_RESPONSE_BYTES = 1 << 20
 
-# Read-size hint, kept well below _MAX_RESPONSE_BYTES: read1 clamps the request to the
-# framing only when the length is known, so a close-delimited response would otherwise
-# allocate the whole cap to receive a few dozen bytes.
-_READ_CHUNK_BYTES = 1 << 16
-
-# Statuses that say the service, not the identifier, is the problem: PubChem answers 503
-# both under load and when it has blocked the caller's IP. Repeating the request for
-# every remaining compound would deepen a rate limit rather than resolve anything.
-_BACK_OFF_STATUSES = frozenset({429, 503})
-
 
 class _ResolverError(Exception):
     """A resolver did not produce a structure.
 
-    Resolvers signal failure with this hierarchy alone, so the fallback chain does not
-    have to enumerate the transport library's exception types on their behalf.
-    """
-
-
-class _ResolverUnavailableError(_ResolverError):
-    """A resolver could not be reached at all.
-
-    Separate from the base class because no response arrived, which distinguishes the
-    failures that cost a full timeout from an HTTP status that comes back promptly.
-    A resolver that is unreachable for one lookup is unreachable for the next, so
-    :func:`resolve_names` stops asking it for the rest of a traversal.
+    Resolvers signal failure with this alone, so the fallback chain does not have to
+    enumerate the transport library's exception types on their behalf.
     """
 
 
@@ -98,46 +73,33 @@ def canonicalize_smiles(smiles: str) -> str:
     return Chem.MolToSmiles(mol)
 
 
-def _resolve_name(
-    value_type: str, value: str, unavailable: set[str]
-) -> tuple[str, str]:
-    """Resolves one identifier, skipping and recording resolvers that are unreachable.
+def resolve_name(value_type: str, value: str) -> tuple[str, str]:
+    """Resolves compound identifiers to SMILES via multiple APIs.
+
+    Resolvers are tried in order until one answers. Any of them failing falls through
+    to the next, so only an exhausted chain is a failure.
 
     Args:
         value_type: The kind of identifier being resolved, e.g. "name".
         value: The identifier to resolve.
-        unavailable: Names of resolvers already found unreachable, added to in place.
-            Callers resolving a single identifier pass an empty set and discard it.
 
     Returns:
         A tuple of SMILES and the name of the resolver that produced it.
 
     Raises:
-        ValueError: If every resolver is skipped or fails.
+        ValueError: If no resolver returns a structure.
     """
     for resolver, resolver_func in _NAME_RESOLVERS.items():
-        if resolver in unavailable:
-            continue
         try:
             smiles = resolver_func(value_type, value)
-            if smiles is not None:
+            # An empty body reaches here as "", which would otherwise be written out as
+            # a SMILES identifier holding nothing -- and would then mask the compound
+            # from a later resolution pass, since it counts as structural.
+            if smiles:
                 return smiles, resolver
         except _ResolverError as error:
-            if isinstance(error, _ResolverUnavailableError):
-                unavailable.add(resolver)
             logger.info(f"{resolver} could not resolve {value_type} {value}: {error}")
     raise ValueError(f"Could not resolve {value_type} {value} to SMILES")
-
-
-def resolve_name(value_type: str, value: str) -> tuple[str, str]:
-    """Resolves compound identifiers to SMILES via multiple APIs.
-
-    Any single resolver being unreachable, erroring, or timing out falls through to the
-    next one, so only an exhausted chain is a failure. Each resolver is bounded
-    separately, which puts the worst case at the length of the chain times
-    ``_REQUEST_TIMEOUT_SECONDS``.
-    """
-    return _resolve_name(value_type, value, set())
 
 
 def resolve_names(message: ord_schema.Message) -> bool:
@@ -147,12 +109,6 @@ def resolve_names(message: ord_schema.Message) -> bool:
     of identifiers for that compound. Note that this function moves on to the
     next Compound after the first successful name resolution.
 
-    A resolver found unreachable is not tried again for the rest of this message.
-    Without that, an outage costs the full request budget once per compound, so a
-    message carrying dozens of names would spend minutes re-confirming the same
-    dead service. The cost is that a resolver which recovers mid-traversal stays
-    unused until the next call.
-
     Args:
         message: Protocol buffer tree containing Compound submessages (e.g. Reaction
             or ReactionInput).
@@ -161,7 +117,6 @@ def resolve_names(message: ord_schema.Message) -> bool:
         Boolean whether `message` was modified.
     """
     modified = False
-    unavailable: set[str] = set()
     compounds = message_helpers.find_submessages(message, reaction_pb2.Compound)
     for compound in compounds:
         if any(
@@ -172,9 +127,7 @@ def resolve_names(message: ord_schema.Message) -> bool:
         for identifier in compound.identifiers:
             if identifier.type == identifier.NAME:
                 try:
-                    smiles, resolver = _resolve_name(
-                        "name", identifier.value, unavailable
-                    )
+                    smiles, resolver = resolve_name("name", identifier.value)
                     new_identifier = compound.identifiers.add()
                     new_identifier.type = new_identifier.SMILES
                     new_identifier.value = smiles
@@ -187,89 +140,50 @@ def resolve_names(message: ord_schema.Message) -> bool:
 
 
 def _fetch_text(url: str) -> str:
-    """Fetches ``url`` as stripped text under a wall-clock deadline and a size cap.
+    """Fetches ``url`` as stripped text, bounded by a timeout and a size cap.
 
-    The socket timeout bounds a single read, not the request: an upstream sending a
-    little data just often enough to reset it would stream forever. Two rules together
-    make the ceiling hard. The body is consumed with ``read1``, which returns as soon as
-    any bytes arrive, so control comes back between chunks rather than being held inside
-    one read that never returns; and a read is only begun when the stall tolerance still
-    fits inside the deadline, so the last read cannot run past it.
+    Every way a request can fail arrives as :class:`_ResolverError`, so the fallback
+    chain treats an unreachable service, an HTTP status, and an unreadable body alike:
+    all of them mean this resolver has no answer, and the next one should be asked.
+    ``OSError`` covers the transport failures, ``URLError`` and ``TimeoutError`` among
+    them; ``HTTPException`` covers a response that is malformed or ends early.
 
     Args:
         url: The URL to fetch.
 
     Returns:
-        The decoded response body with surrounding whitespace removed.
+        The decoded response body with surrounding whitespace removed. Undecodable
+        bytes become replacement characters rather than failing the lookup, since the
+        answer is a SMILES and will not parse as a structure either way.
 
     Raises:
-        _ResolverError: If the resolver answers with an HTTP error status other than a
-            back-off. The service is up and the status describes this identifier, so it
-            is asked again for the next one.
-        _ResolverUnavailableError: If no response arrives, the status asks us to back
-            off, the body arrives incomplete, cannot be finished within the request
-            budget, or exceeds ``_MAX_RESPONSE_BYTES``.
+        _ResolverError: If the request fails, or the body exceeds
+            ``_MAX_RESPONSE_BYTES``.
     """
-    deadline = time.monotonic() + _REQUEST_TIMEOUT_SECONDS
-    body = bytearray()
     try:
-        # S310: every caller builds an https literal here, interpolating only a quoted
-        # path segment, so no caller-supplied scheme can reach urlopen.
-        with urllib.request.urlopen(  # noqa: S310
-            url, timeout=_STALL_TIMEOUT_SECONDS
-        ) as response:
-            while True:
-                if time.monotonic() + _STALL_TIMEOUT_SECONDS > deadline:
-                    raise _ResolverUnavailableError(f"{url} timed out")
-                chunk = response.read1(_READ_CHUNK_BYTES)
-                if not chunk:
-                    break
-                body += chunk
-                if len(body) > _MAX_RESPONSE_BYTES:
-                    raise _ResolverUnavailableError(f"{url} sent too much data")
-            # read1 reports a connection that dies mid-body as EOF rather than raising,
-            # so a short read has to be caught here: a truncated SMILES can still parse,
-            # as a different molecule. read() would have raised, but cannot be used
-            # without giving up the guarantees above.
-            declared = response.getheader("Content-Length")
-            if (
-                declared is not None
-                and declared.isdigit()
-                and len(body) != int(declared)
-            ):
-                raise _ResolverUnavailableError(
-                    f"{url} sent {len(body)} bytes of a declared {declared}"
-                )
-    except http.client.HTTPException as error:
-        # A chunked body that ends early raises IncompleteRead, which is not an OSError
-        # and so is not covered by the URLError clause below.
-        raise _ResolverUnavailableError(
-            f"{url} sent a bad response: {error}"
-        ) from error
-    except urllib.error.HTTPError as error:
-        if error.code in _BACK_OFF_STATUSES:
-            raise _ResolverUnavailableError(
-                f"{url} returned {error.code}; backing off"
-            ) from error
-        # Any other status describes the identifier rather than the service -- notably
-        # CIR, which answers 500 for a name it does not know -- so keep asking.
-        raise _ResolverError(f"{url} returned {error.code}") from error
-    except (urllib.error.URLError, TimeoutError) as error:
-        raise _ResolverUnavailableError(
-            f"{url} could not be reached: {error}"
-        ) from error
-    return body.decode().strip()
+        # S310: the scheme is a literal in each caller's f-string, so no caller-supplied
+        # value can reach urlopen as a scheme.
+        with urllib.request.urlopen(url, timeout=_TIMEOUT_SECONDS) as response:  # noqa: S310
+            body = response.read(_MAX_RESPONSE_BYTES + 1)
+    except (OSError, http.client.HTTPException) as error:
+        raise _ResolverError(f"{url} could not be read: {error}") from error
+    if len(body) > _MAX_RESPONSE_BYTES:
+        raise _ResolverError(f"{url} sent too much data")
+    return body.decode(errors="replace").strip()
 
 
 def _pubchem_resolve(value_type: str, value: str) -> str:
     """Resolves compound identifiers to SMILES via the PubChem REST API.
 
-    A 503 (genuine service load or an IP-level block) propagates to ``resolve_name``,
-    which falls through to the next resolver instead of retrying.
+    A 503 means genuine service load or an IP-level block; it is not retried, and
+    ``resolve_name`` falls through to the next resolver.
     """
+    # Both segments are quoted with safe="" so that a name containing slashes or dot
+    # segments cannot rewrite the request path and resolve a different compound.
     return _fetch_text(
-        f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/{value_type}/"
-        f"{urllib.parse.quote(value)}/property/IsomericSMILES/txt"
+        f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/"
+        f"{urllib.parse.quote(value_type, safe='')}/"
+        f"{urllib.parse.quote(value, safe='')}/property/IsomericSMILES/txt"
     )
 
 
@@ -278,12 +192,13 @@ def _cactus_resolve(value_type: str, value: str) -> str:
 
     CIR resolves trade names, trivial names, abbreviations, and CAS numbers, so it
     serves as a fast fallback when PubChem is unavailable. Unknown names come back as
-    HTTP 500 (not 404), which ``resolve_name`` treats like any other HTTPError and falls
-    through.
+    HTTP 500 (not 404), which is reported like any other failed lookup and falls
+    through to the next resolver.
     """
     del value_type  # CIR infers the identifier type from the string.
     body = _fetch_text(
-        f"https://cactus.nci.nih.gov/chemical/structure/{urllib.parse.quote(value)}/smiles"
+        f"https://cactus.nci.nih.gov/chemical/structure/"
+        f"{urllib.parse.quote(value, safe='')}/smiles"
     )
     # CIR can return several representations newline-separated; take the first.
     return body.split("\n", 1)[0]
@@ -298,7 +213,7 @@ def _opsin_resolve(value_type: str, value: str) -> str:
     """
     del value_type  # OPSIN only supports names.
     return _fetch_text(
-        f"https://www.ebi.ac.uk/opsin/ws/{urllib.parse.quote(value)}.smi"
+        f"https://www.ebi.ac.uk/opsin/ws/{urllib.parse.quote(value, safe='')}.smi"
     )
 
 

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Name/string resolution to structured messages or identifiers."""
 
+import http.client
 import re
 import time
 import urllib.error
@@ -206,8 +207,8 @@ def _fetch_text(url: str) -> str:
             back-off. The service is up and the status describes this identifier, so it
             is asked again for the next one.
         _ResolverUnavailableError: If no response arrives, the status asks us to back
-            off, the body cannot be finished within the request budget, or it exceeds
-            ``_MAX_RESPONSE_BYTES``.
+            off, the body arrives incomplete, cannot be finished within the request
+            budget, or exceeds ``_MAX_RESPONSE_BYTES``.
     """
     deadline = time.monotonic() + _REQUEST_TIMEOUT_SECONDS
     body = bytearray()
@@ -226,6 +227,25 @@ def _fetch_text(url: str) -> str:
                 body += chunk
                 if len(body) > _MAX_RESPONSE_BYTES:
                     raise _ResolverUnavailableError(f"{url} sent too much data")
+            # read1 reports a connection that dies mid-body as EOF rather than raising,
+            # so a short read has to be caught here: a truncated SMILES can still parse,
+            # as a different molecule. read() would have raised, but cannot be used
+            # without giving up the guarantees above.
+            declared = response.getheader("Content-Length")
+            if (
+                declared is not None
+                and declared.isdigit()
+                and len(body) != int(declared)
+            ):
+                raise _ResolverUnavailableError(
+                    f"{url} sent {len(body)} bytes of a declared {declared}"
+                )
+    except http.client.HTTPException as error:
+        # A chunked body that ends early raises IncompleteRead, which is not an OSError
+        # and so is not covered by the URLError clause below.
+        raise _ResolverUnavailableError(
+            f"{url} sent a bad response: {error}"
+        ) from error
     except urllib.error.HTTPError as error:
         if error.code in _BACK_OFF_STATUSES:
             raise _ResolverUnavailableError(

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -29,19 +29,31 @@ from ord_schema.proto import reaction_pb2
 logger = get_logger(__name__)
 
 # Hard wall-clock ceiling on one resolver request, covering connect and body together.
-# An upstream that accepts the connection and then stalls -- or drip-feeds a byte at a
-# time to stay under a per-socket timeout -- would otherwise block the calling thread
-# for good; a caller dispatching to a worker pool loses a worker per hung lookup.
+# A caller dispatching these to a worker pool loses a worker for as long as a hung
+# lookup runs, so the ceiling is what stops an upstream outage from draining the pool.
 _REQUEST_TIMEOUT_SECONDS = 10
 
 # How long the socket may go silent, during connect or mid-body. Must stay below
-# _REQUEST_TIMEOUT_SECONDS: the read loop only begins a read it can finish inside the
-# request budget, so a stall tolerance at or above it leaves no room to read at all.
+# _REQUEST_TIMEOUT_SECONDS; see _fetch_text for how the two combine.
 _STALL_TIMEOUT_SECONDS = 5
 
 # Resolvers answer with a single SMILES, so a response this large means the upstream is
 # misbehaving (an error page, a redirect loop) and is not worth buffering.
 _MAX_RESPONSE_BYTES = 1 << 20
+
+# Read-size hint, kept well below _MAX_RESPONSE_BYTES: read1 clamps the request to the
+# framing only when the length is known, so a close-delimited response would otherwise
+# allocate the whole cap to receive a few dozen bytes.
+_READ_CHUNK_BYTES = 1 << 16
+
+
+class _ResolverUnavailableError(Exception):
+    """A resolver could not be reached, or did not answer usefully.
+
+    Resolvers signal failure with this alone, so the fallback chain does not have to
+    enumerate the transport library's exception types on their behalf.
+    """
+
 
 _COMPOUND_STRUCTURAL_IDENTIFIERS = [
     reaction_pb2.CompoundIdentifier.SMILES,
@@ -74,16 +86,16 @@ def resolve_name(value_type: str, value: str) -> tuple[str, str]:
     """Resolves compound identifiers to SMILES via multiple APIs.
 
     Any single resolver being unreachable, erroring, or timing out falls through to the
-    next one; only an exhausted chain is a failure. ``URLError`` covers ``HTTPError``
-    and connect-time timeouts, while a stall part-way through a response body surfaces
-    as a bare ``TimeoutError``.
+    next one, so only an exhausted chain is a failure. Each resolver is bounded
+    separately, which puts the worst case at the length of the chain times
+    ``_REQUEST_TIMEOUT_SECONDS``.
     """
     for resolver, resolver_func in _NAME_RESOLVERS.items():
         try:
             smiles = resolver_func(value_type, value)
             if smiles is not None:
                 return smiles, resolver
-        except (urllib.error.URLError, TimeoutError) as error:
+        except _ResolverUnavailableError as error:
             logger.info(f"{resolver} could not resolve {value_type} {value}: {error}")
     raise ValueError(f"Could not resolve {value_type} {value} to SMILES")
 
@@ -133,8 +145,7 @@ def _fetch_text(url: str) -> str:
     make the ceiling hard. The body is consumed with ``read1``, which returns as soon as
     any bytes arrive, so control comes back between chunks rather than being held inside
     one read that never returns; and a read is only begun when the stall tolerance still
-    fits inside the deadline, so the last read cannot run past it. Total time is
-    therefore at most ``_REQUEST_TIMEOUT_SECONDS``, not that plus a trailing read.
+    fits inside the deadline, so the last read cannot run past it.
 
     Args:
         url: The URL to fetch.
@@ -143,28 +154,29 @@ def _fetch_text(url: str) -> str:
         The decoded response body with surrounding whitespace removed.
 
     Raises:
-        TimeoutError: If the body cannot be finished within the request budget.
-        urllib.error.URLError: If the response exceeds ``_MAX_RESPONSE_BYTES``.
+        _ResolverUnavailableError: If the request fails, cannot be finished within the
+            request budget, or returns more than ``_MAX_RESPONSE_BYTES``.
     """
     deadline = time.monotonic() + _REQUEST_TIMEOUT_SECONDS
-    chunks: list[bytes] = []
-    size = 0
-    # S310: every caller builds an https literal here, interpolating only a quoted path
-    # segment, so no caller-supplied scheme can reach urlopen.
-    with urllib.request.urlopen(  # noqa: S310
-        url, timeout=_STALL_TIMEOUT_SECONDS
-    ) as response:
-        while True:
-            if time.monotonic() + _STALL_TIMEOUT_SECONDS > deadline:
-                raise TimeoutError(f"Timed out reading a response from {url}")
-            chunk = response.read1(_MAX_RESPONSE_BYTES)
-            if not chunk:
-                break
-            size += len(chunk)
-            if size > _MAX_RESPONSE_BYTES:
-                raise urllib.error.URLError(f"Response from {url} is too large")
-            chunks.append(chunk)
-    return b"".join(chunks).decode().strip()
+    body = bytearray()
+    try:
+        # S310: every caller builds an https literal here, interpolating only a quoted
+        # path segment, so no caller-supplied scheme can reach urlopen.
+        with urllib.request.urlopen(  # noqa: S310
+            url, timeout=_STALL_TIMEOUT_SECONDS
+        ) as response:
+            while True:
+                if time.monotonic() + _STALL_TIMEOUT_SECONDS > deadline:
+                    raise _ResolverUnavailableError(f"{url} timed out")
+                chunk = response.read1(_READ_CHUNK_BYTES)
+                if not chunk:
+                    break
+                body += chunk
+                if len(body) > _MAX_RESPONSE_BYTES:
+                    raise _ResolverUnavailableError(f"{url} sent too much data")
+    except (urllib.error.URLError, TimeoutError) as error:
+        raise _ResolverUnavailableError(f"{url} could not be read: {error}") from error
+    return body.decode().strip()
 
 
 def _pubchem_resolve(value_type: str, value: str) -> str:

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for ord_schema.units."""
 
+import http.client
 import itertools
 import logging
 import os
@@ -223,20 +224,28 @@ def _http_error(code: int, msg: str) -> urllib.error.HTTPError:
     return urllib.error.HTTPError("", code, msg, hdrs=None, fp=None)  # ty: ignore[invalid-argument-type]
 
 
-def _mock_urlopen(monkeypatch, *chunks: bytes, eof: bool = True) -> mock.MagicMock:
+def _mock_urlopen(
+    monkeypatch,
+    *chunks: bytes | BaseException,
+    eof: bool = True,
+    content_length: str | None = None,
+) -> mock.MagicMock:
     """Patches urlopen with a response yielding ``chunks`` from read1.
 
     Args:
         monkeypatch: The pytest fixture.
-        chunks: Bodies returned by successive read1 calls.
+        chunks: Bodies returned by successive read1 calls, or raised if an exception.
         eof: Whether the body ends. False cycles ``chunks`` forever, standing in for an
             upstream that keeps the connection fed and never finishes.
+        content_length: Value of the Content-Length header. None stands in for a chunked
+            response, which declares no length.
 
     Returns:
         The patched urlopen mock; its ``return_value`` is the response.
     """
     response = mock.MagicMock()
     response.read1.side_effect = [*chunks, b""] if eof else itertools.cycle(chunks)
+    response.getheader.return_value = content_length
     response.__enter__.return_value = response
     urlopen = mock.MagicMock(return_value=response)
     monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
@@ -353,6 +362,34 @@ class TestTransportFailuresAreTranslated:
         assert isinstance(caught.value, resolvers._ResolverUnavailableError) is (
             unreachable
         )
+
+
+class TestIncompleteResponses:
+    def test_a_short_content_length_body_is_rejected(self, monkeypatch):
+        # read1 reports a connection dying mid-body as EOF instead of raising, so
+        # without this check a partial body would be returned as though complete --
+        # and a truncated SMILES can parse cleanly as a different molecule.
+        _mock_urlopen(monkeypatch, b"OCC", content_length="12")
+        with pytest.raises(resolvers._ResolverUnavailableError, match="declared 12"):
+            resolvers._opsin_resolve("name", "ethanol")
+
+    def test_a_complete_body_is_accepted(self, monkeypatch):
+        _mock_urlopen(monkeypatch, b"OCCO\n", content_length="5")
+        assert resolvers._opsin_resolve("name", "ethane-1,2-diol") == "OCCO"
+
+    def test_a_chunked_body_declares_no_length(self, monkeypatch):
+        # PubChem and CIR reply chunked, so the check must not fire when the header
+        # is absent.
+        _mock_urlopen(monkeypatch, b"OCCO\n", content_length=None)
+        assert resolvers._opsin_resolve("name", "ethane-1,2-diol") == "OCCO"
+
+    def test_a_truncated_chunked_body_falls_through(self, monkeypatch):
+        # A chunked body that ends early raises IncompleteRead, which is not an
+        # OSError and so escapes the URLError clause entirely, aborting the chain
+        # rather than moving on to the next resolver.
+        _mock_urlopen(monkeypatch, http.client.IncompleteRead(b"OCC"))
+        with pytest.raises(resolvers._ResolverUnavailableError, match="bad response"):
+            resolvers._opsin_resolve("name", "ethanol")
 
 
 class TestUnreachableResolversAreLatched:

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -14,9 +14,9 @@
 """Tests for ord_schema.units."""
 
 import http.client
-import itertools
 import logging
 import os
+import ssl
 import urllib.error
 from unittest import mock
 
@@ -80,7 +80,7 @@ class TestNameResolvers:
         # plumbing (adds a SMILES identifier with details) without the live call,
         # so the logic stays covered if the live smoke test is ever removed.
         monkeypatch.setattr(
-            "ord_schema.resolvers._resolve_name",
+            "ord_schema.resolvers.resolve_name",
             mock.MagicMock(return_value=("CC(=O)Oc1ccccc1C(=O)O", "PubChem API")),
         )
         message = reaction_pb2.Reaction()
@@ -162,11 +162,8 @@ class TestInputResolvers:
             "water": "O",
         }
         monkeypatch.setattr(
-            "ord_schema.resolvers._resolve_name",
-            lambda _value_type, value, _unavailable: (
-                smiles_by_name[value],
-                "PubChem API",
-            ),
+            "ord_schema.resolvers.resolve_name",
+            lambda _value_type, value: (smiles_by_name[value], "PubChem API"),
         )
 
         reaction_input = resolvers.resolve_input("10 g of THF")
@@ -224,28 +221,18 @@ def _http_error(code: int, msg: str) -> urllib.error.HTTPError:
     return urllib.error.HTTPError("", code, msg, hdrs=None, fp=None)  # ty: ignore[invalid-argument-type]
 
 
-def _mock_urlopen(
-    monkeypatch,
-    *chunks: bytes | BaseException,
-    eof: bool = True,
-    content_length: str | None = None,
-) -> mock.MagicMock:
-    """Patches urlopen with a response yielding ``chunks`` from read1.
+def _mock_urlopen(monkeypatch, body: bytes) -> mock.MagicMock:
+    """Patches urlopen with a response whose read returns ``body``.
 
     Args:
         monkeypatch: The pytest fixture.
-        chunks: Bodies returned by successive read1 calls, or raised if an exception.
-        eof: Whether the body ends. False cycles ``chunks`` forever, standing in for an
-            upstream that keeps the connection fed and never finishes.
-        content_length: Value of the Content-Length header. None stands in for a chunked
-            response, which declares no length.
+        body: The response body.
 
     Returns:
         The patched urlopen mock; its ``return_value`` is the response.
     """
     response = mock.MagicMock()
-    response.read1.side_effect = [*chunks, b""] if eof else itertools.cycle(chunks)
-    response.getheader.return_value = content_length
+    response.read.return_value = body
     response.__enter__.return_value = response
     urlopen = mock.MagicMock(return_value=response)
     monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
@@ -263,7 +250,7 @@ class TestPubChemResolve:
         # falls through to the next resolver (see TestNameResolveFallback).
         urlopen = mock.MagicMock(side_effect=_http_error(503, "PUGREST.ServerBusy"))
         monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
-        with pytest.raises(resolvers._ResolverUnavailableError):
+        with pytest.raises(resolvers._ResolverError):
             resolvers._pubchem_resolve("name", "aspirin")
         assert urlopen.call_count == 1
 
@@ -304,7 +291,7 @@ class TestCactusResolve:
     def test_cactus_resolve_live(self):
         try:
             smiles = resolvers._cactus_resolve("name", "aspirin")
-        except resolvers._ResolverUnavailableError as error:
+        except resolvers._ResolverError as error:
             pytest.skip(f"CIR unavailable ({error}); skipping live resolver smoke test")
         assert Chem.MolToSmiles(Chem.MolFromSmiles(smiles)) == Chem.MolToSmiles(
             Chem.MolFromSmiles("CC(=O)Oc1ccccc1C(O)=O")
@@ -314,7 +301,7 @@ class TestCactusResolve:
 class TestNameResolveFallback:
     def test_falls_back_to_next_resolver(self, monkeypatch):
         # A resolver that cannot answer must not strand the chain.
-        first = mock.MagicMock(side_effect=resolvers._ResolverUnavailableError("down"))
+        first = mock.MagicMock(side_effect=resolvers._ResolverError("down"))
         second = mock.MagicMock(return_value="OCCO")
         monkeypatch.setattr(
             "ord_schema.resolvers._NAME_RESOLVERS", {"first": first, "second": second}
@@ -324,121 +311,54 @@ class TestNameResolveFallback:
         second.assert_called_once_with("name", "ethylene glycol")
 
     def test_raises_when_no_resolver_succeeds(self, monkeypatch):
-        only = mock.MagicMock(side_effect=resolvers._ResolverUnavailableError("down"))
+        only = mock.MagicMock(side_effect=resolvers._ResolverError("down"))
         monkeypatch.setattr("ord_schema.resolvers._NAME_RESOLVERS", {"only": only})
         with pytest.raises(ValueError, match="Could not resolve"):
             resolvers.resolve_name("name", "definitely-not-a-compound")
 
 
-class TestTransportFailuresAreTranslated:
+class TestFailuresReachTheFallbackChain:
     @pytest.mark.parametrize(
-        ("error", "unreachable"),
+        "error",
         [
-            # The status describes the identifier, so the service is worth asking again.
-            (_http_error(404, "Not Found"), False),
-            (_http_error(500, "Server Error"), False),  # CIR's answer for a bad name.
-            # The status describes the service, and repeating it deepens a rate limit.
-            (_http_error(429, "Too Many Requests"), True),
-            (_http_error(503, "PUGREST.ServerBusy"), True),
-            # No response arrived; each of these costs a full timeout.
-            (TimeoutError("timed out"), True),  # Stalled part-way through the body.
-            (urllib.error.URLError(TimeoutError("timed out")), True),  # Connecting.
-            (urllib.error.URLError("name resolution failed"), True),
+            _http_error(404, "Not Found"),
+            _http_error(503, "PUGREST.ServerBusy"),
+            TimeoutError("timed out"),
+            urllib.error.URLError("name resolution failed"),
+            ConnectionResetError("connection reset by peer"),
+            ssl.SSLError("handshake failure"),
+            http.client.IncompleteRead(b"OCC"),
         ],
     )
-    def test_a_failure_records_whether_the_resolver_answered(
-        self, monkeypatch, error, unreachable
-    ):
-        # resolve_name catches a single base type rather than enumerating urllib's
-        # taxonomy, which holds only if every failure is translated here. The subtype
-        # is what decides whether the resolver is worth trying for the next compound,
-        # so HTTPError must be caught before URLError -- it is a subclass of it.
+    def test_every_failure_becomes_a_resolver_error(self, monkeypatch, error):
+        # resolve_name catches one type, so every way a request can fail has to arrive
+        # as that type; anything escaping ends the chain instead of falling through to
+        # the next resolver. Catching OSError is what makes this hold -- URLError,
+        # TimeoutError, the connection errors and SSLError are all subclasses of it.
         monkeypatch.setattr(
             "ord_schema.resolvers.urllib.request.urlopen",
             mock.MagicMock(side_effect=error),
         )
-        with pytest.raises(resolvers._ResolverError) as caught:
-            resolvers._opsin_resolve("name", "ethanol")
-        assert isinstance(caught.value, resolvers._ResolverUnavailableError) is (
-            unreachable
-        )
-
-
-class TestIncompleteResponses:
-    def test_a_short_content_length_body_is_rejected(self, monkeypatch):
-        # read1 reports a connection dying mid-body as EOF instead of raising, so
-        # without this check a partial body would be returned as though complete --
-        # and a truncated SMILES can parse cleanly as a different molecule.
-        _mock_urlopen(monkeypatch, b"OCC", content_length="12")
-        with pytest.raises(resolvers._ResolverUnavailableError, match="declared 12"):
-            resolvers._opsin_resolve("name", "ethanol")
-
-    def test_a_complete_body_is_accepted(self, monkeypatch):
-        _mock_urlopen(monkeypatch, b"OCCO\n", content_length="5")
-        assert resolvers._opsin_resolve("name", "ethane-1,2-diol") == "OCCO"
-
-    def test_a_chunked_body_declares_no_length(self, monkeypatch):
-        # PubChem and CIR reply chunked, so the check must not fire when the header
-        # is absent.
-        _mock_urlopen(monkeypatch, b"OCCO\n", content_length=None)
-        assert resolvers._opsin_resolve("name", "ethane-1,2-diol") == "OCCO"
-
-    def test_a_truncated_chunked_body_falls_through(self, monkeypatch):
-        # A chunked body that ends early raises IncompleteRead, which is not an
-        # OSError and so escapes the URLError clause entirely, aborting the chain
-        # rather than moving on to the next resolver.
-        _mock_urlopen(monkeypatch, http.client.IncompleteRead(b"OCC"))
-        with pytest.raises(resolvers._ResolverUnavailableError, match="bad response"):
+        with pytest.raises(resolvers._ResolverError):
             resolvers._opsin_resolve("name", "ethanol")
 
 
-class TestUnreachableResolversAreLatched:
-    def _reaction_with_names(self, *names: str) -> reaction_pb2.Reaction:
-        reaction = reaction_pb2.Reaction()
-        for name in names:
-            reaction.inputs["test"].components.add().identifiers.add(
-                type="NAME", value=name
-            )
-        return reaction
+class TestResponseHandling:
+    def test_an_oversized_response_is_rejected(self, monkeypatch):
+        # A resolver answers with one SMILES, so a body past the cap means the upstream
+        # is misbehaving and is not worth buffering.
+        monkeypatch.setattr("ord_schema.resolvers._MAX_RESPONSE_BYTES", 8)
+        _mock_urlopen(monkeypatch, b"C" * 9)
+        with pytest.raises(resolvers._ResolverError, match="too much data"):
+            resolvers._opsin_resolve("name", "ethanol")
 
-    def test_an_unreachable_resolver_is_asked_once_per_message(self, monkeypatch):
-        # Each attempt against a dead service costs the full request budget, so
-        # re-confirming it for every compound is what turns one outage into minutes.
-        dead = mock.MagicMock(
-            side_effect=resolvers._ResolverUnavailableError("unreachable")
-        )
-        live = mock.MagicMock(return_value="OCCO")
-        monkeypatch.setattr(
-            "ord_schema.resolvers._NAME_RESOLVERS", {"dead": dead, "live": live}
-        )
-        assert resolvers.resolve_names(self._reaction_with_names("a", "b", "c"))
-        assert dead.call_count == 1
-        assert live.call_count == 3
+    def test_an_undecodable_body_does_not_end_the_chain(self, monkeypatch):
+        # An error page in some other encoding would otherwise raise UnicodeDecodeError
+        # past the translation and abort resolution. It cannot parse as a structure
+        # either way, so it degrades to a normal failed lookup.
+        _mock_urlopen(monkeypatch, b"\xff\xfe caf\xe9")
+        assert resolvers._opsin_resolve("name", "ethanol")  # Does not raise.
 
-    def test_a_resolver_that_answered_is_asked_again(self, monkeypatch):
-        # A 404 is specific to the identifier, not the service, so the next compound
-        # may well be one this resolver knows.
-        missing = mock.MagicMock(side_effect=resolvers._ResolverError("no match"))
-        live = mock.MagicMock(return_value="OCCO")
-        monkeypatch.setattr(
-            "ord_schema.resolvers._NAME_RESOLVERS", {"missing": missing, "live": live}
-        )
-        assert resolvers.resolve_names(self._reaction_with_names("a", "b", "c"))
-        assert missing.call_count == 3
-
-    def test_the_latch_does_not_outlive_the_message(self, monkeypatch):
-        # The set is per traversal, so a resolver down during one message is retried
-        # for the next rather than being written off process-wide.
-        dead = mock.MagicMock(
-            side_effect=resolvers._ResolverUnavailableError("unreachable")
-        )
-        monkeypatch.setattr("ord_schema.resolvers._NAME_RESOLVERS", {"dead": dead})
-        for _ in range(3):
-            assert not resolvers.resolve_names(self._reaction_with_names("a"))
-        assert dead.call_count == 3
-
-
-class TestResolverTimeouts:
     @pytest.mark.parametrize(
         "resolve",
         [
@@ -448,49 +368,50 @@ class TestResolverTimeouts:
         ],
     )
     def test_every_resolver_bounds_its_request(self, monkeypatch, resolve):
-        # A missing timeout blocks the calling thread indefinitely against an upstream
-        # that accepts the connection and then goes quiet.
+        # Without a timeout, an upstream that accepts the connection and then goes
+        # quiet blocks the calling thread indefinitely.
         urlopen = _mock_urlopen(monkeypatch, b"OCCO\n")
         resolve("name", "ethylene glycol")
-        assert urlopen.call_args.kwargs["timeout"] == resolvers._STALL_TIMEOUT_SECONDS
+        assert urlopen.call_args.kwargs["timeout"] == resolvers._TIMEOUT_SECONDS
 
-    def test_a_read_is_not_begun_when_it_could_outlast_the_deadline(self, monkeypatch):
-        # The socket timeout applies to whichever read is in flight, so a read started
-        # just under the deadline would run past it. The budget is a ceiling on the
-        # whole request, which holds only if the last read is refused rather than
-        # started: here one chunk lands, then too little budget remains to read again.
-        clock = iter([0, 0, resolvers._REQUEST_TIMEOUT_SECONDS])
-        monkeypatch.setattr("ord_schema.resolvers.time.monotonic", lambda: next(clock))
-        urlopen = _mock_urlopen(monkeypatch, b"OCCO")  # EOF is never reached.
-        with pytest.raises(resolvers._ResolverUnavailableError, match="timed out"):
-            resolvers._opsin_resolve("name", "ethanol")
-        assert urlopen.return_value.read1.call_count == 1
+    @pytest.mark.parametrize(
+        "resolve",
+        [
+            resolvers._pubchem_resolve,
+            resolvers._cactus_resolve,
+            resolvers._opsin_resolve,
+        ],
+    )
+    def test_a_name_cannot_rewrite_the_request_path(self, monkeypatch, resolve):
+        # quote() leaves "/" alone by default, so an unescaped name could climb the
+        # path and resolve a different compound than the one asked for.
+        urlopen = _mock_urlopen(monkeypatch, b"OCCO\n")
+        resolve("name", "../../../pug/compound/cid/2244")
+        assert "/../" not in urlopen.call_args.args[0]
 
-    def test_the_stall_tolerance_leaves_room_to_read(self):
-        # Were these equal, the loop could never begin a read: every check would find
-        # the stall tolerance already overrunning the deadline.
-        assert resolvers._STALL_TIMEOUT_SECONDS < resolvers._REQUEST_TIMEOUT_SECONDS
 
-    def test_a_trickling_response_still_hits_the_deadline(self, monkeypatch):
-        # The socket timeout only bounds a single read, so an upstream that sends a
-        # byte just often enough to reset it would stream forever. Each chunk arrives
-        # "instantly" here and the clock advances a second per check, so the loop can
-        # only terminate via the deadline.
-        clock = itertools.count()
-        monkeypatch.setattr("ord_schema.resolvers.time.monotonic", lambda: next(clock))
-        _mock_urlopen(monkeypatch, b"C", eof=False)
-        with pytest.raises(resolvers._ResolverUnavailableError, match="timed out"):
-            resolvers._opsin_resolve("name", "ethanol")
+class TestBlankResponses:
+    def test_a_blank_body_is_not_a_resolution(self, monkeypatch):
+        # "" would be written out as a SMILES identifier holding nothing, which also
+        # counts as structural -- so the compound would be skipped by any later pass.
+        blank = mock.MagicMock(return_value="")
+        found = mock.MagicMock(return_value="OCCO")
+        monkeypatch.setattr(
+            "ord_schema.resolvers._NAME_RESOLVERS", {"blank": blank, "found": found}
+        )
+        assert resolvers.resolve_name("name", "ethylene glycol") == ("OCCO", "found")
 
-    def test_an_oversized_response_is_rejected(self, monkeypatch):
-        # An upstream streaming an error page is not buffered without limit; the
-        # failure reads like any other, so the chain falls through to the next resolver.
-        monkeypatch.setattr("ord_schema.resolvers._MAX_RESPONSE_BYTES", 8)
-        _mock_urlopen(monkeypatch, b"C" * 9)
-        with pytest.raises(
-            resolvers._ResolverUnavailableError, match="sent too much data"
-        ):
-            resolvers._opsin_resolve("name", "ethanol")
+    def test_a_message_is_unmodified_when_every_resolver_is_blank(self, monkeypatch):
+        monkeypatch.setattr(
+            "ord_schema.resolvers._NAME_RESOLVERS",
+            {"blank": mock.MagicMock(return_value="")},
+        )
+        message = reaction_pb2.Reaction()
+        message.inputs["test"].components.add().identifiers.add(
+            type="NAME", value="aspirin"
+        )
+        assert not resolvers.resolve_names(message)
+        assert len(message.inputs["test"].components[0].identifiers) == 1
 
 
 class TestResolveNamesSkipsStructuralIdentifiers:
@@ -498,7 +419,7 @@ class TestResolveNamesSkipsStructuralIdentifiers:
         # If a Compound already has a structural identifier, name resolution
         # must not be attempted.
         called = mock.MagicMock()
-        monkeypatch.setattr("ord_schema.resolvers._resolve_name", called)
+        monkeypatch.setattr("ord_schema.resolvers.resolve_name", called)
         message = reaction_pb2.Reaction()
         compound = message.inputs["test"].components.add()
         compound.identifiers.add(type="NAME", value="aspirin")
@@ -510,7 +431,7 @@ class TestResolveNamesSkipsStructuralIdentifiers:
         # When resolve_name raises ValueError, resolve_names skips that NAME and
         # reports no modification.
         monkeypatch.setattr(
-            "ord_schema.resolvers._resolve_name",
+            "ord_schema.resolvers.resolve_name",
             mock.MagicMock(side_effect=ValueError("not found")),
         )
         message = reaction_pb2.Reaction()

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -220,10 +220,20 @@ def _http_error(code: int, msg: str) -> urllib.error.HTTPError:
     return urllib.error.HTTPError("", code, msg, hdrs=None, fp=None)  # ty: ignore[invalid-argument-type]
 
 
-def _mock_urlopen(monkeypatch, *chunks: bytes) -> mock.MagicMock:
-    """Patches urlopen with a response yielding ``chunks``, then EOF, from read1."""
+def _mock_urlopen(monkeypatch, *chunks: bytes, eof: bool = True) -> mock.MagicMock:
+    """Patches urlopen with a response yielding ``chunks`` from read1.
+
+    Args:
+        monkeypatch: The pytest fixture.
+        chunks: Bodies returned by successive read1 calls.
+        eof: Whether the body ends. False cycles ``chunks`` forever, standing in for an
+            upstream that keeps the connection fed and never finishes.
+
+    Returns:
+        The patched urlopen mock; its ``return_value`` is the response.
+    """
     response = mock.MagicMock()
-    response.read1.side_effect = [*chunks, b""]
+    response.read1.side_effect = [*chunks, b""] if eof else itertools.cycle(chunks)
     response.__enter__.return_value = response
     urlopen = mock.MagicMock(return_value=response)
     monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
@@ -241,7 +251,7 @@ class TestPubChemResolve:
         # falls through to the next resolver (see TestNameResolveFallback).
         urlopen = mock.MagicMock(side_effect=_http_error(503, "PUGREST.ServerBusy"))
         monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
-        with pytest.raises(urllib.error.HTTPError):
+        with pytest.raises(resolvers._ResolverUnavailableError):
             resolvers._pubchem_resolve("name", "aspirin")
         assert urlopen.call_count == 1
 
@@ -282,7 +292,7 @@ class TestCactusResolve:
     def test_cactus_resolve_live(self):
         try:
             smiles = resolvers._cactus_resolve("name", "aspirin")
-        except (urllib.error.HTTPError, urllib.error.URLError) as error:
+        except resolvers._ResolverUnavailableError as error:
             pytest.skip(f"CIR unavailable ({error}); skipping live resolver smoke test")
         assert Chem.MolToSmiles(Chem.MolFromSmiles(smiles)) == Chem.MolToSmiles(
             Chem.MolFromSmiles("CC(=O)Oc1ccccc1C(O)=O")
@@ -290,49 +300,46 @@ class TestCactusResolve:
 
 
 class TestNameResolveFallback:
-    def test_falls_back_to_next_resolver_on_http_error(self, monkeypatch):
-        # First resolver raises an HTTPError; second resolver succeeds.
-        first = mock.MagicMock(side_effect=_http_error(404, "Not Found"))
-        second = mock.MagicMock(return_value="OCCO")
-        monkeypatch.setattr(
-            "ord_schema.resolvers._NAME_RESOLVERS", {"first": first, "second": second}
-        )
-        smiles, resolver_name = resolvers.resolve_name("name", "ethylene glycol")
-        assert smiles == "OCCO"
-        assert resolver_name == "second"
-        first.assert_called_once_with("name", "ethylene glycol")
-        second.assert_called_once_with("name", "ethylene glycol")
-
-    def test_raises_when_no_resolver_succeeds(self, monkeypatch):
-        only = mock.MagicMock(side_effect=_http_error(404, "Not Found"))
-        monkeypatch.setattr("ord_schema.resolvers._NAME_RESOLVERS", {"only": only})
-        with pytest.raises(ValueError, match="Could not resolve"):
-            resolvers.resolve_name("name", "definitely-not-a-compound")
-
-    @pytest.mark.parametrize(
-        "error",
-        [
-            TimeoutError("timed out"),  # Stalled part-way through the response body.
-            urllib.error.URLError(TimeoutError("timed out")),  # Stalled connecting.
-            urllib.error.URLError("name resolution failed"),
-        ],
-    )
-    def test_falls_back_to_next_resolver_on_unreachable(self, monkeypatch, error):
-        # An unreachable resolver must not strand the chain: a timeout is not an
-        # HTTPError, so it would otherwise propagate past the fallback loop and turn a
-        # single-resolver outage into a total failure.
-        first = mock.MagicMock(side_effect=error)
+    def test_falls_back_to_next_resolver(self, monkeypatch):
+        # A resolver that cannot answer must not strand the chain.
+        first = mock.MagicMock(side_effect=resolvers._ResolverUnavailableError("down"))
         second = mock.MagicMock(return_value="OCCO")
         monkeypatch.setattr(
             "ord_schema.resolvers._NAME_RESOLVERS", {"first": first, "second": second}
         )
         assert resolvers.resolve_name("name", "ethylene glycol") == ("OCCO", "second")
+        first.assert_called_once_with("name", "ethylene glycol")
+        second.assert_called_once_with("name", "ethylene glycol")
 
-    def test_a_timed_out_chain_is_a_value_error(self, monkeypatch):
-        only = mock.MagicMock(side_effect=TimeoutError("timed out"))
+    def test_raises_when_no_resolver_succeeds(self, monkeypatch):
+        only = mock.MagicMock(side_effect=resolvers._ResolverUnavailableError("down"))
         monkeypatch.setattr("ord_schema.resolvers._NAME_RESOLVERS", {"only": only})
         with pytest.raises(ValueError, match="Could not resolve"):
-            resolvers.resolve_name("name", "ethylene glycol")
+            resolvers.resolve_name("name", "definitely-not-a-compound")
+
+
+class TestTransportFailuresAreTranslated:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            _http_error(404, "Not Found"),
+            _http_error(503, "PUGREST.ServerBusy"),
+            TimeoutError("timed out"),  # Stalled part-way through the response body.
+            urllib.error.URLError(TimeoutError("timed out")),  # Stalled connecting.
+            urllib.error.URLError("name resolution failed"),
+        ],
+    )
+    def test_every_transport_failure_becomes_one_type(self, monkeypatch, error):
+        # resolve_name catches a single exception rather than enumerating urllib's
+        # taxonomy, which holds only if every way a request can fail is translated
+        # here. Anything that escapes untranslated ends the whole chain instead of
+        # falling through to the next resolver.
+        monkeypatch.setattr(
+            "ord_schema.resolvers.urllib.request.urlopen",
+            mock.MagicMock(side_effect=error),
+        )
+        with pytest.raises(resolvers._ResolverUnavailableError, match="could not be"):
+            resolvers._opsin_resolve("name", "ethanol")
 
 
 class TestResolverTimeouts:
@@ -358,16 +365,10 @@ class TestResolverTimeouts:
         # started: here one chunk lands, then too little budget remains to read again.
         clock = iter([0, 0, resolvers._REQUEST_TIMEOUT_SECONDS])
         monkeypatch.setattr("ord_schema.resolvers.time.monotonic", lambda: next(clock))
-        response = mock.MagicMock()
-        response.read1.side_effect = [b"OCCO", b""]  # EOF is never reached.
-        response.__enter__.return_value = response
-        monkeypatch.setattr(
-            "ord_schema.resolvers.urllib.request.urlopen",
-            mock.MagicMock(return_value=response),
-        )
-        with pytest.raises(TimeoutError, match="Timed out reading"):
+        urlopen = _mock_urlopen(monkeypatch, b"OCCO")  # EOF is never reached.
+        with pytest.raises(resolvers._ResolverUnavailableError, match="timed out"):
             resolvers._opsin_resolve("name", "ethanol")
-        assert response.read1.call_count == 1
+        assert urlopen.return_value.read1.call_count == 1
 
     def test_the_stall_tolerance_leaves_room_to_read(self):
         # Were these equal, the loop could never begin a read: every check would find
@@ -381,28 +382,18 @@ class TestResolverTimeouts:
         # only terminate via the deadline.
         clock = itertools.count()
         monkeypatch.setattr("ord_schema.resolvers.time.monotonic", lambda: next(clock))
-        response = mock.MagicMock()
-        response.read1.return_value = b"C"  # Never EOF.
-        response.__enter__.return_value = response
-        monkeypatch.setattr(
-            "ord_schema.resolvers.urllib.request.urlopen",
-            mock.MagicMock(return_value=response),
-        )
-        with pytest.raises(TimeoutError, match="Timed out reading"):
+        _mock_urlopen(monkeypatch, b"C", eof=False)
+        with pytest.raises(resolvers._ResolverUnavailableError, match="timed out"):
             resolvers._opsin_resolve("name", "ethanol")
 
     def test_an_oversized_response_is_rejected(self, monkeypatch):
-        # resolve_name catches URLError, so an upstream streaming an error page falls
-        # through to the next resolver rather than being buffered without limit.
+        # An upstream streaming an error page is not buffered without limit; the
+        # failure reads like any other, so the chain falls through to the next resolver.
         monkeypatch.setattr("ord_schema.resolvers._MAX_RESPONSE_BYTES", 8)
-        response = mock.MagicMock()
-        response.read1.return_value = b"C" * 8  # Never EOF.
-        response.__enter__.return_value = response
-        monkeypatch.setattr(
-            "ord_schema.resolvers.urllib.request.urlopen",
-            mock.MagicMock(return_value=response),
-        )
-        with pytest.raises(urllib.error.URLError, match="too large"):
+        _mock_urlopen(monkeypatch, b"C" * 9)
+        with pytest.raises(
+            resolvers._ResolverUnavailableError, match="sent too much data"
+        ):
             resolvers._opsin_resolve("name", "ethanol")
 
 

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -79,7 +79,7 @@ class TestNameResolvers:
         # plumbing (adds a SMILES identifier with details) without the live call,
         # so the logic stays covered if the live smoke test is ever removed.
         monkeypatch.setattr(
-            "ord_schema.resolvers.resolve_name",
+            "ord_schema.resolvers._resolve_name",
             mock.MagicMock(return_value=("CC(=O)Oc1ccccc1C(=O)O", "PubChem API")),
         )
         message = reaction_pb2.Reaction()
@@ -161,8 +161,11 @@ class TestInputResolvers:
             "water": "O",
         }
         monkeypatch.setattr(
-            "ord_schema.resolvers.resolve_name",
-            lambda _value_type, value: (smiles_by_name[value], "PubChem API"),
+            "ord_schema.resolvers._resolve_name",
+            lambda _value_type, value, _unavailable: (
+                smiles_by_name[value],
+                "PubChem API",
+            ),
         )
 
         reaction_input = resolvers.resolve_input("10 g of THF")
@@ -320,26 +323,82 @@ class TestNameResolveFallback:
 
 class TestTransportFailuresAreTranslated:
     @pytest.mark.parametrize(
-        "error",
+        ("error", "unreachable"),
         [
-            _http_error(404, "Not Found"),
-            _http_error(503, "PUGREST.ServerBusy"),
-            TimeoutError("timed out"),  # Stalled part-way through the response body.
-            urllib.error.URLError(TimeoutError("timed out")),  # Stalled connecting.
-            urllib.error.URLError("name resolution failed"),
+            # The status describes the identifier, so the service is worth asking again.
+            (_http_error(404, "Not Found"), False),
+            (_http_error(500, "Server Error"), False),  # CIR's answer for a bad name.
+            # The status describes the service, and repeating it deepens a rate limit.
+            (_http_error(429, "Too Many Requests"), True),
+            (_http_error(503, "PUGREST.ServerBusy"), True),
+            # No response arrived; each of these costs a full timeout.
+            (TimeoutError("timed out"), True),  # Stalled part-way through the body.
+            (urllib.error.URLError(TimeoutError("timed out")), True),  # Connecting.
+            (urllib.error.URLError("name resolution failed"), True),
         ],
     )
-    def test_every_transport_failure_becomes_one_type(self, monkeypatch, error):
-        # resolve_name catches a single exception rather than enumerating urllib's
-        # taxonomy, which holds only if every way a request can fail is translated
-        # here. Anything that escapes untranslated ends the whole chain instead of
-        # falling through to the next resolver.
+    def test_a_failure_records_whether_the_resolver_answered(
+        self, monkeypatch, error, unreachable
+    ):
+        # resolve_name catches a single base type rather than enumerating urllib's
+        # taxonomy, which holds only if every failure is translated here. The subtype
+        # is what decides whether the resolver is worth trying for the next compound,
+        # so HTTPError must be caught before URLError -- it is a subclass of it.
         monkeypatch.setattr(
             "ord_schema.resolvers.urllib.request.urlopen",
             mock.MagicMock(side_effect=error),
         )
-        with pytest.raises(resolvers._ResolverUnavailableError, match="could not be"):
+        with pytest.raises(resolvers._ResolverError) as caught:
             resolvers._opsin_resolve("name", "ethanol")
+        assert isinstance(caught.value, resolvers._ResolverUnavailableError) is (
+            unreachable
+        )
+
+
+class TestUnreachableResolversAreLatched:
+    def _reaction_with_names(self, *names: str) -> reaction_pb2.Reaction:
+        reaction = reaction_pb2.Reaction()
+        for name in names:
+            reaction.inputs["test"].components.add().identifiers.add(
+                type="NAME", value=name
+            )
+        return reaction
+
+    def test_an_unreachable_resolver_is_asked_once_per_message(self, monkeypatch):
+        # Each attempt against a dead service costs the full request budget, so
+        # re-confirming it for every compound is what turns one outage into minutes.
+        dead = mock.MagicMock(
+            side_effect=resolvers._ResolverUnavailableError("unreachable")
+        )
+        live = mock.MagicMock(return_value="OCCO")
+        monkeypatch.setattr(
+            "ord_schema.resolvers._NAME_RESOLVERS", {"dead": dead, "live": live}
+        )
+        assert resolvers.resolve_names(self._reaction_with_names("a", "b", "c"))
+        assert dead.call_count == 1
+        assert live.call_count == 3
+
+    def test_a_resolver_that_answered_is_asked_again(self, monkeypatch):
+        # A 404 is specific to the identifier, not the service, so the next compound
+        # may well be one this resolver knows.
+        missing = mock.MagicMock(side_effect=resolvers._ResolverError("no match"))
+        live = mock.MagicMock(return_value="OCCO")
+        monkeypatch.setattr(
+            "ord_schema.resolvers._NAME_RESOLVERS", {"missing": missing, "live": live}
+        )
+        assert resolvers.resolve_names(self._reaction_with_names("a", "b", "c"))
+        assert missing.call_count == 3
+
+    def test_the_latch_does_not_outlive_the_message(self, monkeypatch):
+        # The set is per traversal, so a resolver down during one message is retried
+        # for the next rather than being written off process-wide.
+        dead = mock.MagicMock(
+            side_effect=resolvers._ResolverUnavailableError("unreachable")
+        )
+        monkeypatch.setattr("ord_schema.resolvers._NAME_RESOLVERS", {"dead": dead})
+        for _ in range(3):
+            assert not resolvers.resolve_names(self._reaction_with_names("a"))
+        assert dead.call_count == 3
 
 
 class TestResolverTimeouts:
@@ -402,7 +461,7 @@ class TestResolveNamesSkipsStructuralIdentifiers:
         # If a Compound already has a structural identifier, name resolution
         # must not be attempted.
         called = mock.MagicMock()
-        monkeypatch.setattr("ord_schema.resolvers.resolve_name", called)
+        monkeypatch.setattr("ord_schema.resolvers._resolve_name", called)
         message = reaction_pb2.Reaction()
         compound = message.inputs["test"].components.add()
         compound.identifiers.add(type="NAME", value="aspirin")
@@ -414,7 +473,7 @@ class TestResolveNamesSkipsStructuralIdentifiers:
         # When resolve_name raises ValueError, resolve_names skips that NAME and
         # reports no modification.
         monkeypatch.setattr(
-            "ord_schema.resolvers.resolve_name",
+            "ord_schema.resolvers._resolve_name",
             mock.MagicMock(side_effect=ValueError("not found")),
         )
         message = reaction_pb2.Reaction()

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -349,9 +349,30 @@ class TestResolverTimeouts:
         # that accepts the connection and then goes quiet.
         urlopen = _mock_urlopen(monkeypatch, b"OCCO\n")
         resolve("name", "ethylene glycol")
-        assert (
-            urlopen.call_args.kwargs["timeout"] == resolvers._RESOLVER_TIMEOUT_SECONDS
+        assert urlopen.call_args.kwargs["timeout"] == resolvers._STALL_TIMEOUT_SECONDS
+
+    def test_a_read_is_not_begun_when_it_could_outlast_the_deadline(self, monkeypatch):
+        # The socket timeout applies to whichever read is in flight, so a read started
+        # just under the deadline would run past it. The budget is a ceiling on the
+        # whole request, which holds only if the last read is refused rather than
+        # started: here one chunk lands, then too little budget remains to read again.
+        clock = iter([0, 0, resolvers._REQUEST_TIMEOUT_SECONDS])
+        monkeypatch.setattr("ord_schema.resolvers.time.monotonic", lambda: next(clock))
+        response = mock.MagicMock()
+        response.read1.side_effect = [b"OCCO", b""]  # EOF is never reached.
+        response.__enter__.return_value = response
+        monkeypatch.setattr(
+            "ord_schema.resolvers.urllib.request.urlopen",
+            mock.MagicMock(return_value=response),
         )
+        with pytest.raises(TimeoutError, match="Timed out reading"):
+            resolvers._opsin_resolve("name", "ethanol")
+        assert response.read1.call_count == 1
+
+    def test_the_stall_tolerance_leaves_room_to_read(self):
+        # Were these equal, the loop could never begin a read: every check would find
+        # the stall tolerance already overrunning the deadline.
+        assert resolvers._STALL_TIMEOUT_SECONDS < resolvers._REQUEST_TIMEOUT_SECONDS
 
     def test_a_trickling_response_still_hits_the_deadline(self, monkeypatch):
         # The socket timeout only bounds a single read, so an upstream that sends a

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -221,18 +221,24 @@ def _http_error(code: int, msg: str) -> urllib.error.HTTPError:
     return urllib.error.HTTPError("", code, msg, hdrs=None, fp=None)  # ty: ignore[invalid-argument-type]
 
 
-def _mock_urlopen(monkeypatch, body: bytes) -> mock.MagicMock:
+def _mock_urlopen(
+    monkeypatch, body: bytes, *, remaining: int | None = 0
+) -> mock.MagicMock:
     """Patches urlopen with a response whose read returns ``body``.
 
     Args:
         monkeypatch: The pytest fixture.
         body: The response body.
+        remaining: Bytes the response still owes, as urllib reports through ``length``.
+            0 is a complete body, a positive value a truncated one, and None a chunked
+            response, which declares no length at all.
 
     Returns:
         The patched urlopen mock; its ``return_value`` is the response.
     """
     response = mock.MagicMock()
     response.read.return_value = body
+    response.length = remaining
     response.__enter__.return_value = response
     urlopen = mock.MagicMock(return_value=response)
     monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
@@ -351,6 +357,20 @@ class TestResponseHandling:
         _mock_urlopen(monkeypatch, b"C" * 9)
         with pytest.raises(resolvers._ResolverError, match="too much data"):
             resolvers._opsin_resolve("name", "ethanol")
+
+    def test_a_body_that_ends_early_is_rejected(self, monkeypatch):
+        # read(size) stops at EOF without raising, so a connection dropped mid-body
+        # would otherwise hand back a short answer as the resolved structure -- and a
+        # truncated SMILES usually parses, as a different molecule.
+        _mock_urlopen(monkeypatch, b"OCC", remaining=9)
+        with pytest.raises(resolvers._ResolverError, match="ended early"):
+            resolvers._opsin_resolve("name", "ethanol")
+
+    def test_a_chunked_body_declares_no_length(self, monkeypatch):
+        # PubChem and CIR answer chunked, where length is None and an early end raises
+        # IncompleteRead instead, so the check must not fire on a healthy response.
+        _mock_urlopen(monkeypatch, b"OCCO\n", remaining=None)
+        assert resolvers._opsin_resolve("name", "ethane-1,2-diol") == "OCCO"
 
     def test_an_undecodable_body_does_not_end_the_chain(self, monkeypatch):
         # An error page in some other encoding would otherwise raise UnicodeDecodeError

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -314,6 +314,54 @@ class TestNameResolveFallback:
         with pytest.raises(ValueError, match="Could not resolve"):
             resolvers.resolve_name("name", "definitely-not-a-compound")
 
+    @pytest.mark.parametrize(
+        "error",
+        [
+            TimeoutError("timed out"),  # Stalled part-way through the response body.
+            urllib.error.URLError(TimeoutError("timed out")),  # Stalled connecting.
+            urllib.error.URLError("name resolution failed"),
+        ],
+    )
+    def test_falls_back_to_next_resolver_on_unreachable(self, monkeypatch, error):
+        # An unreachable resolver must not strand the chain: a timeout is not an
+        # HTTPError, so it would otherwise propagate past the fallback loop and turn a
+        # single-resolver outage into a total failure.
+        first = mock.MagicMock(side_effect=error)
+        second = mock.MagicMock(return_value="OCCO")
+        monkeypatch.setattr(
+            "ord_schema.resolvers._NAME_RESOLVERS", {"first": first, "second": second}
+        )
+        assert resolvers.resolve_name("name", "ethylene glycol") == ("OCCO", "second")
+
+    def test_a_timed_out_chain_is_a_value_error(self, monkeypatch):
+        only = mock.MagicMock(side_effect=TimeoutError("timed out"))
+        monkeypatch.setattr("ord_schema.resolvers._NAME_RESOLVERS", {"only": only})
+        with pytest.raises(ValueError, match="Could not resolve"):
+            resolvers.resolve_name("name", "ethylene glycol")
+
+
+class TestResolverTimeouts:
+    @pytest.mark.parametrize(
+        "resolve",
+        [
+            resolvers._pubchem_resolve,
+            resolvers._cactus_resolve,
+            resolvers._opsin_resolve,
+        ],
+    )
+    def test_every_resolver_bounds_its_request(self, monkeypatch, resolve):
+        # A missing timeout blocks the calling thread indefinitely against an upstream
+        # that accepts the connection and then goes quiet.
+        response = mock.MagicMock()
+        response.read.return_value = b"OCCO\n"
+        response.__enter__.return_value = response
+        urlopen = mock.MagicMock(return_value=response)
+        monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
+        resolve("name", "ethylene glycol")
+        assert (
+            urlopen.call_args.kwargs["timeout"] == resolvers._RESOLVER_TIMEOUT_SECONDS
+        )
+
 
 class TestResolveNamesSkipsStructuralIdentifiers:
     def test_skips_compound_with_existing_smiles(self, monkeypatch):

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for ord_schema.units."""
 
+import itertools
 import logging
 import os
 import urllib.error
@@ -219,13 +220,19 @@ def _http_error(code: int, msg: str) -> urllib.error.HTTPError:
     return urllib.error.HTTPError("", code, msg, hdrs=None, fp=None)  # ty: ignore[invalid-argument-type]
 
 
+def _mock_urlopen(monkeypatch, *chunks: bytes) -> mock.MagicMock:
+    """Patches urlopen with a response yielding ``chunks``, then EOF, from read1."""
+    response = mock.MagicMock()
+    response.read1.side_effect = [*chunks, b""]
+    response.__enter__.return_value = response
+    urlopen = mock.MagicMock(return_value=response)
+    monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
+    return urlopen
+
+
 class TestPubChemResolve:
     def test_pubchem_resolve(self, monkeypatch):
-        response = mock.MagicMock()
-        response.read.return_value = b"CC(=O)Oc1ccccc1C(=O)O\n"
-        response.__enter__.return_value = response
-        urlopen = mock.MagicMock(return_value=response)
-        monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
+        urlopen = _mock_urlopen(monkeypatch, b"CC(=O)Oc1ccccc1C(=O)O\n")
         assert resolvers._pubchem_resolve("name", "aspirin") == "CC(=O)Oc1ccccc1C(=O)O"
         assert urlopen.call_count == 1
 
@@ -253,11 +260,7 @@ class TestCanonicalizeSmiles:
 
 class TestOpsinResolve:
     def test_opsin_resolve(self, monkeypatch):
-        response = mock.MagicMock()
-        response.read.return_value = b"OCCO\n"
-        response.__enter__.return_value = response
-        urlopen = mock.MagicMock(return_value=response)
-        monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
+        urlopen = _mock_urlopen(monkeypatch, b"OCCO\n")
         # value_type is ignored by OPSIN.
         assert resolvers._opsin_resolve("name", "ethane-1,2-diol") == "OCCO"
         assert urlopen.call_count == 1
@@ -265,22 +268,14 @@ class TestOpsinResolve:
 
 class TestCactusResolve:
     def test_cactus_resolve(self, monkeypatch):
-        response = mock.MagicMock()
-        response.read.return_value = b"OCCO\n"
-        response.__enter__.return_value = response
-        urlopen = mock.MagicMock(return_value=response)
-        monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
+        urlopen = _mock_urlopen(monkeypatch, b"OCCO\n")
         # value_type is ignored by CIR.
         assert resolvers._cactus_resolve("name", "ethylene glycol") == "OCCO"
         assert urlopen.call_count == 1
 
     def test_cactus_resolve_takes_first_line(self, monkeypatch):
         # CIR can return multiple newline-separated representations.
-        response = mock.MagicMock()
-        response.read.return_value = b"OCCO\nC(CO)O\n"
-        response.__enter__.return_value = response
-        urlopen = mock.MagicMock(return_value=response)
-        monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
+        _mock_urlopen(monkeypatch, b"OCCO\nC(CO)O\n")
         assert resolvers._cactus_resolve("name", "ethylene glycol") == "OCCO"
 
     @_live_resolvers
@@ -352,15 +347,42 @@ class TestResolverTimeouts:
     def test_every_resolver_bounds_its_request(self, monkeypatch, resolve):
         # A missing timeout blocks the calling thread indefinitely against an upstream
         # that accepts the connection and then goes quiet.
-        response = mock.MagicMock()
-        response.read.return_value = b"OCCO\n"
-        response.__enter__.return_value = response
-        urlopen = mock.MagicMock(return_value=response)
-        monkeypatch.setattr("ord_schema.resolvers.urllib.request.urlopen", urlopen)
+        urlopen = _mock_urlopen(monkeypatch, b"OCCO\n")
         resolve("name", "ethylene glycol")
         assert (
             urlopen.call_args.kwargs["timeout"] == resolvers._RESOLVER_TIMEOUT_SECONDS
         )
+
+    def test_a_trickling_response_still_hits_the_deadline(self, monkeypatch):
+        # The socket timeout only bounds a single read, so an upstream that sends a
+        # byte just often enough to reset it would stream forever. Each chunk arrives
+        # "instantly" here and the clock advances a second per check, so the loop can
+        # only terminate via the deadline.
+        clock = itertools.count()
+        monkeypatch.setattr("ord_schema.resolvers.time.monotonic", lambda: next(clock))
+        response = mock.MagicMock()
+        response.read1.return_value = b"C"  # Never EOF.
+        response.__enter__.return_value = response
+        monkeypatch.setattr(
+            "ord_schema.resolvers.urllib.request.urlopen",
+            mock.MagicMock(return_value=response),
+        )
+        with pytest.raises(TimeoutError, match="Timed out reading"):
+            resolvers._opsin_resolve("name", "ethanol")
+
+    def test_an_oversized_response_is_rejected(self, monkeypatch):
+        # resolve_name catches URLError, so an upstream streaming an error page falls
+        # through to the next resolver rather than being buffered without limit.
+        monkeypatch.setattr("ord_schema.resolvers._MAX_RESPONSE_BYTES", 8)
+        response = mock.MagicMock()
+        response.read1.return_value = b"C" * 8  # Never EOF.
+        response.__enter__.return_value = response
+        monkeypatch.setattr(
+            "ord_schema.resolvers.urllib.request.urlopen",
+            mock.MagicMock(return_value=response),
+        )
+        with pytest.raises(urllib.error.URLError, match="too large"):
+            resolvers._opsin_resolve("name", "ethanol")
 
 
 class TestResolveNamesSkipsStructuralIdentifiers:


### PR DESCRIPTION
The PubChem, CIR, and OPSIN calls in `resolvers.py` used `urlopen` with no timeout, so an upstream that accepted the connection and then stopped responding blocked its caller forever. Greptile caught this on #919, where the exposure is worst: the agent path dispatches resolution with `asyncio.to_thread`, so a hung lookup holds its worker for good. Splitting it out here keeps #919 to the move it advertises.

What lands is a timeout, a response size cap, a completeness check, and a single exception type that every failure arrives as. Catching `OSError` is what makes the fallback chain hold: it covers `URLError` and `TimeoutError` along with the connection and TLS errors that were escaping the chain entirely and aborting resolution rather than moving on to the next resolver.

The completeness check is subtler than it looks. `read()` only verifies that it received the whole body in its no-argument form; called with a size, as it is here to bound the response, it stops at EOF and returns a short body without complaint. That matters more than a loud failure would, because a truncated answer is not detectably broken downstream — a truncated SMILES usually parses, as a different molecule. Checking what the response still owes distinguishes the two, verified against a socket that declares twelve bytes and sends three. A chunked body raises `IncompleteRead` instead, which the same clause covers.

Two defects that predate this branch turned up in review and are fixed here, both of which corrupt data quietly rather than failing. An empty response body satisfied `is not None` and was written out as a SMILES identifier holding nothing, which then counts as a structural identifier and hides the compound from any later resolution pass. And `urllib.parse.quote` leaves `/` unescaped by default, so a name containing dot segments could climb the PubChem request path and resolve a different compound than the one asked for.

One finding is deliberately not addressed: a peer that trickles bytes can still hold a worker, because each partial read resets the socket timeout. That is accurate, and it is not fixable at this layer. Python threads cannot be cancelled, so an in-function deadline only takes effect between reads and does nothing for a call parked in a blocking syscall; DNS and connect are unbounded regardless of the socket timeout. An earlier revision of this PR did attempt it, with a wall-clock deadline, a stall timeout, a chunked read loop and a per-message latch for dead resolvers. Review found ten defects in that machinery, including one that failed a healthy PubChem taking six seconds to first byte with zero reads — body already in the socket buffer — and then skipped it for every remaining compound. That fires under ordinary load, where the trickle case needs a hostile upstream, so the defense was more damaging than the attack and the machinery was removed. The effective mitigation is a caller-side request deadline, filed as open-reaction-database/ord-app#825.

Because `resolve_names` and `resolve_input` share this path, the validation pipeline picks up the same bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR bounds resolver socket operations and normalizes transport failures for fallback.
- Routes PubChem, CIR, and OPSIN requests through a shared timeout- and size-aware fetch helper.
- Encodes resolver path segments and rejects blank, oversized, malformed, or prematurely terminated responses.
- Expands resolver fallback and response-handling tests.
</details>

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a trickling resolver response can still hold a worker indefinitely.

The reply from “” states that the request-wide bound was fixed with `read1()`, but current HEAD instead calls one blocking `response.read(_MAX_RESPONSE_BYTES + 1)`; a peer sending partial data within each socket-timeout interval prevents that call from returning, so the previously reported executor-exhaustion path remains.

**Files Needing Attention:** ord_schema/resolvers.py

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/resolvers.py | Centralizes resolver HTTP handling, fallback normalization, path encoding, response-size limits, and empty-response handling. |
| ord_schema/resolvers_test.py | Adds coverage for resolver fallback, transport exceptions, response framing, size limits, timeout arguments, and URL path encoding. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Name[Compound name] --> PubChem[PubChem]
  PubChem -->|failure| CIR[NCI/CADD CIR]
  CIR -->|failure| OPSIN[OPSIN]
  PubChem -->|answer| Result[SMILES]
  CIR -->|answer| Result
  OPSIN -->|answer| Result
  OPSIN -->|failure| Exhausted[ValueError]
```
</details>

<sub>Reviews (8): Last reviewed commit: ["Reject a declared body that ends early"](https://github.com/open-reaction-database/ord-schema/commit/a6f9faa156cd57b56630180bf32b73e9d0dde442) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49268256)</sub>

<!-- /greptile_comment -->
