### PR TITLE
Move dataset-scoped reads onto DatasetView

### DIFF
--- a/ord_schema/datasets.py
+++ b/ord_schema/datasets.py
@@ -17,7 +17,7 @@ These are the convenience entry points for reading and writing a complete
 ``Dataset``: ``.parquet`` routes to the (lower-level) ``parquet``
 serialization, and other suffixes go through ``message_helpers`` single-message
 I/O. For large Parquet datasets prefer the streaming ``parquet``
-interfaces (``DatasetView`` / ``iter_reactions``) over loading the whole thing
+interfaces (``DatasetView`` and its ``iter_reactions``) over loading the whole thing
 into memory.
 """
 
@@ -51,7 +51,7 @@ def load_dataset(filename: str | os.PathLike[str]) -> dataset_pb2.Dataset:
         warnings.warn(
             f"Loading the entire Parquet dataset {filename} into memory; for large "
             "datasets prefer the streaming loader ord_schema.parquet.DatasetView "
-            "(or iter_reactions/load_reaction).",
+            "(or its iter_reactions/get_reaction).",
             UserWarning,
             stacklevel=2,
         )

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -958,7 +958,7 @@ def load_message(
         raise ValueError(
             f"{path} is a Parquet dataset; load_message reads a single serialized "
             "message. Use ord_schema.datasets.load_dataset for the whole Dataset, or "
-            "ord_schema.parquet.DatasetView / iter_reactions to stream large ones."
+            "ord_schema.parquet.DatasetView to stream large ones."
         )
     this_open = gzip.open if path.suffix == ".gz" else open
     input_format = _message_format(path)

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -485,7 +485,7 @@ def add_parquet_reactions(
         _copy_rows(dbapi_connection, rows_by_table)
         batch.clear()
 
-    reactions: Any = parquet.iter_reactions(path, row_group=row_group)
+    reactions: Any = parquet.DatasetView(path).iter_reactions(row_group=row_group)
     if progress_desc is not None:
         reactions = tqdm(
             reactions,

--- a/ord_schema/orm/loading_test.py
+++ b/ord_schema/orm/loading_test.py
@@ -124,7 +124,8 @@ def test_parquet_sharded_ingest_matches_single_process(tmp_path):
     of every table.
     """
     parquet_path, _ = _write_parquet_dataset(tmp_path, row_group_size=10)
-    assert parquet.num_row_groups(parquet_path) > 1  # Sharding is actually exercised.
+    view = parquet.DatasetView(parquet_path)
+    assert view.num_row_groups > 1  # Sharding is actually exercised.
     result: dict[str, dict[str, tuple[int, str | None]]] = {}
     for label, n_jobs in (("sharded", 2), ("single", 1)):
         with Postgresql() as postgres:

