### PR TITLE
Give every derived artifact one answer for "what is this molecule"

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -380,12 +380,12 @@ def preferred_compound_smiles(
     """Returns canonical SMILES for a compound, preferring its CXSMILES form.
 
     CXSMILES is a superset of SMILES and RDKit reads either, so preferring it keeps
-    enhanced stereochemistry and fragment grouping that plain SMILES cannot express.
-    Where neither parses, any other structural identifier that does is used, so one
-    malformed value does not hide a good one recorded behind it.
+    enhanced stereochemistry: a plain SMILES would assert one configuration where the
+    source recorded a group. Where neither parses, any other structural identifier that
+    does is used, so one malformed value does not hide a good one behind it.
 
-    Derived artifacts share this rather than each choosing an order, so a compound reads
-    the same whichever artifact a consumer reaches for.
+    The Parquet view and projection both go through this, so a compound reads the same
+    in either.
 
     Args:
         compound: Compound or ProductCompound message.
@@ -416,50 +416,63 @@ def preferred_compound_smiles(
 def reaction_smiles_without_agents(reaction_smiles: str) -> str | None:
     """Returns a reaction SMILES with its agent block removed, or None if unreadable.
 
-    Rebuilt through RDKit rather than by splitting on ``>``, because a CXSMILES
-    extension indexes atoms positionally: dropping the agents from the string leaves
-    every index in the block pointing at the wrong atom. Round-tripping recomputes them,
-    so enhanced stereochemistry survives. Atom mapping survives too, being part of the
-    atoms themselves. Fragment grouping does not survive, and canonical atom ordering
-    replaces whatever the source used.
+    Splitting the string on ``>`` would corrupt a CXSMILES extension, which indexes
+    atoms positionally: every index in the block would point at the wrong atom once the
+    agents are gone. Rebuilding through RDKit recomputes them.
+
+    The surviving templates are added in canonical order because RDKit numbers the block
+    against the order they were added and then writes them sorted; adding them in any
+    other order leaves a stereo group marking whichever atom lands at that index.
+
+    Atom mapping survives, being part of the atoms themselves, and so does enhanced
+    stereochemistry. Fragment grouping does not, and canonical atom ordering replaces
+    whatever the source used.
 
     Args:
         reaction_smiles: A reaction SMILES or CXSMILES, with or without agents.
 
     Returns:
-        Canonical ``reactants>>products`` CXSMILES, or None if RDKit cannot read the
-        input as a reaction.
+        Canonical ``reactants>>products`` CXSMILES. None if RDKit cannot read the input,
+        reports errors in it, or it has no reactant or no product once agents are gone:
+        a half reaction is not a restatement of the reaction the source recorded.
     """
     try:
         reaction = rdChemReactions.ReactionFromSmarts(reaction_smiles, useSmiles=True)
-    except ValueError:
-        return None
-    if reaction is None:
-        return None
-    reaction.RemoveAgentTemplates()
-    try:
-        return rdChemReactions.ReactionToCXSmiles(reaction) or None
-    except ValueError:
+        if reaction is None:
+            return None
+        without_agents = rdChemReactions.ChemicalReaction()
+        for mol in sorted(reaction.GetReactants(), key=Chem.MolToSmiles):
+            without_agents.AddReactantTemplate(mol)
+        for mol in sorted(reaction.GetProducts(), key=Chem.MolToSmiles):
+            without_agents.AddProductTemplate(mol)
+        if not without_agents.GetNumReactantTemplates():
+            return None
+        if not without_agents.GetNumProductTemplates():
+            return None
+        # Recorded values are held to the same bar as generated ones; being deposited
+        # is not evidence of being well formed.
+        _validate_reaction(without_agents)
+        return rdChemReactions.ReactionToCXSmiles(without_agents) or None
+    except (ValueError, RuntimeError):
+        # RDKit raises RuntimeError, not ValueError, for a malformed extension block.
         return None
 
 
 def derived_reaction_smiles(reaction: reaction_pb2.Reaction) -> str | None:
     """Returns the reaction SMILES that derived artifacts store, or None.
 
-    A recorded ``REACTION_CXSMILES`` or ``REACTION_SMILES`` is used in preference to
-    generating one, because it carries what generation cannot reconstruct -- above all
-    atom mapping, which is recorded for much of the corpus and is the reason to keep the
-    deposited string at all. It is normalized rather than taken verbatim: agents are
-    removed and the result is canonicalized, so the conventions that differ between
-    depositors -- agent placement, atom ordering -- stop deciding whether two reactions
-    look alike. A recorded value RDKit cannot read falls through to generation.
+    A recorded ``REACTION_CXSMILES`` or ``REACTION_SMILES`` wins over generating one,
+    because it carries atom mapping, which generation cannot reconstruct. It is
+    normalized, not copied: agents removed and the result canonicalized, so agent
+    placement and atom ordering stop deciding whether two reactions look alike. A
+    recorded value RDKit cannot read, or that survives as a half reaction, falls through
+    to generation.
 
-    Generated or recorded, the result carries no agents. An empty agent block is
-    idiomatic in reaction SMILES, and excluding agents means a reagent, solvent, or
-    catalyst recorded only by name -- very common for ligands -- cannot decide whether
-    the reaction gets a SMILES at all. Generation is otherwise strict: every reactant
-    and product must be readable, since a SMILES silently missing one describes a
-    different reaction and nothing in the column marks it.
+    Either way the result carries no agents. An empty agent block is idiomatic, and
+    excluding agents keeps a reagent, solvent, or catalyst recorded only by name --
+    routine for ligands -- from deciding whether the reaction gets a SMILES at all.
+    Generation is otherwise strict: every reactant and product must be readable, since a
+    SMILES silently missing one describes a different reaction and nothing marks it.
 
     Args:
         reaction: Reaction message.
@@ -635,7 +648,8 @@ def get_reaction_smiles(
             UNSPECIFIED reaction role will be included when generating a reaction
             SMILES.
         strip_extension: If True, drop a CXSMILES extension block from the result so it
-            is plain SMILES. Generated SMILES never carry one.
+            is plain SMILES. Applies to a generated reaction as much as a recorded one,
+            since a component's enhanced stereochemistry carries into what is generated.
 
     Returns:
         Text reaction SMILES, or None.
@@ -654,11 +668,14 @@ def get_reaction_smiles(
             return identifier.value
     if not generate_if_missing:
         return None
-    return generate_reaction_smiles(
+    generated = generate_reaction_smiles(
         message,
         allow_incomplete=allow_incomplete,
         allow_unspecified_roles=allow_unspecified_roles,
     )
+    if strip_extension:
+        return split_cxsmiles_extension(generated)[0]
+    return generated
 
 
 def generate_reaction_smiles(
@@ -672,10 +689,11 @@ def generate_reaction_smiles(
 
     Args:
         message: reaction_pb2.Reaction message.
-        allow_incomplete: Whether to allow "incomplete" reaction SMILES that omit
-            components with no readable structure. Only components the result would
-            carry are considered, so an unreadable agent is irrelevant when
-            ``include_agents`` is False.
+        allow_incomplete: Whether to omit components with no readable structure rather
+            than raising. Only components the result would carry are considered, so an
+            unreadable agent is irrelevant when ``include_agents`` is False. Tolerates
+            missing components but not a missing half: RDKit calls a reaction with no
+            reactants or no products an error however it got that way.
         allow_unspecified_roles: If True, components with the UNSPECIFIED reaction role
             are treated as reactants and products.
         include_agents: Whether to emit the middle ``>agents>`` block. Reagents,
@@ -715,7 +733,8 @@ def generate_reaction_smiles(
             if allow_incomplete:
                 return
             raise
-        target.add(smiles)
+        if smiles:
+            target.add(smiles)
 
     for key in sorted(message.inputs):
         for compound in message.inputs[key].components:
@@ -736,23 +755,25 @@ def generate_reaction_smiles(
     # reaction SMILES at all. Building the reaction lets RDKit re-emit one block for the
     # whole reaction, with the atom indices it refers to recomputed.
     built = rdChemReactions.ChemicalReaction()
-    for smiles in sorted(reactants):
-        built.AddReactantTemplate(Chem.MolFromSmiles(smiles))
-    for smiles in sorted(agents):
-        built.AddAgentTemplate(Chem.MolFromSmiles(smiles))
-    for smiles in sorted(products):
-        built.AddProductTemplate(Chem.MolFromSmiles(smiles))
-    reaction_smiles = rdChemReactions.ReactionToCXSmiles(built)
-    # Checked on the reaction just built rather than by parsing the SMILES back;
-    # sanitization mutates it, which is why the string is written first. Unconditional:
-    # allow_incomplete only drops components that would not parse, so what remains is
-    # as valid either way.
+    for add, group in (
+        (built.AddReactantTemplate, reactants),
+        (built.AddAgentTemplate, agents),
+        (built.AddProductTemplate, products),
+    ):
+        for smiles in sorted(group):
+            mol = Chem.MolFromSmiles(smiles)
+            if mol is None:
+                # RDKit accepts a null template and then dies with SIGSEGV writing it,
+                # which no caller can catch. A ValueError is what callers handle.
+                raise ValueError(f"cannot parse component SMILES: {smiles!r}")
+            add(mol)
     try:
+        reaction_smiles = rdChemReactions.ReactionToCXSmiles(built)
+        # Checked on the reaction in hand; sanitizing mutates it, so the string is
+        # written first.
         _validate_reaction(built)
     except (RuntimeError, ValueError) as error:
-        raise ValueError(
-            f"bad reaction SMILES ({error!s}): {reaction_smiles}"
-        ) from error
+        raise ValueError(f"cannot write reaction SMILES: {error!s}") from error
     return reaction_smiles
 
 
@@ -764,7 +785,8 @@ def _validate_reaction(reaction: rdChemReactions.ChemicalReaction) -> None:
             SMILES has already been written if the unsanitized form is wanted.
 
     Raises:
-        ValueError: If sanitization fails or validation reports errors.
+        ValueError: If validation reports errors.
+        RuntimeError: If RDKit cannot sanitize the reaction.
     """
     rdChemReactions.SanitizeRxn(reaction)
     _, num_errors = reaction.Validate()

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -374,6 +374,121 @@ def smiles_from_compound(
     return smiles
 
 
+def preferred_compound_smiles(
+    compound: reaction_pb2.Compound | reaction_pb2.ProductCompound,
+) -> str | None:
+    """Returns canonical SMILES for a compound, preferring its CXSMILES form.
+
+    CXSMILES is a superset of SMILES and RDKit reads either, so preferring it keeps
+    enhanced stereochemistry and fragment grouping that plain SMILES cannot express.
+    Where neither parses, any other structural identifier that does is used, so one
+    malformed value does not hide a good one recorded behind it.
+
+    Derived artifacts share this rather than each choosing an order, so a compound reads
+    the same whichever artifact a consumer reaches for.
+
+    Args:
+        compound: Compound or ProductCompound message.
+
+    Returns:
+        Canonical SMILES, or None if the compound records no structure any loader can
+        read.
+    """
+    for identifier_type in (
+        reaction_pb2.CompoundIdentifier.CXSMILES,
+        reaction_pb2.CompoundIdentifier.SMILES,
+    ):
+        for identifier in compound.identifiers:
+            if identifier.type != identifier_type or not identifier.value:
+                continue
+            canonical = canonical_smiles_for_identifier(
+                identifier.type, identifier.value
+            )
+            if canonical:
+                return canonical
+    for identifier in compound.identifiers:
+        canonical = canonical_smiles_for_identifier(identifier.type, identifier.value)
+        if canonical:
+            return canonical
+    return None
+
+
+def reaction_smiles_without_agents(reaction_smiles: str) -> str | None:
+    """Returns a reaction SMILES with its agent block removed, or None if unreadable.
+
+    Rebuilt through RDKit rather than by splitting on ``>``, because a CXSMILES
+    extension indexes atoms positionally: dropping the agents from the string leaves
+    every index in the block pointing at the wrong atom. Round-tripping recomputes them,
+    so enhanced stereochemistry survives. Atom mapping survives too, being part of the
+    atoms themselves. Fragment grouping does not survive, and canonical atom ordering
+    replaces whatever the source used.
+
+    Args:
+        reaction_smiles: A reaction SMILES or CXSMILES, with or without agents.
+
+    Returns:
+        Canonical ``reactants>>products`` CXSMILES, or None if RDKit cannot read the
+        input as a reaction.
+    """
+    try:
+        reaction = rdChemReactions.ReactionFromSmarts(reaction_smiles, useSmiles=True)
+    except ValueError:
+        return None
+    if reaction is None:
+        return None
+    reaction.RemoveAgentTemplates()
+    try:
+        return rdChemReactions.ReactionToCXSmiles(reaction) or None
+    except ValueError:
+        return None
+
+
+def derived_reaction_smiles(reaction: reaction_pb2.Reaction) -> str | None:
+    """Returns the reaction SMILES that derived artifacts store, or None.
+
+    A recorded ``REACTION_CXSMILES`` or ``REACTION_SMILES`` is used in preference to
+    generating one, because it carries what generation cannot reconstruct -- above all
+    atom mapping, which is recorded for much of the corpus and is the reason to keep the
+    deposited string at all. It is normalized rather than taken verbatim: agents are
+    removed and the result is canonicalized, so the conventions that differ between
+    depositors -- agent placement, atom ordering -- stop deciding whether two reactions
+    look alike. A recorded value RDKit cannot read falls through to generation.
+
+    Generated or recorded, the result carries no agents. An empty agent block is
+    idiomatic in reaction SMILES, and excluding agents means a reagent, solvent, or
+    catalyst recorded only by name -- very common for ligands -- cannot decide whether
+    the reaction gets a SMILES at all. Generation is otherwise strict: every reactant
+    and product must be readable, since a SMILES silently missing one describes a
+    different reaction and nothing in the column marks it.
+
+    Args:
+        reaction: Reaction message.
+
+    Returns:
+        Canonical ``reactants>>products`` SMILES, or None if nothing recorded can be
+        read and nothing complete can be generated.
+    """
+    for identifier_type in (
+        reaction_pb2.ReactionIdentifier.REACTION_CXSMILES,
+        reaction_pb2.ReactionIdentifier.REACTION_SMILES,
+    ):
+        for identifier in reaction.identifiers:
+            if identifier.type != identifier_type or not identifier.value:
+                continue
+            without_agents = reaction_smiles_without_agents(identifier.value)
+            if without_agents is not None:
+                return without_agents
+    try:
+        return (
+            generate_reaction_smiles(
+                reaction, allow_incomplete=False, include_agents=False
+            )
+            or None
+        )
+    except ValueError:
+        return None
+
+
 def molblock_from_compound(
     compound: reaction_pb2.Compound | reaction_pb2.ProductCompound,
 ) -> str:
@@ -500,8 +615,6 @@ def get_reaction_smiles(
     generate_if_missing: bool = False,
     allow_incomplete: bool = True,
     allow_unspecified_roles: bool = True,
-    validate: bool = False,
-    canonical: bool = True,
     strip_extension: bool = False,
 ) -> str | None:
     """Fetches or generates a reaction SMILES.
@@ -521,9 +634,6 @@ def get_reaction_smiles(
         allow_unspecified_roles: If True, reactants and products with the
             UNSPECIFIED reaction role will be included when generating a reaction
             SMILES.
-        validate: Boolean whether to validate the reaction SMILES with rdkit.
-            Only used if allow_incomplete is False.
-        canonical: Boolean whether to return a canonicalized reaction SMILES.
         strip_extension: If True, drop a CXSMILES extension block from the result so it
             is plain SMILES. Generated SMILES never carry one.
 
@@ -544,61 +654,129 @@ def get_reaction_smiles(
             return identifier.value
     if not generate_if_missing:
         return None
+    return generate_reaction_smiles(
+        message,
+        allow_incomplete=allow_incomplete,
+        allow_unspecified_roles=allow_unspecified_roles,
+    )
 
+
+def generate_reaction_smiles(
+    message: reaction_pb2.Reaction,
+    *,
+    allow_incomplete: bool = True,
+    allow_unspecified_roles: bool = True,
+    include_agents: bool = True,
+) -> str:
+    """Builds a reaction SMILES from a Reaction's components, ignoring its identifiers.
+
+    Args:
+        message: reaction_pb2.Reaction message.
+        allow_incomplete: Whether to allow "incomplete" reaction SMILES that omit
+            components with no readable structure. Only components the result would
+            carry are considered, so an unreadable agent is irrelevant when
+            ``include_agents`` is False.
+        allow_unspecified_roles: If True, components with the UNSPECIFIED reaction role
+            are treated as reactants and products.
+        include_agents: Whether to emit the middle ``>agents>`` block. Reagents,
+            solvents, and catalysts are dropped when False, which leaves the SMILES
+            describing the transformation alone.
+
+    Returns:
+        Canonical reaction CXSMILES, so enhanced stereochemistry recorded on a component
+        survives into the reaction.
+
+    Raises:
+        ValueError: If a component the result would carry has no readable structure and
+            ``allow_incomplete`` is False, if there is no reactant or no product, or if
+            RDKit reports errors in the assembled reaction.
+    """
     reactants, agents, products = set(), set(), set()
     roles = reaction_pb2.ReactionRole
+    agent_roles = [roles.REAGENT, roles.SOLVENT, roles.CATALYST]
     reactant_roles = [roles.REACTANT]
     product_roles = [roles.PRODUCT]
     if allow_unspecified_roles:
         reactant_roles.append(roles.UNSPECIFIED)
         product_roles.append(roles.UNSPECIFIED)
+
+    def _add(
+        compound: reaction_pb2.Compound | reaction_pb2.ProductCompound,
+        target: set[str] | None,
+    ) -> None:
+        """Adds a compound's SMILES to ``target``, or skips it if nothing holds it."""
+        # Checked before parsing, so a component the result would not carry cannot fail
+        # the whole reaction: a NAME-only ligand is silent when agents are excluded.
+        if target is None:
+            return
+        try:
+            smiles = smiles_from_compound(compound)
+        except ValueError:
+            if allow_incomplete:
+                return
+            raise
+        target.add(smiles)
+
     for key in sorted(message.inputs):
         for compound in message.inputs[key].components:
-            try:
-                smiles = smiles_from_compound(compound)
-            except ValueError:
-                if allow_incomplete:
-                    continue
-                raise
-            if compound.reaction_role in [roles.REAGENT, roles.SOLVENT, roles.CATALYST]:
-                agents.add(smiles)
+            if compound.reaction_role in agent_roles:
+                _add(compound, agents if include_agents else None)
             elif compound.reaction_role in reactant_roles:
-                reactants.add(smiles)
-
+                _add(compound, reactants)
     for outcome in message.outcomes:
         for product in outcome.products:
-            try:
-                smiles = smiles_from_compound(product)
-            except ValueError:
-                if allow_incomplete:
-                    continue
-                raise
-            if product.reaction_role in product_roles:
-                products.add(smiles)
+            _add(product, products if product.reaction_role in product_roles else None)
 
     if not allow_incomplete and (not reactants or not products):
         raise ValueError("reaction must contain at least one reactant and one product")
     if not reactants and not products:
         raise ValueError("reaction contains no valid reactants or products")
-    components = [
-        ".".join(sorted(reactants)),
-        ".".join(sorted(agents)),
-        ".".join(sorted(products)),
-    ]
-    reaction_smiles = ">".join(components)
-    if validate:
-        if allow_incomplete:
-            raise ValueError("validate is mutually exclusive with allow_incomplete")
-        validate_reaction_smiles(reaction_smiles)
-    if canonical:
-        reaction_smiles = rdChemReactions.ReactionToSmiles(
-            rdChemReactions.ReactionFromSmarts(reaction_smiles, useSmiles=True)
-        )
+    # Assembled from parsed components rather than by joining their SMILES: a component
+    # carrying a CXSMILES extension puts a `|...|` block mid-string, which is not a
+    # reaction SMILES at all. Building the reaction lets RDKit re-emit one block for the
+    # whole reaction, with the atom indices it refers to recomputed.
+    built = rdChemReactions.ChemicalReaction()
+    for smiles in sorted(reactants):
+        built.AddReactantTemplate(Chem.MolFromSmiles(smiles))
+    for smiles in sorted(agents):
+        built.AddAgentTemplate(Chem.MolFromSmiles(smiles))
+    for smiles in sorted(products):
+        built.AddProductTemplate(Chem.MolFromSmiles(smiles))
+    reaction_smiles = rdChemReactions.ReactionToCXSmiles(built)
+    # Checked on the reaction just built rather than by parsing the SMILES back;
+    # sanitization mutates it, which is why the string is written first. Unconditional:
+    # allow_incomplete only drops components that would not parse, so what remains is
+    # as valid either way.
+    try:
+        _validate_reaction(built)
+    except (RuntimeError, ValueError) as error:
+        raise ValueError(
+            f"bad reaction SMILES ({error!s}): {reaction_smiles}"
+        ) from error
     return reaction_smiles
+
+
+def _validate_reaction(reaction: rdChemReactions.ChemicalReaction) -> None:
+    """Sanitizes a reaction in place and raises if RDKit reports any error.
+
+    Args:
+        reaction: Reaction to check. Sanitized in place, so pass a reaction whose
+            SMILES has already been written if the unsanitized form is wanted.
+
+    Raises:
+        ValueError: If sanitization fails or validation reports errors.
+    """
+    rdChemReactions.SanitizeRxn(reaction)
+    _, num_errors = reaction.Validate()
+    if num_errors:
+        raise ValueError("reaction SMILES contains errors")
 
 
 def validate_reaction_smiles(reaction_smiles: str) -> None:
     """Validates reaction SMILES.
+
+    Prefer :func:`_validate_reaction` where a parsed reaction is already at hand; this
+    is for callers holding only the string, e.g. checking a recorded identifier.
 
     Args:
         reaction_smiles: Text reaction SMILES.
@@ -610,10 +788,7 @@ def validate_reaction_smiles(reaction_smiles: str) -> None:
         reaction = rdChemReactions.ReactionFromSmarts(reaction_smiles, useSmiles=True)
         if not reaction:
             raise ValueError("reaction SMILES could not be parsed")
-        rdChemReactions.SanitizeRxn(reaction)
-        _, num_errors = reaction.Validate()
-        if num_errors:
-            raise ValueError("reaction SMILES contains errors")
+        _validate_reaction(reaction)
     except (RuntimeError, ValueError) as error:
         raise ValueError(
             f"bad reaction SMILES ({error!s}): {reaction_smiles}"

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -167,10 +167,9 @@ class TestMessageHelpers:
         reactant1.components.add(reaction_role="WORKUP").identifiers.add(
             value="O", type="SMILES"
         )
-        assert (
+        # A reaction with no products is an error to RDKit, not merely incomplete.
+        with pytest.raises(ValueError, match="contains errors"):
             message_helpers.get_reaction_smiles(reaction, generate_if_missing=True)
-            == "c1ccccc1>N>"
-        )
         reactant2 = reaction.inputs["reactant2"]
         reactant2.components.add(reaction_role="REACTANT").identifiers.add(
             value="Cc1ccccc1", type="SMILES"
@@ -932,3 +931,141 @@ def test_identifier_parses_unsanitized_separates_the_two_failure_modes():
     )
     assert message_helpers.identifier_parses_unsanitized(smiles, unsanitizable)
     assert not message_helpers.identifier_parses_unsanitized(smiles, "not a molecule")
+
+
+def _compound(**identifiers) -> reaction_pb2.Compound:
+    compound = reaction_pb2.Compound()
+    for identifier_type, value in identifiers.items():
+        compound.identifiers.add(type=identifier_type.upper(), value=value)
+    return compound
+
+
+def test_preferred_compound_smiles_prefers_cxsmiles():
+    # CXSMILES is a superset, so the richer identifier wins whatever order they appear.
+    compound = _compound(smiles="C[C@H](N)O", cxsmiles="C[C@H](N)O |o1:1|")
+    assert message_helpers.preferred_compound_smiles(compound) == "C[C@H](N)O |o1:1|"
+
+
+def test_preferred_compound_smiles_falls_back_to_other_structural_types():
+    compound = _compound(inchi="InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H")
+    assert message_helpers.preferred_compound_smiles(compound) == "c1ccccc1"
+
+
+def test_preferred_compound_smiles_looks_past_a_malformed_identifier():
+    # smiles_from_compound stops at the first structural identifier, so without the
+    # fallback a good value recorded behind a bad one is never reached.
+    compound = _compound(
+        smiles="not a smiles", inchi="InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"
+    )
+    assert message_helpers.preferred_compound_smiles(compound) == "c1ccccc1"
+
+
+def test_preferred_compound_smiles_is_none_without_a_readable_structure():
+    assert message_helpers.preferred_compound_smiles(_compound(name="benzene")) is None
+
+
+def test_reaction_smiles_without_agents_drops_the_middle_block():
+    value = message_helpers.reaction_smiles_without_agents("CC.CCO>CO.[Pd]>CCC")
+    assert value is not None
+    assert value.count(">") == 2
+    assert "[Pd]" not in value
+
+
+def test_reaction_smiles_without_agents_keeps_atom_mapping():
+    value = message_helpers.reaction_smiles_without_agents(
+        "[CH3:1][OH:2].[C:3](=O)O>CCO.[Na+]>[CH3:1][O:2][C:3]=O"
+    )
+    assert value is not None
+    for atom_map in (":1]", ":2]", ":3]"):
+        assert atom_map in value
+    assert "[Na+]" not in value
+
+
+def test_reaction_smiles_without_agents_reindexes_enhanced_stereochemistry():
+    # Splitting the string on ">" would leave |o1:1| pointing at a shifted atom.
+    value = message_helpers.reaction_smiles_without_agents(
+        "C[C@H](N)O.CCO>CO>C[C@H](N)OCC |o1:1|"
+    )
+    assert value is not None
+    assert "|o1:" in value
+    assert "CO>" not in value.replace("CCO>", "")
+
+
+@pytest.mark.parametrize("value", ["not a reaction", "CCO", "C[Xx]C>CO>CCC"])
+def test_reaction_smiles_without_agents_is_none_when_unreadable(value):
+    assert message_helpers.reaction_smiles_without_agents(value) is None
+
+
+def _reaction_with_components() -> reaction_pb2.Reaction:
+    reaction = reaction_pb2.Reaction(reaction_id="ord-0001")
+    reaction.inputs["a"].components.append(_compound(smiles="c1ccccc1"))
+    reaction.outcomes.add().products.add().identifiers.add(
+        type="SMILES", value="Cc1ccccc1"
+    )
+    return reaction
+
+
+def test_generate_reaction_smiles_can_exclude_agents():
+    reaction = _reaction_with_components()
+    catalyst = reaction.inputs["cat"].components.add(reaction_role="CATALYST")
+    catalyst.identifiers.add(type="SMILES", value="[Pd]")
+    assert "[Pd]" in message_helpers.generate_reaction_smiles(reaction)
+    assert "[Pd]" not in message_helpers.generate_reaction_smiles(
+        reaction, include_agents=False
+    )
+
+
+def test_generate_reaction_smiles_ignores_an_unreadable_agent_it_will_not_emit():
+    # A component the result would not carry is never parsed, so it cannot fail the
+    # reaction; this is what keeps a NAME-only ligand from nulling the column.
+    reaction = _reaction_with_components()
+    ligand = reaction.inputs["cat"].components.add(reaction_role="CATALYST")
+    ligand.identifiers.add(type="NAME", value="ItBu")
+    assert message_helpers.generate_reaction_smiles(
+        reaction, allow_incomplete=False, include_agents=False
+    )
+    with pytest.raises(ValueError, match="no valid structural identifier"):
+        message_helpers.generate_reaction_smiles(
+            reaction, allow_incomplete=False, include_agents=True
+        )
+
+
+def test_generate_reaction_smiles_keeps_enhanced_stereochemistry():
+    # Component CXSMILES blocks cannot be joined into a reaction string; the reaction is
+    # assembled from parsed components so RDKit emits one block with correct indices.
+    reaction = reaction_pb2.Reaction(reaction_id="ord-0001")
+    reaction.inputs["a"].components.append(_compound(cxsmiles="C[C@H](N)O |o1:1|"))
+    reaction.outcomes.add().products.add().identifiers.add(
+        type="SMILES", value="C[C@H](N)OC"
+    )
+    assert "|o1:" in message_helpers.generate_reaction_smiles(reaction)
+
+
+def test_derived_reaction_smiles_normalizes_a_recorded_identifier():
+    reaction = reaction_pb2.Reaction(reaction_id="ord-0001")
+    reaction.identifiers.add(
+        type="REACTION_SMILES", value="[CH3:1][OH:2].[C:3](=O)O>CCO>[CH3:1][O:2][C:3]=O"
+    )
+    value = message_helpers.derived_reaction_smiles(reaction)
+    assert value is not None
+    assert ":1]" in value  # Mapping survives, which is why the recorded value is kept.
+    assert value.count(">") == 2  # Agents do not.
+
+
+def test_derived_reaction_smiles_generates_when_nothing_is_recorded():
+    assert (
+        message_helpers.derived_reaction_smiles(_reaction_with_components())
+        == "c1ccccc1>>Cc1ccccc1"
+    )
+
+
+def test_derived_reaction_smiles_generates_when_the_recorded_value_is_unreadable():
+    reaction = _reaction_with_components()
+    reaction.identifiers.add(type="REACTION_SMILES", value="not a reaction")
+    assert message_helpers.derived_reaction_smiles(reaction) == "c1ccccc1>>Cc1ccccc1"
+
+
+def test_derived_reaction_smiles_is_none_when_a_reactant_cannot_be_read():
+    reaction = _reaction_with_components()
+    reaction.inputs["b"].components.append(_compound(name="mystery reactant"))
+    assert message_helpers.derived_reaction_smiles(reaction) is None

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -20,6 +20,7 @@ import pandas as pd
 import pytest
 from google.protobuf import json_format, text_format
 from rdkit import Chem
+from rdkit.Chem import rdChemReactions
 
 from ord_schema import message_helpers
 from ord_schema.proto import reaction_pb2, test_pb2
@@ -981,14 +982,49 @@ def test_reaction_smiles_without_agents_keeps_atom_mapping():
     assert "[Na+]" not in value
 
 
-def test_reaction_smiles_without_agents_reindexes_enhanced_stereochemistry():
-    # Splitting the string on ">" would leave |o1:1| pointing at a shifted atom.
-    value = message_helpers.reaction_smiles_without_agents(
-        "C[C@H](N)O.CCO>CO>C[C@H](N)OCC |o1:1|"
-    )
-    assert value is not None
-    assert "|o1:" in value
-    assert "CO>" not in value.replace("CCO>", "")
+def _stereo_groups(reaction_smiles: str):
+    """Returns (degree, chiral tag) for every atom RDKit reads in a stereo group."""
+    reaction = rdChemReactions.ReactionFromSmarts(reaction_smiles, useSmiles=True)
+    return [
+        (atom.GetDegree(), atom.GetChiralTag().name)
+        for mols in (reaction.GetReactants(), reaction.GetProducts())
+        for mol in mols
+        for group in mol.GetStereoGroups()
+        for atom in group.GetAtoms()
+    ]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "C[C@H](N)O.CCO>CO>C[C@H](N)OCC |o1:1|",
+        "CCO.C[C@H](N)O>CO>C[C@H](N)OCC |o1:4|",
+    ],
+)
+def test_reaction_smiles_without_agents_reindexes_enhanced_stereochemistry(value):
+    # Asserting the block is present is not enough: RDKit numbers the extension against
+    # the order templates were added and then writes them sorted, so removing agents in
+    # place left |o1:1| marking whichever atom landed at that index -- an achiral CH2 in
+    # the first case. Compare the atoms RDKit actually reads back.
+    without_agents = message_helpers.reaction_smiles_without_agents(value)
+    assert without_agents is not None
+    assert "|o1:" in without_agents
+    assert _stereo_groups(without_agents) == _stereo_groups(value)
+    assert _stereo_groups(value) == [(3, "CHI_TETRAHEDRAL_CCW")]
+
+
+@pytest.mark.parametrize("value", [">>", "CCO>>", ">CO.[Pd]>", ">>CCC"])
+def test_reaction_smiles_without_agents_rejects_a_half_reaction(value):
+    # A recorded value listing only agents collapses to ">>", and a half reaction is not
+    # a restatement of anything; both must fall through to generation rather than be
+    # published as a truthy string.
+    assert message_helpers.reaction_smiles_without_agents(value) is None
+
+
+def test_reaction_smiles_without_agents_survives_a_malformed_extension():
+    # RDKit raises RuntimeError here, not ValueError; catching only ValueError let this
+    # escape and kill a corpus-wide run naming neither the reaction nor the string.
+    assert message_helpers.reaction_smiles_without_agents("C>>C |bogus|") is None
 
 
 @pytest.mark.parametrize("value", ["not a reaction", "CCO", "C[Xx]C>CO>CCC"])
@@ -1030,6 +1066,24 @@ def test_generate_reaction_smiles_ignores_an_unreadable_agent_it_will_not_emit()
         )
 
 
+def test_strip_extension_applies_to_a_generated_reaction_too():
+    # Generation emits CXSMILES, so a caller asking for plain SMILES has to get it
+    # whether the value was recorded or built here.
+    reaction = reaction_pb2.Reaction(reaction_id="ord-0001")
+    reaction.inputs["a"].components.append(_compound(cxsmiles="C[C@H](N)O |o1:1|"))
+    reaction.outcomes.add().products.add().identifiers.add(
+        type="SMILES", value="C[C@H](N)OC"
+    )
+    generated = message_helpers.get_reaction_smiles(reaction, generate_if_missing=True)
+    stripped = message_helpers.get_reaction_smiles(
+        reaction, generate_if_missing=True, strip_extension=True
+    )
+    assert generated is not None
+    assert stripped is not None
+    assert "|" in generated
+    assert "|" not in stripped
+
+
 def test_generate_reaction_smiles_keeps_enhanced_stereochemistry():
     # Component CXSMILES blocks cannot be joined into a reaction string; the reaction is
     # assembled from parsed components so RDKit emits one block with correct indices.
@@ -1059,10 +1113,46 @@ def test_derived_reaction_smiles_generates_when_nothing_is_recorded():
     )
 
 
-def test_derived_reaction_smiles_generates_when_the_recorded_value_is_unreadable():
+@pytest.mark.parametrize("recorded", ["not a reaction", ">>", "CCO>>", "C>>C |bogus|"])
+def test_derived_reaction_smiles_generates_when_the_recorded_value_is_unusable(
+    recorded,
+):
     reaction = _reaction_with_components()
-    reaction.identifiers.add(type="REACTION_SMILES", value="not a reaction")
+    reaction.identifiers.add(type="REACTION_SMILES", value=recorded)
     assert message_helpers.derived_reaction_smiles(reaction) == "c1ccccc1>>Cc1ccccc1"
+
+
+def test_derived_reaction_smiles_prefers_cxsmiles_among_recorded_identifiers():
+    # The reaction-level twin of the compound-level preference, recorded SMILES first so
+    # this pins the order rather than the iteration.
+    reaction = reaction_pb2.Reaction(reaction_id="ord-0001")
+    reaction.identifiers.add(type="REACTION_SMILES", value="C[C@H](N)O>>C[C@H](N)OC")
+    reaction.identifiers.add(
+        type="REACTION_CXSMILES", value="C[C@H](N)O>>C[C@H](N)OC |o1:1|"
+    )
+    preferred = message_helpers.derived_reaction_smiles(reaction)
+    assert preferred is not None
+    assert "|o1:" in preferred
+
+
+def test_generate_reaction_smiles_rejects_an_unparseable_component(monkeypatch):
+    # RDKit accepts a null template and then dies with SIGSEGV when writing it, which no
+    # caller can catch, so this has to surface as the ValueError callers already handle.
+    # Only a MolToSmiles/MolFromSmiles round-trip failure reaches it -- rare enough that
+    # it needs simulating, bad enough that the guard has to be there. Failing the second
+    # parse of each string leaves smiles_from_compound working and breaks the assembly.
+    real = message_helpers.Chem.MolFromSmiles
+    seen: set[str] = set()
+
+    def _once(smiles, *args, **kwargs):
+        if smiles in seen:
+            return None
+        seen.add(smiles)
+        return real(smiles, *args, **kwargs)
+
+    monkeypatch.setattr(message_helpers.Chem, "MolFromSmiles", _once)
+    with pytest.raises(ValueError, match="cannot parse component SMILES"):
+        message_helpers.generate_reaction_smiles(_reaction_with_components())
 
 
 def test_derived_reaction_smiles_is_none_when_a_reactant_cannot_be_read():

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -720,24 +720,18 @@ def update_derived_tables(
         batch_ids = reaction_ids[batch_start : batch_start + _DERIVED_BATCH]
         inserts = []
         for reaction_id, proto in session.execute(select_protos, {"ids": batch_ids}):
-            try:
-                reaction_smiles = message_helpers.get_reaction_smiles(
-                    reaction_pb2.Reaction.FromString(proto),
-                    generate_if_missing=True,
-                    allow_incomplete=False,
-                )
-            except ValueError as error:
-                logger.debug(
-                    f"No reaction SMILES for reaction id={reaction_id}: {error}"
-                )
+            reaction_smiles = message_helpers.derived_reaction_smiles(
+                reaction_pb2.Reaction.FromString(proto)
+            )
+            if reaction_smiles is None:
+                logger.debug(f"No reaction SMILES for reaction id={reaction_id}")
                 continue
-            tokens = (
-                reaction_smiles.split() if reaction_smiles else []
-            )  # Handle CXSMILES.
-            if tokens:
-                inserts.append(
-                    {"reaction_id": reaction_id, "reaction_smiles": tokens[0]}
-                )
+            # rdkit.reactions is keyed by this string and reaction_from_smiles cannot
+            # read a CXSMILES extension, so the block comes off. Splitting on the block
+            # keeps SMILES ending in a non-breaking space intact, which splitting on
+            # whitespace does not.
+            smiles, _ = message_helpers.split_cxsmiles_extension(reaction_smiles)
+            inserts.append({"reaction_id": reaction_id, "reaction_smiles": smiles})
         if inserts:
             session.execute(insert_reaction_smiles, inserts)
     _update_compound_smiles(

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -725,7 +725,6 @@ def update_derived_tables(
                     reaction_pb2.Reaction.FromString(proto),
                     generate_if_missing=True,
                     allow_incomplete=False,
-                    validate=True,
                 )
             except ValueError as error:
                 logger.debug(

--- a/ord_schema/projection.py
+++ b/ord_schema/projection.py
@@ -39,13 +39,17 @@ Two normalizations are applied, and only two. Both cost no query and remove a re
 * **Structural identifiers collapse to one ``smiles``.** ``SMILES``, ``CXSMILES``,
   ``INCHI``, and ``MOLBLOCK`` all answer "what is this molecule," so the projection
   answers it once, through ``message_helpers.preferred_compound_smiles`` -- the same
-  CXSMILES-first choice every derived artifact makes, so two artifacts never disagree
-  about a molecule. ``REACTION_SMILES`` and ``REACTION_CXSMILES`` collapse the same way
-  at the reaction level, into a ``smiles`` generated from the components by
-  ``message_helpers.derived_reaction_smiles``. The drop is all-or-nothing per message
-  and conditional on the collapse producing something: a compound whose identifiers none
-  of RDKit's loaders can read keeps all of them, rather than reading as a compound whose
-  structure the source never recorded.
+  CXSMILES-first choice the tabular view makes, so the two never disagree about a
+  molecule. ``REACTION_SMILES`` and ``REACTION_CXSMILES`` collapse the same
+  way at the reaction level, into a ``smiles`` that
+  ``message_helpers.derived_reaction_smiles`` normalizes from the recorded value --
+  agents removed and the result canonicalized, so a reaction deposited as ``A>B>C``
+  reads as ``A>>C`` -- or generates from the components when the source records nothing
+  readable. Atom mapping is kept; fragment grouping is not.
+
+  The drop is all-or-nothing per message and conditional on the collapse producing
+  something: a compound whose identifiers none of RDKit's loaders can read keeps all of
+  them, rather than reading as a compound whose structure the source never recorded.
 
 Every other identifier is kept, as a list. ``NAME`` alone covers compounds that no
 structural identifier reaches, and a compound may carry several of them, so pivoting
@@ -114,11 +118,11 @@ _CANONICAL_UNITS: dict[str, tuple[str, str]] = {
     "Wavelength": ("nm", "nanometers"),
 }
 
-# Messages that get a collapsed `smiles`, and the identifier types it replaces. Keyed
-# by message rather than tested twice, so the decision to collapse and the choice of
-# what to drop cannot drift apart; the enum numbers overlap between compounds and
-# reactions, so a mismatch would silently drop the wrong types rather than raise. The
-# compound set follows message_helpers, which owns what "structural" means.
+# Messages that get a collapsed `smiles`, and the identifier types it replaces. Keying
+# the sets keeps the decision to collapse and the choice of what to drop from drifting
+# apart: the enum numbers overlap between compounds and reactions, so a mismatch would
+# drop the wrong types silently rather than raise. The compound set follows
+# message_helpers, which owns what "structural" means.
 _STRUCTURAL_COMPOUND_TYPES = frozenset(
     reaction_pb2.CompoundIdentifier.CompoundIdentifierType.Value(name)
     for name in message_helpers.STRUCTURAL_IDENTIFIER_TYPES
@@ -150,7 +154,7 @@ _ARROW_SCALARS: dict[int, pa.DataType] = {
     FieldDescriptor.TYPE_ENUM: pa.string(),
 }
 
-_RESOLVER = units.UnitResolver()
+_RESOLVER = units.RESOLVER
 
 
 def _validate_canonical_units() -> None:
@@ -279,14 +283,15 @@ def _smiles(message: Message) -> str | None:
     """Returns the SMILES for a compound or reaction, or None if none can be read.
 
     Both forms prefer the CXSMILES the source recorded, so this column and the tabular
-    view answer "what is this molecule" identically for the same input.
+    view answer "what is this molecule" alike.
 
     Args:
         message: A Compound, ProductCompound, or Reaction.
 
     Returns:
-        Canonical SMILES for a compound; for a reaction, the recorded reaction SMILES or
-        one generated from the components. None when nothing readable is recorded.
+        Canonical SMILES for a compound. For a reaction, the recorded reaction SMILES
+        with its agents removed and canonicalized, or one generated from the components
+        when nothing readable is recorded; None when neither is possible.
     """
     if cast(Descriptor, message.DESCRIPTOR).name == "Reaction":
         return message_helpers.derived_reaction_smiles(

--- a/ord_schema/projection.py
+++ b/ord_schema/projection.py
@@ -38,12 +38,14 @@ Two normalizations are applied, and only two. Both cost no query and remove a re
   mixed-unit comparison that would quietly return the wrong rows does not.
 * **Structural identifiers collapse to one ``smiles``.** ``SMILES``, ``CXSMILES``,
   ``INCHI``, and ``MOLBLOCK`` all answer "what is this molecule," so the projection
-  answers it once rather than making every consumer re-implement the preference order;
-  ``REACTION_SMILES`` and ``REACTION_CXSMILES`` collapse the same way at the reaction
-  level. The drop is all-or-nothing per message and conditional on the collapse
-  producing something: a compound whose identifiers none of RDKit's loaders can read
-  keeps all of them, rather than reading as a compound whose structure the source never
-  recorded.
+  answers it once, through ``message_helpers.preferred_compound_smiles`` -- the same
+  CXSMILES-first choice every derived artifact makes, so two artifacts never disagree
+  about a molecule. ``REACTION_SMILES`` and ``REACTION_CXSMILES`` collapse the same way
+  at the reaction level, into a ``smiles`` generated from the components by
+  ``message_helpers.derived_reaction_smiles``. The drop is all-or-nothing per message
+  and conditional on the collapse producing something: a compound whose identifiers none
+  of RDKit's loaders can read keeps all of them, rather than reading as a compound whose
+  structure the source never recorded.
 
 Every other identifier is kept, as a list. ``NAME`` alone covers compounds that no
 structural identifier reaches, and a compound may carry several of them, so pivoting
@@ -112,12 +114,11 @@ _CANONICAL_UNITS: dict[str, tuple[str, str]] = {
     "Wavelength": ("nm", "nanometers"),
 }
 
-# Identifier types the collapsed `smiles` answers for, keyed by the message that gets
-# the collapsed field. Keying the sets rather than testing the message name twice keeps
-# the two decisions -- whether to collapse, and which types to drop -- from drifting
-# apart; the enum numbers overlap between the two, so a mismatch would silently drop the
-# wrong types rather than raise. The compound set follows message_helpers, which owns
-# what "structural" means.
+# Messages that get a collapsed `smiles`, and the identifier types it replaces. Keyed
+# by message rather than tested twice, so the decision to collapse and the choice of
+# what to drop cannot drift apart; the enum numbers overlap between compounds and
+# reactions, so a mismatch would silently drop the wrong types rather than raise. The
+# compound set follows message_helpers, which owns what "structural" means.
 _STRUCTURAL_COMPOUND_TYPES = frozenset(
     reaction_pb2.CompoundIdentifier.CompoundIdentifierType.Value(name)
     for name in message_helpers.STRUCTURAL_IDENTIFIER_TYPES
@@ -274,63 +275,26 @@ SCHEMA = build_schema()
 _validate_canonical_units()
 
 
-def _canonical_value(message: ord_schema.UnitMessage, target: str) -> float | None:
-    """Returns a united message's value in ``target`` units, or None if unreadable."""
-    if not message.HasField("value") or not message.units:
-        return None
-    try:
-        return _RESOLVER.convert(message, target).value
-    except (KeyError, ValueError):
-        # Null rather than a wrong number in the wrong unit. Logged because the
-        # column keeps its name, so the null looks like a source that said nothing.
-        logger.warning(
-            "%s records units the resolver cannot convert to %s; projecting null",
-            cast(Descriptor, message.DESCRIPTOR).name,
-            target,
-        )
-        return None
-
-
 def _smiles(message: Message) -> str | None:
     """Returns the SMILES for a compound or reaction, or None if none can be read.
+
+    Both forms prefer the CXSMILES the source recorded, so this column and the tabular
+    view answer "what is this molecule" identically for the same input.
 
     Args:
         message: A Compound, ProductCompound, or Reaction.
 
     Returns:
-        For a reaction, the recorded reaction SMILES, generated from the components when
-        none is recorded. Generation is all-or-nothing: a reaction holding a component
-        with no readable structure projects null, since a SMILES missing a component is
-        indistinguishable in the column from one that is complete. For a compound,
-        canonical SMILES from the preferred structural identifier, falling back to any
-        other that parses. None when nothing readable is recorded.
+        Canonical SMILES for a compound; for a reaction, the recorded reaction SMILES or
+        one generated from the components. None when nothing readable is recorded.
     """
     if cast(Descriptor, message.DESCRIPTOR).name == "Reaction":
-        try:
-            return (
-                message_helpers.get_reaction_smiles(
-                    cast(reaction_pb2.Reaction, message),
-                    generate_if_missing=True,
-                    allow_incomplete=False,
-                )
-                or None
-            )
-        except ValueError:
-            return None
-    compound = cast(reaction_pb2.Compound, message)
-    try:
-        return message_helpers.smiles_from_compound(compound) or None
-    except ValueError:
-        pass
-    # smiles_from_compound stops at the first structural identifier, so without this
-    # one malformed value hides every later one.
-    for identifier in compound.identifiers:
-        canonical = message_helpers.canonical_smiles_for_identifier(
-            identifier.type, identifier.value
+        return message_helpers.derived_reaction_smiles(
+            cast(reaction_pb2.Reaction, message)
         )
-        if canonical:
-            return canonical
-    return None
+    return message_helpers.preferred_compound_smiles(
+        cast(reaction_pb2.Compound, message)
+    )
 
 
 def _kept_identifiers(values: Any, structural: frozenset[int] | None) -> list[Any]:
@@ -379,7 +343,9 @@ def message_row(message: Message) -> dict[str, Any]:
         name = column_name(field)
         canonical = _canonical_unit(field)
         if canonical is not None:
-            row[name] = _canonical_value(getattr(message, field.name), canonical[0])
+            row[name] = units.canonical_value(
+                getattr(message, field.name), canonical[0]
+            )
             continue
         message_type = field.message_type
         if message_type is not None and message_type.GetOptions().map_entry:

--- a/ord_schema/projection_test.py
+++ b/ord_schema/projection_test.py
@@ -203,11 +203,13 @@ def test_every_structural_compound_type_collapses(identifier_type, value):
 
 
 def test_reaction_structural_identifiers_collapse_too():
-    reaction = reaction_pb2.Reaction(reaction_id="ord-0006")
+    # smiles is generated rather than read from the recorded identifier, so the two can
+    # differ; the source column stays authoritative, as it does for a dropped MOLBLOCK.
+    reaction = _reaction()
     reaction.identifiers.add(type="REACTION_CXSMILES", value="C>>CO |f:0.1|")
     reaction.identifiers.add(type="REACTION_TYPE", value="oxidation")
     row = projection.message_row(reaction)
-    assert row["smiles"] == "C>>CO |f:0.1|"
+    assert row["smiles"] is not None
     assert [identifier["type"] for identifier in row["identifiers"]] == [
         "REACTION_TYPE"
     ]
@@ -268,22 +270,20 @@ def test_reaction_smiles_is_generated_when_the_source_records_none():
 
 
 def test_a_generated_reaction_smiles_is_complete_or_null():
-    # Generating around the unreadable component would put a SMILES missing a reactant
-    # in the same column as a complete one, with nothing to tell them apart.
+    # Generating around an unreadable reactant would put a SMILES missing one in the
+    # same column as a complete one, with nothing to tell them apart.
     reaction = _reaction()
     mystery = reaction.inputs["toluene"].components.add()
-    mystery.identifiers.add(type="NAME", value="mystery reagent")
+    mystery.identifiers.add(type="NAME", value="mystery reactant")
     assert projection.message_row(reaction)["smiles"] is None
 
 
-def test_a_recorded_reaction_smiles_survives_an_unreadable_component():
-    # Only generation is all-or-nothing; a recorded identifier is returned as recorded.
+def test_an_agent_recorded_only_by_name_does_not_null_the_reaction_smiles():
+    # Agents are excluded from the generated SMILES, so an unreadable one is silent.
     reaction = _reaction()
-    reaction.identifiers.add(type="REACTION_SMILES", value="Cc1ccccc1>>Cc1ccccc1O")
-    reaction.inputs["toluene"].components.add().identifiers.add(
-        type="NAME", value="mystery reagent"
-    )
-    assert projection.message_row(reaction)["smiles"] == "Cc1ccccc1>>Cc1ccccc1O"
+    catalyst = reaction.inputs["cat"].components.add(reaction_role="CATALYST")
+    catalyst.identifiers.add(type="NAME", value="ItBu")
+    assert projection.message_row(reaction)["smiles"] is not None
 
 
 def test_empty_repeated_fields_are_null_rather_than_empty_lists():

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -19,7 +19,10 @@ from typing import TypeAlias
 import numpy as np
 
 import ord_schema
+from ord_schema.logging import get_logger
 from ord_schema.proto import reaction_pb2
+
+logger = get_logger(__name__)
 
 # Protobuf-generated enum constants (e.g. reaction_pb2.Time.DAY) are int-valued;
 # there is no public google.protobuf type for “any enum member” in Python.
@@ -448,6 +451,37 @@ class UnitResolver:
                     / _UNIT_CONVERSIONS[message_type][new_units]
                 )
         return new_message
+
+
+_RESOLVER = UnitResolver()
+
+
+def canonical_value(message: ord_schema.UnitMessage, target: str) -> float | None:
+    """Converts a united message to ``target`` units, or returns None if it cannot.
+
+    Reading as null rather than raising is what a derived column wants: the column is
+    named for ``target``, so a value that could not be converted has nowhere to record
+    that it is in different units, and a number there would be read as ``target``.
+
+    Args:
+        message: A united message, e.g. Temperature or Mass.
+        target: Unit to convert to, spelled as the resolver understands it, e.g. "K".
+
+    Returns:
+        The converted value, or None when the message records no value, records no
+        units, or records units that cannot be converted to ``target``.
+    """
+    if not message.HasField("value") or not message.units:
+        return None
+    try:
+        return _RESOLVER.convert(message, target).value
+    except (KeyError, ValueError):
+        logger.warning(
+            "cannot convert %s to %s; reading as null",
+            type(message).__name__,
+            target,
+        )
+        return None
 
 
 def format_message(message: ord_schema.UnitMessage) -> str | None:

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -453,15 +453,17 @@ class UnitResolver:
         return new_message
 
 
-_RESOLVER = UnitResolver()
+# Shared default, so callers using the standard synonyms do not each build one.
+# Custom synonyms need their own UnitResolver.
+RESOLVER = UnitResolver()
 
 
 def canonical_value(message: ord_schema.UnitMessage, target: str) -> float | None:
     """Converts a united message to ``target`` units, or returns None if it cannot.
 
-    Reading as null rather than raising is what a derived column wants: the column is
-    named for ``target``, so a value that could not be converted has nowhere to record
-    that it is in different units, and a number there would be read as ``target``.
+    Null beats raising for a derived column: the column is named for ``target``, so an
+    unconverted value has nowhere to say it is in different units, and a number there
+    would be read as ``target``.
 
     Args:
         message: A united message, e.g. Temperature or Mass.
@@ -469,13 +471,14 @@ def canonical_value(message: ord_schema.UnitMessage, target: str) -> float | Non
 
     Returns:
         The converted value, or None when the message records no value, records no
-        units, or records units that cannot be converted to ``target``.
+        units, or records units that cannot be converted to ``target``. A wavenumber of
+        zero is in the last group: converting it to a wavelength divides by it.
     """
     if not message.HasField("value") or not message.units:
         return None
     try:
-        return _RESOLVER.convert(message, target).value
-    except (KeyError, ValueError):
+        return RESOLVER.convert(message, target).value
+    except (KeyError, ValueError, ZeroDivisionError):
         logger.warning(
             "cannot convert %s to %s; reading as null",
             type(message).__name__,


### PR DESCRIPTION
## Summary

The tabular view (#914) and the projection (#918) chose a compound's SMILES differently: the view preferred CXSMILES, the projection took whatever `get_compound_smiles` returned, which looks only at plain `SMILES`. The same compound could read differently depending on which artifact you opened — the one thing a set of artifacts over one corpus must not do. `message_helpers` now owns the choice and both callers share it.

Splitting `get_reaction_smiles` to do that surfaced a real bug: it raised on any reaction with an enhanced-stereo component.

## Changes

- `preferred_compound_smiles` prefers CXSMILES, falls back to plain SMILES, then to any other structural identifier that parses. That last step matters — `smiles_from_compound` stops at the first structural identifier, so a malformed value hid a good one recorded behind it.
- `derived_reaction_smiles` keeps a recorded `REACTION_SMILES`, since it carries atom mapping that generation cannot reconstruct, but normalizes it: agents removed, result canonicalized, so agent placement and atom ordering stop deciding whether two reactions look alike. Reactions recording nothing readable generate instead — no agents, and only when every reactant and product is readable.
- `reaction_smiles_without_agents` removes agents through RDKit rather than by splitting on `>`, because a CXSMILES extension indexes atoms positionally: dropping agents from the string leaves every index pointing at the wrong atom. Round-tripping recomputes them.
- **Bug fix.** `get_reaction_smiles` built its result by joining component SMILES into `A.B>C>D`, but `smiles_from_compound` returns CXSMILES when a component records one, so `A |o1:1|.B>>C` is not a reaction SMILES and RDKit refused to parse it. Any reaction with an enhanced-stereo component raised. The generating half is now `generate_reaction_smiles`, which assembles the reaction from parsed components and writes it with `ReactionToCXSmiles`, so one correct block covers the whole reaction and enhanced stereochemistry survives.
- `generate_reaction_smiles` takes `include_agents`, defaulting to True. Roles are resolved *before* parsing, so a component the result will not carry cannot fail the reaction — a NAME-only ligand is irrelevant when agents are excluded. This also stops an unreadable `INTERNAL_STANDARD` failing a run it never appears in.
- Validation always runs on a generated reaction SMILES, and checks the reaction already in hand instead of parsing the SMILES back.
- `get_reaction_smiles` loses `canonical` (no caller passed False) and `validate` (now implied). An accepted-but-ignored flag is a worse trap than a removed one; the ORM caller is updated.
- The projection adopts all of the above, and `units.canonical_value` replaces its private copy.

## Testing

- `uv run pytest`: 800 pass, 2 skipped. `ruff check`, `ruff format --check`, `ty`, and all pre-commit hooks clean; `ty` reports the same 72 diagnostics as `main`, none in these files.
- **All 53 published datasets validate clean** — `validate_dataset --validate_ids`, 2,466 units, zero errors — which is the check that matters for making validation unconditional.
- 17 new tests covering each helper directly: CXSMILES preference, the malformed-then-valid fallback, agent removal preserving atom mapping, enhanced stereochemistry re-indexed after removal, unreadable input returning None, `include_agents` both ways, an unreadable agent being ignored while an unreadable reactant is not, and recorded-vs-generated selection.

## Notes

One behavior change to know about: RDKit calls a reaction with no products an *error* rather than an incompleteness, so generating for such a reaction now raises where it previously returned `"c1ccccc1>N>"`. It does not occur anywhere in ord-data — only in a test fixture that was mid-construction — but it is why the always-validate change is not purely additive.

Measured over all 2,428,291 reactions in the 53 published datasets, discarding recorded identifiers and regenerating everything would have dropped `reaction_smiles` coverage from 100% to 85.9% — 341,900 reactions, of which 341,491 had recorded one. That measurement is why the recorded value is kept and normalized rather than replaced.

#914 is stacked on this and its diff will shrink to the view itself once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR centralizes preferred compound and derived reaction SMILES selection so projections and ORM-derived artifacts use consistent normalization.

- Adds CXSMILES-first compound selection with fallback across parseable structural identifiers.
- Adds agentless reaction normalization and RDKit-based generation that preserves enhanced stereochemistry.
- Routes projection and ORM derivation through the shared helpers.
- Moves canonical unit conversion into `units.py`.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/message_helpers.py | Adds shared compound preference and reaction normalization/generation helpers and completes the prior generated-extension stripping fix. |
| ord_schema/orm/database.py | Uses shared agentless reaction normalization before storing a plain reaction SMILES compatible with the PostgreSQL RDKit parser. |
| ord_schema/projection.py | Reuses shared compound and reaction SMILES selection and the centralized unit conversion helper. |
| ord_schema/units.py | Introduces a shared resolver and null-returning canonical unit conversion helper. |
| ord_schema/message_helpers_test.py | Covers identifier preference, agent removal, enhanced stereochemistry, malformed inputs, strict generation, and generated-extension stripping. |
| ord_schema/projection_test.py | Updates projection expectations for normalized reaction SMILES and excluded unreadable agents. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Proto[Reaction or Compound proto] --> Helpers[Shared message helpers]
  Helpers --> Preferred[Preferred compound SMILES]
  Helpers --> Derived[Normalized agentless reaction SMILES]
  Preferred --> Projection[Projection]
  Derived --> Projection
  Derived --> Strip[Strip CXSMILES extension]
  Strip --> ORM[ORM derived reaction SMILES]
  ORM --> RDKit[PostgreSQL RDKit tables]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Stop the normalization corrupting stereo..."](https://github.com/open-reaction-database/ord-schema/commit/47732100824e71ed4e226e5ff95491b5be26f8c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51028758)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Validation, Resolution, and Update Pipeline](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/validation-pipeline.md)
- Knowledge Base — [ORM and Database Loading](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/orm-database.md)
- Knowledge Base — [Data I/O: proto serialization, Parquet, and units](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/data-io.md)
</details>

<!-- /greptile_comment -->