### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!-- markdownlint-disable-file MD041 -- an h1 would be oversized as the first line of a PR body -->
+<!--
+Keep it short: the body should fit on one screen. Reviewers can read the diff, so
+spend the space on why the change is right and how you know it works.
+
+Bullets over paragraphs, and no paragraph longer than about three sentences. Don't
+restate the diff file by file, and don't narrate the review history — that belongs
+in the review thread, not the description.
+
+Delete any section you don't need, including these comments.
+-->
+
+## Summary
+
+<!--
+Two to four sentences: the problem, and what this does about it. Link the issue it
+resolves ("Closes #123") or relates to ("Part of #123").
+-->
+
+## Changes
+
+<!-- One line each, and only for things the summary doesn't already cover. -->
+
+-
+
+## Testing
+
+<!--
+What you ran, and what new coverage proves the change works. "CI is green" is not a
+test plan. Note anything you couldn't test and why.
+
+Before pushing: `uv run pytest`, plus `uv lock` if you touched `pyproject.toml` and
+`./compile_proto_wrappers.sh` if you touched `proto/`.
+-->
+
+-
+
+## Notes
+
+<!-- Optional: known gaps, deliberate omissions, follow-ups. Delete if empty. -->


### PR DESCRIPTION
### Summary

The repo has issue templates but no PR template. Recent PR bodies run long and unstructured — #920 is 5.2k characters, #887 is 10k — so this adds a default template that chunks the body into four short sections and states length budgets up front.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md`: Summary / Changes / Testing / Notes, with all guidance in HTML comments so a filled-in body renders without leftover boilerplate.
- Guidance sets explicit budgets ("fit on one screen", "two to four sentences", bullets over paragraphs) and names two anti-patterns visible in recent PRs: restating the diff file by file, and narrating review history in the description.
- Testing section reminds authors of the two steps CI catches late: `uv lock` after `pyproject.toml` changes, and `./compile_proto_wrappers.sh` after `proto/` changes, since `test_proto_wrappers` fails on wrapper drift.

### Testing

- `pre-commit run --files .github/PULL_REQUEST_TEMPLATE.md` passes; `markdownlint-cli2 "**/*.md"` reports 0 issues across all 9 files.
- This PR body is written from the template, so it doubles as the first check that the format holds.

## Notes

- `MD041` is disabled for the file. Satisfying it would put an `# h1` as the first line of every PR body; an inline disable with a reason keeps the rule active elsewhere and matches the `MD033` disable in `CONTRIBUTING.md`.
- No checklist, deliberately — it would be boilerplate on every PR, and CI already enforces the mechanical items.
- ord-data's `PULL_REQUEST_TEMPLATE/submission.md` is a data-submission template in a directory, so it doesn't conflict with a default template here. Its YAML front matter renders literally in PR bodies (GitHub strips front matter only for issue templates), which is why there's none here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a default pull request template to encourage concise, structured PR descriptions.
- Organizes descriptions into Summary, Changes, Testing, and optional Notes sections.
- Uses hidden HTML comments to provide writing and repository-specific testing guidance.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable defects identified in the new pull request template.

The change is limited to repository documentation and introduces a valid default GitHub pull request template whose guidance does not alter build, test, or runtime behavior.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/PULL_REQUEST_TEMPLATE.md | Adds clear, non-rendered author guidance and a concise four-section pull request structure without affecting runtime behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Add a pull request template"](https://github.com/open-reaction-database/ord-schema/commit/0c654fd619aea80b7610e1bd4c24dd4b736cddbf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49279565)</sub>

<!-- /greptile_comment -->