### PR TITLE
Tighten docstrings and comments across ord_schema

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -988,7 +988,8 @@ def id_filename(filename: str) -> str:
     if not shard.isalnum():
         raise ValueError(f"basename shard must be alphanumeric: {basename}")
     result = posixpath.join("data", shard, basename)
-    # Defense-in-depth: mirror what werkzeug.security.safe_join used to check.
+    # Defense in depth: basename carries no separator and shard is alphanumeric, so
+    # this is redundant -- but it is what pins the result inside the "data/" root.
     if posixpath.normpath(result) != result or not result.startswith("data/"):
         raise ValueError(f"unsafe path from basename: {basename}")
     return result

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -290,7 +290,8 @@ def smiles_from_compound(
 ) -> str:
     """Fetches or generates a SMILES identifier for a compound.
 
-    If a SMILES identifier already exists, it is simply returned.
+    An existing SMILES identifier is used in preference to regenerating one from the
+    structure, but it is still canonicalized when ``canonical`` is True.
 
     Args:
         compound: reaction_pb2.Compound or reaction_pb2.ProductCompound message.

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -205,7 +205,7 @@ def test_update_derived_tables_sharded_covers_all(prepared_engine):
         if sharded[table] >= 2 * num_shards:
             non_empty = sum(1 for shard in per_shard if shard[table] > 0)
             assert non_empty >= 2, (table, [shard[table] for shard in per_shard])
-    # A whole-dataset pass now adds nothing: the shards covered every row.
+    # A whole-dataset pass adds nothing: the shards already covered every row.
     with Session(prepared_engine) as session, session.begin():
         update_derived_tables(dataset.dataset_id, session)
     assert counts() == sharded
@@ -275,8 +275,8 @@ def test_rdkit_sharded_matches_serial(prepared_engine):
         "linked_products",
     ):
         assert sharded[key] > 0, (key, sharded)
-    # A serial (whole-dataset) pass now inserts and links nothing new: the shards
-    # covered it all.
+    # A serial (whole-dataset) pass inserts and links nothing new: the shards
+    # already covered it all.
     run_shard(None)
     assert counts() == sharded
 
@@ -323,7 +323,7 @@ def test_classify_sharded_covers_all(prepared_engine):
     # into more than one of the 4 buckets, so this holds for it (a 1-reaction fixture
     # would not).
     assert 0 < first < sharded, (first, sharded)
-    # A whole-dataset pass now adds nothing: the shards classified every reaction.
+    # A whole-dataset pass adds nothing: the shards already classified every reaction.
     with Session(prepared_engine) as session, session.begin():
         classify_dataset(dataset.dataset_id, session)
     assert count() == sharded

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -588,8 +588,8 @@ def load_datasets(
         # Datasets are processed serially (the rdkit.* dedup tables are shared, so
         # cross-dataset concurrency could collide on the same structure), but each
         # dataset's pass is sharded by SMILES hash across the pool -- disjoint
-        # partitions keep concurrent inserts off each other's rdkit.* keys, so one large
-        # dataset no longer runs single-threaded.
+        # partitions keep concurrent inserts off each other's rdkit.* keys, so even a
+        # single large dataset occupies the whole pool.
         engine = create_engine(dsn)
         try:
             for dataset_id in tqdm(dataset_ids, desc="RDKit"):

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -588,8 +588,8 @@ def load_datasets(
         # Datasets are processed serially (the rdkit.* dedup tables are shared, so
         # cross-dataset concurrency could collide on the same structure), but each
         # dataset's pass is sharded by SMILES hash across the pool -- disjoint
-        # partitions keep concurrent inserts off each other's rdkit.* keys, so even a
-        # single large dataset occupies the whole pool.
+        # partitions keep concurrent inserts off each other's rdkit.* keys, allowing a
+        # single large dataset to use multiple workers.
         engine = create_engine(dsn)
         try:
             for dataset_id in tqdm(dataset_ids, desc="RDKit"):

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -106,8 +106,8 @@ def resolve_names(message: ord_schema.Message) -> bool:
     """Attempts to resolve compound NAME identifiers to SMILES.
 
     When a NAME identifier is resolved, a SMILES identifier is added to the list