--- a/ord_schema/parquet.py
+++ b/ord_schema/parquet.py
@@ -243,19 +243,16 @@ def save_dataset(
         writer.write_all(dataset.reactions)
 
 
-class _ReactionStream:
-    """Re-iterable, indexable Reaction stream with a known length.
+class _RowGroupReader:
+    """Row-group reads for one Parquet file, with a one-entry cache.
 
-    Each iteration opens a fresh read over the backing Parquet file so callers that
-    iterate more than once stay memory-bounded. ``__len__`` and ``__bool__`` come from
-    the footer row count, so emptiness checks (e.g., ``if not dataset.reactions``)
-    behave like a list instead of always being truthy the way a bare generator would be.
-    ``__getitem__`` reads only the row group holding the requested index, so random
-    access does not scan the file.
+    Shared by ``DatasetView.iter_reactions(row_group=...)`` and by positional access
+    through ``DatasetView.reactions``, so streaming a row group and indexing into one
+    resolve and cache it the same way.
     """
 
-    def __init__(self, path: str | os.PathLike[str], num_reactions: int) -> None:
-        """Opens a stream over the Reactions in a Parquet file.
+    def __init__(self, path: str, num_reactions: int) -> None:
+        """Prepares row-group reads against a Parquet file.
 
         Args:
             path: Path to the backing Parquet file.
@@ -263,12 +260,111 @@ class _ReactionStream:
         """
         self._path = path
         self._num_reactions = num_reactions
-        # Deferred to the first indexed access: building the index costs a second
+        # Deferred to the first positional read: building the index costs a second
         # footer read and one RowGroupMetaData per row group, neither of which a
         # caller that only iterates ever needs.
         self._row_group_starts: list[int] | None = None
         # Row group index paired with its table, so the two cannot desynchronize.
         self._cache: tuple[int, pa.Table] | None = None
+
+    def read(self, row_group: int) -> pa.Table:
+        """Reads one row group, caching the most recent read.
+
+        Args:
+            row_group: Row group index.
+
+        Returns:
+            A Table holding the ``reaction_id`` and ``reaction`` columns.
+        """
+        cached = self._cache
+        if cached is not None and cached[0] == row_group:
+            return cached[1]
+        with pq.ParquetFile(self._path) as parquet_file:
+            table = parquet_file.read_row_group(
+                row_group, columns=["reaction_id", "reaction"]
+            )
+        self._cache = (row_group, table)
+        return table
+
+    def reaction_at(self, position: int) -> reaction_pb2.Reaction:
+        """Reads the Reaction at an absolute row position.
+
+        Args:
+            position: Row position; callers bounds-check against the row count.
+
+        Returns:
+            A freshly deserialized Reaction, not a live sub-message of a Dataset.
+
+        Raises:
+            RuntimeError: If the file's row count disagrees with the count read when
+                the view was opened, meaning the file was replaced.
+        """
+        row_group, offset = self._locate(position)
+        blob = self.read(row_group).column("reaction")[offset].as_py()
+        return reaction_pb2.Reaction.FromString(blob)
+
+    def _locate(self, position: int) -> tuple[int, int]:
+        """Maps an absolute row position onto the row group holding it.
+
+        Args:
+            position: Row position, already bounds-checked against the row count.
+
+        Returns:
+            ``(row_group, offset_within_row_group)``.
+
+        Raises:
+            RuntimeError: If the file was replaced since the view was opened.
+        """
+        if self._row_group_starts is None:
+            with pq.ParquetFile(self._path) as parquet_file:
+                metadata = parquet_file.metadata
+                counts = [
+                    metadata.row_group(i).num_rows
+                    for i in range(metadata.num_row_groups)
+                ]
+            # The row count was read from the footer when the view was opened, so a
+            # disagreement means the file was replaced underneath it -- which
+            # DatasetWriter does by design, publishing via rename onto the path.
+            # Refuse rather than serve rows resolved against the wrong layout.
+            if sum(counts) != self._num_reactions:
+                raise RuntimeError(
+                    f"{self._path} changed since this view was opened: the footer now "
+                    f"reports {sum(counts)} reactions, the view was opened on "
+                    f"{self._num_reactions}. Re-open the DatasetView."
+                )
+            # Exclusive prefix sum: element i is the absolute position of row group i's
+            # first row. Sizes come from the footer because row groups are not
+            # guaranteed uniform; bisect_right lands past any empty groups, which
+            # share a start position with the group that follows them.
+            self._row_group_starts = list(itertools.accumulate(counts, initial=0))[:-1]
+        row_group = bisect.bisect_right(self._row_group_starts, position) - 1
+        return row_group, position - self._row_group_starts[row_group]
+
+
+class _ReactionStream:
+    """List-like facade over the Reactions in a ``DatasetView``.
+
+    Owns no file state: iteration delegates to the view's ``iter_reactions`` and
+    indexing to the shared ``_RowGroupReader``, so this adds list semantics without a
+    second way to read the file. ``__len__`` and ``__bool__`` come from the footer row
+    count, so emptiness checks (e.g., ``if not dataset.reactions``) behave like a list
+    instead of always being truthy the way a bare generator would be.
+    """
+
+    def __init__(
+        self, view: "DatasetView", reader: _RowGroupReader, num_reactions: int
+    ) -> None:
+        """Wraps a view as a re-iterable, indexable sequence of Reactions.
+
+        Args:
+            view: View owning this stream; supplies the no-argument
+                ``iter_reactions`` that ``__iter__`` delegates to.
+            reader: Shared row-group reader backing positional access.
+            num_reactions: Row count taken from the file footer.
+        """
+        self._view = view
+        self._reader = reader
+        self._num_reactions = num_reactions
 
     def __iter__(self) -> Iterator[reaction_pb2.Reaction]:
         """Opens a fresh read over the backing file.
@@ -276,7 +372,7 @@ class _ReactionStream:
         Yields:
             Each Reaction, in file order.
         """
-        for _, reaction in iter_reactions(self._path):
+        for _, reaction in self._view.iter_reactions():
             yield reaction
 
     def __len__(self) -> int:
@@ -329,7 +425,7 @@ class _ReactionStream:
             index: Reaction index; negative values count from the end.
 
         Returns:
-            A freshly deserialized Reaction, not a live sub-message of a Dataset.
+            The Reaction at ``index``.
 
         Raises:
             IndexError: If ``index`` is out of range.
@@ -340,64 +436,7 @@ class _ReactionStream:
                 f"reaction index {index} out of range for "
                 f"{self._num_reactions} reactions"
             )
