### PR TITLE
Report unreadable datasets against the file, not the run

### DIFF
--- a/ord_schema/scripts/validate_dataset.py
+++ b/ord_schema/scripts/validate_dataset.py
@@ -26,6 +26,7 @@ import re
 import warnings
 from collections.abc import Iterable
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
 
 from tqdm import tqdm
 
@@ -35,10 +36,35 @@ from ord_schema.proto import dataset_pb2
 
 logger = get_logger(__name__)
 
+# Header of an unsmudged Git LFS pointer. Datasets in ord-data are LFS objects,
+# so a checkout that skipped `git lfs pull` leaves these small text files in
+# place of content, and each format's parser then fails on them in its own
+# confusing way (gzip reports a bad magic number, parquet a missing footer).
+_LFS_POINTER_HEADER = b"version https://git-lfs.github.com/spec/"
+
 
 def filter_filenames(filenames: Iterable[str], pattern: str) -> list[str]:
     """Filters filenames according to a regex pattern."""
     return [filename for filename in filenames if re.search(pattern, filename)]
+
+
+def _is_lfs_pointer(filename: str) -> bool:
+    """Tests whether a file holds a Git LFS pointer rather than dataset content."""
+    try:
+        with Path(filename).open("rb") as f:
+            return f.read(len(_LFS_POINTER_HEADER)) == _LFS_POINTER_HEADER
+    except OSError:
+        return False
+
+
+def _describe_failure(filename: str, error: BaseException) -> str:
+    """Formats a file that could not be read or parsed at all."""
+    if _is_lfs_pointer(filename):
+        return (
+            f"{filename}: file is a Git LFS pointer, not dataset content; "
+            "run `git lfs pull` to fetch it"
+        )
+    return f"{filename}: {type(error).__name__}: {error}"
 
 
 def _validate_pb(filename: str) -> list[str]:
@@ -128,7 +154,13 @@ def main(args: argparse.Namespace) -> None:
         futures: dict = {}
         for filename in filenames:
             if filename.endswith(".parquet"):
-                footer = parquet.load_footer(filename)
+                try:
+                    footer = parquet.load_footer(filename)
+                # A file this job cannot read at all is that file's failure, not
+                # the run's: record it and keep validating the rest.
+                except Exception as error:  # noqa: BLE001
+                    failures.append(_describe_failure(filename, error))
+                    continue
                 entry = _ParquetEntry(
                     remaining=footer.num_row_groups,
                     footer=footer,
@@ -151,10 +183,20 @@ def main(args: argparse.Namespace) -> None:
         total_tasks = len(futures)
         for future in tqdm(as_completed(futures), total=total_tasks):
             kind, filename, _ = futures[future]
+            try:
+                result = future.result()
+            # As above: attribute an unreadable or unparseable file to itself.
+            # A parquet row group that fails this way leaves `remaining` above
+            # zero, which skips the dataset-level check for that file -- correct,
+            # since the aggregated state is incomplete and the file already
+            # counts as failed.
+            except Exception as error:  # noqa: BLE001
+                failures.append(_describe_failure(filename, error))
+                continue
             if kind == "pb":
-                failures.extend(f"{filename}: {error}" for error in future.result())
+                failures.extend(f"{filename}: {error}" for error in result)
             else:
-                errors, state = future.result()
+                errors, state = result
                 failures.extend(f"{filename}: {error}" for error in errors)
                 entry = parquet_entries[filename]
                 entry.state.merge(state)

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -185,6 +185,54 @@ def test_parquet_per_reaction_error_in_late_row_group(tmp_path):
         )
 
 
