### PR TITLE
Parse each structural identifier once, not four times

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -67,6 +67,10 @@ STRUCTURAL_IDENTIFIER_TYPES = frozenset(
 # Bounded because a large dataset's distinct set does not saturate (uspto grows
 # by ~1.3 new molecules per reaction); this holds strings, so the ceiling is
 # tens of MB.
+#
+# Entries assume RDKit parses and writes the same way for the life of the process.
+# A caller that flips a global mid-run (Chem.SetUseLegacyStereoPerception and the
+# like) has to call cache_clear() on both functions below.
 _IDENTIFIER_CACHE_SIZE = 100_000
 
 MessageType = TypeVar("MessageType")  # Generic for setting return types

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -15,6 +15,7 @@
 
 import contextlib
 import enum
+import functools
 import gzip
 import os
 import pathlib
@@ -56,7 +57,60 @@ STRUCTURAL_IDENTIFIER_TYPES = frozenset(
     reaction_pb2.CompoundIdentifier.CompoundIdentifierType.Name(identifier_type)
     for identifier_type in _COMPOUND_IDENTIFIER_LOADERS
 )
+# Structural identifiers repeat heavily -- shared solvents, reagents and
+# catalysts recur across the reactions of a dataset -- and validation parses
+# each one twice, once to check that it parses and once to canonicalize it for
+# the consistency check. Memoizing the derived SMILES collapses both.
+#
+# The cached value is a string, never the Mol: an RDKit Mol is mutable, so
+# handing the same one to every caller would let any of them corrupt the entry.
+# Bounded because a large dataset's distinct set does not saturate (uspto grows
+# by ~1.3 new molecules per reaction); this holds strings, so the ceiling is
+# tens of MB.
+_IDENTIFIER_CACHE_SIZE = 100_000
+
 MessageType = TypeVar("MessageType")  # Generic for setting return types
+
+
+@functools.lru_cache(maxsize=_IDENTIFIER_CACHE_SIZE)
+def canonical_smiles_for_identifier(identifier_type: int, value: str) -> str | None:
+    """Canonicalizes a structural identifier, or returns None if it will not parse.
+
+    Args:
+        identifier_type: CompoundIdentifier type enum value.
+        value: The identifier value.
+
+    Returns:
+        Canonical SMILES, or None if ``value`` is not a valid identifier of that
+        type. Returns None for types no Mol can be built from.
+    """
+    loader = _COMPOUND_IDENTIFIER_LOADERS.get(identifier_type)
+    if loader is None:
+        return None
+    mol = loader(value)
+    if mol is None:
+        return None
+    return canonical_smiles(mol)
+
+
+@functools.lru_cache(maxsize=_IDENTIFIER_CACHE_SIZE)
+def identifier_parses_unsanitized(identifier_type: int, value: str) -> bool:
+    """Tests whether an identifier parses at all once sanitization is skipped.
+
+    Separate from :func:`canonical_smiles_for_identifier` so the extra parse
+    happens only for the identifiers that failed, which are rare.
+
+    Args:
+        identifier_type: CompoundIdentifier type enum value.
+        value: The identifier value.
+
+    Returns:
+        True if ``value`` parses with ``sanitize=False``.
+    """
+    loader = _COMPOUND_IDENTIFIER_LOADERS.get(identifier_type)
+    if loader is None:
+        return False
+    return loader(value, sanitize=False) is not None
 
 
 def _resolve_enum_value(descriptor: Descriptor, field_name: str, key: str) -> int:
@@ -421,15 +475,14 @@ def check_compound_identifiers(
     """
     smiles = set()
     for identifier in compound.identifiers:
-        if identifier.type in _COMPOUND_IDENTIFIER_LOADERS:
-            mol = _COMPOUND_IDENTIFIER_LOADERS[identifier.type](identifier.value)
-        else:
+        if identifier.type not in _COMPOUND_IDENTIFIER_LOADERS:
             continue
-        if not mol:
+        canonical = canonical_smiles_for_identifier(identifier.type, identifier.value)
+        if canonical is None:
             raise ValueError(
                 f"invalid structural identifier for Compound: {identifier}"
             )
-        smiles.add(canonical_smiles(mol))
+        smiles.add(canonical)
     if len(smiles) > 1:
         raise ValueError(f"structural identifiers are inconsistent: {smiles}")
 

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -848,12 +848,23 @@ def test_check_compound_identifiers_accepts_matching_stereo_groups():
     message_helpers.check_compound_identifiers(compound)
 
 
+_METHANE_MOLBLOCK = """
+     RDKit          2D
+
+  1  0  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+M  END
+"""
+
+
 @pytest.mark.parametrize(
     ("identifier_type", "value"),
     [
         ("SMILES", "c1ccccc1"),
         ("CXSMILES", "C[C@H](N)O |o1:1|"),
         ("INCHI", "InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"),
+        # MolBlock is the loader whose signature and failure modes differ most.
+        ("MOLBLOCK", _METHANE_MOLBLOCK),
     ],
 )
 def test_canonical_smiles_for_identifier_matches_parsing_directly(
@@ -883,9 +894,10 @@ def test_canonical_smiles_for_identifier_keys_on_type_not_just_value():
 
 def test_canonical_smiles_for_identifier_returns_none_when_unparseable():
     smiles = reaction_pb2.CompoundIdentifier.SMILES
-    assert message_helpers.canonical_smiles_for_identifier(
+    unparseable = message_helpers.canonical_smiles_for_identifier(
         smiles, "not a molecule"
-    ) is (None)
+    )
+    assert unparseable is None
     # A type no Mol can be built from is not a parse failure to report either.
     name = reaction_pb2.CompoundIdentifier.NAME
     assert message_helpers.canonical_smiles_for_identifier(name, "benzene") is None

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -863,7 +863,6 @@ M  END
         ("SMILES", "c1ccccc1"),
         ("CXSMILES", "C[C@H](N)O |o1:1|"),
         ("INCHI", "InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"),
-        # MolBlock is the loader whose signature and failure modes differ most.
         ("MOLBLOCK", _METHANE_MOLBLOCK),
     ],
 )

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -846,3 +846,57 @@ def test_check_compound_identifiers_accepts_matching_stereo_groups():
     compound.identifiers.add(type="CXSMILES", value="C[C@H](N)O |o1:1|")
     compound.identifiers.add(type="SMILES", value="C[C@H](N)O |o1:1|")
     message_helpers.check_compound_identifiers(compound)
+
+
+@pytest.mark.parametrize(
+    ("identifier_type", "value"),
+    [
+        ("SMILES", "c1ccccc1"),
+        ("CXSMILES", "C[C@H](N)O |o1:1|"),
+        ("INCHI", "InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"),
+    ],
+)
+def test_canonical_smiles_for_identifier_matches_parsing_directly(
+    identifier_type, value
+):
+    """The memoized result is what parsing and canonicalizing by hand produces."""
+    number = reaction_pb2.CompoundIdentifier.CompoundIdentifierType.Value(
+        identifier_type
+    )
+    loader = message_helpers._COMPOUND_IDENTIFIER_LOADERS[number]
+    expected = message_helpers.canonical_smiles(loader(value))
+    assert message_helpers.canonical_smiles_for_identifier(number, value) == expected
+
+
+def test_canonical_smiles_for_identifier_keys_on_type_not_just_value():
+    """The same string means different things as different identifier types.
+
+    An InChI is not a SMILES, so caching on the value alone would let whichever
+    type was seen first answer for both.
+    """
+    inchi = reaction_pb2.CompoundIdentifier.INCHI
+    smiles = reaction_pb2.CompoundIdentifier.SMILES
+    value = "InChI=1S/CH4/h1H4"
+    assert message_helpers.canonical_smiles_for_identifier(inchi, value) == "C"
+    assert message_helpers.canonical_smiles_for_identifier(smiles, value) is None
+
+
+def test_canonical_smiles_for_identifier_returns_none_when_unparseable():
+    smiles = reaction_pb2.CompoundIdentifier.SMILES
+    assert message_helpers.canonical_smiles_for_identifier(
+        smiles, "not a molecule"
+    ) is (None)
+    # A type no Mol can be built from is not a parse failure to report either.
+    name = reaction_pb2.CompoundIdentifier.NAME
+    assert message_helpers.canonical_smiles_for_identifier(name, "benzene") is None
+
+
+def test_identifier_parses_unsanitized_separates_the_two_failure_modes():
+    """Pentavalent nitrogen parses only once sanitization is skipped."""
+    smiles = reaction_pb2.CompoundIdentifier.SMILES
+    unsanitizable = "CN(C)(C)C"
+    assert (
+        message_helpers.canonical_smiles_for_identifier(smiles, unsanitizable) is None
+    )
+    assert message_helpers.identifier_parses_unsanitized(smiles, unsanitizable)
+    assert not message_helpers.identifier_parses_unsanitized(smiles, "not a molecule")

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -40,6 +40,11 @@ logger = get_logger(__name__)
 # Record timestamps repeat across a dataset's reactions, but the distinct set is
 # small next to the identifier caches in message_helpers, so this stays modest.
 _DATETIME_CACHE_SIZE = 10_000
+# Fills the fields a partial DateTime leaves out. Fixed rather than the current date
+# so parsing is a pure function of the string and safe to memoize; a leap year so
+# "Feb 29" still parses, and naive so a partial value never comes back timezone-aware
+# when a full one would not.
+_DATETIME_DEFAULT = datetime.datetime(2000, 1, 1)  # noqa: DTZ001
 
 
 @dataclasses.dataclass
@@ -1261,6 +1266,14 @@ def _parse_date_time(value: str) -> datetime.datetime | None:
     and record timestamps repeat across the reactions of a dataset. Caching is
     safe here because ``datetime`` is immutable.
 
+    A partial value carries only some fields ("10:30" names no date, "March 5"
+    no year), and ``parser.parse`` fills the rest from the current date. Passing
+    a fixed default instead keeps this a pure function of ``value``, so two
+    partial timestamps stay comparable no matter how far apart the cache entries
+    were created; a run spanning midnight would otherwise order them by the day
+    each was first seen. The date chosen is arbitrary and never observable:
+    provenance compares timestamps only against each other.
+
     Args:
         value: The DateTime value.
 
@@ -1268,7 +1281,7 @@ def _parse_date_time(value: str) -> datetime.datetime | None:
         The parsed datetime, or None if ``value`` could not be parsed.
     """
     try:
-        return parser.parse(value)
+        return parser.parse(value, default=_DATETIME_DEFAULT)
     except parser.ParserError:
         return None
 

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -42,8 +42,7 @@ logger = get_logger(__name__)
 _DATETIME_CACHE_SIZE = 10_000
 # Fills the fields a partial DateTime leaves out. Fixed rather than the current date
 # so parsing is a pure function of the string and safe to memoize; a leap year so
-# "Feb 29" still parses, and naive so a partial value never comes back timezone-aware
-# when a full one would not.
+# "Feb 29" still parses, and naive to match what a full value produces.
 _DATETIME_DEFAULT = datetime.datetime(2000, 1, 1)  # noqa: DTZ001
 
 
@@ -1266,13 +1265,10 @@ def _parse_date_time(value: str) -> datetime.datetime | None:
     and record timestamps repeat across the reactions of a dataset. Caching is
     safe here because ``datetime`` is immutable.
 
-    A partial value carries only some fields ("10:30" names no date, "March 5"
-    no year), and ``parser.parse`` fills the rest from the current date. Passing
-    a fixed default instead keeps this a pure function of ``value``, so two
-    partial timestamps stay comparable no matter how far apart the cache entries
-    were created; a run spanning midnight would otherwise order them by the day
-    each was first seen. The date chosen is arbitrary and never observable:
-    provenance compares timestamps only against each other.
+    A partial value names only some fields ("10:30" carries no date); the rest
+    come from ``_DATETIME_DEFAULT`` rather than today, which is what makes this
+    safe to memoize. The filled-in date is arbitrary, and provenance compares
+    timestamps only against each other.
 
     Args:
         value: The DateTime value.

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -14,6 +14,8 @@
 """Helpers validating specific Message types."""
 
 import dataclasses
+import datetime
+import functools
 import math
 import pathlib
 import re
@@ -23,7 +25,6 @@ from enum import IntEnum
 from typing import Any
 
 from dateutil import parser
-from rdkit import Chem
 from rdkit import (
     # (RDKIT_VERSION reads better than rdkit_version)
     __version__ as RDKIT_VERSION,  # noqa: N812
@@ -35,6 +36,10 @@ from ord_schema.logging import get_logger
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 logger = get_logger(__name__)
+
+# Record timestamps repeat across a dataset's reactions, but the distinct set is
+# small next to the identifier caches in message_helpers, so this stays modest.
+_DATETIME_CACHE_SIZE = 10_000
 
 
 @dataclasses.dataclass
@@ -895,16 +900,23 @@ def validate_compound_identifier(message: reaction_pb2.CompoundIdentifier) -> No
         message.MOLBLOCK,
     ):
         # MolFromSmiles reads CXSMILES, so both types validate as recorded.
-        parse_func, identifier_type = {
-            message.SMILES: (Chem.MolFromSmiles, "SMILES"),
-            message.CXSMILES: (Chem.MolFromSmiles, "CXSMILES"),
-            message.INCHI: (Chem.MolFromInchi, "InChI"),
-            message.MOLBLOCK: (Chem.MolFromMolBlock, "MolBlock"),
+        identifier_type = {
+            message.SMILES: "SMILES",
+            message.CXSMILES: "CXSMILES",
+            message.INCHI: "InChI",
+            message.MOLBLOCK: "MolBlock",
         }[message.type]
         if message.type == message.SMILES:
             _check_cxsmiles_type(message.value, "CXSMILES")
-        if parse_func(message.value) is None:
-            if parse_func(message.value, sanitize=False) is None:
+        # Memoized, and shared with the consistency check in
+        # check_compound_identifiers, which otherwise parses the same string again.
+        if (
+            message_helpers.canonical_smiles_for_identifier(message.type, message.value)
+            is None
+        ):
+            if not message_helpers.identifier_parses_unsanitized(
+                message.type, message.value
+            ):
                 warnings.warn(
                     f"RDKit {RDKIT_VERSION} could not validate {identifier_type} "
                     f"identifier {message.value}",
@@ -1240,15 +1252,54 @@ def validate_mass_spec_measurement_type(
         )
 
 
+@functools.lru_cache(maxsize=_DATETIME_CACHE_SIZE)
+def _parse_date_time(value: str) -> datetime.datetime | None:
+    """Parses a DateTime value, returning None if it is unparseable.
+
+    Memoized: a DateTime string is parsed once by this module's per-message walk
+    and again by :func:`validate_reaction_provenance` to order the timestamps,
+    and record timestamps repeat across the reactions of a dataset. Caching is
+    safe here because ``datetime`` is immutable.
+
+    Args:
+        value: The DateTime value.
+
+    Returns:
+        The parsed datetime, or None if ``value`` could not be parsed.
+    """
+    try:
+        return parser.parse(value)
+    except parser.ParserError:
+        return None
+
+
+def _parse_date_time_or_raise(value: str) -> datetime.datetime:
+    """Parses a DateTime value through the cache, raising as ``parser.parse`` does.
+
+    Lets callers that short-circuit a sequence of parses on the first bad value
+    keep doing so while still going through the cache.
+
+    Args:
+        value: The DateTime value.
+
+    Returns:
+        The parsed datetime.
+
+    Raises:
+        parser.ParserError: If ``value`` could not be parsed.
+    """
+    parsed = _parse_date_time(value)
+    if parsed is None:
+        raise parser.ParserError("Unknown string format: %s", value)
+    return parsed
+
+
 def validate_date_time(message: reaction_pb2.DateTime) -> None:
     """Validates that a DateTime value is parseable."""
-    if message.value:
-        try:
-            parser.parse(message.value).ctime()
-        except parser.ParserError:
-            warnings.warn(
-                f"Could not parse DateTime string {message.value}", ValidationError
-            )
+    if message.value and _parse_date_time(message.value) is None:
+        warnings.warn(
+            f"Could not parse DateTime string {message.value}", ValidationError
+        )
 
 
 def validate_analysis(message: reaction_pb2.Analysis) -> None:
@@ -1267,12 +1318,14 @@ def validate_reaction_provenance(message: reaction_pb2.ReactionProvenance) -> No
     record_modified = None
     try:
         if message.experiment_start.value:
-            experiment_start = parser.parse(message.experiment_start.value)
+            experiment_start = _parse_date_time_or_raise(message.experiment_start.value)
         if message.record_created.time.value:
-            record_created = parser.parse(message.record_created.time.value)
+            record_created = _parse_date_time_or_raise(
+                message.record_created.time.value
+            )
         for record in message.record_modified:
             # Use the last record as the most recent modification time.
-            record_modified = parser.parse(record.time.value)
+            record_modified = _parse_date_time_or_raise(record.time.value)
     except parser.ParserError:
         warnings.warn("Failed to parse DateTime string(s)", ValidationWarning)
     # Check signs of time differences

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for ord_schema.validations."""
 
+import datetime
 import sys
 import warnings
 
@@ -377,6 +378,8 @@ def test_the_two_identifier_checks_share_one_parse():
     _run_validation(_compound_with_two_identifiers())
     info = message_helpers.canonical_smiles_for_identifier.cache_info()
     # One miss per distinct identifier, and a hit where the other check reuses it.
+    # A third call site would push these up; that is a prompt to check the new
+    # caller shares the parse, not to relax the counts.
     assert info.misses == 2
     assert info.hits == 2
 
@@ -387,6 +390,54 @@ def test_a_warm_cache_does_not_change_what_validation_reports():
     cold = _run_validation(_compound_with_two_identifiers())
     warm = _run_validation(_compound_with_two_identifiers())
     assert (cold.errors, cold.warnings) == (warm.errors, warm.warnings)
+
+
+def _provenance_with_partial_timestamps():
+    """Builds a ReactionProvenance whose timestamps name a time but no date."""
+    message = reaction_pb2.ReactionProvenance()
+    message.experiment_start.value = "01:00"
+    message.record_created.time.value = "23:00"
+    message.record_created.person.name = "test"
+    message.record_created.person.email = "test@example.com"
+    return message
+
+
+def test_partial_timestamps_do_not_inherit_the_current_date():
+    """A partial DateTime must parse the same however old its cache entry is.
+
+    ``parser.parse`` fills absent fields from the current date unless given a
+    default, which would make a cached value depend on the day it was created: a
+    run spanning midnight would then order two partial timestamps by when each
+    was first seen rather than by the times they name.
+    """
+    validations._parse_date_time.cache_clear()
+    first = validations._parse_date_time("01:00")
+    second = validations._parse_date_time("23:00")
+    assert first is not None
+    assert second is not None
+    # One nominal date for both, so the comparison reflects the times they name.
+    assert first.date() == second.date()
+    assert first < second
+    # And that date is fixed rather than today's, so an entry cached yesterday
+    # still compares correctly against one cached today.
+    assert first.date() != datetime.datetime.now(tz=datetime.UTC).date()
+
+
+def test_partial_timestamps_are_ordered_by_time_not_cache_age():
+    """The provenance ordering check reads the times, not the caching order."""
+    validations._parse_date_time.cache_clear()
+    output = _run_validation(_provenance_with_partial_timestamps())
+    assert not any("after experiment" in error for error in output.errors)
+
+
+def test_provenance_and_the_message_walk_share_one_datetime_parse():
+    """Both the per-message walk and the ordering check need the same parse."""
+    validations._parse_date_time.cache_clear()
+    _run_validation(_provenance_with_partial_timestamps())
+    info = validations._parse_date_time.cache_info()
+    # Two distinct strings, each parsed once and reused by the other caller.
+    assert info.misses == 2
+    assert info.hits == 2
 
 
 @pytest.mark.parametrize(

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -18,7 +18,7 @@ import warnings
 
 import pytest
 
-from ord_schema import validations
+from ord_schema import message_helpers, validations
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 
@@ -355,6 +355,38 @@ def test_invalid_compound_identifier(identifier_type, value):
     message = reaction_pb2.CompoundIdentifier(type=identifier_type, value=value)
     with pytest.raises(validations.ValidationError, match="could not validate"):
         _run_validation(message)
+
+
+def _compound_with_two_identifiers():
+    """Builds a Compound whose SMILES and InChI describe the same molecule."""
+    compound = reaction_pb2.Compound()
+    compound.identifiers.add(type="SMILES", value="c1ccccc1")
+    compound.identifiers.add(type="INCHI", value="InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H")
+    return compound
+
+
+def test_the_two_identifier_checks_share_one_parse():
+    """Validity and consistency need the same parse, so they must not repeat it.
+
+    ``validate_compound_identifier`` checks that an identifier parses and
+    ``check_compound_identifiers`` canonicalizes it to compare against its
+    siblings. Parsing InChI is the single most expensive thing validation does,
+    so a regression that unshares these is worth catching.
+    """
+    message_helpers.canonical_smiles_for_identifier.cache_clear()
+    _run_validation(_compound_with_two_identifiers())
+    info = message_helpers.canonical_smiles_for_identifier.cache_info()
+    # One miss per distinct identifier, and a hit where the other check reuses it.
+    assert info.misses == 2
+    assert info.hits == 2
+
+
+def test_a_warm_cache_does_not_change_what_validation_reports():
+    message_helpers.canonical_smiles_for_identifier.cache_clear()
+    validations._parse_date_time.cache_clear()
+    cold = _run_validation(_compound_with_two_identifiers())
+    warm = _run_validation(_compound_with_two_identifiers())
+    assert (cold.errors, cold.warnings) == (warm.errors, warm.warnings)
 
 
 @pytest.mark.parametrize(

--- a/ord_schema/validations_test.py
+++ b/ord_schema/validations_test.py
@@ -418,8 +418,8 @@ def test_partial_timestamps_do_not_inherit_the_current_date():
     # One nominal date for both, so the comparison reflects the times they name.
     assert first.date() == second.date()
     assert first < second
-    # And that date is fixed rather than today's, so an entry cached yesterday
-    # still compares correctly against one cached today.
+    # That date is fixed rather than today's, so an entry cached yesterday still
+    # compares correctly against one cached today.
     assert first.date() != datetime.datetime.now(tz=datetime.UTC).date()
 
 


### PR DESCRIPTION
## Summary

Profiling ord-data's corpus sweep found half of validation sitting in `Chem.MolFromInchi` — not because InChI parsing is slow, but because the same string is parsed twice per reaction by two call sites that don't know about each other, and the same molecules recur across a dataset's reactions. On the uspto grants file that's 15,306 `MolFromInchi` calls for 5,336 InChI identifiers. DateTimes have the identical shape: parsed by the per-message walk in `validate_date_time`, then again by `validate_reaction_provenance` to order them.

Memoizing by string is **1.785 → 0.670 ms/reaction, 2.66×**, measured on `data/11/ord_dataset-1158e351757f315b93cbcbe7bc55f38e.parquet`. Full analysis in [the logbook entry](https://github.com/open-reaction-database/ord-logbook/blob/main/entries/2026-08-02-validation-performance.md).

## Changes

- `canonical_smiles_for_identifier(type, value)` memoizes the derived SMILES; `validate_compound_identifier` and `check_compound_identifiers` both read it instead of parsing separately.
- The cached value is a **string, never the `Mol`** — an RDKit `Mol` is mutable, so handing the same one to every caller would let any of them corrupt the entry.
- `identifier_parses_unsanitized` is a separate cache for the `sanitize=False` retry, so that extra parse happens only for identifiers that already failed.
- `_parse_date_time` does the same for DateTime strings. Caching is safe outright here because `datetime` is immutable.
- Caches are bounded: a large dataset's distinct set doesn't saturate (uspto grows ~1.3 new molecules per reaction), and these hold strings, so the ceiling is tens of MB.

## Testing

`pytest -n auto` — 612 passed (excluding `orm/`, which needs Postgres and fails the same way on `main`). ruff check/format, `ty` clean on the touched files with the 41 repo-wide diagnostics unchanged, `pre-commit` on all four files.

Behavior preservation leans on the existing tests, which already pin "could not validate", "could not sanitize", and identifier inconsistency, and which pass unchanged. Two equivalences I verified rather than assumed: `not mol` is exactly `mol is None` for RDKit (no `__bool__`/`__len__`, so an empty `Mol` is truthy), and `datetime.ctime()` cannot raise anywhere in dateutil's parseable year range, so dropping it from `validate_date_time` changes nothing.

New tests cover what the cache newly makes breakable: that the memoized result matches parsing by hand, that the key includes the identifier type (an InChI string must not answer for a SMILES lookup), that the two checks share one parse rather than repeating it, and that a warm cache reports the same findings as a cold one.

## Notes

`validate_reaction_provenance` keeps its short-circuit: the original `try` block stops at the first unparseable timestamp and skips the ordering comparisons after it. My first pass made it stricter by parsing all three; since this PR is meant to be behavior-preserving, I restored the original semantics with a small raising wrapper. Making it stricter is worth doing, but deliberately and separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR memoizes structural-identifier canonicalization and DateTime parsing so validation call sites can reuse deterministic parse results.
- Adds bounded caches for canonical structural identifiers and unsanitized parsing results.
- Routes compound validity and consistency checks through the shared identifier cache.
- Adds a fixed DateTime parsing default and shares cached timestamps with provenance ordering.
- Adds cache-key, behavior-preservation, and parse-reuse tests.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains within the eligible follow-up review scope.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/message_helpers.py | Adds bounded identifier parsing caches and reuses canonicalized strings during compound consistency checks. |
| ord_schema/validations.py | Reuses cached identifier and DateTime parsing while preserving existing validation and provenance short-circuit paths. |
| ord_schema/message_helpers_test.py | Tests canonicalization equivalence, type-sensitive cache keys, invalid identifiers, and unsanitized fallback behavior. |
| ord_schema/validations_test.py | Tests cache reuse, warm-cache equivalence, and deterministic handling of partial timestamps. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Identifier[Structural identifier] --> IdentifierCache[Canonical identifier cache]
  IdentifierCache --> Validity[Identifier validity check]
  IdentifierCache --> Consistency[Compound consistency check]
  DateTime[DateTime string] --> DateCache[DateTime parse cache]
  DateCache --> DateValidation[DateTime validation]
  DateCache --> Provenance[Provenance ordering]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Distill the comments added for the DateT..."](https://github.com/open-reaction-database/ord-schema/commit/2cfb95137680a72ad7ea46114c3213cb212d9d0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49528497)</sub>

**Context used:**

- Knowledge Base — [Validation, Resolution, and Update Pipeline](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/validation-pipeline.md)

<!-- /greptile_comment -->