### PR TITLE
Make DatasetView.reactions indexable and add to_proto

### DIFF
--- a/ord_schema/parquet.py
+++ b/ord_schema/parquet.py
@@ -255,22 +255,36 @@ class _ReactionStream:
     """
 
     def __init__(self, path: str | os.PathLike[str], num_reactions: int) -> None:
+        """Opens a stream over the Reactions in a Parquet file.
+
+        Args:
+            path: Path to the backing Parquet file.
+            num_reactions: Row count taken from the file footer.
+        """
         self._path = path
         self._num_reactions = num_reactions
-        # The index and the cache are built on first indexed access, so constructing a
-        # view stays a footer-only read for callers that only iterate.
+        # Deferred to the first indexed access: building the index costs a second
+        # footer read and one RowGroupMetaData per row group, neither of which a
+        # caller that only iterates ever needs.
         self._row_group_starts: list[int] | None = None
-        self._cached_row_group: int | None = None
-        self._cached_table: pa.Table | None = None
+        # Row group index paired with its table, so the two cannot desynchronize.
+        self._cache: tuple[int, pa.Table] | None = None
 
     def __iter__(self) -> Iterator[reaction_pb2.Reaction]:
+        """Opens a fresh read over the backing file.
+
+        Yields:
+            Each Reaction, in file order.
+        """
         for _, reaction in iter_reactions(self._path):
             yield reaction
 
     def __len__(self) -> int:
+        """Returns the number of Reactions, taken from the file footer."""
         return self._num_reactions
 
     def __bool__(self) -> bool:
+        """Returns whether the dataset holds any Reactions."""
         return self._num_reactions > 0
 
     @overload
@@ -282,20 +296,25 @@ class _ReactionStream:
     def __getitem__(
         self, key: int | slice
     ) -> reaction_pb2.Reaction | list[reaction_pb2.Reaction]:
-        """Returns the Reaction at ``key``, or a list of Reactions for a slice.
+        """Reads Reactions from the backing file by position.
 
-        Reading one index costs a single row-group read, and the most recently read
-        row group is cached, so walking indices in order pays that cost once per row
-        group rather than once per Reaction. Iterating is cheaper still and should be
-        preferred where either works.
+        A cache miss costs a footer read plus a row-group read, and the most recently
+        read row group is cached, so walking indices in order pays that once per row
+        group rather than once per Reaction. Iterating ``reactions`` is cheaper than
+        indexing every position because it opens the file once; indexing wins when
+        only a few Reactions are needed.
 
         Args:
             key: Index of a Reaction, negative counting from the end, or a slice.
                 Slices materialize a list, matching protobuf repeated-field slicing,
                 so a slice spanning the dataset costs as much memory as ``to_proto``.
 
+        Returns:
+            The Reaction at an integer ``key``, or a list of Reactions for a slice.
+
         Raises:
             IndexError: If an integer ``key`` is out of range.
+            TypeError: If ``key`` is neither an integer nor a slice.
         """
         if isinstance(key, slice):
             return [
@@ -304,6 +323,17 @@ class _ReactionStream:
         return self._get(operator.index(key))
 
     def _get(self, index: int) -> reaction_pb2.Reaction:
+        """Reads a single Reaction by index.
+
+        Args:
+            index: Reaction index; negative values count from the end.
+
+        Returns:
+            A freshly deserialized Reaction, not a live sub-message of a Dataset.
+
+        Raises:
+            IndexError: If ``index`` is out of range.
+        """
         position = index + self._num_reactions if index < 0 else index
         if not 0 <= position < self._num_reactions:
             raise IndexError(
@@ -315,7 +345,18 @@ class _ReactionStream:
         return reaction_pb2.Reaction.FromString(blob)
 
     def _locate(self, position: int) -> tuple[int, int]:
-        """Maps an absolute row position to ``(row_group, offset_within_group)``."""
+        """Maps an absolute row position onto the row group holding it.
+
+        Args:
+            position: Row position, already bounds-checked against the row count.
+
+        Returns:
+            ``(row_group, offset_within_row_group)``.
+
+        Raises:
+            RuntimeError: If the file's row count disagrees with the count read when
+                the view was opened, meaning the file was replaced.
+        """
         if self._row_group_starts is None:
             with pq.ParquetFile(self._path) as parquet_file:
                 metadata = parquet_file.metadata
@@ -323,6 +364,16 @@ class _ReactionStream:
                     metadata.row_group(i).num_rows
                     for i in range(metadata.num_row_groups)
                 ]
+            # The row count was read from the footer when the view was opened, so a
+            # disagreement means the file was replaced underneath it -- which
+            # DatasetWriter does by design, publishing via rename onto the path.
+            # Refuse rather than serve rows resolved against the wrong layout.
+            if sum(counts) != self._num_reactions:
+                raise RuntimeError(
+                    f"{self._path} changed since this view was opened: the footer now "
+                    f"reports {sum(counts)} reactions, the view was opened on "
+                    f"{self._num_reactions}. Re-open the DatasetView."
+                )
             # Exclusive prefix sum: element i is the absolute position of row group i's
             # first row. Sizes come from the footer because row groups are not
             # guaranteed uniform; bisect_right lands past any empty groups, which
@@ -332,13 +383,21 @@ class _ReactionStream:
         return row_group, position - self._row_group_starts[row_group]
 
     def _read_row_group(self, row_group: int) -> pa.Table:
-        """Returns the ``reaction`` column of ``row_group``, caching the last read."""
-        if self._cached_row_group != row_group or self._cached_table is None:
-            with pq.ParquetFile(self._path) as parquet_file:
-                table = parquet_file.read_row_group(row_group, columns=["reaction"])
-            self._cached_table = table
-            self._cached_row_group = row_group
-        return self._cached_table
+        """Reads one row group, caching the most recent read.
+
+        Args:
+            row_group: Row group index.
+
+        Returns:
+            A Table holding only the ``reaction`` column of ``row_group``.
+        """
+        cached = self._cache
+        if cached is not None and cached[0] == row_group:
+            return cached[1]
+        with pq.ParquetFile(self._path) as parquet_file:
+            table = parquet_file.read_row_group(row_group, columns=["reaction"])
+        self._cache = (row_group, table)
+        return table
 
 
 class DatasetView:
@@ -350,9 +409,15 @@ class DatasetView:
     read on each iteration, reports its length from the footer, and resolves
     an index to a single row group, so iteration, length, emptiness, and
     indexing all behave like a list. ``reactions`` is exposed as a read-only
-    property so accidental rebinding raises. Mutation and the protobuf
-    message surface (``SerializeToString``, ``MessageToJson``, ``CopyFrom``)
-    are unavailable; ``to_proto`` materializes a real message.
+    property so accidental rebinding raises; the scalars are plain writable
+    attributes, which ``updates.assign_dataset_id`` relies on. The protobuf
+    message methods (``SerializeToString``, ``CopyFrom``) are absent and no
+    write reaches the file; ``to_proto`` materializes a real message.
+
+    The backing file must not be replaced while a view is open: the row count
+    is read once at construction, and ``DatasetWriter`` publishes by renaming
+    onto its destination. Indexing detects the mismatch and raises; iteration
+    silently reads whatever the path points at.
 
     ``reaction_ids`` is always empty by design: in the schema it names
     reactions stored *outside* the Dataset and is mutually exclusive with
@@ -394,8 +459,17 @@ class DatasetView:
         conversion, mutation, and helpers that require a protobuf message. Peak
         memory scales with the whole dataset, so prefer iterating ``reactions``
         when the message itself is not required.
+
+        Returns:
+            A Dataset whose Reactions are streamed from the backing file and whose
+            scalars are taken from this view, so an assignment such as
+            ``updates.assign_dataset_id`` reaches the message.
         """
-        return load_dataset(self._path)
+        dataset = dataset_pb2.Dataset(
+            name=self.name, description=self.description, dataset_id=self.dataset_id
+        )
+        dataset.reactions.extend(self.reactions)
+        return dataset
 
 
 def load_dataset(path: str | os.PathLike[str]) -> dataset_pb2.Dataset:

--- a/ord_schema/parquet.py
+++ b/ord_schema/parquet.py
@@ -26,15 +26,18 @@ This layout supports random access (by row group) and streaming iteration
 without loading the full dataset into memory.
 """
 
+import bisect
 import contextlib
 import dataclasses
 import hashlib
+import itertools
+import operator
 import os
 import pathlib
 import tempfile
 from collections.abc import Iterable, Iterator
 from types import TracebackType
-from typing import Self
+from typing import Self, overload
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -241,17 +244,24 @@ def save_dataset(
 
 
 class _ReactionStream:
-    """Re-iterable Reaction stream with a known length.
+    """Re-iterable, indexable Reaction stream with a known length.
 
     Each iteration opens a fresh read over the backing Parquet file so callers that
     iterate more than once stay memory-bounded. ``__len__`` and ``__bool__`` come from
     the footer row count, so emptiness checks (e.g., ``if not dataset.reactions``)
     behave like a list instead of always being truthy the way a bare generator would be.
+    ``__getitem__`` reads only the row group holding the requested index, so random
+    access does not scan the file.
     """
 
     def __init__(self, path: str | os.PathLike[str], num_reactions: int) -> None:
         self._path = path
         self._num_reactions = num_reactions
+        # The index and the cache are built on first indexed access, so constructing a
+        # view stays a footer-only read for callers that only iterate.
+        self._row_group_starts: list[int] | None = None
+        self._cached_row_group: int | None = None
+        self._cached_table: pa.Table | None = None
 
     def __iter__(self) -> Iterator[reaction_pb2.Reaction]:
         for _, reaction in iter_reactions(self._path):
@@ -263,17 +273,92 @@ class _ReactionStream:
     def __bool__(self) -> bool:
         return self._num_reactions > 0
 
+    @overload
+    def __getitem__(self, key: int) -> reaction_pb2.Reaction: ...
+
+    @overload
+    def __getitem__(self, key: slice) -> list[reaction_pb2.Reaction]: ...
+
+    def __getitem__(
+        self, key: int | slice
+    ) -> reaction_pb2.Reaction | list[reaction_pb2.Reaction]:
+        """Returns the Reaction at ``key``, or a list of Reactions for a slice.
+
+        Reading one index costs a single row-group read, and the most recently read
+        row group is cached, so walking indices in order pays that cost once per row
+        group rather than once per Reaction. Iterating is cheaper still and should be
+        preferred where either works.
+
+        Args:
+            key: Index of a Reaction, negative counting from the end, or a slice.
+                Slices materialize a list, matching protobuf repeated-field slicing,
+                so a slice spanning the dataset costs as much memory as ``to_proto``.
+
+        Raises:
+            IndexError: If an integer ``key`` is out of range.
+        """
+        if isinstance(key, slice):
+            return [
+                self._get(index) for index in range(*key.indices(self._num_reactions))
+            ]
+        return self._get(operator.index(key))
+
+    def _get(self, index: int) -> reaction_pb2.Reaction:
+        position = index + self._num_reactions if index < 0 else index
+        if not 0 <= position < self._num_reactions:
+            raise IndexError(
+                f"reaction index {index} out of range for "
+                f"{self._num_reactions} reactions"
+            )
+        row_group, offset = self._locate(position)
+        blob = self._read_row_group(row_group).column("reaction")[offset].as_py()
+        return reaction_pb2.Reaction.FromString(blob)
+
+    def _locate(self, position: int) -> tuple[int, int]:
+        """Maps an absolute row position to ``(row_group, offset_within_group)``."""
+        if self._row_group_starts is None:
+            with pq.ParquetFile(self._path) as parquet_file:
+                metadata = parquet_file.metadata
+                counts = [
+                    metadata.row_group(i).num_rows
+                    for i in range(metadata.num_row_groups)
+                ]
+            # Exclusive prefix sum: element i is the absolute position of row group i's
+            # first row. Sizes come from the footer because row groups are not
+            # guaranteed uniform; bisect_right lands past any empty groups, which
+            # share a start position with the group that follows them.
+            self._row_group_starts = list(itertools.accumulate(counts, initial=0))[:-1]
+        row_group = bisect.bisect_right(self._row_group_starts, position) - 1
+        return row_group, position - self._row_group_starts[row_group]
+
+    def _read_row_group(self, row_group: int) -> pa.Table:
+        """Returns the ``reaction`` column of ``row_group``, caching the last read."""
+        if self._cached_row_group != row_group or self._cached_table is None:
+            with pq.ParquetFile(self._path) as parquet_file:
+                table = parquet_file.read_row_group(row_group, columns=["reaction"])
+            self._cached_table = table
+            self._cached_row_group = row_group
+        return self._cached_table
+
 
 class DatasetView:
     """A read-only, streaming view of a Parquet-serialized Dataset.
 
-    Quacks like a ``dataset_pb2.Dataset`` for the read-only attributes used
-    during validation: ``name``, ``description``, and ``dataset_id`` come
-    from the Parquet footer; ``reaction_ids`` is always empty (Parquet does
-    not persist it); and ``reactions`` is a re-iterable ``_ReactionStream``
-    that opens a fresh read on each iteration and reports its length from
-    the footer, so emptiness/length checks behave like a list. ``reactions``
-    is exposed as a read-only property so accidental rebinding raises.
+    Quacks like a ``dataset_pb2.Dataset`` for read-only access: ``name``,
+    ``description``, and ``dataset_id`` come from the Parquet footer, and
+    ``reactions`` is a re-iterable ``_ReactionStream`` that opens a fresh
+    read on each iteration, reports its length from the footer, and resolves
+    an index to a single row group, so iteration, length, emptiness, and
+    indexing all behave like a list. ``reactions`` is exposed as a read-only
+    property so accidental rebinding raises. Mutation and the protobuf
+    message surface (``SerializeToString``, ``MessageToJson``, ``CopyFrom``)
+    are unavailable; ``to_proto`` materializes a real message.
+
+    ``reaction_ids`` is always empty by design: in the schema it names
+    reactions stored *outside* the Dataset and is mutually exclusive with
+    ``reactions``, so serving it from the ``reaction_id`` column would make
+    every Parquet dataset fail validation. Use ``iter_reaction_ids`` for the
+    IDs of the reactions this dataset contains.
     """
 
     def __init__(self, path: str | os.PathLike[str]) -> None:
@@ -301,6 +386,16 @@ class DatasetView:
     def reactions(self) -> _ReactionStream:
         """Re-iterable stream of Reactions read from the backing file."""
         return self._reactions
+
+    def to_proto(self) -> dataset_pb2.Dataset:
+        """Materializes a real ``Dataset`` message, deserializing every Reaction.
+
+        Escape hatch for the operations a view cannot serve: serialization, JSON
+        conversion, mutation, and helpers that require a protobuf message. Peak
+        memory scales with the whole dataset, so prefer iterating ``reactions``
+        when the message itself is not required.
+        """
+        return load_dataset(self._path)
 
 
 def load_dataset(path: str | os.PathLike[str]) -> dataset_pb2.Dataset:

--- a/ord_schema/parquet_test.py
+++ b/ord_schema/parquet_test.py
@@ -668,3 +668,28 @@ def test_dataset_view_to_proto_carries_scalar_mutations(tmp_path):
     assert materialized.dataset_id == assigned
     assert materialized.name == "renamed"
     assert list(materialized.reactions) == list(source.reactions)
+
+
+def test_dataset_view_to_proto_carries_every_scalar_field(tmp_path):
+    """Every scalar Dataset field set on the view must survive materialization.
+
+    ``to_proto`` names the scalars one by one, so a field added to the proto would be
+    dropped silently. Driving off the descriptor fails here until it is carried.
+    """
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(_make_dataset(n=1), path)
+    view = dataset.DatasetView(path)
+    descriptor = dataset_pb2.Dataset.DESCRIPTOR
+    assert descriptor is not None  # Type hint.
+    expected = {}
+    for field in descriptor.fields:
+        if field.label == field.LABEL_REPEATED:
+            continue
+        assert field.type == field.TYPE_STRING, (
+            f"non-string scalar {field.name!r} added to Dataset; extend this test"
+        )
+        expected[field.name] = f"mutated-{field.name}"
+        setattr(view, field.name, expected[field.name])
+    assert expected, "Dataset declares no scalar fields; this test is vacuous"
+    materialized = view.to_proto()
+    assert {name: getattr(materialized, name) for name in expected} == expected

--- a/ord_schema/parquet_test.py
+++ b/ord_schema/parquet_test.py
@@ -18,6 +18,7 @@ import pyarrow.parquet as pq
 import pytest
 
 from ord_schema import parquet as dataset
+from ord_schema import updates
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 
@@ -466,10 +467,18 @@ def test_dataset_view_values_round_trip(tmp_path):
 
 
 def _write_row_groups(path, group_sizes: list[int]) -> list[str]:
-    """Writes a Parquet dataset with explicitly sized row groups; returns reaction IDs.
+    """Writes a Parquet dataset with explicitly sized row groups.
 
-    DatasetWriter emits fixed-size row groups, so this drops to pyarrow to build the
-    ragged (and empty-group) layouts that random access has to resolve correctly.
+    DatasetWriter flushes on a fixed threshold, so it can only ever produce a short
+    group at the end; this drops to pyarrow for the interior short groups and zero-row
+    groups that random access also has to resolve correctly.
+
+    Args:
+        path: Destination path for the Parquet file.
+        group_sizes: Number of reactions to write into each row group, in order.
+
+    Returns:
+        The reaction IDs written, in file order.
     """
     schema = dataset._build_schema(name="n", description="d", dataset_id=None)
     reaction_ids = []
@@ -539,6 +548,14 @@ def test_dataset_view_reactions_indexing_ragged_row_groups(tmp_path):
     """
     path = tmp_path / "ragged.parquet"
     reaction_ids = _write_row_groups(path, [3, 0, 1, 4])
+    # Assert the layout rather than trusting it: a pyarrow that dropped empty tables on
+    # write would leave this test passing with its coverage silently gone.
+    with pq.ParquetFile(path) as parquet_file:
+        metadata = parquet_file.metadata
+        counts = [
+            metadata.row_group(i).num_rows for i in range(metadata.num_row_groups)
+        ]
+    assert counts == [3, 0, 1, 4]
     view = dataset.DatasetView(path)
     assert len(view.reactions) == len(reaction_ids)
     assert [view.reactions[i].reaction_id for i in range(len(reaction_ids))] == (
@@ -556,16 +573,71 @@ def test_dataset_view_indexing_reads_each_row_group_once(tmp_path, monkeypatch):
     dataset.save_dataset(_make_dataset(n=10), path, row_group_size=5)
     view = dataset.DatasetView(path)
     reads = []
-    unpatched = pq.ParquetFile.read_row_group
+    opens = []
+    unpatched_read = pq.ParquetFile.read_row_group
+    unpatched_init = pq.ParquetFile.__init__
 
-    def _record(self, row_group, **kwargs):
+    def _record_read(self, row_group, *args, **kwargs):
         reads.append(row_group)
-        return unpatched(self, row_group, **kwargs)
+        return unpatched_read(self, row_group, *args, **kwargs)
 
-    monkeypatch.setattr(pq.ParquetFile, "read_row_group", _record)
+    def _record_init(self, *args, **kwargs):
+        opens.append(1)
+        return unpatched_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(pq.ParquetFile, "read_row_group", _record_read)
+    monkeypatch.setattr(pq.ParquetFile, "__init__", _record_init)
     for i in range(10):
         view.reactions[i]
     assert reads == [0, 1]
+    # One open to build the row-group index, then one per row-group read. A regression
+    # that rebuilt the index per access would leave `reads` correct and inflate this.
+    assert len(opens) == 3
+
+
+def test_dataset_view_reactions_empty_dataset(tmp_path):
+    """Indexing an empty dataset raises rather than reaching the row-group index.
+
+    A zero-row-group file gives an empty prefix sum, where a bisect would resolve to
+    row group -1 and silently read from the end.
+    """
+    path = tmp_path / "empty.parquet"
+    with dataset.DatasetWriter(path, name="n", description="d"):
+        pass
+    view = dataset.DatasetView(path)
+    assert view.reactions[:] == []
+    with pytest.raises(IndexError, match="reaction index 0 out of range"):
+        view.reactions[0]
+    with pytest.raises(IndexError, match="reaction index -1 out of range"):
+        view.reactions[-1]
+
+
+@pytest.mark.parametrize("key", ["0", 1.0, 2.7, None])
+def test_dataset_view_reactions_rejects_non_integer_key(tmp_path, key):
+    """Non-integer keys raise TypeError instead of being coerced.
+
+    Guards ``operator.index``: ``int(key)`` would truncate ``reactions[n / 2]`` to a
+    silently wrong Reaction rather than failing.
+    """
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(_make_dataset(n=5), path)
+    view = dataset.DatasetView(path)
+    with pytest.raises(TypeError):
+        view.reactions[key]
+
+
+def test_dataset_view_detects_replaced_file(tmp_path):
+    """A view must refuse to resolve indices against a file replaced underneath it.
+
+    DatasetWriter publishes by renaming onto its destination, so a view outliving a
+    republish would otherwise resolve positions against a stale row count.
+    """
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(_make_dataset(n=10), path, row_group_size=5)
+    view = dataset.DatasetView(path)
+    dataset.save_dataset(_make_dataset(n=3), path)
+    with pytest.raises(RuntimeError, match="changed since this view was opened"):
+        view.reactions[0]
 
 
 def test_dataset_view_to_proto_round_trips(tmp_path):
@@ -578,3 +650,21 @@ def test_dataset_view_to_proto_round_trips(tmp_path):
     assert materialized.SerializeToString(
         deterministic=True
     ) == source.SerializeToString(deterministic=True)
+
+
+def test_dataset_view_to_proto_carries_scalar_mutations(tmp_path):
+    """Scalars assigned on the view must survive materialization.
+
+    ``updates.assign_dataset_id`` accepts a DatasetView and writes ``dataset_id`` in
+    place, so materializing from the footer alone would silently drop the assignment.
+    """
+    source = _make_dataset(n=2, dataset_id="")
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(source, path)
+    view = dataset.DatasetView(path)
+    assigned = updates.assign_dataset_id(view)
+    view.name = "renamed"
+    materialized = view.to_proto()
+    assert materialized.dataset_id == assigned
+    assert materialized.name == "renamed"
+    assert list(materialized.reactions) == list(source.reactions)

--- a/ord_schema/parquet_test.py
+++ b/ord_schema/parquet_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests for ord_schema.parquet."""
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
@@ -462,3 +463,118 @@ def test_dataset_view_values_round_trip(tmp_path):
     assert list(view.reactions) == list(source.reactions)
     # Re-iterating must yield the same sequence (each access re-streams).
     assert list(view.reactions) == list(source.reactions)
+
+
+def _write_row_groups(path, group_sizes: list[int]) -> list[str]:
+    """Writes a Parquet dataset with explicitly sized row groups; returns reaction IDs.
+
+    DatasetWriter emits fixed-size row groups, so this drops to pyarrow to build the
+    ragged (and empty-group) layouts that random access has to resolve correctly.
+    """
+    schema = dataset._build_schema(name="n", description="d", dataset_id=None)
+    reaction_ids = []
+    with pq.ParquetWriter(path, schema) as writer:
+        for group, size in enumerate(group_sizes):
+            ids = [f"ord-{group:02d}{i:02d}" for i in range(size)]
+            blobs = [
+                _make_reaction(reaction_id).SerializeToString(deterministic=True)
+                for reaction_id in ids
+            ]
+            writer.write_table(
+                pa.table({"reaction_id": ids, "reaction": blobs}, schema=schema)
+            )
+            reaction_ids.extend(ids)
+    return reaction_ids
+
+
+def test_dataset_view_reactions_indexing_matches_source(tmp_path):
+    """``view.reactions[i]`` must match the source Dataset across row group bounds."""
+    source = _make_dataset(n=7)
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(source, path, row_group_size=3)
+    view = dataset.DatasetView(path)
+    assert [view.reactions[i] for i in range(7)] == list(source.reactions)
+    # Descending order exercises cache misses in the other direction.
+    assert [view.reactions[i] for i in reversed(range(7))] == list(
+        reversed(source.reactions)
+    )
+
+
+def test_dataset_view_reactions_negative_indices(tmp_path):
+    source = _make_dataset(n=5)
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(source, path, row_group_size=2)
+    view = dataset.DatasetView(path)
+    assert view.reactions[-1] == source.reactions[-1]
+    assert view.reactions[-5] == source.reactions[-5]
+
+
+@pytest.mark.parametrize("index", [5, 6, -6, -100])
+def test_dataset_view_reactions_index_out_of_range(tmp_path, index):
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(_make_dataset(n=5), path, row_group_size=2)
+    view = dataset.DatasetView(path)
+    with pytest.raises(IndexError, match=f"reaction index {index} out of range"):
+        view.reactions[index]
+
+
+def test_dataset_view_reactions_slices(tmp_path):
+    """Slices materialize a list, matching protobuf repeated-field slicing."""
+    source = _make_dataset(n=6)
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(source, path, row_group_size=2)
+    view = dataset.DatasetView(path)
+    assert view.reactions[:] == list(source.reactions)
+    assert view.reactions[1:4] == list(source.reactions[1:4])
+    assert view.reactions[::2] == list(source.reactions[::2])
+    assert view.reactions[::-1] == list(source.reactions[::-1])
+    assert view.reactions[10:20] == []
+
+
+def test_dataset_view_reactions_indexing_ragged_row_groups(tmp_path):
+    """Index resolution must use footer row counts, not an assumed uniform size.
+
+    Includes a zero-row group, which pyarrow does write and which shares a start
+    position with the group that follows it.
+    """
+    path = tmp_path / "ragged.parquet"
+    reaction_ids = _write_row_groups(path, [3, 0, 1, 4])
+    view = dataset.DatasetView(path)
+    assert len(view.reactions) == len(reaction_ids)
+    assert [view.reactions[i].reaction_id for i in range(len(reaction_ids))] == (
+        reaction_ids
+    )
+
+
+def test_dataset_view_indexing_reads_each_row_group_once(tmp_path, monkeypatch):
+    """Walking indices in order must cost one row-group read per group, not per row.
+
+    Without the cache this degrades to a full decompress per element, which turns a
+    ``for i in range(len(...))`` loop over a large dataset into an apparent hang.
+    """
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(_make_dataset(n=10), path, row_group_size=5)
+    view = dataset.DatasetView(path)
+    reads = []
+    unpatched = pq.ParquetFile.read_row_group
+
+    def _record(self, row_group, **kwargs):
+        reads.append(row_group)
+        return unpatched(self, row_group, **kwargs)
+
+    monkeypatch.setattr(pq.ParquetFile, "read_row_group", _record)
+    for i in range(10):
+        view.reactions[i]
+    assert reads == [0, 1]
+
+
+def test_dataset_view_to_proto_round_trips(tmp_path):
+    """``to_proto`` returns a real message supporting the protobuf surface."""
+    source = _make_dataset(n=3)
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(source, path)
+    materialized = dataset.DatasetView(path).to_proto()
+    assert isinstance(materialized, dataset_pb2.Dataset)
+    assert materialized.SerializeToString(
+        deterministic=True
+    ) == source.SerializeToString(deterministic=True)


### PR DESCRIPTION
## Summary

`_ReactionStream` implemented `__iter__`, `__len__`, and `__bool__` but not `__getitem__`, so `dataset.reactions[0]` — the most common idiom in the docs and downstream examples — raised `TypeError` on a `DatasetView`. This adds random access backed by row-group lookup, plus an escape hatch for the protobuf-only operations, so that a later change to what `datasets.load_dataset` returns is mechanical rather than a migration event.

Part of #929 (step 1 of two; step 2 flips the `load_dataset` default and is breaking).

## Changes

- `__getitem__` resolves an index to `(row_group, offset)` by bisecting an exclusive prefix sum of the footer's per-group row counts, then reads only that group. Sizes come from the footer rather than assumed uniform, and `bisect_right` lands past empty row groups, which pyarrow does write.
- The most recently read row group is cached, so an in-order index walk costs one read per row group rather than one decompress per element. Without it, indexing in a loop over a large dataset would trade a loud `TypeError` for a silent hang.
- The index and cache are built on first indexed access, so construction stays a footer-only read.
- Negative indices count from the end; slices materialize a list, matching protobuf repeated-field slicing.
- `DatasetView.to_proto()` materializes a real message, taking Reactions from the file and scalars from the view, so `updates.assign_dataset_id(view)` survives materialization.
- Indexing raises if the footer's row count no longer matches the count read at construction — `DatasetWriter` publishes by renaming onto its destination, so a view outliving a republish would otherwise mix rows from two files.
- Documents that `reaction_ids` is empty by design: the schema treats it as mutually exclusive with `reactions`, so serving it from the `reaction_id` column would fail validation on every Parquet dataset. `iter_reaction_ids` is the answer for callers that want the IDs.

## Testing

- `uv run pytest`: 637 non-ORM tests and 56 ORM tests pass; `ruff` and `ty` clean.
- 14 new tests in `parquet_test.py`: index/source parity in both directions across row-group boundaries, negative indices, out-of-range both ways, five slice forms, a ragged `[3, 0, 1, 4]` layout written through raw pyarrow with the group counts asserted, non-integer keys, indexing an empty dataset, a file replaced under a live view, and `to_proto` plain, after a scalar assignment, and driven off the Dataset descriptor so a scalar added to the proto fails until materialization carries it.
- Two tests pin cost rather than behavior: a monkeypatched `read_row_group` asserts a 10-row/2-group walk reads exactly `[0, 1]`, and a `ParquetFile.__init__` counter asserts 3 opens, which fails if the row-group index is rebuilt per access.

## Notes

- `DatasetView` holds no open file handle, so each cache *miss* reopens the file for the footer. Walking all 1772 row groups of the USPTO grants file pays ~1772 footer reads (~0.6 s measured per 1000 opens) on top of the decode — small next to deserializing 1.77M reactions. The fix, if it matters, is a `close()`/context manager so the handle can persist; left out to keep the resource story consistent with the rest of the module, where every function opens its own `ParquetFile`.
- `reaction_ids` is a public mutable list whose "always empty" invariant is documented but unenforced; making it a read-only property is a follow-up, since it predates this PR.
- Not adopted from review: registering `_ReactionStream` as a `collections.abc.Sequence`. `__contains__` and `__reversed__` already work through the legacy sequence protocol, and the mixins would add `index`/`count`, which a real `RepeatedCompositeContainer` does not have — making the stand-in a strict superset. Worth revisiting when `reactions` needs a public `Sequence[Reaction]` annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds indexed and sliced access to Parquet-backed `DatasetView.reactions`, with lazy row-group lookup and single-group caching, and adds `DatasetView.to_proto()` for full protobuf materialization.
- Supports positive and negative indices, slices, ragged and empty row groups, and bounds/type validation.
- Detects row-count changes before constructing the row-group index.
- Preserves mutable scalar attributes when materializing a protobuf.
- Adds coverage for behavior, replacement detection, cache efficiency, and scalar propagation.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains within the eligible follow-up-review scope.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/parquet.py | Adds lazy row-group indexing, recent-group caching, slice handling, replacement-count validation, and protobuf materialization to DatasetView. |
| ord_schema/parquet_test.py | Adds comprehensive indexing, row-group layout, cache-cost, replacement, key-validation, and materialization coverage. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A["reactions[index]"] --> B["Normalize and bounds-check index"]
  B --> C{"Row-group starts cached?"}
  C -->|No| D["Read footer row-group counts"]
  D --> E["Verify total row count"]
  E --> F["Build exclusive prefix sums"]
  C -->|Yes| G["Bisect starts to locate group and offset"]
  F --> G
  G --> H{"Requested group cached?"}
  H -->|Yes| I["Read serialized reaction from cached table"]
  H -->|No| J["Open Parquet file and read one row group"]
  J --> K["Cache group table"]
  K --> I
  I --> L["Deserialize and return Reaction"]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Guard to\_proto against a scalar field ad..."](https://github.com/open-reaction-database/ord-schema/commit/ae398d1422143e5718daf44656ef11889b86ac8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49920818)</sub>

**Context used:**

- Knowledge Base — [Data I/O: proto serialization, Parquet, and units](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/data-io.md)

<!-- /greptile_comment -->