### PR TITLE
Add --shard to validate_dataset

### DIFF
--- a/ord_schema/scripts/validate_dataset.py
+++ b/ord_schema/scripts/validate_dataset.py
@@ -36,6 +36,32 @@ from ord_schema.proto import dataset_pb2
 logger = get_logger(__name__)
 
 
+def parse_shard(value: str | None) -> tuple[int, int] | None:
+    """Parses a ``--shard`` value of the form ``I/N``.
+
+    Args:
+        value: Shard specification, e.g. ``0/4``, or None for no sharding.
+
+    Returns:
+        ``(index, count)``, or None when ``value`` is None.
+
+    Raises:
+        ValueError: If ``value`` is malformed or the index is out of range.
+    """
+    if value is None:
+        return None
+    try:
+        index_text, count_text = value.split("/", 1)
+        index, count = int(index_text), int(count_text)
+    except ValueError:
+        msg = f"--shard must look like I/N; got {value!r}"
+        raise ValueError(msg) from None
+    if count < 1 or not 0 <= index < count:
+        msg = f"--shard needs 0 <= I < N; got {value!r}"
+        raise ValueError(msg)
+    return index, count
+
+
 def filter_filenames(filenames: Iterable[str], pattern: str) -> list[str]:
     """Filters filenames according to a regex pattern."""
     return [filename for filename in filenames if re.search(pattern, filename)]
@@ -110,6 +136,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--n_jobs", type=int, default=1, help="Number of parallel workers"
     )