+_LFS_POINTER = (
+    b"version https://git-lfs.github.com/spec/v1\n"
+    b"oid sha256:4d7a214614ab2935c943f9e0ff69d22eadbb8f32b1258daaa5e2ca24d17e2393\n"
+    b"size 261136\n"
+)
+
+
+@pytest.mark.parametrize("suffix", [".pb.gz", ".pbtxt", ".parquet"])
+def test_lfs_pointer_names_the_file_and_the_remedy(tmp_path, suffix):
+    """An unsmudged LFS pointer reports as such, not as a format-specific error."""
+    path = tmp_path / f"pointer{suffix}"
+    path.write_bytes(_LFS_POINTER)
+    with pytest.raises(validations.ValidationError) as excinfo:
+        validate_dataset.main(
+            validate_dataset.parse_args(["--input_pattern", str(path)])
+        )
+    message = str(excinfo.value)
+    assert str(path) in message
+    assert "Git LFS pointer" in message
+    assert "git lfs pull" in message
+
+
+def test_unreadable_file_is_attributed_and_does_not_stop_the_sweep(tmp_path):
+    """A corrupt file is reported against itself; other files are still validated."""
+    corrupt = tmp_path / "corrupt.pb.gz"
+    corrupt.write_bytes(b"not gzip, not a proto, not anything")
+    invalid = tmp_path / "invalid.pbtxt"
+    datasets.save_dataset(
+        dataset_pb2.Dataset(
+            name="test", description="test", reactions=[reaction_pb2.Reaction()]
+        ),
+        invalid,
+    )
+    with pytest.raises(validations.ValidationError) as excinfo:
+        validate_dataset.main(
+            validate_dataset.parse_args(
+                ["--input_pattern", str(tmp_path / "*"), "--n_jobs", "2"]
+            )
+        )
+    message = str(excinfo.value)
+    # The corrupt file is named, and identified as a read failure rather than
+    # misreported as a Git LFS pointer.
+    assert str(corrupt) in message
+    assert "Git LFS pointer" not in message
+    # The sweep continued past it and validated the other file.
+    assert "Reactions should have at least 1 reaction input" in message
+
+
 @pytest.mark.parametrize(
     ("pattern", "expected"),
     [


### PR DESCRIPTION
## Summary

`validate_dataset.py` let a file it could not read at all escape as a raw traceback from `future.result()`, naming whichever parser choked first rather than the file. The common trigger is an unsmudged Git LFS pointer — ord-data's datasets are LFS objects, so a checkout that skipped `git lfs pull` leaves 130-byte text files in their place and the error reads `gzip.BadGzipFile: Not a gzipped file (b've')`. That aborted the whole sweep and pointed at gzip instead of at LFS.

Found while reworking ord-data's validation workflow to run this script out of the installed wheel (open-reaction-database/ord-data#280).

## Changes

- Collect read/parse failures against their filename like any other failure, so a run reports every bad file instead of stopping at the first.
- Identify a Git LFS pointer by name and give the command that fixes it, for pb and parquet alike.
- Catch the parquet read in the parent process too, which had the same behavior.

## Testing

`pytest ord_schema/scripts` (26 passed), plus the full suite (650 non-ORM, 56 ORM). `ruff check`/`format`, `ty`, and `pre-commit` all clean.

Four new tests, all confirmed to fail against the unmodified script and pass with it: an LFS pointer named `.pb.gz` / `.pbtxt` / `.parquet` reports as a pointer with the remedy, and a corrupt file alongside an invalid dataset is attributed to itself while the sweep continues and still reports the other file's validation error.

## Notes

Rebased onto the Parquet API consolidation (#930-#934). The parent-process read this guards was `parquet.load_footer`, which no longer exists; it is now `parquet.DatasetView(filename)`, which reads the same footer and raises the same way. LFS detection sniffs the file header rather than the exception type, so it is unaffected.

(#922 is closed, so the rebase note that was here no longer applies.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes dataset validation collect unreadable-file errors instead of aborting the entire sweep.
- Attributes read and parse failures to the affected filename.
- Detects unsmudged Git LFS pointers and reports the remediation command.
- Covers synchronous Parquet footer loading and asynchronous worker failures.
- Adds tests for protobuf, text-protobuf, and Parquet pointers plus continued validation after corruption.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/scripts/validate_dataset.py | Adds filename-aware read-failure collection and Git LFS pointer diagnostics across protobuf and Parquet validation paths. |
| ord_schema/scripts/validate_dataset_test.py | Adds coverage for LFS pointer diagnostics and for continuing a multi-file validation sweep after an unreadable input. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/mai..."](https://github.com/open-reaction-database/ord-schema/commit/4b28a5a10b3dc54336ee33776e87ae96826bad6e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49519437)</sub>

**Context used:**

- Knowledge Base — [Dataset Scripts](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/dataset-scripts.md)

<!-- /greptile_comment -->