-    of identifiers for that compound. Note that this function moves on to the
-    next Compound after the first successful name resolution.
+    of identifiers for that compound. The first success ends work on that
+    Compound; any remaining NAME identifiers on it are left unresolved.
 
     Args:
         message: Protocol buffer tree containing Compound submessages (e.g. Reaction
@@ -283,8 +283,8 @@ def resolve_input(input_string: str) -> reaction_pb2.ReactionInput:
 # that lookup services may not index.
 #
 # eMolecules' public /lookup?q= endpoint is unusable (it always replies "__END__";
-# their current API requires authentication), and ChemSpider now requires a
-# registered RSC API key, so neither is included.
+# their current API requires authentication), and ChemSpider requires a registered
+# RSC API key, so neither is included.
 _NAME_RESOLVERS = {
     "PubChem API": _pubchem_resolve,
     "NCI/CADD CIR": _cactus_resolve,

--- a/ord_schema/templating.py
+++ b/ord_schema/templating.py
@@ -37,9 +37,10 @@ def load_spreadsheet(
     """Reads a {csv, xls, xlsx} spreadsheet file.
 
     Args:
-        file_name_or_buffer: Filename or buffer. Note that a buffer is only
-            allowed if suffix is not None.
-        suffix: Filename suffix, used to determine the data encoding.
+        file_name_or_buffer: Filename, or an open binary buffer. A buffer
+            requires ``suffix``, since there is no name to read it from.
+        suffix: Filename suffix, used to determine the data encoding. Anything
+            other than ".xls" or ".xlsx" is read as CSV.
 
     Returns:
         DataFrame containing the reaction spreadsheet data.
@@ -77,13 +78,13 @@ def _fill_template(
 
     These edits are logged for easier error checking.
 
-    Note that these edits are focused on *inputs* and are not intended to be
-    exhaustive (e.g. by covering all Compound messages anywhere in Reaction).
+    These edits cover *inputs* only; Compound messages elsewhere in the Reaction
+    are left alone.
 
     Args:
-        string: A string whose contents should be modified.
-        substitutions: A dictionary where each (key, value) pair defines
-            a substring to replace and what its replacement should be.
+        string: Reaction pbtxt containing placeholder substrings to replace.
+        substitutions: Maps each placeholder substring to its replacement. A null
+            value triggers the pruning edits described above.
 
     Returns:
         Reaction message with substitutions filled in.
@@ -139,8 +140,8 @@ def generate_dataset(
             may only use letters, numbers, and underscores.
         df: Pandas Dataframe where each row corresponds to one reaction and
             column names match placeholders in the template_string.
-        validate: Optional Boolean controlling whether Reaction messages should
-            be validated as they are defined. Defaults to True.
+        validate: If True, validate each enumerated Reaction and raise on the
+            first one with errors.
 
     Returns:
         A Dataset message.
@@ -164,7 +165,8 @@ def generate_dataset(
     reactions = []
     for _, substitutions in df[list(placeholders)].iterrows():
         reaction = _fill_template(template_string, substitutions)
-        # remove the reaction id field if reaction exits to avoid id conflicts
+        # Clear any templated reaction_id so the enumerated reactions do not
+        # all share one ID.
         if reaction.reaction_id:
             reaction.ClearField("reaction_id")
 

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -25,8 +25,8 @@ from ord_schema.proto import reaction_pb2
 # there is no public google.protobuf type for “any enum member” in Python.
 ProtoEnumMember: TypeAlias = int
 
-# Accepted synonyms for units. Note that all values will be converted to
-# lowercase.
+# Accepted synonyms for units. Both these entries and the string being resolved are
+# lowercased before matching, so the casing below is decorative.
 _UNIT_SYNONYMS: dict[type[ord_schema.UnitMessage], dict[ProtoEnumMember, list[str]]] = {
     reaction_pb2.Time: {
         reaction_pb2.Time.DAY: ["d", "day", "days"],
@@ -266,16 +266,14 @@ class UnitResolver:
         """Initializes a UnitResolver.
 
         Args:
-            unit_synonyms: A dictionary of dictionaries that defines, for each
-                message type (first key) and for each unit option (second key),
-                a list of strings that defines how that unit can be written.
-                Defaults to None. If None, uses default _UNIT_SYNONYMS dict.
-            forbidden_units: A dictionary where each key is a string that is a
-                plausible way of writing a unit and a value explaining why
-                the UnitResolver cannot resolve that unit. The prototypical
-                case is one of ambiguity (e.g., "m" can mean meter or minute).
-                Defaults to None. If None, uses default _FORBIDDEN_UNITS dict.
-                If no units are forbidden, an empty dictionary should be used.
+            unit_synonyms: Maps message type, then unit enum member, to the
+                strings that spell that unit. Entries are lowercased while the
+                lookup table is built, and two units may not claim the same
+                spelling. Defaults to ``_UNIT_SYNONYMS``.
+            forbidden_units: Maps a plausible spelling to the reason it cannot
+                be resolved; the prototypical case is ambiguity (e.g. "m" can
+                mean meter or minute). Defaults to ``_FORBIDDEN_UNITS``; pass an
+                empty dictionary to forbid nothing.
         """
         if unit_synonyms is None:
             unit_synonyms = _UNIT_SYNONYMS

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -155,23 +155,24 @@ def validate_message(
     enforced in the schema (e.g., non-negativity of certain measurements,
     consistency of cross-referenced keys).
 
-    Note that the message may be modified in-place with any unambiguous changes
-    needed to ensure validity.
+    The message may be modified in place with any unambiguous changes needed to
+    ensure validity.
 
     Args:
         message: A message to validate.
-        recurse: A boolean that controls whether submessages of message (i.e.,
-            fields that are messages) should also be validated. Defaults to
-            True.
+        recurse: If True, also validate submessages, meaning fields that are
+            themselves messages.
         raise_on_error: If True, raises a ValidationError exception when errors
             are encountered. If False, the user must manually check the return
             value to identify validation errors.
-        options: ValidationOptions.
+        options: Toggles for the checks that are not always applied; see
+            ``ValidationOptions``.
         trace: Tuple containing a string "stack trace" to track the position of
             the current message relative to the recursion root.
 
     Returns:
-        ValidationOutput.
+        Errors and warnings accumulated over the message and, when recursing,
+        its submessages.
 
     Raises:
         ValidationError: If any fields are invalid.
@@ -181,10 +182,9 @@ def validate_message(
         assert root_desc is not None  # Type hint.
         trace = (root_desc.name,)
     output = ValidationOutput()
-    # Recurse through submessages
     if recurse:
         for field, value in message.ListFields():
-            if field.type == field.TYPE_MESSAGE:  # need to recurse
+            if field.type == field.TYPE_MESSAGE:
                 _validate_message(
                     field=field,
                     value=value,
@@ -238,13 +238,13 @@ def _validate_message(
         raise_on_error: If True, raises a ValidationError exception when errors
             are encountered. If False, the user must manually check the return
             value to identify validation errors.
-        options: ValidationOptions.
+        options: Toggles for the checks that are not always applied; see
+            ``ValidationOptions``.
         trace: Tuple containing a string "stack trace" to track the position of
             the current message relative to the recursion root.
     """
     if field.label == field.LABEL_REPEATED:
-        if field.message_type.GetOptions().map_entry:  # map
-            # value is message
+        if field.message_type.GetOptions().map_entry:
             if field.message_type.fields_by_name["value"].type == field.TYPE_MESSAGE:
                 for key, submessage in value.items():
                     this_trace = (*trace, f'{field.name}["{key}"]')

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -285,7 +285,7 @@ def test_reaction_smiles():
     output = _run_validation(message)
     assert len(output.errors) == 0
     assert len(output.warnings) == 0
-    # Now disable the exception for reaction SMILES only.
+    # With allow_reaction_smiles_only off, the same message must fail.
     options = validations.ValidationOptions()
     options.allow_reaction_smiles_only = False
     with pytest.raises(validations.ValidationError, match="reaction input"):
@@ -538,7 +538,8 @@ def test_compound_identifier_is_validated_as_recorded(value):
 
 @pytest.mark.parametrize("identifier_type", ["REACTION_SMILES", "REACTION_CXSMILES"])
 def test_empty_reaction_identifier_reports_rather_than_raises(identifier_type):
-    # An empty CXSMILES value used to index off the end of an empty token list.
+    # An empty value tokenizes to nothing, so the check must report it rather than
+    # indexing off the end of the token list.
     message = reaction_pb2.ReactionIdentifier(type=identifier_type, value="")
     output = _run_validation(message, raise_on_error=False)
     assert any("value must be set" in error for error in output.errors)


### PR DESCRIPTION
## Summary

A prose-only pass over `ord_schema`: comments and docstrings now state what the code does, not the change that produced it, and thin `Args:` entries say something a caller can use. The pass also turned up one docstring that was outright wrong — `smiles_from_compound` claimed an existing SMILES identifier "is simply returned", but `canonical=True` is the default and re-canonicalizes it first.

Deliberately small at +50/-48. Most of what a history-narration grep flags in this repo is standing design rationale, which is worth keeping.

## Changes

- Rewrite four transition notes as standing facts: "no longer runs single-threaded" → what the sharding actually buys, "ChemSpider now requires" → drops the "now", and the regression comment in `validations_test.py` says what the test guards instead of what used to break.
- Change three `# A whole-dataset pass now adds nothing` test comments to `already covered`, so they read as within-test sequencing rather than as history.
- Correct the `smiles_from_compound` docstring to say an existing identifier is preferred over regenerating one, but is still canonicalized when `canonical` is True.
- Expand bare type-restatement `Args:` entries (`options: ValidationOptions.`, `unit_synonyms: A dictionary of dictionaries...`) into what the caller needs: fallbacks, the duplicate-spelling constraint, and that an empty dict forbids nothing.
- Record in `units.py` that the synonym table's casing is decorative — both the table and the input string are lowercased before matching, so `"mL"` and `"ml"` are the same key.
- Drop comments that restate the next line (`# value is message`, `# need to recurse`) and the "Note that" openers.
- Fix a typo in a `templating.py` comment being rewritten anyway ("if reaction exits").

## Testing

- `uv run pytest -n auto` — 660 passed, 2 skipped.
- Verified no behavior change mechanically: parsed every touched file before and after, stripped docstrings, and compared the ASTs. Identical in all 8. The only executable lines in the diff are two trailing-comment removals, where the code before the `#` is byte-identical.
- `ruff format --check` and `ruff check` pass; pre-commit ran `ruff` and `ty` clean.

## Notes

- Resolved the `message_helpers.py` werkzeug question rather than leaving it open. Not switching to `werkzeug.utils.safe_join`: it would add a WSGI toolkit as a direct dependency to replace two lines of `posixpath`, it returns `None` rather than raising so it is not a drop-in, and the guard here is already tighter (`basename` comes from `Path(filename).name` and cannot hold a separator; `shard` is `.isalnum()`-gated). The comment now states the invariant it enforces instead of citing a module path that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR clarifies comments and docstrings across `ord_schema` without changing executable behavior.
- Corrects the documented canonicalization behavior of `smiles_from_compound`.
- Rewords ORM sharding comments to describe actual worker utilization accurately.
- Expands caller-facing documentation for validation options, unit synonyms, spreadsheet loading, and templating.
- Removes redundant or historical wording from tests and implementation comments.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/message_helpers.py | Corrects and clarifies documentation for SMILES canonicalization and path containment without changing behavior. |
| ord_schema/orm/database_test.py | Rephrases sharding test comments as standing descriptions of the asserted behavior. |
| ord_schema/orm/loading.py | Fixes the prior overstated pool-utilization comment by saying a large dataset can use multiple workers. |
| ord_schema/resolvers.py | Clarifies first-success resolution behavior and external resolver requirements. |
| ord_schema/templating.py | Improves API documentation and corrects comments describing template pruning and reaction ID clearing. |
| ord_schema/units.py | Clarifies case-insensitive synonym handling and caller requirements for unit configuration. |
| ord_schema/validations.py | Expands validation-option and synonym documentation while removing redundant comments. |
| ord_schema/validations_test.py | Rewords regression-test commentary to describe the invariant currently being guarded. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Correct the sharding comment and drop a ..."](https://github.com/open-reaction-database/ord-schema/commit/b6565d4891d91fd59495fd8f37c2109aba3550f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49522096)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [ORM and Database Loading](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/orm-database.md)
- Knowledge Base — [Validation, Resolution, and Update Pipeline](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/validation-pipeline.md)
- Knowledge Base — [Data I/O: proto serialization, Parquet, and units](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/data-io.md)
</details>

<!-- /greptile_comment -->