-        row_group, offset = self._locate(position)
-        blob = self._read_row_group(row_group).column("reaction")[offset].as_py()
-        return reaction_pb2.Reaction.FromString(blob)
-
-    def _locate(self, position: int) -> tuple[int, int]:
-        """Maps an absolute row position onto the row group holding it.
-
-        Args:
-            position: Row position, already bounds-checked against the row count.
-
-        Returns:
-            ``(row_group, offset_within_row_group)``.
-
-        Raises:
-            RuntimeError: If the file's row count disagrees with the count read when
-                the view was opened, meaning the file was replaced.
-        """
-        if self._row_group_starts is None:
-            with pq.ParquetFile(self._path) as parquet_file:
-                metadata = parquet_file.metadata
-                counts = [
-                    metadata.row_group(i).num_rows
-                    for i in range(metadata.num_row_groups)
-                ]
-            # The row count was read from the footer when the view was opened, so a
-            # disagreement means the file was replaced underneath it -- which
-            # DatasetWriter does by design, publishing via rename onto the path.
-            # Refuse rather than serve rows resolved against the wrong layout.
-            if sum(counts) != self._num_reactions:
-                raise RuntimeError(
-                    f"{self._path} changed since this view was opened: the footer now "
-                    f"reports {sum(counts)} reactions, the view was opened on "
-                    f"{self._num_reactions}. Re-open the DatasetView."
-                )
-            # Exclusive prefix sum: element i is the absolute position of row group i's
-            # first row. Sizes come from the footer because row groups are not
-            # guaranteed uniform; bisect_right lands past any empty groups, which
-            # share a start position with the group that follows them.
-            self._row_group_starts = list(itertools.accumulate(counts, initial=0))[:-1]
-        row_group = bisect.bisect_right(self._row_group_starts, position) - 1
-        return row_group, position - self._row_group_starts[row_group]
-
-    def _read_row_group(self, row_group: int) -> pa.Table:
-        """Reads one row group, caching the most recent read.
-
-        Args:
-            row_group: Row group index.
-
-        Returns:
-            A Table holding only the ``reaction`` column of ``row_group``.
-        """
-        cached = self._cache
-        if cached is not None and cached[0] == row_group:
-            return cached[1]
-        with pq.ParquetFile(self._path) as parquet_file:
-            table = parquet_file.read_row_group(row_group, columns=["reaction"])
-        self._cache = (row_group, table)
-        return table
+        return self._reader.reaction_at(position)
 
 
 class DatasetView:
@@ -423,7 +462,8 @@ class DatasetView:
     reactions stored *outside* the Dataset and is mutually exclusive with
     ``reactions``, so serving it from the ``reaction_id`` column would make
     every Parquet dataset fail validation. Use ``iter_reaction_ids`` for the