+    parser.add_argument(
+        "--shard",
+        default=None,
+        help=(
+            "Validate part of the work, as I/N (e.g. 0/4). Tasks -- one per "
+            "parquet row group, one per pb file -- are dealt out round-robin, so "
+            "N shards cover everything between them. Dataset-level "
+            "cross-reference checks are skipped, since they need every row group "
+            "of a file at once."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -120,6 +157,30 @@ def main(args: argparse.Namespace) -> None:
     if args.filter:
         filenames = filter_filenames(filenames, args.filter)
         logger.info("Filtered to %d datasets", len(filenames))
+
+    shard = parse_shard(args.shard)
+    if shard is not None:
+        # Cross-reference checks aggregate every row group of a file: a shard
+        # holding some of them would call a reaction defined in another shard
+        # undefined, and would miss a duplicate id spanning two. Reporting
+        # nothing is the only honest option on partial state.
+        logger.warning(
+            "Shard %d/%d: per-reaction checks only. Dataset-level "
+            "cross-reference checks need every row group and are skipped; run "
+            "without --shard for those.",
+            shard[0],
+            shard[1],
+        )
+    # Dealt out round-robin over a counter that spans files, so shards stay even
+    # whether the input is one big dataset or many small ones.
+    task_index = 0
+
+    def mine() -> bool:
+        """Returns whether the next task is this shard's, advancing the counter."""
+        nonlocal task_index
+        index = task_index
+        task_index += 1
+        return shard is None or index % shard[1] == shard[0]
 
     parquet_entries: dict[str, _ParquetEntry] = {}
     failures: list[str] = []
@@ -136,15 +197,23 @@ def main(args: argparse.Namespace) -> None:
                 )
                 parquet_entries[filename] = entry
                 if footer.num_row_groups == 0:
-                    failures.extend(
-                        f"{filename}: {e}"
-                        for e in _finalize_parquet(footer, entry.state)
-                    )
+                    if shard is None:
+                        failures.extend(
+                            f"{filename}: {e}"
+                            for e in _finalize_parquet(footer, entry.state)
+                        )
                     continue
+                submitted = 0
                 for row_group in range(footer.num_row_groups):
+                    if not mine():
+                        continue
                     future = executor.submit(_validate_row_group, filename, row_group)
                     futures[future] = ("parquet", filename, row_group)
-            else:
+                    submitted += 1
+                # Only the row groups this shard runs can count down towards
+                # finalization; the rest belong to other shards.
+                entry.remaining = submitted
+            elif mine():
                 future = executor.submit(_validate_pb, filename)
                 futures[future] = ("pb", filename, None)
 
@@ -159,7 +228,7 @@ def main(args: argparse.Namespace) -> None:
                 entry = parquet_entries[filename]
                 entry.state.merge(state)
                 entry.remaining -= 1
-                if entry.remaining == 0:
+                if entry.remaining == 0 and shard is None:
                     failures.extend(
                         f"{filename}: {error}"
                         for error in _finalize_parquet(entry.footer, entry.state)

--- a/ord_schema/scripts/validate_dataset.py
+++ b/ord_schema/scripts/validate_dataset.py
@@ -96,6 +96,28 @@ def _validate_row_group(
     return errors, state
 
 
+def _cross_ref_state(filename: str) -> validations.DatasetCrossRefState:
+    """Builds a file's complete cross-reference state, decoding but not validating.
+
+    Cross-reference checks need every reaction in the file at once, which a shard
+    holding a subset of row groups cannot supply. Reading them is cheap next to
+    validating them -- on ord-data's 1.77M-reaction uspto parquet this pass takes
+    about 20 seconds against the ~52 CPU-minutes of validate_message -- so one
+    shard runs it over the whole file rather than the checks being skipped.
+
+    Args:
+        filename: Parquet dataset to scan.
+
+    Returns:
+        Aggregated cross-reference observations for every reaction in the file.
+    """
+    silence_rdkit_logs()
+    state = validations.DatasetCrossRefState()
+    for _, reaction in parquet.iter_reactions(filename):
+        state.observe(reaction)
+    return state
+
+
 def _finalize_parquet(
     footer: parquet.ParquetFooter, state: validations.DatasetCrossRefState
 ) -> list[str]:
@@ -160,16 +182,13 @@ def main(args: argparse.Namespace) -> None:
 
     shard = parse_shard(args.shard)
     if shard is not None:
-        # Cross-reference checks aggregate every row group of a file: a shard
-        # holding some of them would call a reaction defined in another shard
-        # undefined, and would miss a duplicate id spanning two. Reporting
-        # nothing is the only honest option on partial state.
-        logger.warning(
-            "Shard %d/%d: per-reaction checks only. Dataset-level "
-            "cross-reference checks need every row group and are skipped; run "
-            "without --shard for those.",
+        logger.info(
+            "Shard %d/%d of the per-reaction checks%s",
             shard[0],
             shard[1],
+            "; also running the dataset-level cross-reference pass"
+            if shard[0] == 0
+            else "",
         )
     # Dealt out round-robin over a counter that spans files, so shards stay even
     # whether the input is one big dataset or many small ones.
@@ -196,6 +215,13 @@ def main(args: argparse.Namespace) -> None:
                     state=validations.DatasetCrossRefState(),
                 )
                 parquet_entries[filename] = entry
+                # Dataset-level checks need every reaction in the file at once.
+                # Unsharded they fall out of merging the row-group states below;
+                # sharded, no one shard holds them all, so shard 0 makes a single
+                # cheap pass over the whole file instead.
+                if shard is not None and shard[0] == 0:
+                    future = executor.submit(_cross_ref_state, filename)
+                    futures[future] = ("crossref", filename, None)
                 if footer.num_row_groups == 0:
                     if shard is None:
                         failures.extend(
@@ -222,6 +248,13 @@ def main(args: argparse.Namespace) -> None:
             kind, filename, _ = futures[future]
             if kind == "pb":
                 failures.extend(f"{filename}: {error}" for error in future.result())
+            elif kind == "crossref":
+                failures.extend(
+                    f"{filename}: {error}"
+                    for error in _finalize_parquet(
+                        parquet_entries[filename].footer, future.result()
+                    )
+                )
             else:
                 errors, state = future.result()
                 failures.extend(f"{filename}: {error}" for error in errors)

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -203,3 +203,73 @@ def test_filter_filenames(pattern, expected):
         "data/1a/foo.pb",
     ]
     assert expected == validate_dataset.filter_filenames(filenames, pattern)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, None), ("0/1", (0, 1)), ("0/4", (0, 4)), ("3/4", (3, 4))],
+)
+def test_parse_shard(value, expected):
+    assert validate_dataset.parse_shard(value) == expected
+
+
+@pytest.mark.parametrize("value", ["", "1", "4/", "/4", "a/4", "4/4", "-1/4", "0/0"])
+def test_parse_shard_rejects_malformed(value):
+    with pytest.raises(ValueError, match="--shard"):
+        validate_dataset.parse_shard(value)
+
+
+def _sharded_dataset(tmp_path, name):
+    """Writes a 4-row-group parquet whose third row group holds an invalid reaction."""
+    reactions = [_valid_reaction() for _ in range(7)]
+    reactions.append(reaction_pb2.Reaction())  # invalid: no inputs / no outcomes
+    path = tmp_path / name
+    with parquet.DatasetWriter(
+        str(path), name="test", description="test", row_group_size=2
+    ) as writer:
+        writer.write_all(reactions)
+    assert parquet.num_row_groups(str(path)) == 4
+    return path
+
+
+def test_shard_covers_every_row_group_between_them(tmp_path):
+    """Some shard must catch an error, and exactly the shard holding it."""
+    path = _sharded_dataset(tmp_path, "sharded.parquet")
+    failing = []
+    for index in range(4):
+        try:
+            validate_dataset.main(
+                validate_dataset.parse_args(
+                    ["--input_pattern", str(path), "--shard", f"{index}/4"]
+                )
+            )
+        except validations.ValidationError:
+            failing.append(index)
+    # The invalid reaction is the 8th of 8, so it lands in the last row group,
+    # which round-robin deals to shard 3.
+    assert failing == [3]
+
+
+def test_shard_skips_dataset_level_checks(tmp_path):
+    """A duplicate id spanning row groups is dataset-level, so a shard stays quiet."""
+    reaction = _valid_reaction()
+    reaction.reaction_id = "ord-0000000000000000000000000000000a"
+    path = tmp_path / "duplicate.parquet"
+    with parquet.DatasetWriter(
+        str(path), name="test", description="test", row_group_size=1
+    ) as writer:
+        writer.write_all([reaction, reaction])
+    assert parquet.num_row_groups(str(path)) == 2
+    # Unsharded, the duplicate is reported.
+    with pytest.raises(validations.ValidationError, match=r"[Dd]uplicate"):
+        validate_dataset.main(
+            validate_dataset.parse_args(["--input_pattern", str(path)])
+        )
+    # Sharded, each shard sees one copy and must not guess: reporting a
+    # duplicate, or an undefined cross-reference, would be wrong on partial state.
+    for index in range(2):
+        validate_dataset.main(
+            validate_dataset.parse_args(
+                ["--input_pattern", str(path), "--shard", f"{index}/2"]
+            )
+        )

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -250,8 +250,8 @@ def test_shard_covers_every_row_group_between_them(tmp_path):
     assert failing == [3]
 
 
