### PR TITLE
One compound-SMILES function, and stop dropping CXSMILES extension blocks

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -344,38 +344,6 @@ def find_submessages(
 
 def smiles_from_compound(
     compound: reaction_pb2.Compound | reaction_pb2.ProductCompound,
-    canonical: bool = True,
-) -> str:
-    """Fetches or generates a SMILES identifier for a compound.
-
-    An existing SMILES identifier is used in preference to regenerating one from the
-    structure, but it is still canonicalized when ``canonical`` is True.
-
-    Args:
-        compound: reaction_pb2.Compound or reaction_pb2.ProductCompound message.
-        canonical: If True, returns a canonicalized SMILES.
-
-    Returns:
-        Text SMILES, carrying an enhanced-stereochemistry block where the structure has
-        one (see :func:`canonical_smiles`).
-
-    Raises:
-        ValueError: if no structural identifiers are defined.
-    """
-    smiles = get_compound_smiles(compound)
-    if not smiles:
-        # Deferred: mol_from_compound raises for compounds with no structure at all.
-        smiles = canonical_smiles(cast("Chem.Mol", mol_from_compound(compound)))
-    if canonical:
-        mol = Chem.MolFromSmiles(smiles)
-        if mol is None:
-            raise ValueError(f"Cannot parse SMILES: {smiles}")
-        smiles = canonical_smiles(mol)
-    return smiles
-
-
-def preferred_compound_smiles(
-    compound: reaction_pb2.Compound | reaction_pb2.ProductCompound,
 ) -> str | None:
     """Returns canonical SMILES for a compound, preferring its CXSMILES form.
 
@@ -384,15 +352,16 @@ def preferred_compound_smiles(
     source recorded a group. Where neither parses, any other structural identifier that
     does is used, so one malformed value does not hide a good one behind it.
 
-    The Parquet view and projection both go through this, so a compound reads the same
-    in either.
+    A compound with nothing readable is an ordinary state in ORD -- ligands and reagents
+    are routinely recorded by name alone -- so it reads as None rather than raising.
 
     Args:
         compound: Compound or ProductCompound message.
 
     Returns:
-        Canonical SMILES, or None if the compound records no structure any loader can
-        read.
+        Canonical SMILES, carrying an enhanced-stereochemistry block where the structure
+        has one (see :func:`canonical_smiles`), or None if the compound records no
+        structure any loader can read.
     """
     for identifier_type in (
         reaction_pb2.CompoundIdentifier.CXSMILES,
@@ -628,14 +597,14 @@ def get_reaction_smiles(
     generate_if_missing: bool = False,
     allow_incomplete: bool = True,
     allow_unspecified_roles: bool = True,
-    strip_extension: bool = False,
 ) -> str | None:
     """Fetches or generates a reaction SMILES.
 
-    A stored REACTION_CXSMILES identifier is returned whole, extension block and all, so
-    the result is not necessarily parseable as plain SMILES. Pass ``strip_extension`` to
-    get the SMILES half; ``split_cxsmiles_extension`` returns both parts if the block
-    itself is wanted.
+    A stored REACTION_CXSMILES identifier is returned whole, extension block and all.
+    The block is chemistry the source recorded -- enhanced stereochemistry, fragment
+    grouping -- and RDKit reads it, so there is nothing to gain by dropping it.
+    ``split_cxsmiles_extension`` separates the two parts for a caller that needs the
+    bare SMILES, e.g. to look for atom maps.
 
     Args:
         message: reaction_pb2.Reaction message.
@@ -647,9 +616,6 @@ def get_reaction_smiles(
         allow_unspecified_roles: If True, reactants and products with the
             UNSPECIFIED reaction role will be included when generating a reaction
             SMILES.
-        strip_extension: If True, drop a CXSMILES extension block from the result so it
-            is plain SMILES. Applies to a generated reaction as much as a recorded one,
-            since a component's enhanced stereochemistry carries into what is generated.
 
     Returns:
         Text reaction SMILES, or None.
@@ -663,19 +629,14 @@ def get_reaction_smiles(
     ]
     for identifier in message.identifiers:
         if identifier.type in types:
-            if strip_extension:
-                return split_cxsmiles_extension(identifier.value)[0]
             return identifier.value
     if not generate_if_missing:
         return None
-    generated = generate_reaction_smiles(
+    return generate_reaction_smiles(
         message,
         allow_incomplete=allow_incomplete,
         allow_unspecified_roles=allow_unspecified_roles,
     )
-    if strip_extension:
-        return split_cxsmiles_extension(generated)[0]
-    return generated
 
 
 def generate_reaction_smiles(
@@ -727,14 +688,14 @@ def generate_reaction_smiles(
         # the whole reaction: a NAME-only ligand is silent when agents are excluded.
         if target is None:
             return
-        try:
-            smiles = smiles_from_compound(compound)
-        except ValueError:
+        smiles = smiles_from_compound(compound)
+        if smiles is None:
             if allow_incomplete:
                 return
-            raise
-        if smiles:
-            target.add(smiles)
+            raise ValueError(
+                f"no readable structure for a component: {compound.identifiers}"
+            )
+        target.add(smiles)
 
     for key in sorted(message.inputs):
         for compound in message.inputs[key].components:

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -210,7 +210,7 @@ class TestMessageHelpers:
         reaction.outcomes.add().products.add(reaction_role="PRODUCT").identifiers.add(
             value="invalid", type="SMILES"
         )
-        with pytest.raises(ValueError, match="Cannot parse SMILES"):
+        with pytest.raises(ValueError, match="no readable structure"):
             message_helpers.get_reaction_smiles(
                 reaction, generate_if_missing=True, allow_incomplete=False
             )
@@ -815,23 +815,6 @@ def test_enhanced_stereochemistry_survives_smiles_from_compound():
     assert Chem.MolFromSmiles(smiles) is not None
 
 
-@pytest.mark.parametrize(
-    ("value", "identifier_type", "strip", "expected"),
-    [
-        ("CCO>>CCO |f:0.1|", "REACTION_CXSMILES", False, "CCO>>CCO |f:0.1|"),
-        ("CCO>>CCO |f:0.1|", "REACTION_CXSMILES", True, "CCO>>CCO"),
-        # Padding is not an extension block, so nothing is dropped.
-        ("CCO>>CCO\xa0", "REACTION_SMILES", True, "CCO>>CCO\xa0"),
-        ("CCO>>CCO", "REACTION_SMILES", True, "CCO>>CCO"),
-    ],
-)
-def test_get_reaction_smiles_strip_extension(value, identifier_type, strip, expected):
-    reaction = reaction_pb2.Reaction()
-    reaction.identifiers.add(type=identifier_type, value=value)
-    actual = message_helpers.get_reaction_smiles(reaction, strip_extension=strip)
-    assert actual == expected
-
-
 def test_check_compound_identifiers_compares_enhanced_stereochemistry():
     """Identifiers that disagree about stereo are not the same assertion."""
     compound = reaction_pb2.Compound()
@@ -941,28 +924,28 @@ def _compound(**identifiers) -> reaction_pb2.Compound:
     return compound
 
 
-def test_preferred_compound_smiles_prefers_cxsmiles():
+def test_smiles_from_compound_prefers_cxsmiles():
     # CXSMILES is a superset, so the richer identifier wins whatever order they appear.
     compound = _compound(smiles="C[C@H](N)O", cxsmiles="C[C@H](N)O |o1:1|")
-    assert message_helpers.preferred_compound_smiles(compound) == "C[C@H](N)O |o1:1|"
+    assert message_helpers.smiles_from_compound(compound) == "C[C@H](N)O |o1:1|"
 
 
-def test_preferred_compound_smiles_falls_back_to_other_structural_types():
+def test_smiles_from_compound_falls_back_to_other_structural_types():
     compound = _compound(inchi="InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H")
-    assert message_helpers.preferred_compound_smiles(compound) == "c1ccccc1"
+    assert message_helpers.smiles_from_compound(compound) == "c1ccccc1"
 
 
-def test_preferred_compound_smiles_looks_past_a_malformed_identifier():
+def test_smiles_from_compound_looks_past_a_malformed_identifier():
     # smiles_from_compound stops at the first structural identifier, so without the
     # fallback a good value recorded behind a bad one is never reached.
     compound = _compound(
         smiles="not a smiles", inchi="InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"
     )
-    assert message_helpers.preferred_compound_smiles(compound) == "c1ccccc1"
+    assert message_helpers.smiles_from_compound(compound) == "c1ccccc1"
 
 
-def test_preferred_compound_smiles_is_none_without_a_readable_structure():
-    assert message_helpers.preferred_compound_smiles(_compound(name="benzene")) is None
+def test_smiles_from_compound_is_none_without_a_readable_structure():
+    assert message_helpers.smiles_from_compound(_compound(name="benzene")) is None
 
 
 def test_reaction_smiles_without_agents_drops_the_middle_block():
@@ -1060,28 +1043,10 @@ def test_generate_reaction_smiles_ignores_an_unreadable_agent_it_will_not_emit()
     assert message_helpers.generate_reaction_smiles(
         reaction, allow_incomplete=False, include_agents=False
     )
-    with pytest.raises(ValueError, match="no valid structural identifier"):
+    with pytest.raises(ValueError, match="no readable structure"):
         message_helpers.generate_reaction_smiles(
             reaction, allow_incomplete=False, include_agents=True
         )
-
-
-def test_strip_extension_applies_to_a_generated_reaction_too():
-    # Generation emits CXSMILES, so a caller asking for plain SMILES has to get it
-    # whether the value was recorded or built here.
-    reaction = reaction_pb2.Reaction(reaction_id="ord-0001")
-    reaction.inputs["a"].components.append(_compound(cxsmiles="C[C@H](N)O |o1:1|"))
-    reaction.outcomes.add().products.add().identifiers.add(
-        type="SMILES", value="C[C@H](N)OC"
-    )
-    generated = message_helpers.get_reaction_smiles(reaction, generate_if_missing=True)
-    stripped = message_helpers.get_reaction_smiles(
-        reaction, generate_if_missing=True, strip_extension=True
-    )
-    assert generated is not None
-    assert stripped is not None
-    assert "|" in generated
-    assert "|" not in stripped
 
 
 def test_generate_reaction_smiles_keeps_enhanced_stereochemistry():
@@ -1139,18 +1104,10 @@ def test_generate_reaction_smiles_rejects_an_unparseable_component(monkeypatch):
     # RDKit accepts a null template and then dies with SIGSEGV when writing it, which no
     # caller can catch, so this has to surface as the ValueError callers already handle.
     # Only a MolToSmiles/MolFromSmiles round-trip failure reaches it -- rare enough that
-    # it needs simulating, bad enough that the guard has to be there. Failing the second
-    # parse of each string leaves smiles_from_compound working and breaks the assembly.
-    real = message_helpers.Chem.MolFromSmiles
-    seen: set[str] = set()
-
-    def _once(smiles, *args, **kwargs):
-        if smiles in seen:
-            return None
-        seen.add(smiles)
-        return real(smiles, *args, **kwargs)
-
-    monkeypatch.setattr(message_helpers.Chem, "MolFromSmiles", _once)
+    # it needs simulating, bad enough that the guard has to be there. Patching Chem here
+    # reaches only the assembly: smiles_from_compound goes through the loader table,
+    # which holds the original function.
+    monkeypatch.setattr(message_helpers.Chem, "MolFromSmiles", lambda *_, **__: None)
     with pytest.raises(ValueError, match="cannot parse component SMILES"):
         message_helpers.generate_reaction_smiles(_reaction_with_components())
 

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -726,12 +726,11 @@ def update_derived_tables(
             if reaction_smiles is None:
                 logger.debug(f"No reaction SMILES for reaction id={reaction_id}")
                 continue
-            # rdkit.reactions is keyed by this string and reaction_from_smiles cannot
-            # read a CXSMILES extension, so the block comes off. Splitting on the block
-            # keeps SMILES ending in a non-breaking space intact, which splitting on
-            # whitespace does not.
-            smiles, _ = message_helpers.split_cxsmiles_extension(reaction_smiles)
-            inserts.append({"reaction_id": reaction_id, "reaction_smiles": smiles})
+            # Stored whole: an extension block is chemistry the source recorded, and
+            # reaction_from_smiles reads one, so rdkit.reactions can be keyed by it.
+            inserts.append(
+                {"reaction_id": reaction_id, "reaction_smiles": reaction_smiles}
+            )
         if inserts:
             session.execute(insert_reaction_smiles, inserts)
     _update_compound_smiles(
@@ -874,12 +873,11 @@ def _update_compound_smiles(
         for compound_id in batch_ids:
             value = stored_smiles.get(compound_id)
             # An absent or empty SMILES identifier both fall through to the
-            # reconstruction path, matching smiles_from_compound's
-            # `get_compound_smiles(...) or ...` falsiness (an empty string is not a
-            # parseable structure to canonicalize).
+            # reconstruction path: an empty string is not a structure to canonicalize.
             if value:
-                # Canonicalize the stored SMILES, matching smiles_from_compound's
-                # default.
+                # Canonicalize the stored SMILES. Plain MolToSmiles, so this path
+                # drops the enhanced stereochemistry smiles_from_compound keeps; see
+                # #936, which is about closing that gap.
                 mol = Chem.MolFromSmiles(value)
                 if mol is None:
                     logger.debug(
@@ -888,22 +886,21 @@ def _update_compound_smiles(
                     continue
                 smiles = Chem.MolToSmiles(mol)
             elif compound_id not in derivable:
-                # Only non-structural identifiers: smiles_from_compound would raise, so
-                # skip the reconstruction (see select_structural).
+                # Only non-structural identifiers, so smiles_from_compound has nothing
+                # to read; skip the reconstruction (see select_structural).
                 continue
             else:
                 # No stored SMILES: reconstruct the message and derive from other
                 # identifiers.
                 compound = session.get(compound_class, compound_id)
                 assert compound is not None  # Selected by id above.
-                try:
-                    smiles = message_helpers.smiles_from_compound(
-                        cast(
-                            "reaction_pb2.Compound | reaction_pb2.ProductCompound",
-                            to_proto(compound),
-                        )
+                smiles = message_helpers.smiles_from_compound(
+                    cast(
+                        "reaction_pb2.Compound | reaction_pb2.ProductCompound",
+                        to_proto(compound),
                     )
-                except ValueError:
+                )
+                if smiles is None:
                     continue
             inserts.append({derived_id: compound_id, "smiles": smiles})
         if inserts:

--- a/ord_schema/projection.py
+++ b/ord_schema/projection.py
@@ -38,7 +38,7 @@ Two normalizations are applied, and only two. Both cost no query and remove a re
   mixed-unit comparison that would quietly return the wrong rows does not.
 * **Structural identifiers collapse to one ``smiles``.** ``SMILES``, ``CXSMILES``,
   ``INCHI``, and ``MOLBLOCK`` all answer "what is this molecule," so the projection
-  answers it once, through ``message_helpers.preferred_compound_smiles`` -- the same
+  answers it once, through ``message_helpers.smiles_from_compound`` -- the same
   CXSMILES-first choice the tabular view makes, so the two never disagree about a
   molecule. ``REACTION_SMILES`` and ``REACTION_CXSMILES`` collapse the same
   way at the reaction level, into a ``smiles`` that
@@ -297,9 +297,7 @@ def _smiles(message: Message) -> str | None:
         return message_helpers.derived_reaction_smiles(
             cast(reaction_pb2.Reaction, message)
         )
-    return message_helpers.preferred_compound_smiles(
-        cast(reaction_pb2.Compound, message)
-    )
+    return message_helpers.smiles_from_compound(cast(reaction_pb2.Compound, message))
 
 
 def _kept_identifiers(values: Any, structural: frozenset[int] | None) -> list[Any]:

--- a/ord_schema/views.py
+++ b/ord_schema/views.py
@@ -215,7 +215,7 @@ def _component_smiles(
     inputs = []
     for key in sorted(reaction.inputs):
         for compound in reaction.inputs[key].components:
-            smiles = message_helpers.preferred_compound_smiles(compound)
+            smiles = message_helpers.smiles_from_compound(compound)
             if smiles:
                 inputs.append(smiles)
             else:
@@ -223,7 +223,7 @@ def _component_smiles(
     outputs = []
     for outcome in reaction.outcomes:
         for product in outcome.products:
-            smiles = message_helpers.preferred_compound_smiles(product)
+            smiles = message_helpers.smiles_from_compound(product)
             if smiles:
                 outputs.append(smiles)
             else:


### PR DESCRIPTION
## Summary

#935 added `preferred_compound_smiles` beside `smiles_from_compound` because the derived artifacts needed a CXSMILES-first choice and a wide fallback, and the existing function had neither. That left two public functions answering "what is this molecule" with different preferences and different failure modes — and the more guessable name gave the worse answer. This merges them and stops dropping CXSMILES extension blocks anywhere.

## Changes

- **`smiles_from_compound` absorbs `preferred_compound_smiles`**, which is deleted. It prefers CXSMILES, falls back to plain SMILES and then to any other structural identifier that parses.
- It **returns `str | None` instead of raising.** A compound with no readable structure is an ordinary state in ORD — ligands and reagents are routinely recorded by name alone — and every caller already handled it, three of them by catching an exception for the expected case. Its unused `canonical` parameter goes too.
- **`get_reaction_smiles` loses `strip_extension`**, and the ORM stores the recorded reaction SMILES whole. An extension block is chemistry the source recorded; nothing drops it now.
- **`split_cxsmiles_extension` stays.** Every *stripping* call site is gone, but `validations.py` uses it to inspect — to warn when a plain-SMILES identifier carries a block, and to take the bare half because atom maps live in the SMILES half and never in the block.
- Three ORM comments described the old contract; one now points at #936.

## Testing

- `uv run pytest`: 861 pass, 2 skipped, including the 56 ORM tests that exercise both changed derivation paths. `ruff`, `ty`, and all pre-commit hooks clean; `ty` reports the same 72 diagnostics as `main`.
- The ORM change rested on a claim of mine that was **wrong**. The comment said `reaction_from_smiles` cannot read a CXSMILES extension — I wrote that inheriting the intent of an older `.split()[0]  # Handle CXSMILES`. Checked against the cartridge in a real Postgres:

  ```
  mol_from_smiles('C[C@H](N)O |o1:1|')   -> parses
  mol_to_cxsmiles(...)                    -> 'C[C@H](N)O |o1:1|'    block intact
  reaction_from_smiles('...  |o1:1|')     -> parses
  ```

  So the block round-trips through the `mol` type and `rdkit.reactions` can be keyed by a CXSMILES. Storing the bare half was discarding enhanced stereochemistry for nothing.
- The existing `preferred_compound_smiles` tests carry over unchanged under the merged name, so the CXSMILES preference, the malformed-then-valid fallback, and the None case stay pinned.

## Notes

Requires a rebuild of `derived.reaction_smiles` for any database loaded before this, on top of the one #937 already tracks — the stored values change wherever a source recorded a CXSMILES.

`derived.compound_smiles` still canonicalizes with plain `Chem.MolToSmiles` on its fast path, so it drops the enhanced stereochemistry this helper now preserves. That is #936, unchanged by this PR; the comment there points at it rather than overstating what is aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR consolidates compound structure selection into `smiles_from_compound`, makes unreadable structures return `None`, and preserves CXSMILES extension blocks in reaction-derived data.
- Prefers CXSMILES before plain SMILES and other parseable structural identifiers.
- Updates projections, tabular views, reaction generation, and ORM derivation for the nullable helper contract.
- Stores complete reaction CXSMILES values instead of stripping extension metadata.
- Updates tests for the unified selection and error-handling behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The changed callers consistently handle nullable compound structures, and preserving reaction CXSMILES aligns the helper, projection, view, and database derivation paths without leaving a demonstrated failure.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/message_helpers.py | Unifies compound-SMILES selection, adopts a nullable failure contract, and removes reaction CXSMILES stripping. |
| ord_schema/message_helpers_test.py | Updates coverage for CXSMILES preference, fallback parsing, nullable results, and reaction-generation failures. |
| ord_schema/orm/database.py | Persists complete reaction CXSMILES and adapts compound derivation to the helper's nullable return. |
| ord_schema/projection.py | Switches compound projection to the consolidated SMILES helper. |
| ord_schema/views.py | Switches component rendering to the consolidated SMILES helper while retaining existing missing-structure handling. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[Compound identifiers] --> S[smiles_from_compound]
  S -->|CXSMILES first| P[Parse and canonicalize]
  S -->|Nothing readable| N[None]
  P --> V[Views and projections]
  P --> G[Reaction SMILES generation]
  G --> D[derived.reaction_smiles]
  D --> R[RDKit reaction tables]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["One compound-SMILES function, and stop d..."](https://github.com/open-reaction-database/ord-schema/commit/39a06d7f1469d75035ac371d607aba22f5473e31) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51042779)</sub>

**Context used:**

- Knowledge Base — [Validation, Resolution, and Update Pipeline](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/validation-pipeline.md)
- Knowledge Base — [ORM and Database Loading](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/orm-database.md)

<!-- /greptile_comment -->