-    IDs of the reactions this dataset contains.
+    IDs of the reactions this dataset does contain, or ``get_reaction`` to
+    look one up.
     """
 
     def __init__(self, path: str | os.PathLike[str]) -> None:
@@ -436,11 +476,16 @@ class DatasetView:
         with pq.ParquetFile(path) as parquet_file:
             scalars = _dataset_from_metadata(parquet_file.schema_arrow.metadata)
             num_rows = parquet_file.metadata.num_rows
+            self._num_row_groups = parquet_file.num_row_groups
         self.name = scalars.name
         self.description = scalars.description
         self.dataset_id = scalars.dataset_id
         self.reaction_ids: list[str] = []
-        self._reactions = _ReactionStream(self._path, num_rows)
+        # Built on the first get_reaction call; reading the whole reaction_id column
+        # is wasted on views that only iterate or index by position.
+        self._positions: dict[str, int] | None = None
+        self._reader = _RowGroupReader(self._path, num_rows)
+        self._reactions = _ReactionStream(self, self._reader, num_rows)
 
     @property
     def path(self) -> str:
@@ -448,9 +493,102 @@ class DatasetView:
         return self._path
 
     @property
+    def num_row_groups(self) -> int:
+        """Number of row groups, the unit of parallelism for ``iter_reactions``."""
+        return self._num_row_groups
+
+    @property
     def reactions(self) -> _ReactionStream:
         """Re-iterable stream of Reactions read from the backing file."""
         return self._reactions
+
+    def iter_reactions(
+        self,
+        reaction_ids: Iterable[str] | None = None,
+        *,
+        row_group: int | None = None,
+    ) -> Iterator[tuple[str, reaction_pb2.Reaction]]:
+        """Streams ``(reaction_id, Reaction)`` pairs from the backing file.
+
+        Iterating ``reactions`` is the same read with the IDs dropped; use this when
+        the ID is wanted alongside the message, or to restrict the read.
+
+        Args:
+            reaction_ids: Optional iterable of reaction IDs to restrict iteration
+                to. IDs not present in the file are silently skipped. Filtering
+                is applied row-wise; row groups are still read in full. Pass
+                ``None`` (the default) to iterate all reactions; an explicitly
+                empty iterable raises ``ValueError`` since it is almost always a
+                bug.
+            row_group: Optional row-group index. When set, only that row group is
+                read; this is the unit of parallelism for callers that fan out
+                across row groups (see ``num_row_groups``).
+
+        Yields:
+            Each ``(reaction_id, Reaction)`` pair, in file order.
+
+        Raises:
+            ValueError: If ``reaction_ids`` is provided but empty.
+            IndexError: If ``row_group`` is out of range.
+        """
+        if reaction_ids is None:
+            filter_set = None
+        else:
+            filter_set = set(reaction_ids)
+            if not filter_set:
+                raise ValueError(
+                    "reaction_ids must be non-empty when provided; pass None to "
+                    "iterate all"
+                )
+        if row_group is None:
+            with pq.ParquetFile(self._path) as parquet_file:
+                yield from _iter_reactions(parquet_file, filter_set=filter_set)
+            return
+        if not 0 <= row_group < self._num_row_groups:
+            raise IndexError(
+                f"row_group {row_group} out of range [0, {self._num_row_groups})"
+            )
+        yield from _iter_table(self._reader.read(row_group), filter_set=filter_set)
+
+    def iter_reaction_ids(self) -> Iterator[str]:
+        """Streams ``reaction_id`` values without deserializing any Reaction.
+
+        Reads only the ``reaction_id`` column, a row group at a time, so this stays
+        cheap on very large files. Order matches ``iter_reactions``.
+
+        Yields:
+            Each reaction ID, in file order.
+        """
+        with pq.ParquetFile(self._path) as parquet_file:
+            for batch in parquet_file.iter_batches(columns=["reaction_id"]):
+                yield from batch.column("reaction_id").to_pylist()
+
+    def get_reaction(self, reaction_id: str) -> reaction_pb2.Reaction:
+        """Reads a single Reaction by ID.
+
+        The first call reads the ``reaction_id`` column to build an ID-to-position
+        index; later calls are a dict lookup plus one row-group read. Reading the
+        whole column costs far less than deserializing the Reactions, so this beats
+        a scan as soon as more than one lookup is made. Where a reaction ID appears
+        more than once, the first occurrence wins.
+
+        Args:
+            reaction_id: ID of the Reaction to read.
+
+        Returns:
+            A freshly deserialized Reaction.
+
+        Raises:
+            KeyError: If ``reaction_id`` is not present in the file.
+        """
+        if self._positions is None:
+            positions: dict[str, int] = {}
+            for position, candidate in enumerate(self.iter_reaction_ids()):
+                positions.setdefault(candidate, position)
+            self._positions = positions
+        if reaction_id not in self._positions:
+            raise KeyError(reaction_id)
+        return self._reader.reaction_at(self._positions[reaction_id])
 
     def to_proto(self) -> dataset_pb2.Dataset:
         """Materializes a real ``Dataset`` message, deserializing every Reaction.
@@ -475,8 +613,8 @@ class DatasetView:
 def load_dataset(path: str | os.PathLike[str]) -> dataset_pb2.Dataset:
     """Reads a full Dataset from a Parquet file.
 
-    All reactions are deserialized into memory; prefer ``iter_reactions`` or
-    ``load_reaction`` for large datasets.
+    All reactions are deserialized into memory; prefer ``DatasetView`` and its
+    streaming reads for large datasets.
     """
     with pq.ParquetFile(path) as parquet_file:
         dataset = _dataset_from_metadata(parquet_file.schema_arrow.metadata)
@@ -516,60 +654,6 @@ def load_footer(path: str | os.PathLike[str]) -> ParquetFooter:
             num_row_groups=parquet_file.num_row_groups,
             num_rows=parquet_file.metadata.num_rows,
         )