-def test_shard_skips_dataset_level_checks(tmp_path):
-    """A duplicate id spanning row groups is dataset-level, so a shard stays quiet."""
+def test_shard_zero_runs_dataset_level_checks(tmp_path):
+    """A duplicate id spanning row groups must still be caught when sharded."""
     reaction = _valid_reaction()
     reaction.reaction_id = "ord-0000000000000000000000000000000a"
     path = tmp_path / "duplicate.parquet"
@@ -265,11 +265,41 @@ def test_shard_skips_dataset_level_checks(tmp_path):
         validate_dataset.main(
             validate_dataset.parse_args(["--input_pattern", str(path)])
         )
-    # Sharded, each shard sees one copy and must not guess: reporting a
-    # duplicate, or an undefined cross-reference, would be wrong on partial state.
-    for index in range(2):
+    # No shard holds both copies, so the check cannot come from merging their
+    # partial state. Shard 0 makes its own pass over the whole file and catches
+    # it; the other shard reports only its own per-reaction findings.
+    with pytest.raises(validations.ValidationError, match=r"[Dd]uplicate"):
         validate_dataset.main(
             validate_dataset.parse_args(
-                ["--input_pattern", str(path), "--shard", f"{index}/2"]
+                ["--input_pattern", str(path), "--shard", "0/2"]
+            )
+        )
+    validate_dataset.main(
+        validate_dataset.parse_args(["--input_pattern", str(path), "--shard", "1/2"])
+    )
+
+
+def test_shard_zero_catches_cross_file_reference(tmp_path):
+    """An undefined cross-reference is found even from another shard's slice."""
+    defined = _valid_reaction()
+    defined.reaction_id = "ord-0000000000000000000000000000000a"
+    referring = _valid_reaction()
+    referring.reaction_id = "ord-0000000000000000000000000000000b"
+    component = referring.inputs["dummy_input"].components[0]
+    component.preparations.add(
+        type="SYNTHESIZED", reaction_id="ord-000000000000000000000000000000ff"
+    )
+    path = tmp_path / "crossref.parquet"
+    with parquet.DatasetWriter(
+        str(path), name="test", description="test", row_group_size=1
+    ) as writer:
+        writer.write_all([defined, referring])
+    assert parquet.num_row_groups(str(path)) == 2
+    # Shard 0 owns row group 0, so the referring reaction is not even in its
+    # slice -- the finding can only come from its whole-file cross-ref pass.
+    with pytest.raises(validations.ValidationError, match="undefined reaction_ids"):
+        validate_dataset.main(
+            validate_dataset.parse_args(
+                ["--input_pattern", str(path), "--shard", "0/2"]
             )
         )

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -303,3 +303,40 @@ def test_shard_zero_catches_cross_file_reference(tmp_path):
                 ["--input_pattern", str(path), "--shard", "0/2"]
             )
         )
