### PR TITLE
Fix lazy argument validation in iter_reactions; revamp the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,9 @@
 [![DOI:10.1007/978-3-319-76207-4_15](https://zenodo.org/badge/DOI/10.1021/jacs.1c09820.svg)](https://doi.org/10.1021/jacs.1c09820)
 [![PyPI version](https://badge.fury.io/py/ord-schema.svg)](https://badge.fury.io/py/ord-schema)
 
-This repository contains the schema for the Open Reaction Database initiative; please see the documentation
-at <https://docs.open-reaction-database.org>.
+This repository contains the schema for the Open Reaction Database initiative; please see the documentation at <https://docs.open-reaction-database.org>.
 
-This repository does not contain the database itself; that is stored
-in [ord-data](https://github.com/open-reaction-database/ord-data). Rather, `ord-schema` is
-designed to store the database schema and tools for creating, validating, and submitting data to the database.
+This repository does not contain the database itself; that is stored in [ord-data](https://github.com/open-reaction-database/ord-data). Rather, `ord-schema` is designed to store the database schema and tools for creating, validating, and submitting data to the database.
 
 ## Installation
 
@@ -16,9 +13,7 @@ designed to store the database schema and tools for creating, validating, and su
 $ pip install ord-schema
 ```
 
-This installs the core schema and helpers (building, parsing, validation, and
-message/Parquet I/O). Heavier, single-purpose features live behind optional
-extras so the default install stays lightweight:
+This installs the core schema and helpers (building, parsing, validation, and message/Parquet I/O). Heavier, single-purpose features live behind optional extras so the default install stays lightweight:
 
 | Extra | Enables | Install |
 | ------- | --------- | --------- |
@@ -26,12 +21,175 @@ extras so the default install stays lightweight:
 | `orm` | `ord_schema.orm`: map the schema into a relational (SQLAlchemy + PostgreSQL) database | `pip install "ord-schema[orm]"` |
 | `examples` | running the notebooks under `examples/` (see below) | `pip install "ord-schema[examples]"` |
 
-Extras combine, e.g. `pip install "ord-schema[orm,huggingface]"`. Importing a
-feature without its extra installed raises a normal `ImportError`.
+Extras combine, e.g. `pip install "ord-schema[orm,huggingface]"`. Importing a feature without its extra installed raises a normal `ImportError`.
 
-## Examples
+## Quick start
 
-The `examples/` directory contains examples of dataset creation and use. To run locally, install with:
+### Build a reaction
+
+A `Reaction` is a protocol buffer message. Build it field by field, using `message_helpers.build_compound` for the parts with a lot of boilerplate:
+
+```python
+from ord_schema import message_helpers
+from ord_schema.proto import reaction_pb2
+
+reaction = reaction_pb2.Reaction()
+reaction.identifiers.add(type="REACTION_SMILES", value="CC(=O)O.OCC>>CC(=O)OCC.O")
+
+reaction.inputs["acid"].components.add().CopyFrom(
+    message_helpers.build_compound(
+        smiles="CC(=O)O",
+        name="acetic acid",
+        amount="10 mmol",
+        role="reactant",
+        is_limiting=True,
+    )
+)
+reaction.inputs["alcohol"].components.add().CopyFrom(
+    message_helpers.build_compound(
+        smiles="OCC", name="ethanol", amount="12 mmol", role="reactant"
+    )
+)
+
+outcome = reaction.outcomes.add()
+outcome.reaction_time.CopyFrom(reaction_pb2.Time(value=3, units="HOUR"))
+product = outcome.products.add()
+product.identifiers.add(type="SMILES", value="CC(=O)OCC")
+product.measurements.add(type="YIELD", percentage=reaction_pb2.Percentage(value=87))
+
+reaction.provenance.record_created.time.value = "2026-01-15"
+reaction.provenance.record_created.person.name = "Marie Curie"
+reaction.provenance.record_created.person.email = "curie@example.edu"
+```
+
+### Validate
+
+Validation reports errors and warnings separately. Pass `raise_on_error=False` to inspect them instead of raising:
+
+```python
+from ord_schema import validations
+
+output = validations.validate_message(reaction, raise_on_error=False)
+print(output.errors)    # [] -- the reaction above is valid
+print(output.warnings)  # advisory only; submissions are not blocked on these
+```
+
+RDKit writes parse diagnostics straight to stderr. `ord_schema.logging.silence_rdkit_logs()` quiets them.
+
+### Assemble and write a dataset
+
+`updates.update_dataset` assigns the canonical `ord_dataset-*` and `ord-*` IDs and rewrites cross-references between reactions:
+
+```python
+from ord_schema import updates
+from ord_schema.proto import dataset_pb2
+
+dataset = dataset_pb2.Dataset(
+    name="Esterifications", description="Fischer esterification screen"
+)
+dataset.reactions.append(reaction)
+updates.update_dataset(dataset)
+```
+
+`datasets.save_dataset` dispatches on the filename suffix:
+
+```python
+from ord_schema import datasets
+
+datasets.save_dataset(dataset, "esterifications.parquet")
+```
+
+| Suffix | Format |
+| --- | --- |
+| `.parquet` | Parquet, one row per reaction; streamable and the storage format for ord-data |
+| `.pb` / `.binpb` | binary protocol buffer |
+| `.pbtxt` / `.txtpb` | text protocol buffer |
+| `.json` | protobuf JSON |
+
+Any of these may be gzipped (`.pb.gz`). For a dataset too large to hold in memory, write it a reaction at a time instead — `DatasetWriter` keeps peak memory to one row group and publishes atomically, so an interrupted write leaves no file behind:
+
+```python
+from ord_schema import parquet
+
+with parquet.DatasetWriter(
+    "esterifications.parquet",
+    name="Esterifications",
+    description="Fischer esterification screen",
+) as writer:
+    for reaction in produce_reactions():
+        writer.write(reaction)
+```
+
+### Read a dataset
+
+`DatasetView` is the read API for Parquet. Opening one reads only the file footer, so it is cheap regardless of dataset size:
+
+```python
+from ord_schema import parquet
+
+view = parquet.DatasetView("esterifications.parquet")
+
+view.name             # "Esterifications"
+view.dataset_id       # "ord_dataset-..."
+len(view.reactions)   # row count, from the footer -- no reactions deserialized
+view.reactions[0]     # reads only the row group holding index 0
+```
+
+`reactions` behaves like a list — iteration, `len`, truthiness, indexing, and slicing — while reading from the file on demand:
+
+```python
+for reaction in view.reactions:  # streams; peak memory is one row group
+    print(message_helpers.get_reaction_smiles(reaction))
+```
+
+Look a reaction up by ID, or stream IDs without deserializing anything:
+
+```python
+view.get_reaction("ord-1f6c...")   # builds an ID index on first call, then O(1)
+list(view.iter_reaction_ids())     # reads one column; cheap on huge files
+```
+
+Use `iter_reactions()` when you want the ID alongside the message, and `row_group=` to fan out — row groups are the unit of parallelism:
+
+```python
+for reaction_id, reaction in view.iter_reactions():
+    ...
+
+for i in range(view.num_row_groups):
+    executor.submit(process_row_group, "esterifications.parquet", i)
+```
+
+When you genuinely need a `Dataset` message — to serialize, convert to JSON, or mutate — materialize one. This deserializes everything, so peak memory scales with the whole dataset:
+
+```python
+dataset = view.to_proto()
+```
+
+Non-Parquet formats load whole; `datasets.load_dataset` dispatches on suffix the same way `save_dataset` does:
+
+```python
+dataset = datasets.load_dataset("dataset.pb.gz")
+```
+
+### Fetch a published dataset
+
+With the `huggingface` extra, pull a dataset from the mirror instead of constructing one. `fetch_dataset` downloads the file and returns its path without parsing it; it prefers Parquet and falls back to `.pb.gz` for datasets not yet converted, so dispatch on the suffix:
+
+```python
+import pathlib
+
+from ord_schema import datasets, huggingface, parquet
+
+path = huggingface.fetch_dataset("ord_dataset-...")
+if pathlib.Path(path).suffix == ".parquet":
+    view = parquet.DatasetView(path)
+else:
+    dataset = datasets.load_dataset(path)
+```
+
+## Notebook examples
+
+The `examples/` directory contains worked examples of dataset creation and use, drawn from published papers. To run locally:
 
 ```shell
 $ pip install "ord-schema[examples]"
@@ -50,9 +208,7 @@ $ cd ord-schema
 $ uv sync --extra tests
 ```
 
-The `tests` extra pulls in the feature extras (`huggingface`, `orm`) it needs to
-exercise their code paths, so this is enough to run the full suite.
-Add `--extra examples` as well to run the notebooks (heavier deps):
+The `tests` extra pulls in the feature extras (`huggingface`, `orm`) it needs to exercise their code paths, so this is enough to run the full suite. Add `--extra examples` as well to run the notebooks (heavier deps):
 
 ```shell
 $ uv sync --extra examples --extra tests
@@ -60,8 +216,7 @@ $ uv sync --extra examples --extra tests
 
 You can still use pip if you prefer: `pip install -e ".[tests]"`.
 
-If you make changes to the protocol buffer definitions, [install](https://grpc.io/docs/protoc-installation/) `protoc`
-and run `./compile_proto_wrappers.sh` to rebuild the wrappers.
+If you make changes to the protocol buffer definitions, [install](https://grpc.io/docs/protoc-installation/) `protoc` and run `./compile_proto_wrappers.sh` to rebuild the wrappers.
 
 ## Conventions
 

--- a/ord_schema/parquet.py
+++ b/ord_schema/parquet.py
@@ -298,11 +298,24 @@ class _RowGroupReader:
 
         Returns:
             A Table holding the ``reaction_id`` and ``reaction`` columns.
+
+        Raises:
+            RuntimeError: If the file no longer has that row group, meaning it was
+                replaced since the view was opened.
         """
         cached = self._cache
         if cached is not None and cached[0] == row_group:
             return cached[1]
         with pq.ParquetFile(self._path) as parquet_file:
+            # The caller bounds-checked against the footer read when the view was
+            # opened; re-check against the file in hand so a replaced file reports
+            # itself instead of surfacing as a pyarrow index error.
+            if not 0 <= row_group < parquet_file.num_row_groups:
+                raise RuntimeError(
+                    f"{self._path} has no row group {row_group} "
+                    f"({parquet_file.num_row_groups} present); the file changed "
+                    "since this view was opened. Re-open the DatasetView."
+                )
             table = parquet_file.read_row_group(
                 row_group, columns=["reaction_id", "reaction"]
             )
@@ -483,10 +496,17 @@ class DatasetView:
     message methods (``SerializeToString``, ``CopyFrom``) are absent and no
     write reaches the file; ``to_proto`` materializes a real message.
 
+    Two things differ from a real message and are worth knowing before
+    substituting one for the other. Indexing returns a freshly deserialized
+    Reaction rather than a live sub-message, so ``reactions[0] is
+    reactions[0]`` is False and mutating the result changes nothing; and
+    ``reactions`` does not compare equal to a list, so compare against
+    ``list(view.reactions)`` or ``view.reactions[:]``.
+
     The backing file must not be replaced while a view is open: the row count
     is read once at construction, and ``DatasetWriter`` publishes by renaming
-    onto its destination. Indexing detects the mismatch and raises; iteration
-    silently reads whatever the path points at.
+    onto its destination. Reads that can detect the mismatch raise and name
+    the path; iteration reads whatever the path points at.
 
     ``reaction_ids`` is always empty by design: in the schema it names
     reactions stored *outside* the Dataset and is mutually exclusive with
@@ -561,6 +581,8 @@ class DatasetView:
             ValueError: If ``reaction_ids`` is provided but empty.
             IndexError: If ``row_group`` is out of range.
         """
+        # Arguments are checked here rather than in the generator below, so a bad
+        # call fails at the call rather than at the first next().
         if reaction_ids is None:
             filter_set = None
         else:
@@ -570,14 +592,28 @@ class DatasetView:
                     "reaction_ids must be non-empty when provided; pass None to "
                     "iterate all"
                 )
+        if row_group is not None and not 0 <= row_group < self._num_row_groups:
+            raise IndexError(
+                f"row_group {row_group} out of range [0, {self._num_row_groups})"
+            )
+        return self._stream_reactions(filter_set, row_group)
+
+    def _stream_reactions(
+        self, filter_set: set[str] | None, row_group: int | None
+    ) -> Iterator[tuple[str, reaction_pb2.Reaction]]:
+        """Streams the file after ``iter_reactions`` has validated its arguments.
+
+        Args:
+            filter_set: Reaction IDs to keep, or None to keep all.
+            row_group: Row group to restrict to, or None to read the whole file.
+
+        Yields:
+            Each ``(reaction_id, Reaction)`` pair, in file order.
+        """
         if row_group is None:
             with pq.ParquetFile(self._path) as parquet_file:
                 yield from _iter_reactions(parquet_file, filter_set=filter_set)
             return
-        if not 0 <= row_group < self._num_row_groups:
-            raise IndexError(
-                f"row_group {row_group} out of range [0, {self._num_row_groups})"
-            )
         yield from _iter_table(self._reader.read(row_group), filter_set=filter_set)
 
     def iter_reaction_ids(self) -> Iterator[str]:

--- a/ord_schema/parquet_test.py
+++ b/ord_schema/parquet_test.py
@@ -150,6 +150,37 @@ def test_iter_reactions_empty_filter_raises(tmp_path):
         list(dataset.DatasetView(path).iter_reactions(reaction_ids=[]))
 
 
+def test_iter_reactions_validates_arguments_eagerly(tmp_path):
+    """A bad call must raise at the call, not at the first next().
+
+    The body streams, so without an explicit split the documented ValueError and
+    IndexError would surface wherever the caller happened to start iterating.
+    """
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(_make_dataset(n=5), path, row_group_size=2)
+    view = dataset.DatasetView(path)
+    with pytest.raises(ValueError, match="non-empty"):
+        view.iter_reactions(reaction_ids=[])
+    with pytest.raises(IndexError, match="out of range"):
+        view.iter_reactions(row_group=99)
+
+
+def test_read_reports_a_row_group_lost_to_a_replaced_file(tmp_path):
+    """A row group that vanished under a live view must name the file, not pyarrow.
+
+    The construction-time row count only catches this on the first positional read;
+    afterwards the stale bound would reach pyarrow and surface as an ArrowInvalid
+    mentioning row_group_indices, which names nothing in this API.
+    """
+    path = tmp_path / "ds.parquet"
+    dataset.save_dataset(_make_dataset(n=6), path, row_group_size=2)
+    view = dataset.DatasetView(path)
+    view.reactions[0]  # Build the row-group index while the file still has 3 groups.
+    dataset.save_dataset(_make_dataset(n=2), path, row_group_size=2)
+    with pytest.raises(RuntimeError, match="has no row group 2"):
+        view.reactions[5]
+
+
 def test_get_reaction_hit(tmp_path):
     original = _make_dataset(n=5)
     path = tmp_path / "ds.parquet"


### PR DESCRIPTION
## Summary

A from-scratch review of `ord_schema/parquet.py` after the consolidation in #930-#932, plus the README revamp it made possible. Two real defects found and fixed; the README goes from install-and-dev-setup to worked examples of the actual API.

## Changes

- `iter_reactions` validated its arguments lazily. The body is a generator, so the documented `ValueError` (empty `reaction_ids`) and `IndexError` (out-of-range `row_group`) did not fire until the first `next()` — a caller that built the iterator and consumed it elsewhere saw the error nowhere near the mistake. Validation now happens in the method, which returns a separate generator.
- A row group lost to a file replaced under a live view reached pyarrow and surfaced as `ArrowInvalid: Some index in row_group_indices is 2, ...`, naming an identifier that appears nowhere in this API. The construction-time row count only catches that on the *first* positional read. `_RowGroupReader.read` now re-checks against the file in hand, which is free because the footer is parsed on open anyway, and raises naming the path.
- Documents the two ways the view diverges from a real message, both confirmed by probe: `reactions[0] is reactions[0]` is False (fresh message, not a live sub-message), and `reactions` does not compare equal to a list.
- README rewritten around examples: building a reaction, validating, assigning IDs with `updates`, writing whole or streaming with `DatasetWriter`, and the `DatasetView` read API — indexing, streaming, ID lookup, row-group fan-out, and materializing. Adds a suffix/format table and a note that `fetch_dataset` can return `.pb.gz`.

## Testing

- `uv run pytest`: 644 non-ORM and 56 ORM tests pass; `ruff`, `ty`, and `markdownlint` clean.
- Two new tests: `iter_reactions` raises without being iterated, and a row group lost to a replaced file raises `RuntimeError` naming the file rather than leaking `ArrowInvalid`. The pre-existing tests wrapped these calls in `list(...)`, so they passed either way and could not have caught the lazy validation.
- Every ```python block in the README was extracted and executed in order — 11 of 12 run end to end, the 12th (`fetch_dataset`) is compile-checked since it needs network. Every suffix in the new format table was round-tripped through `save_dataset`/`load_dataset`.

## Notes

Checked and found correct, so not changed:

- Interleaving two `iter_reactions(row_group=...)` generators from one view, and interleaving iteration with indexing, both return correct results. Each generator holds its own table, so the shared one-entry cache thrashes without corrupting anything.
- Error paths on bad input are already legible: a missing file gives `FileNotFoundError`, and a valid Parquet file that is not an ORD dataset gives `ValueError: missing required Parquet footer key: 'ord.schema_version'`.

Known and unchanged: staleness detection remains best-effort. `len(view.reactions)` still reports the count from construction after the file is replaced, and iteration reads whatever the path points at. Closing that properly needs a persistent file handle, which was considered and rejected in #932 because views are constructed per row group in two call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes `DatasetView.iter_reactions` validate arguments when called, improves errors when a replaced Parquet file loses a requested row group, and rewrites the README around practical API examples.
- Separates eager argument validation from reaction streaming.
- Converts a low-level PyArrow row-group error into a path-specific `RuntimeError`.
- Adds regression tests for eager validation and replaced-file handling.
- Documents dataset creation, validation, streaming I/O, lookup, materialization, and supported formats.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable changed-code defects were identified.

The eager validation preserves streaming while moving documented errors to call time, the row-group check safely translates the targeted stale-file failure, and the new documentation matches the implemented APIs.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/parquet.py | Eager validation and the new row-group bounds check correctly address the two stated defects without introducing a changed-code failure. |
| ord_schema/parquet_test.py | Adds focused regression coverage for call-time validation and missing row groups after atomic file replacement. |
| README.md | Replaces minimal setup documentation with API examples that match current signatures, format dispatch, and streaming behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Validate iter\_reactions arguments eagerl..."](https://github.com/open-reaction-database/ord-schema/commit/8e11a8ca6ad8011ab89a463342e36129019dbec0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49932061)</sub>

**Context used:**

- Knowledge Base — [Data I/O: proto serialization, Parquet, and units](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/data-io.md)

<!-- /greptile_comment -->