-
-
-def iter_reactions(
-    path: str | os.PathLike[str],
-    reaction_ids: Iterable[str] | None = None,
-    *,
-    row_group: int | None = None,
-) -> Iterator[tuple[str, reaction_pb2.Reaction]]:
-    """Yields ``(reaction_id, Reaction)`` pairs from a Parquet dataset.
-
-    Args:
-        path: Parquet file path.
-        reaction_ids: Optional iterable of reaction IDs to restrict iteration
-            to. IDs not present in the file are silently skipped. Filtering
-            is applied row-wise; row groups are still read in full. Pass
-            ``None`` (the default) to iterate all reactions; an explicitly
-            empty iterable raises ``ValueError`` since it is almost always a
-            bug.
-        row_group: Optional row-group index. When set, only that row group is
-            read; this is the unit of parallelism for callers that fan out
-            across row groups (see ``num_row_groups``). Out-of-range indices
-            raise ``IndexError``.
-    """
-    if reaction_ids is None:
-        filter_set = None
-    else:
-        filter_set = set(reaction_ids)
-        if not filter_set:
-            raise ValueError(
-                "reaction_ids must be non-empty when provided; pass None to iterate all"
-            )
-    with pq.ParquetFile(path) as parquet_file:
-        if row_group is not None:
-            if not 0 <= row_group < parquet_file.num_row_groups:
-                raise IndexError(
-                    f"row_group {row_group} out of range "
-                    f"[0, {parquet_file.num_row_groups})"
-                )
-            table = parquet_file.read_row_group(
-                row_group, columns=["reaction_id", "reaction"]
-            )
-            yield from _iter_table(table, filter_set=filter_set)
-        else:
-            yield from _iter_reactions(parquet_file, filter_set=filter_set)
-
-
-def num_row_groups(path: str | os.PathLike[str]) -> int:
-    """Returns the number of row groups in a Parquet dataset.
-
-    Used by callers that parallelize over row groups via ``iter_reactions(...,
-    row_group=i)``. Cheap: only reads the file footer.
-    """
-    with pq.ParquetFile(path) as parquet_file:
-        return parquet_file.num_row_groups
 
 
 def _iter_reactions(
@@ -631,44 +715,6 @@ def streaming_md5(path: str | os.PathLike[str]) -> tuple[str, int]:
                 hasher.update(blob)
                 num_reactions += 1
     return hasher.hexdigest(), num_reactions
-
-
-def iter_reaction_ids(path: str | os.PathLike[str]) -> Iterator[str]:
-    """Yields ``reaction_id`` values from a Parquet dataset without decoding Reactions.
-
-    Reads only the ``reaction_id`` column row-group at a time, so this is cheap even for
-    very large files. Iteration order matches ``iter_reactions``.
-    """
-    with pq.ParquetFile(path) as parquet_file:
-        for batch in parquet_file.iter_batches(columns=["reaction_id"]):
-            yield from batch.column("reaction_id").to_pylist()
-
-
-def load_reaction(
-    path: str | os.PathLike[str], reaction_id: str
-) -> reaction_pb2.Reaction:
-    """Reads a single Reaction by ID.
-
-    Passes ``reaction_id`` as a Parquet predicate, which lets row groups be
-    pruned via per-group min/max statistics **when** ``reaction_id`` values
-    are clustered within groups (e.g., sorted). For unsorted writes every
-    row group's range typically covers the query, so this falls back to a
-    full scan of the ``reaction_id``/``reaction`` columns.
-
-    Raises:
-        KeyError: If ``reaction_id`` is not present in the file.
-    """
-    table = pq.read_table(
-        path,
-        columns=["reaction_id", "reaction"],
-        filters=[("reaction_id", "=", reaction_id)],
-    )
-    ids = table.column("reaction_id").to_pylist()
-    blobs = table.column("reaction").to_pylist()
-    for candidate_id, blob in zip(ids, blobs, strict=True):
-        if candidate_id == reaction_id:
-            return reaction_pb2.Reaction.FromString(blob)
-    raise KeyError(reaction_id)
 
 
 def _build_schema(*, name: str, description: str, dataset_id: str | None) -> pa.Schema:

--- a/ord_schema/parquet_test.py
+++ b/ord_schema/parquet_test.py
@@ -84,9 +84,18 @@ def test_iter_reactions_all(tmp_path):
     original = _make_dataset(n=3)
     path = tmp_path / "ds.parquet"
     dataset.save_dataset(original, path)
-    pairs = list(dataset.iter_reactions(path))
+    pairs = list(dataset.DatasetView(path).iter_reactions())
     assert [rid for rid, _ in pairs] == [r.reaction_id for r in original.reactions]
     assert [r.outcomes[0].conversion.value for _, r in pairs] == [0.0, 1.0, 2.0]
+
+
+def test_iter_reactions_matches_reactions_stream(tmp_path):
+    """``reactions`` is ``iter_reactions()`` with the IDs dropped."""
+    original = _make_dataset(n=4)
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(original, path)
+    view = dataset.DatasetView(path)
+    assert [reaction for _, reaction in view.iter_reactions()] == list(view.reactions)
 
 
 def test_iter_reactions_filtered(tmp_path):
@@ -96,7 +105,7 @@ def test_iter_reactions_filtered(tmp_path):
     # Output order follows file order, not the order of ``reaction_ids``;
     # ord-9999 is absent and silently skipped.
     wanted = {"ord-0003", "ord-0001", "ord-9999"}
-    pairs = list(dataset.iter_reactions(path, reaction_ids=wanted))
+    pairs = list(dataset.DatasetView(path).iter_reactions(reaction_ids=wanted))
     assert [rid for rid, _ in pairs] == ["ord-0001", "ord-0003"]
 
 
@@ -108,18 +117,19 @@ def test_iter_reactions_row_group(tmp_path):
         path, name=original.name, description=original.description, row_group_size=2
     ) as writer:
         writer.write_all(original.reactions)