+
+
+def test_sharded_and_unsharded_report_the_same_findings(tmp_path):
+    """The merge path and shard 0's whole-file pass must not drift apart.
+
+    Dataset-level state is assembled two ways -- merged from per-row-group
+    observations when unsharded, and from one pass over the file on shard 0 --
+    and both feed the same finalizer. Nothing else forces them to agree.
+    """
+    reaction = _valid_reaction()
+    reaction.reaction_id = "ord-0000000000000000000000000000000a"
+    referring = _valid_reaction()
+    referring.reaction_id = "ord-0000000000000000000000000000000b"
+    referring.inputs["dummy_input"].components[0].preparations.add(
+        type="SYNTHESIZED", reaction_id="ord-000000000000000000000000000000ff"
+    )
+    path = tmp_path / "both.parquet"
+    with parquet.DatasetWriter(
+        str(path), name="test", description="test", row_group_size=1
+    ) as writer:
+        writer.write_all([reaction, reaction, referring])
+
+    def findings(argv):
+        try:
+            validate_dataset.main(validate_dataset.parse_args(argv))
+        except validations.ValidationError as error:
+            return {
+                line.split("Dataset: ", 1)[1]
+                for line in str(error).splitlines()
+                if "Dataset: " in line
+            }
+        return set()
+
+    unsharded = findings(["--input_pattern", str(path)])
+    sharded = findings(["--input_pattern", str(path), "--shard", "0/3"])
+    assert unsharded, "expected the duplicate and the undefined reference"
+    assert sharded == unsharded


### PR DESCRIPTION
## Summary

Validating ord-data's uspto grants parquet takes 69–93 minutes: 1,772 row groups across the four workers a standard GitHub runner provides. The work is already one task per row group, so it splits cleanly across machines — there was simply no way to ask for part of it.

