### PR TITLE
Return a DatasetView from load_dataset for Parquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ with parquet.DatasetWriter(
 
 ### Read a dataset
 
-`DatasetView` is the read API for Parquet. Opening one reads only the file footer, so it is cheap regardless of dataset size:
+`datasets.load_dataset` is the entry point for every format. A Parquet dataset reads back as a `DatasetView`, which takes its scalars and row count from the file footer and reads reactions on demand, so opening one is cheap regardless of dataset size:
 
 ```python
-from ord_schema import parquet
+from ord_schema import datasets
 
-view = parquet.DatasetView("esterifications.parquet")
+view = datasets.load_dataset("esterifications.parquet")
 
 view.name             # "Esterifications"
 view.dataset_id       # "ord_dataset-..."
@@ -165,26 +165,27 @@ When you genuinely need a `Dataset` message — to serialize, convert to JSON, o
 dataset = view.to_proto()
 ```
 
-Non-Parquet formats load whole; `datasets.load_dataset` dispatches on suffix the same way `save_dataset` does:
+The other formats have no streaming form, so they read back as a `Dataset` message directly:
 
 ```python
-dataset = datasets.load_dataset("dataset.pb.gz")
+dataset = datasets.load_dataset("dataset.pb.gz")  # a Dataset, not a view
+```
+
+Code that only reads does not need to care which it got — iteration, `len`, indexing, and slicing work on both. Code that needs the protobuf surface and cannot know the format should ask for a message up front, which materializes a Parquet dataset in full:
+
+```python
+dataset = datasets.load_dataset(path, as_dataset=True)  # always a Dataset
 ```
 
 ### Fetch a published dataset
 
-With the `huggingface` extra, pull a dataset from the mirror instead of constructing one. `fetch_dataset` downloads the file and returns its path without parsing it; it prefers Parquet and falls back to `.pb.gz` for datasets not yet converted, so dispatch on the suffix:
+With the `huggingface` extra, pull a dataset from the mirror instead of constructing one. `fetch_dataset` downloads the file and returns its path without parsing it; it prefers Parquet and falls back to `.pb.gz` for datasets not yet converted, which is exactly the dispatch `load_dataset` already handles:
 
 ```python
-import pathlib
-
-from ord_schema import datasets, huggingface, parquet
+from ord_schema import datasets, huggingface
 
 path = huggingface.fetch_dataset("ord_dataset-...")
-if pathlib.Path(path).suffix == ".parquet":
-    view = parquet.DatasetView(path)
-else:
-    dataset = datasets.load_dataset(path)
+dataset = datasets.load_dataset(path)  # a DatasetView for .parquet, else a Dataset
 ```
 
 ## Notebook examples

--- a/ord_schema/datasets.py
+++ b/ord_schema/datasets.py
@@ -13,49 +13,63 @@
 # limitations under the License.
 """Whole-dataset file I/O, dispatching on filename suffix.
 
-These are the convenience entry points for reading and writing a complete
-``Dataset``: ``.parquet`` routes to the (lower-level) ``parquet``
-serialization, and other suffixes go through ``message_helpers`` single-message
-I/O. For large Parquet datasets prefer the streaming ``parquet``
-interfaces (``DatasetView`` and its ``iter_reactions``) over loading the whole thing
-into memory.
+The entry point for reading and writing a complete ``Dataset``, whatever it is
+serialized as. ``.parquet`` reads back as a ``parquet.DatasetView``, which
+streams from the file instead of materializing it; every other suffix reads back
+as a ``dataset_pb2.Dataset`` through ``message_helpers`` single-message I/O.
 """
 
 import os
 import pathlib
-import warnings
+from typing import Literal, overload
 
 from ord_schema import message_helpers, parquet
 from ord_schema.proto import dataset_pb2
 
 
-def load_dataset(filename: str | os.PathLike[str]) -> dataset_pb2.Dataset:
+@overload
+def load_dataset(
+    filename: str | os.PathLike[str], *, as_dataset: Literal[False] = False
+) -> dataset_pb2.Dataset | parquet.DatasetView: ...
+
+
+@overload
+def load_dataset(
+    filename: str | os.PathLike[str], *, as_dataset: Literal[True]
+) -> dataset_pb2.Dataset: ...
+
+
+def load_dataset(
+    filename: str | os.PathLike[str], *, as_dataset: bool = False
+) -> dataset_pb2.Dataset | parquet.DatasetView:
     """Loads a Dataset from disk, dispatching on filename suffix.
 
-    The dataset-level counterpart to ``message_helpers.load_message``:
-    ``.parquet`` routes to ``parquet.load_dataset``, which deserializes
-    every reaction into memory; other suffixes go through ``load_message``.
+    A Parquet dataset reads back as a ``parquet.DatasetView``, which takes its
+    scalars and row count from the file footer and reads Reactions on demand.
+    The view is a read-only stand-in for the message: iteration, ``len``,
+    emptiness, indexing, and slicing over ``reactions`` behave the same, so code
+    that only reads needs no change. Materializing every Reaction is the
+    exception rather than the default, which matters because published datasets
+    run to millions of rows.
 
-    Loading an entire Parquet dataset into memory defeats the format's
-    streaming benefits, so this path warns and recommends the streaming
-    ``parquet.DatasetView`` loader for large datasets.
+    Other suffixes have no streaming form and read back as a real message.
 
     Args:
         filename: Path to a serialized Dataset (``.parquet`` or any suffix
-            understood by ``load_message``).
+            understood by ``message_helpers.load_message``).
+        as_dataset: If True, always return a ``dataset_pb2.Dataset``,
+            materializing a Parquet dataset in full. Use this when the caller
+            needs the protobuf surface -- serialization, JSON conversion,
+            mutation -- and cannot know which format it was handed; a caller
+            that knows it holds a view can call ``to_proto`` instead.
 
     Returns:
-        The in-memory Dataset proto.
+        A ``parquet.DatasetView`` for ``.parquet`` unless ``as_dataset`` is set,
+        and a ``dataset_pb2.Dataset`` otherwise.
     """
     if pathlib.Path(filename).suffix == ".parquet":
-        warnings.warn(
-            f"Loading the entire Parquet dataset {filename} into memory; for large "
-            "datasets prefer the streaming loader ord_schema.parquet.DatasetView "
-            "(or its iter_reactions/get_reaction).",
-            UserWarning,
-            stacklevel=2,
-        )
-        return parquet.load_dataset(filename)
+        view = parquet.DatasetView(filename)
+        return view.to_proto() if as_dataset else view
     return message_helpers.load_message(filename, dataset_pb2.Dataset)
 
 
@@ -66,6 +80,10 @@ def save_dataset(
 
     ``.parquet`` routes to ``parquet.save_dataset``; other suffixes go through
     ``message_helpers.save_message``.
+
+    Args:
+        dataset: Dataset message to write.
+        filename: Output path; its suffix selects the serialization.
     """
     if pathlib.Path(filename).suffix == ".parquet":
         parquet.save_dataset(dataset, filename)

--- a/ord_schema/datasets.py
+++ b/ord_schema/datasets.py
@@ -39,6 +39,14 @@ def load_dataset(
 ) -> dataset_pb2.Dataset: ...
 
 
+# A caller passing a computed bool matches neither Literal overload; without this
+# mypy reports no-matching-overload for a call that is valid at runtime.
+@overload
+def load_dataset(
+    filename: str | os.PathLike[str], *, as_dataset: bool
+) -> dataset_pb2.Dataset | parquet.DatasetView: ...
+
+
 def load_dataset(
     filename: str | os.PathLike[str], *, as_dataset: bool = False
 ) -> dataset_pb2.Dataset | parquet.DatasetView:

--- a/ord_schema/datasets_test.py
+++ b/ord_schema/datasets_test.py
@@ -78,7 +78,8 @@ class TestLoadAndSaveDataset:
         assert loaded.description == "d"
         assert list(loaded.reactions) == list(dataset.reactions)
 
-    def test_load_dataset_parquet_warns(self, tmp_path):
+    def test_load_dataset_parquet_returns_a_view(self, tmp_path):
+        """Parquet reads back as a streaming view, not a materialized message."""
         dataset = dataset_pb2.Dataset(
             name="n",
             description="d",
@@ -86,8 +87,39 @@ class TestLoadAndSaveDataset:
         )
         path = (tmp_path / "ds.parquet").as_posix()
         datasets.save_dataset(dataset, path)
-        with pytest.warns(UserWarning, match="DatasetView"):
-            loaded = datasets.load_dataset(path)
+        loaded = datasets.load_dataset(path)
+        assert isinstance(loaded, parquet.DatasetView)
+        # The read-only surface a caller would otherwise have had to change.
         assert loaded.name == "n"
         assert loaded.description == "d"
+        assert len(loaded.reactions) == 1
+        assert loaded.reactions[0] == dataset.reactions[0]
         assert list(loaded.reactions) == list(dataset.reactions)
+
+    def test_load_dataset_parquet_as_dataset(self, tmp_path):
+        """``as_dataset`` materializes, for callers that need the message surface."""
+        dataset = dataset_pb2.Dataset(
+            name="n",
+            description="d",
+            reactions=[reaction_pb2.Reaction(reaction_id="ord-0")],
+        )
+        path = (tmp_path / "ds.parquet").as_posix()
+        datasets.save_dataset(dataset, path)
+        loaded = datasets.load_dataset(path, as_dataset=True)
+        assert isinstance(loaded, dataset_pb2.Dataset)
+        assert loaded.SerializeToString(
+            deterministic=True
+        ) == dataset.SerializeToString(deterministic=True)
+
+    def test_load_dataset_as_dataset_is_a_no_op_for_proto_formats(self, tmp_path):
+        """``as_dataset`` must not change what the non-streaming formats return."""
+        dataset = dataset_pb2.Dataset(
+            name="n",
+            description="d",
+            reactions=[reaction_pb2.Reaction(reaction_id="ord-0")],
+        )
+        path = (tmp_path / "ds.pbtxt").as_posix()
+        datasets.save_dataset(dataset, path)
+        assert datasets.load_dataset(path) == datasets.load_dataset(
+            path, as_dataset=True
+        )

--- a/ord_schema/orm/conftest.py
+++ b/ord_schema/orm/conftest.py
@@ -49,7 +49,8 @@ def prepared_engine_fixture(test_engine: Engine) -> Engine:
 def test_session_fixture(test_engine: Engine) -> Iterator[Session]:
     datasets = [
         load_dataset(
-            pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+            pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt",
+            as_dataset=True,
         )
     ]
     rdkit_cartridge = prepare_database(test_engine)

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -167,7 +167,8 @@ def test_update_derived_tables_sharded_covers_all(prepared_engine):
     dataset pass finds nothing new.
     """
     dataset = load_dataset(
-        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt",
+        as_dataset=True,
     )
     with Session(prepared_engine) as session, session.begin():
         add_dataset(dataset, session)
@@ -220,7 +221,8 @@ def test_rdkit_sharded_matches_serial(prepared_engine):
     would -- a following serial pass inserts and links nothing new.
     """
     dataset = load_dataset(
-        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt",
+        as_dataset=True,
     )
     with Session(prepared_engine) as session, session.begin():
         add_dataset(dataset, session)
@@ -293,7 +295,8 @@ def test_classify_sharded_covers_all(prepared_engine):
     would -- a following whole-dataset pass adds nothing.
     """
     dataset = load_dataset(
-        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt",
+        as_dataset=True,
     )
     with Session(prepared_engine) as session, session.begin():
         add_dataset(dataset, session)
@@ -373,7 +376,8 @@ def test_compound_smiles_fallback_without_stored_smiles(prepared_engine):
     standard fixture (every compound carries a SMILES) never reaches.
     """
     dataset = load_dataset(
-        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt",
+        as_dataset=True,
     )
     # Replace one compound's SMILES identifier with the equivalent InChI so only the
     # fallback (structure reconstruction from a non-SMILES identifier) can derive its
@@ -421,7 +425,8 @@ def test_underivable_compound_skips_reconstruction(prepared_engine, monkeypatch)
     zero new rows on every re-run.
     """
     dataset = load_dataset(
-        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt",
+        as_dataset=True,
     )
     # Strip one compound down to a NAME-only identifier so it has no structural
     # identifier to derive a SMILES from; every other compound keeps its SMILES fast
@@ -508,7 +513,8 @@ def test_derived_compound_smiles_covers_every_attachment(prepared_engine):
     attachments appear and none loses rows to the derived or RDKit passes.
     """
     dataset = load_dataset(
-        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt"
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt",
+        as_dataset=True,
     )
     # The fixture has workup inputs but no authentic standard; attach one so the
     # product_measurement path is populated.


### PR DESCRIPTION
## Summary

`datasets.load_dataset` materialized every reaction for `.parquet` and warned that you probably wanted the streaming loader. That warning was the only thing pointing callers at `DatasetView`, and it made streaming a second entry point you had to know to reach for. It now returns the view, so streaming is what you get by default and materializing is the exception.

This is the flip described in #929, held back there because `DatasetView` was not close enough to a `Dataset` for the substitution to be quiet. It is now — #930-#933 gave the view indexing, slicing, ID lookup, row-group iteration, `to_proto`, and `md5`. Breaking. Closes #929.

## Changes

- `load_dataset` returns a `parquet.DatasetView` for `.parquet`. Other suffixes have no streaming form and are unaffected.
- Adds `as_dataset=True`, overloaded on `Literal`, for callers that need the protobuf surface and cannot know which format they were handed. A caller that knows it holds a view can call `to_proto()` instead.
- Drops the "loading the entire Parquet dataset into memory" warning, which existed to point at the loader that is now the default.
- README updated: `load_dataset` is presented as the entry point for every format, with `as_dataset` for the materializing case.

## Testing

- `uv run pytest`: 646 non-ORM and 56 ORM tests pass; `ruff`, `ty`, and `markdownlint` clean.
- The warning test is replaced by three: Parquet returns a `DatasetView` whose read-only surface matches the source, `as_dataset=True` returns a byte-identical `Dataset`, and `as_dataset` is a no-op for the proto formats.
- All 13 Python blocks in the README were extracted and executed; the one needing network is compile-checked.

## Notes

The union return type is real, and `as_dataset` is the answer to it rather than a convenience. `ty` flagged seven sites the moment the return type widened — the ORM fixtures load `.pbtxt` and pass the result straight to `add_dataset(dataset: Dataset)`. They now pass `as_dataset=True`, which is free for a format that materializes anyway and is what downstream code in the same position should do. Callers that only read need no change at all, which is the whole point of the parity work in #930-#933.

Worth knowing when migrating: indexing a view returns a copy rather than a live sub-message, and `view.reactions` does not compare equal to a list. Both are documented on `DatasetView`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

`load_dataset` now returns a streaming `DatasetView` for Parquet by default while preserving an explicit materialization path.
- Adds precise overloads plus computed-boolean support for `as_dataset`.
- Updates tests, ORM callers, and README guidance for the new return contract.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The fallback boolean overload resolves the previously reported computed-argument typing failure, and no blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/datasets.py | Changes Parquet loading to return a streaming view by default and adds a fallback boolean overload that resolves the prior computed-argument typing defect. |
| ord_schema/datasets_test.py | Replaces warning coverage with tests for streaming, explicit materialization, and unchanged proto-format behavior. |
| README.md | Documents format-dependent loading and the explicit materialization option. |
| ord_schema/orm/conftest.py | Requests a concrete Dataset where the ORM fixture requires the protobuf surface. |
| ord_schema/orm/database_test.py | Updates ORM test callers to request materialized Dataset messages explicitly. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[load_dataset filename] --> B{Suffix is .parquet?}
  B -->|No| C[Load and return Dataset proto]
  B -->|Yes| D[Create DatasetView]
  D --> E{as_dataset?}
  E -->|False| F[Return streaming DatasetView]
  E -->|True| G[Materialize and return Dataset proto]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Add a bool overload so computed flags re..."](https://github.com/open-reaction-database/ord-schema/commit/53d5283ce9aac44e87ccdb2f7f5e020d279b45be) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49934883)</sub>

**Context used:**

- Knowledge Base — [Data I/O: proto serialization, Parquet, and units](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/data-io.md)

<!-- /greptile_comment -->