-    assert dataset.num_row_groups(path) == 3
-    assert [rid for rid, _ in dataset.iter_reactions(path, row_group=0)] == [
+    view = dataset.DatasetView(path)
+    assert view.num_row_groups == 3
+    assert [rid for rid, _ in view.iter_reactions(row_group=0)] == [
         "ord-0000",
         "ord-0001",
     ]
-    assert [rid for rid, _ in dataset.iter_reactions(path, row_group=1)] == [
+    assert [rid for rid, _ in view.iter_reactions(row_group=1)] == [
         "ord-0002",
         "ord-0003",
     ]
-    assert [rid for rid, _ in dataset.iter_reactions(path, row_group=2)] == ["ord-0004"]
+    assert [rid for rid, _ in view.iter_reactions(row_group=2)] == ["ord-0004"]
     with pytest.raises(IndexError, match="out of range"):
-        list(dataset.iter_reactions(path, row_group=3))
+        list(view.iter_reactions(row_group=3))
 
 
 def test_iter_reactions_empty_filter_raises(tmp_path):
@@ -127,24 +137,79 @@ def test_iter_reactions_empty_filter_raises(tmp_path):
     path = tmp_path / "ds.parquet"
     dataset.save_dataset(original, path)
     with pytest.raises(ValueError, match="non-empty"):
-        list(dataset.iter_reactions(path, reaction_ids=[]))
+        list(dataset.DatasetView(path).iter_reactions(reaction_ids=[]))
 
 
-def test_load_reaction_hit(tmp_path):
+def test_get_reaction_hit(tmp_path):
     original = _make_dataset(n=5)
     path = tmp_path / "ds.parquet"
     dataset.save_dataset(original, path)
-    reaction = dataset.load_reaction(path, "ord-0002")
+    reaction = dataset.DatasetView(path).get_reaction("ord-0002")
     assert reaction.reaction_id == "ord-0002"
     assert reaction.outcomes[0].conversion.value == 2.0
 
 
-def test_load_reaction_miss(tmp_path):
+def test_get_reaction_miss(tmp_path):
     original = _make_dataset(n=2)
     path = tmp_path / "ds.parquet"
     dataset.save_dataset(original, path)
-    with pytest.raises(KeyError):
-        dataset.load_reaction(path, "ord-nope")
+    with pytest.raises(KeyError, match="ord-nope"):
+        dataset.DatasetView(path).get_reaction("ord-nope")
+
+
+def test_get_reaction_across_row_groups(tmp_path):
+    """Every ID resolves to its own Reaction, including across row group bounds."""
+    original = _make_dataset(n=7)
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(original, path, row_group_size=3)
+    view = dataset.DatasetView(path)
+    for reaction in original.reactions:
+        assert view.get_reaction(reaction.reaction_id) == reaction
+
+
+def test_get_reaction_builds_id_index_once(tmp_path, monkeypatch):
+    """The reaction_id column is read once, not per lookup."""
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(_make_dataset(n=6), path, row_group_size=2)
+    view = dataset.DatasetView(path)
+    calls = []
+    unpatched = dataset.DatasetView.iter_reaction_ids
+
+    def _record(self):
+        calls.append(self.path)
+        return unpatched(self)
+
+    monkeypatch.setattr(dataset.DatasetView, "iter_reaction_ids", _record)
+    for i in range(6):
+        assert view.get_reaction(f"ord-{i:04d}").reaction_id == f"ord-{i:04d}"
+    assert len(calls) == 1
+
+
+def test_row_group_read_shared_by_iteration_and_lookup(tmp_path, monkeypatch):
+    """Streaming a row group, indexing into it, and ID lookup share one cached read.
+
+    All three go through the same _RowGroupReader, so once a row group is resolved the
+    other two paths must not re-read it.
+    """
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(_make_dataset(n=6), path, row_group_size=3)
+    view = dataset.DatasetView(path)
+    reads = []
+    unpatched = pq.ParquetFile.read_row_group
+
+    def _record(self, row_group, *args, **kwargs):
+        reads.append(row_group)
+        return unpatched(self, row_group, *args, **kwargs)
+
+    monkeypatch.setattr(pq.ParquetFile, "read_row_group", _record)
+    assert [rid for rid, _ in view.iter_reactions(row_group=1)] == [
+        "ord-0003",
+        "ord-0004",
+        "ord-0005",
+    ]
+    assert view.reactions[4].reaction_id == "ord-0004"
+    assert view.get_reaction("ord-0005").reaction_id == "ord-0005"
+    assert reads == [1]
 
 
 def test_row_group_boundaries(tmp_path):
@@ -263,7 +328,7 @@ def test_multi_row_group_streaming_preserves_order(tmp_path):
     dataset.save_dataset(original, path, row_group_size=500)
     parquet_file = pq.ParquetFile(path)
     assert parquet_file.num_row_groups == 5
-    streamed = [rid for rid, _ in dataset.iter_reactions(path)]
+    streamed = [rid for rid, _ in dataset.DatasetView(path).iter_reactions()]
     assert streamed == [r.reaction_id for r in original.reactions]
 
 

--- a/ord_schema/scripts/validate_dataset.py
+++ b/ord_schema/scripts/validate_dataset.py
@@ -59,7 +59,7 @@ def _validate_row_group(
     errors: list[str] = []
     state = validations.DatasetCrossRefState()
     for i, (_, reaction) in enumerate(
-        parquet.iter_reactions(filename, row_group=row_group)
+        parquet.DatasetView(filename).iter_reactions(row_group=row_group)
     ):
         output = validations.validate_message(
             reaction, raise_on_error=False, options=options

--- a/ord_schema/scripts/validate_dataset_test.py
+++ b/ord_schema/scripts/validate_dataset_test.py
@@ -134,7 +134,7 @@ def test_parquet_cross_row_group_duplicate_id(tmp_path):
     ) as writer:
         writer.write_all(reactions)
     # Sanity-check the layout the test is asserting against.
-    assert parquet.num_row_groups(str(path)) == 3
+    assert parquet.DatasetView(str(path)).num_row_groups == 3
     with pytest.raises(
         validations.ValidationError,
         match="Multiple Reactions should never have the same IDs",
@@ -153,7 +153,7 @@ def test_parquet_empty_file(tmp_path):
     path = tmp_path / "empty.parquet"
     with parquet.DatasetWriter(str(path), name="test", description="test") as writer:
         writer.write_all([])
-    assert parquet.num_row_groups(str(path)) == 0
+    assert parquet.DatasetView(str(path)).num_row_groups == 0
     with pytest.raises(
         validations.ValidationError,
         match="Dataset requires reactions or reaction_ids",
@@ -175,7 +175,7 @@ def test_parquet_per_reaction_error_in_late_row_group(tmp_path):
         str(path), name="test", description="test", row_group_size=2
     ) as writer:
         writer.write_all(reactions)
-    assert parquet.num_row_groups(str(path)) == 2
+    assert parquet.DatasetView(str(path)).num_row_groups == 2
     with pytest.raises(
         validations.ValidationError,
         match="Reactions should have at least 1 reaction input",

--- a/ord_schema/updates.py
+++ b/ord_schema/updates.py
@@ -185,7 +185,7 @@ def update_parquet_dataset(
     """
     header = parquet.load_metadata(input_path)
     new_ids, id_substitutions = assign_id_substitutions(
-        parquet.iter_reaction_ids(input_path)
+        parquet.DatasetView(input_path).iter_reaction_ids()
     )
     with parquet.DatasetWriter(
         output_path,
@@ -193,7 +193,7 @@ def update_parquet_dataset(
         description=header.description,
         dataset_id=dataset_id,
     ) as writer:
-        reactions = (reaction for _, reaction in parquet.iter_reactions(input_path))
+        reactions = parquet.DatasetView(input_path).reactions
         for reaction, new_id in zip(reactions, new_ids, strict=True):
             apply_reaction_updates(reaction, new_id=new_id)
             apply_cross_reference_substitutions(reaction, id_substitutions)

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -647,7 +647,7 @@ def validate_dataset_streaming(
     in slices (e.g., per Parquet row group) by upstream workers, with each worker
     contributing a ``DatasetCrossRefState`` that the caller has merged.
     ``has_reactions`` should reflect the source's row count (e.g.,
-    ``parquet.load_metadata`` plus ``num_row_groups`` for parquet); inferring it from
+    ``parquet.load_footer`` for parquet); inferring it from
     ``state`` would misclassify reactions without reaction_ids or references as empty.
     Pass ``reaction_ids=[]`` for the typical streaming case (parquet does not persist
     Dataset.reaction_ids).


### PR DESCRIPTION
## Summary

`ord_schema.parquet` exposed four module functions that each took a path and re-derived state a `DatasetView` already holds, and the streaming and random-access paths read row groups through separate code. This folds those functions onto the view and gives both paths one shared reader.

Breaking: `parquet.iter_reactions`, `parquet.iter_reaction_ids`, `parquet.load_reaction`, and `parquet.num_row_groups` are removed. Follows #930; relates to #929.

## Changes

- `DatasetView` gains `iter_reactions(reaction_ids=None, *, row_group=None)`, `iter_reaction_ids()`, `get_reaction(reaction_id)`, and a `num_row_groups` property.
- `get_reaction` replaces `load_reaction`, which passed `reaction_id` as a Parquet predicate and degraded to a full scan (~2 s on the USPTO file) because published files are not sorted by ID. It builds an ID-to-position index from the `reaction_id` column on first use, so later lookups are a dict hit plus one row-group read.
- New `_RowGroupReader` owns the row-group index and the one-entry cache. Positional access and `iter_reactions(row_group=...)` previously opened the file and read the same row group independently; both now go through it.
- `_ReactionStream` keeps no file state — iteration delegates to `view.iter_reactions()`, indexing to the reader — so list semantics are the only thing it adds.
- `num_row_groups` is cached at construction instead of reopening the file per access; `__init__` already reads the footer.
- Path-in/value-out calls (`save_dataset`, `load_dataset`, `load_metadata`, `load_footer`, `streaming_md5`) stay module level. They are single-pass, and both `load_footer` callers store the result in scheduler bookkeeping held across a `ProcessPoolExecutor` fan-out, where a frozen value beats a cache-carrying handle.

## Testing

- `uv run pytest`: 642 non-ORM and 56 ORM tests pass; `ruff` and `ty` clean.
- Migrated call sites: `orm/database.py`, `scripts/validate_dataset.py`, `updates.py` (two).
- New tests: `reactions` equals `iter_reactions()` with IDs dropped; `get_reaction` hit, miss, and across row-group boundaries; the ID index is built once across six lookups; and streaming a row group, indexing into it, and an ID lookup together issue exactly one `read_row_group`.

## Notes

- ord-data needs a one-line change: `parquet.iter_reaction_ids(dataset.path)` → `dataset.iter_reaction_ids()` in `scripts/process_dataset.py`, where `dataset` is already a `DatasetView`. No other downstream repo calls the removed functions.
- `reaction_ids` stays a plain attribute rather than becoming a stream property: the name belongs to the proto field, which must stay empty for a Parquet dataset or validation rejects it as "reactions or reaction_ids, not both".
- The row-group reader now projects `reaction_id` alongside `reaction` so both paths can share one cached table. That column is small next to the serialized Reactions, and it lets `iter_reactions(row_group=...)` reuse a table positional access already fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR moves dataset-scoped Parquet reads onto `DatasetView`, adds indexed reaction lookup, and consolidates positional and row-group reads behind a shared reader.
- Adds `DatasetView.iter_reactions`, `iter_reaction_ids`, `get_reaction`, and `num_row_groups`.
- Introduces a cached row-group reader and lazily built reaction-ID index.
- Migrates validation, update, and ORM ingestion call sites from the removed module-level APIs.
- Extends tests for indexed lookup, row-group boundaries, and shared read caching.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable changed-code failures identified.

The new DatasetView methods preserve existing streaming and sharded workflows, all in-repository consumers of the intentionally removed APIs were migrated, and the shared reader and indexed lookup are covered across row-group boundaries and cache reuse.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/parquet.py | Centralizes dataset-scoped reads on DatasetView, adds indexed ID lookup, and shares cached row-group access across lookup and positional APIs. |
| ord_schema/updates.py | Migrates the two-pass Parquet update flow to DatasetView while preserving streaming behavior. |
| ord_schema/scripts/validate_dataset.py | Migrates row-group validation workers to DatasetView without changing validation aggregation. |
| ord_schema/orm/database.py | Migrates Parquet reaction ingestion to DatasetView while retaining row-group sharding. |
| ord_schema/parquet_test.py | Adds coverage for reaction lookup, ID-index reuse, row-group boundaries, and shared reader caching. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Caller[Dataset-scoped caller] --> View[DatasetView]
  View --> Iterate[iter_reactions / reactions iteration]
  View --> IDs[iter_reaction_ids]
  View --> Lookup[get_reaction]
  View --> Count[num_row_groups]
  Lookup --> Index[Lazy ID-to-position index]
  Index --> Reader[_RowGroupReader]
  Count --> Footer[Cached footer metadata]
  Iterate -->|whole file| Parquet[Parquet file]
  Iterate -->|one row group| Reader
  Reader --> Cache[One-entry row-group cache]
  Cache --> Parquet
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Move dataset-scoped reads onto DatasetVi..."](https://github.com/open-reaction-database/ord-schema/commit/51707b2666602c79181fc3a92c32b57562eb0ecb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49928065)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Data I/O: proto serialization, Parquet, and units](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/data-io.md)
- Knowledge Base — [Dataset Scripts](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/dataset-scripts.md)
- Knowledge Base — [ORM and Database Loading](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/orm-database.md)
- Knowledge Base — [Validation, Resolution, and Update Pipeline](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/validation-pipeline.md)
</details>

<!-- /greptile_comment -->