`--shard I/N` deals tasks out round-robin over a counter spanning files, so N shards cover everything between them whether the input is one large dataset or many small ones. Useful locally for fast feedback on a slice, and it makes a CI matrix possible without paying for a larger runner.

## Changes

- `parse_shard` accepts `I/N`, rejecting malformed values and out-of-range indices.
- `--shard` selects tasks by index; `entry.remaining` counts only the row groups a shard actually runs.
- Shard 0 additionally makes one pass over each whole parquet file to run the dataset-level cross-reference checks, which no shard can derive from its own slice.

## Testing

- `parse_shard` accepts `0/1`, `0/4`, `3/4`, `None`; rejects `""`, `1`, `4/`, `/4`, `a/4`, `4/4`, `-1/4`, `0/0`.
- Coverage: a 4-row-group dataset whose last row group holds an invalid reaction is validated as `0/4` … `3/4`; exactly shard 3 fails, so the error is caught once and by the shard that owns it.
- A duplicate reaction id split across two row groups is caught by shard 0 when sharded, and by the ordinary merge path when not.
- A reaction referring to an undefined id is caught by shard 0 even though the referring reaction lives in a row group shard 0 does not own — the case that can only come from the whole-file pass.
- 56 script tests pass; `ruff check` and `ruff format --check` clean. `ty` reports 41 diagnostics, identical to `main` with these changes stashed and none in this file.

## Notes

An earlier revision skipped the dataset-level checks when sharding, on the grounds that collecting cross-reference state needs decoded Reactions and that was the expensive part. Measurement says otherwise, on the real 1.77M-reaction file:

| pass | whole file, 1 core |
| --- | --- |
| `reaction_id` column only | 0.5 s |
| decode every Reaction | ~0.2 min |
| decode + `state.observe` | ~0.3 min |
| `validate_message` | ~52 min |

The cost is RDKit validation, not deserialization, so the checks were being dropped to save about twenty seconds. Shard 0 running them over the whole file keeps sharded and unsharded runs reporting the same thing.

One designated shard doing a whole-file pass also beats merging partial state across machines: no artifact plumbing between jobs, and correctness does not depend on every shard reporting back.

No caller changes here — ord-data's `validation.yml` keeps running unsharded.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds round-robin task sharding to the dataset-validation CLI while retaining complete dataset-level Parquet validation on shard 0.
- Parses and validates `--shard I/N`.
- Distributes Parquet row groups and protobuf files across shards using a global task counter.
- Adds a whole-file cross-reference pass on shard 0 and test coverage for shard ownership and dataset-level findings.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/scripts/validate_dataset.py | Adds shard parsing, round-robin task assignment, and shard-0 whole-file dataset finalization. |
| ord_schema/scripts/validate_dataset_test.py | Covers shard parsing, row-group partitioning, and parity of dataset-level findings between sharded and unsharded validation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Input[Matched dataset files] --> Kind{File type}
  Kind -->|PB| PBShard{Task belongs to shard?}
  PBShard -->|Yes| PBValidate[Validate whole protobuf dataset]
  Kind -->|Parquet| Groups[Enumerate row groups]
  Groups --> GroupShard{Row group belongs to shard?}
  GroupShard -->|Yes| ReactionChecks[Run per-reaction validation]
  Kind -->|Parquet and shard 0| WholePass[Build complete cross-reference state]
  WholePass --> Finalize[Run dataset-level validation]
  PBValidate --> Results[Aggregate failures]
  ReactionChecks --> Results
  Finalize --> Results
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Pin that both ways of building cross-ref..."](https://github.com/open-reaction-database/ord-schema/commit/f3d80a29145a3df0665c83049cab2dffb49ec483) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49427855)</sub>

**Context used:**

- Knowledge Base — [Dataset Scripts](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/dataset-scripts.md)

<!-- /greptile_comment -->