### PR TITLE
One canonicalization path, and stop dropping coordinate bonds

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -39,8 +39,15 @@ import ord_schema
 from ord_schema import atomic_io, units
 from ord_schema.proto import reaction_pb2
 
-# Enhanced stereochemistry is structural; atom labels and coordinates are not.
-_CX_ENHANCED_STEREO = rdmolfiles.CXSmilesFields.CX_ENHANCEDSTEREO
+# The CXSMILES fields that carry structure. Enhanced stereochemistry and coordinate
+# bonds both describe bonding the SMILES half cannot; atom labels, coordinates, and
+# polymer markup are presentation or provenance. Coordinate bonds are here because
+# RDKit writes them to the |C:| field rather than inline: omitting it turns a dative
+# bond into a plain single bond, changing the molecule rather than its rendering.
+_CX_STRUCTURAL_FIELDS = (
+    rdmolfiles.CXSmilesFields.CX_ENHANCEDSTEREO
+    | rdmolfiles.CXSmilesFields.CX_COORDINATE_BONDS
+)
 
 _COMPOUND_IDENTIFIER_LOADERS = {
     reaction_pb2.CompoundIdentifier.SMILES: Chem.MolFromSmiles,
@@ -517,20 +524,25 @@ def molblock_from_compound(
 
 
 def canonical_smiles(mol: Chem.Mol) -> str:
-    """Returns a canonical SMILES, keeping enhanced stereochemistry if present.
+    """Returns a canonical SMILES, keeping the bonding plain SMILES cannot express.
 
     Plain SMILES cannot express AND/OR stereo groups, so writing one would silently
-    assert a more specific structure than the source recorded. Only that field is
-    emitted; atom labels and coordinates are presentation, not structure.
+    assert a more specific structure than the source recorded. Coordinate bonds are kept
+    for the same reason: dropping the ``|C:...|`` block leaves a dative bond written as
+    a plain single bond, which is a different molecule and not recoverable by
+    canonicalizing again. Presentation fields -- atom labels, coordinates -- are
+    omitted.
 
     Args:
         mol: RDKit Mol.
 
     Returns:
-        Canonical SMILES, with a ``|a:...|``/``|o...|`` block only for molecules that
-        have enhanced stereochemistry; others match ``Chem.MolToSmiles`` exactly.
+        Canonical SMILES, with a ``|a:...|``/``|o...|``/``|C:...|`` block only for
+        molecules that have enhanced stereochemistry or coordinate bonds. Others match
+        ``Chem.MolToSmiles`` exactly; molecules with dative bonds do not, since
+        ``MolToSmiles`` writes those inline as ``->`` instead.
     """
-    return Chem.MolToCXSmiles(mol, Chem.SmilesWriteParams(), _CX_ENHANCED_STEREO)
+    return Chem.MolToCXSmiles(mol, Chem.SmilesWriteParams(), _CX_STRUCTURAL_FIELDS)
 
 
 def split_cxsmiles_extension(value: str) -> tuple[str, str | None]:

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -49,11 +49,14 @@ _COMPOUND_IDENTIFIER_LOADERS = {
     reaction_pb2.CompoundIdentifier.INCHI: Chem.MolFromInchi,
     reaction_pb2.CompoundIdentifier.MOLBLOCK: Chem.MolFromMolBlock,
 }
-# Enum names of the identifier types a Mol can be built from, keyed off the
-# loaders above so callers (e.g. the derived-SMILES pass) share this module's
-# single source of truth for what "structural" means. These match the values
-# stored in ord.compound_identifier.type.
-STRUCTURAL_IDENTIFIER_TYPES = frozenset(
+# The identifier types a Mol can be built from, keyed off the loaders above so
+# every caller shares this module's single source of truth for what "structural"
+# means: a type absent from the loaders yields no structure anywhere downstream,
+# so treating it as one only hides the compound from the passes that could fill
+# the gap. STRUCTURAL_IDENTIFIER_TYPE_NAMES matches the values stored in
+# ord.compound_identifier.type, for callers querying the database.
+STRUCTURAL_IDENTIFIER_TYPES = frozenset(_COMPOUND_IDENTIFIER_LOADERS)
+STRUCTURAL_IDENTIFIER_TYPE_NAMES = frozenset(
     reaction_pb2.CompoundIdentifier.CompoundIdentifierType.Name(identifier_type)
     for identifier_type in _COMPOUND_IDENTIFIER_LOADERS
 )
@@ -342,15 +345,50 @@ def find_submessages(
     return submessages
 
 
+def structural_identifiers(
+    compound: reaction_pb2.Compound | reaction_pb2.ProductCompound,
+) -> Iterator[reaction_pb2.CompoundIdentifier]:
+    """Yields a compound's structural identifiers, best first.
+
+    CXSMILES comes before SMILES because it is a superset and RDKit reads either, so
+    preferring it keeps enhanced stereochemistry: a plain SMILES would assert one
+    configuration where the source recorded a group. Everything else follows in message
+    order.
+
+    Yielding rather than picking one lets a caller keep trying, so a malformed value
+    does not hide a good identifier behind it. Nothing here parses the values, so a
+    yielded identifier is a candidate rather than a promise.
+
+    Args:
+        compound: Compound or ProductCompound message.
+
+    Yields:
+        Each identifier with a non-empty value whose type a Mol can be built from.
+    """
+    preferred = (
+        reaction_pb2.CompoundIdentifier.CXSMILES,
+        reaction_pb2.CompoundIdentifier.SMILES,
+    )
+    for identifier_type in preferred:
+        for identifier in compound.identifiers:
+            if identifier.type == identifier_type and identifier.value:
+                yield identifier
+    for identifier in compound.identifiers:
+        if (
+            identifier.type not in preferred
+            and identifier.type in _COMPOUND_IDENTIFIER_LOADERS
+            and identifier.value
+        ):
+            yield identifier
+
+
 def smiles_from_compound(
     compound: reaction_pb2.Compound | reaction_pb2.ProductCompound,
 ) -> str | None:
     """Returns canonical SMILES for a compound, preferring its CXSMILES form.
 
-    CXSMILES is a superset of SMILES and RDKit reads either, so preferring it keeps
-    enhanced stereochemistry: a plain SMILES would assert one configuration where the
-    source recorded a group. Where neither parses, any other structural identifier that
-    does is used, so one malformed value does not hide a good one behind it.
+    Identifiers are tried in :func:`structural_identifiers` order, so this and
+    :func:`mol_from_compound` agree about which one describes the compound.
 
     A compound with nothing readable is an ordinary state in ORD -- ligands and reagents
     are routinely recorded by name alone -- so it reads as None rather than raising.
@@ -363,19 +401,7 @@ def smiles_from_compound(
         has one (see :func:`canonical_smiles`), or None if the compound records no
         structure any loader can read.
     """
-    for identifier_type in (
-        reaction_pb2.CompoundIdentifier.CXSMILES,
-        reaction_pb2.CompoundIdentifier.SMILES,
-    ):
-        for identifier in compound.identifiers:
-            if identifier.type != identifier_type or not identifier.value:
-                continue
-            canonical = canonical_smiles_for_identifier(
-                identifier.type, identifier.value
-            )
-            if canonical:
-                return canonical
-    for identifier in compound.identifiers:
+    for identifier in structural_identifiers(compound):
         canonical = canonical_smiles_for_identifier(identifier.type, identifier.value)
         if canonical:
             return canonical
@@ -532,6 +558,10 @@ def mol_from_compound(
 ) -> Chem.Mol | tuple[Chem.Mol, reaction_pb2.CompoundIdentifier]:
     """Creates an RDKit Mol from a Compound message.
 
+    Identifiers are tried in :func:`structural_identifiers` order, so this and
+    :func:`smiles_from_compound` agree about which one describes the compound, and one
+    malformed identifier does not mask a readable one recorded alongside it.
+
     Args:
         compound: reaction_pb2.Compound message.
         return_identifier: If True, return the CompoundIdentifier used to
@@ -543,16 +573,13 @@ def mol_from_compound(
             if `return_identifier` is True.
 
     Raises:
-        ValueError: If no structural identifier is available, or if the
-            resulting Mol object is invalid.
+        ValueError: If no structural identifier reads as a Mol. Unlike
+            :func:`smiles_from_compound`, which reports that as None, callers here want
+            a Mol in hand and have nothing to do with its absence.
     """
-    for identifier in compound.identifiers:
-        if identifier.type in _COMPOUND_IDENTIFIER_LOADERS:
-            mol = _COMPOUND_IDENTIFIER_LOADERS[identifier.type](identifier.value)
-            if not mol:
-                raise ValueError(
-                    f"invalid structural identifier for Compound: {identifier}"
-                )
+    for identifier in structural_identifiers(compound):
+        mol = _COMPOUND_IDENTIFIER_LOADERS[identifier.type](identifier.value)
+        if mol is not None:
             if return_identifier:
                 return mol, identifier
             return mol
@@ -824,18 +851,31 @@ def get_product_yield(
 
     If multiple measurements of type YIELD exist, only the first is returned.
 
+    A yield recorded as ``float_value``, ``amount``, or text has no percentage to
+    report: reading one as a percentage would assume a scale the source did not state.
+    Pass ``as_measurement`` to reach those. ``views`` applies the same rule across every
+    outcome and counts what it drops.
+
     Args:
         product: ProductCompound message.
         as_measurement: Whether to return the full ProductMeasurement that
             corresponds to the yield measurement. Defaults to False.
 
     Returns:
-        Yield value as a percentage, the ProductMeasurement message, or None.
+        The ProductMeasurement when ``as_measurement`` is set. Otherwise the yield as a
+        percentage, or None when the product records no yield or records one that is not
+        a percentage.
     """
     for measurement in product.measurements:
         if measurement.type == measurement.YIELD:
             if as_measurement:
                 return measurement
+            # An unset percentage, and an unset value within one, both read as 0.0
+            # through protobuf; a fabricated zero yield is worse than a null.
+            if not measurement.HasField(
+                "percentage"
+            ) or not measurement.percentage.HasField("value"):
+                return None
             return measurement.percentage.value
     return None
 

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -57,18 +57,21 @@ M  END"""
 
 
 def test_structural_identifier_types():
-    """STRUCTURAL_IDENTIFIER_TYPES mirrors _COMPOUND_IDENTIFIER_LOADERS exactly."""
+    """Both public spellings mirror _COMPOUND_IDENTIFIER_LOADERS exactly."""
     assert {
         "SMILES",
         "CXSMILES",
         "INCHI",
         "MOLBLOCK",
-    } == message_helpers.STRUCTURAL_IDENTIFIER_TYPES
-    expected = {
+    } == message_helpers.STRUCTURAL_IDENTIFIER_TYPE_NAMES
+    assert (
+        set(message_helpers._COMPOUND_IDENTIFIER_LOADERS)
+        == message_helpers.STRUCTURAL_IDENTIFIER_TYPES
+    )
+    assert {
         reaction_pb2.CompoundIdentifier.CompoundIdentifierType.Name(identifier_type)
-        for identifier_type in message_helpers._COMPOUND_IDENTIFIER_LOADERS
-    }
-    assert expected == message_helpers.STRUCTURAL_IDENTIFIER_TYPES
+        for identifier_type in message_helpers.STRUCTURAL_IDENTIFIER_TYPES
+    } == message_helpers.STRUCTURAL_IDENTIFIER_TYPE_NAMES
 
 
 class TestMessageHelpers:
@@ -135,7 +138,7 @@ class TestMessageHelpers:
     def test_mol_from_compound_failures(self, value, identifier_type):
         compound = reaction_pb2.Compound()
         compound.identifiers.add(value=value, type=identifier_type)
-        with pytest.raises(ValueError, match="invalid structural identifier"):
+        with pytest.raises(ValueError, match="no valid structural identifier"):
             message_helpers.mol_from_compound(compound)
 
     def test_get_product_yield(self):
@@ -946,6 +949,52 @@ def test_smiles_from_compound_looks_past_a_malformed_identifier():
 
 def test_smiles_from_compound_is_none_without_a_readable_structure():
     assert message_helpers.smiles_from_compound(_compound(name="benzene")) is None
+
+
+def test_structural_identifiers_skips_non_structural_and_empty_values():
+    compound = _compound(
+        name="benzene", smiles="", inchi="InChI=1S/C6H6/c1-2-4-6-5-3-1"
+    )
+    assert [
+        identifier.type
+        for identifier in message_helpers.structural_identifiers(compound)
+    ] == [reaction_pb2.CompoundIdentifier.INCHI]
+
+
+def test_mol_from_compound_prefers_cxsmiles():
+    # The plain SMILES asserts one configuration where the CXSMILES records a group, so
+    # picking by message order would build a Mol the source did not describe.
+    compound = _compound(smiles="C[C@H](N)O", cxsmiles="C[C@H](N)O |o1:1|")
+    mol, identifier = message_helpers.mol_from_compound(
+        compound, return_identifier=True
+    )
+    assert identifier.type == reaction_pb2.CompoundIdentifier.CXSMILES
+    assert mol.GetStereoGroups()
+
+
+def test_mol_from_compound_looks_past_a_malformed_identifier():
+    # A malformed identifier recorded ahead of a good one used to raise, which made
+    # mol_from_compound fail on compounds smiles_from_compound could read.
+    compound = _compound(inchi="not an inchi", smiles="c1ccccc1")
+    assert Chem.MolToSmiles(message_helpers.mol_from_compound(compound)) == "c1ccccc1"
+    # molblock_from_compound reaches the same Mol, so it generates rather than failing.
+    assert "M  END" in message_helpers.molblock_from_compound(compound)
+
+
+def test_get_product_yield_is_none_for_a_yield_that_is_not_a_percentage():
+    # float_value states no scale, so reading it as a percentage would invent one; an
+    # unset percentage reads as 0.0 through protobuf, which is a real yield value.
+    product = reaction_pb2.ProductCompound()
+    measurement = product.measurements.add(type="YIELD")
+    measurement.float_value.value = 0.62
+    assert message_helpers.get_product_yield(product) is None
+    assert (
+        message_helpers.get_product_yield(product, as_measurement=True) is measurement
+    )
+
+    unset = reaction_pb2.ProductCompound()
+    unset.measurements.add(type="YIELD", percentage={})
+    assert message_helpers.get_product_yield(unset) is None
 
 
 def test_reaction_smiles_without_agents_drops_the_middle_block():

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -801,13 +801,37 @@ def test_cxsmiles_is_a_structural_identifier():
         # Enhanced stereochemistry cannot be written as plain SMILES, so it stays.
         ("C[C@H](N)O |a:1|", "C[C@H](N)O |a:1|"),
         ("C[C@H](N)O |o1:1|", "C[C@H](N)O |o1:1|"),
+        # Coordinate bonds live in the |C:| block, not inline; dropping it would leave
+        # a plain single bond behind.
+        ("Cl[Pd](Cl)<-P(C)(C)C", "C[P](C)(C)[Pd]([Cl])[Cl] |C:1.3|"),
         # Presentation and provenance fields are dropped.
         ("c1ccccc1 |$_R1;;;;;$|", "c1ccccc1"),
         ("CC |(0,0,;1,0,)|", "CC"),
     ],
 )
-def test_canonical_smiles_keeps_only_enhanced_stereochemistry(smiles, expected):
+def test_canonical_smiles_keeps_only_structural_fields(smiles, expected):
     assert message_helpers.canonical_smiles(Chem.MolFromSmiles(smiles)) == expected
+
+
+@pytest.mark.parametrize(
+    "smiles",
+    [
+        "Cl[Pd](Cl)<-P(C)(C)C",
+        "C[C@H](N)O |o1:1|",
+        "c1ccccc1",
+        "CC(=O)Oc1ccccc1C(=O)O",
+    ],
+)
+def test_canonical_smiles_round_trips_the_same_molecule(smiles):
+    # Canonicalizing must not change the bonding. A dative bond written without its
+    # |C:| block reads back as a single bond, and canonicalizing again cannot tell:
+    # the result is idempotent, so the loss would be silent and permanent.
+    mol = Chem.MolFromSmiles(smiles)
+    back = Chem.MolFromSmiles(message_helpers.canonical_smiles(mol))
+    assert back is not None
+    assert sorted(bond.GetBondType() for bond in back.GetBonds()) == sorted(
+        bond.GetBondType() for bond in mol.GetBonds()
+    )
 
 
 def test_enhanced_stereochemistry_survives_smiles_from_compound():

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -830,9 +830,10 @@ def _update_compound_smiles(
     # reconstruction fallback below is skipped for it -- keeping the re-attempt of a
     # permanently underivable compound (no derived row is ever inserted, so it is
     # re-selected every run) cheap instead of paying an ORM load plus to_proto that is
-    # certain to raise. The type list is bound from
-    # message_helpers.STRUCTURAL_IDENTIFIER_TYPES so it tracks the loaders that back the
-    # reconstruction, rather than a hand-maintained literal that could drift from them.
+    # certain to raise. The type list is bound from message_helpers, so it tracks the
+    # loaders that back the reconstruction rather than a hand-maintained literal that
+    # could drift from them; the names, not the enum numbers, are what this column
+    # stores.
     select_structural = text(f"""
         SELECT DISTINCT ord.compound_identifier.{derived_id}
         FROM ord.compound_identifier
@@ -864,7 +865,7 @@ def _update_compound_smiles(
                 {
                     "ids": batch_ids,
                     "structural_types": list(
-                        message_helpers.STRUCTURAL_IDENTIFIER_TYPES
+                        message_helpers.STRUCTURAL_IDENTIFIER_TYPE_NAMES
                     ),
                 },
             )

--- a/ord_schema/projection.py
+++ b/ord_schema/projection.py
@@ -123,10 +123,7 @@ _CANONICAL_UNITS: dict[str, tuple[str, str]] = {
 # apart: the enum numbers overlap between compounds and reactions, so a mismatch would
 # drop the wrong types silently rather than raise. The compound set follows
 # message_helpers, which owns what "structural" means.
-_STRUCTURAL_COMPOUND_TYPES = frozenset(
-    reaction_pb2.CompoundIdentifier.CompoundIdentifierType.Value(name)
-    for name in message_helpers.STRUCTURAL_IDENTIFIER_TYPES
-)
+_STRUCTURAL_COMPOUND_TYPES = message_helpers.STRUCTURAL_IDENTIFIER_TYPES
 _STRUCTURAL_REACTION_TYPES = frozenset(
     {
         reaction_pb2.ReactionIdentifier.REACTION_SMILES,

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -46,17 +46,14 @@ class _ResolverError(Exception):
     """
 
 
-_COMPOUND_STRUCTURAL_IDENTIFIERS = [
-    reaction_pb2.CompoundIdentifier.SMILES,
-    reaction_pb2.CompoundIdentifier.INCHI,
-    reaction_pb2.CompoundIdentifier.MOLBLOCK,
-    reaction_pb2.CompoundIdentifier.CXSMILES,
-    reaction_pb2.CompoundIdentifier.XYZ,
-]
-
-
 def canonicalize_smiles(smiles: str) -> str:
     """Canonicalizes a SMILES string.
+
+    Deliberately plain ``MolToSmiles`` rather than
+    :func:`message_helpers.canonical_smiles`: this is the query side of structure
+    search, and ``derived.compound_smiles`` is written the same way, so emitting an
+    enhanced-stereochemistry block here would stop queries matching the index. #936
+    tracks moving both onto the shared helper together.
 
     Args:
         smiles: SMILES string.
@@ -109,6 +106,10 @@ def resolve_names(message: ord_schema.Message) -> bool:
     of identifiers for that compound. The first success ends work on that
     Compound; any remaining NAME identifiers on it are left unresolved.
 
+    A compound already carrying an identifier a Mol can be built from is skipped.
+    Coordinates alone do not count, since nothing in this library reads them into a
+    structure, so a compound recorded as XYZ plus a name is worth resolving.
+
     Args:
         message: Protocol buffer tree containing Compound submessages (e.g. Reaction
             or ReactionInput).
@@ -120,7 +121,7 @@ def resolve_names(message: ord_schema.Message) -> bool:
     compounds = message_helpers.find_submessages(message, reaction_pb2.Compound)
     for compound in compounds:
         if any(
-            identifier.type in _COMPOUND_STRUCTURAL_IDENTIFIERS
+            identifier.type in message_helpers.STRUCTURAL_IDENTIFIER_TYPES
             for identifier in compound.identifiers
         ):
             continue  # Compound already has a structural identifier.

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -47,27 +47,26 @@ class _ResolverError(Exception):
 
 
 def canonicalize_smiles(smiles: str) -> str:
-    """Canonicalizes a SMILES string.
+    """Canonicalizes a SMILES string, raising if it will not parse.
 
-    Deliberately plain ``MolToSmiles`` rather than
-    :func:`message_helpers.canonical_smiles`: this is the query side of structure
-    search, and ``derived.compound_smiles`` is written the same way, so emitting an
-    enhanced-stereochemistry block here would stop queries matching the index. #936
-    tracks moving both onto the shared helper together.
+    A thin wrapper over :func:`message_helpers.canonical_smiles`, so a resolved
+    structure is written the same way as one derived from a Compound. Callers holding a
+    Mol should use that directly; this exists for the string-in, string-out case.
 
     Args:
-        smiles: SMILES string.
+        smiles: SMILES string, which may carry a CXSMILES extension block.
 
     Returns:
-        Canonicalized SMILES string.
+        Canonical SMILES, carrying a block where the structure has enhanced
+        stereochemistry or coordinate bonds.
 
     Raises:
         ValueError: If the SMILES cannot be parsed by RDKit.
     """
     mol = Chem.MolFromSmiles(smiles)
-    if not mol:
+    if mol is None:
         raise ValueError(f"Could not parse SMILES: {smiles}")
-    return Chem.MolToSmiles(mol)
+    return message_helpers.canonical_smiles(mol)
 
 
 def resolve_name(value_type: str, value: str) -> tuple[str, str]:

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -23,7 +23,7 @@ from unittest import mock
 import pytest
 from rdkit import Chem
 
-from ord_schema import resolvers
+from ord_schema import message_helpers, resolvers
 from ord_schema.proto import reaction_pb2
 
 # The live resolver smoke tests below run on a single CI matrix entry (set by the
@@ -272,10 +272,16 @@ class TestCanonicalizeSmiles:
         with pytest.raises(ValueError, match="Could not parse SMILES"):
             resolvers.canonicalize_smiles("not a smiles")
 
-    def test_does_not_emit_an_extension_block(self):
-        # Structure search matches this against derived.compound_smiles, which is
-        # written with plain MolToSmiles; a block here would stop the query matching.
-        assert resolvers.canonicalize_smiles("C[C@H](N)O |o1:1|") == "C[C@H](N)O"
+    def test_keeps_enhanced_stereochemistry(self):
+        # Consumers parse the result rather than string-matching it, so the stereo
+        # group is worth keeping: a plain SMILES would assert one configuration.
+        assert resolvers.canonicalize_smiles("C[C@H](N)O |o1:1|") == "C[C@H](N)O |o1:1|"
+
+    def test_agrees_with_the_shared_helper(self):
+        mol = Chem.MolFromSmiles("C(CO)O")
+        assert resolvers.canonicalize_smiles(
+            "C(CO)O"
+        ) == message_helpers.canonical_smiles(mol)
 
 
 class TestOpsinResolve:

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -272,6 +272,11 @@ class TestCanonicalizeSmiles:
         with pytest.raises(ValueError, match="Could not parse SMILES"):
             resolvers.canonicalize_smiles("not a smiles")
 
+    def test_does_not_emit_an_extension_block(self):
+        # Structure search matches this against derived.compound_smiles, which is
+        # written with plain MolToSmiles; a block here would stop the query matching.
+        assert resolvers.canonicalize_smiles("C[C@H](N)O |o1:1|") == "C[C@H](N)O"
+
 
 class TestOpsinResolve:
     def test_opsin_resolve(self, monkeypatch):

--- a/ord_schema/validations.py
+++ b/ord_schema/validations.py
@@ -722,6 +722,14 @@ def _validate_reaction(
             context.error("Reaction requires provenance")
 
 
+# Identifier types whose conventional spelling differs from their enum name, for use in
+# messages a depositor reads. Anything absent falls back to the enum name, which already
+# reads correctly for SMILES and CXSMILES.
+_IDENTIFIER_NAMES = {
+    reaction_pb2.CompoundIdentifier.INCHI: "InChI",
+    reaction_pb2.CompoundIdentifier.MOLBLOCK: "MolBlock",
+}
+
 # Block formats whose leading and trailing newlines are part of the format.
 _WHITESPACE_EXEMPT_TYPES = frozenset(
     {
@@ -923,19 +931,13 @@ def _validate_compound_identifier(
     _check_surrounding_whitespace(message, context)
     if not message.value:
         context.error("value must be set")
-    if message.type in (
-        message.SMILES,
-        message.CXSMILES,
-        message.INCHI,
-        message.MOLBLOCK,
-    ):
-        # MolFromSmiles reads CXSMILES, so both types validate as recorded.
-        identifier_type = {
-            message.SMILES: "SMILES",
-            message.CXSMILES: "CXSMILES",
-            message.INCHI: "InChI",
-            message.MOLBLOCK: "MolBlock",
-        }[message.type]
+    if message.type in message_helpers.STRUCTURAL_IDENTIFIER_TYPES:
+        # Taken from message_helpers rather than listed here, so a type gaining a loader
+        # gains this parse check with it instead of passing unvalidated.
+        identifier_type = _IDENTIFIER_NAMES.get(
+            message.type,
+            reaction_pb2.CompoundIdentifier.CompoundIdentifierType.Name(message.type),
+        )
         if message.type == message.SMILES:
             _check_cxsmiles_type(message.value, "CXSMILES", context)
         # Memoized, and shared with the consistency check in


### PR DESCRIPTION
## Summary

A sweep for the defect #938 fixed — a second function quietly disagreeing with the shared one about chemistry — found three more instances, a latent bug, and one silent data loss. `mol_from_compound` picked identifiers by a different rule than `smiles_from_compound`; `validations` and `resolvers` each kept their own idea of what "structural" means; `get_product_yield` reported a fabricated zero; and `canonical_smiles` was downgrading dative bonds to single bonds.

## Changes

- `structural_identifiers` yields a compound's readable identifiers best-first, and `smiles_from_compound` and `mol_from_compound` both consume it. That makes `mol_from_compound` prefer CXSMILES and look past a malformed identifier rather than raising; `molblock_from_compound` is the in-repo caller that inherited both defects.
- `canonical_smiles` keeps coordinate bonds. RDKit writes them to the `|C:|` field rather than inline, so emitting only the enhanced-stereo field turned `P-Pd:DATIVE` into `P-Pd:SINGLE` — a different molecule, and idempotent, so canonicalizing again could never recover it.
- `resolvers.canonicalize_smiles` delegates to `canonical_smiles` instead of carrying a second `MolToSmiles` path. Structure search parses this value rather than string-matching it, so there is no index spelling to conform to.
- `STRUCTURAL_IDENTIFIER_TYPES` is now the enum values, with the names kept as `STRUCTURAL_IDENTIFIER_TYPE_NAMES` for the ORM's SQL. `validations` and `resolvers` take the set from there; `projection` stops converting between spellings.
- `resolvers` no longer counts `XYZ` as structural: nothing here reads coordinates into a Mol, so an XYZ-plus-name compound was skipped for resolution and then had no structure downstream.
- `get_product_yield` returns None when the first YIELD records `float_value`, `amount`, or text. Protobuf reports 0.0 for an unset field, so those read as real zero yields. `as_measurement=True` still reaches them.

## Testing

- `uv run pytest -n auto`: 872 pass, 2 skipped, including 56 ORM tests against a live Postgres. `ruff`, `ty`, and all pre-commit hooks clean; `ty` reports the same 42 diagnostics as `main`.
- Round-tripped **198,421** real compound identifiers (row group 0 of all 53 published datasets) through both masks, comparing canonical forms. The shipped stereo-only mask changed **2,046** molecules across 6 datasets; with coordinate bonds that drops to **2**.
- Those 2 are an upstream RDKit stereo-perception instability on a bridged adamantyl cage, not a mask problem: `canonical_smiles` emits a string byte-identical to `MolToSmiles`, and plain `MolToSmiles` is itself non-idempotent there, not stabilizing even on a second pass.
- Checked `CX_ALL_BUT_COORDS` over a 40,007-identifier sample: it differs on 55, all redundant `|^N:|` radical marks (bracket atoms already carry radicals) plus 10 `|0|` artifacts, and it would newly emit atom labels and Sgroup markup. Kept the mask to the fields that encode bonding the SMILES half cannot express.
- Verified against a live RDKit cartridge that the CX form works in every operator ord-interface uses — `mol`/`qmol` casts, `morganbv_fp`, `@>`, `mol_from_smiles` — and round-trips the block intact, including `|C:1.3|`.
- Validated all 53 datasets with `--validate_ids`.

## Notes

`derived.compound_smiles` and the view/projection `smiles` columns change for dative-bond compounds, so this needs a rebuild alongside the one #937 already tracks.

`molblock_from_compound` returns a recorded MOLBLOCK identifier without parsing it, so a malformed one comes back verbatim. Out of scope here, but it means the function can return a non-molblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR consolidates structural-identifier handling and canonicalization while preserving coordinate bonds and avoiding fabricated product yields.
- Adds a shared best-first structural-identifier iterator used by molecule and SMILES conversion.
- Preserves enhanced stereochemistry and coordinate bonds in canonical CXSMILES.
- Aligns validation, resolution, projection, and ORM derivation around shared identifier-type constants.
- Returns no scalar yield when the recorded yield is not a populated percentage.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/message_helpers.py | Centralizes structural-identifier ordering, preserves coordinate bonds during canonicalization, and distinguishes absent percentages from zero yields. |
| ord_schema/message_helpers_test.py | Adds coverage for identifier fallback and priority, coordinate-bond round trips, and non-percentage yields. |
| ord_schema/orm/database.py | Uses database-facing identifier names when filtering structural identifiers. |
| ord_schema/projection.py | Consumes numeric structural identifier enum values directly without redundant conversion. |
| ord_schema/resolvers.py | Delegates SMILES canonicalization and structural-type checks to shared helpers. |
| ord_schema/resolvers_test.py | Verifies resolver canonicalization preserves enhanced stereochemistry and matches the shared helper. |
| ord_schema/validations.py | Derives structural parse validation from the shared loader-backed type set. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    C[Compound identifiers] --> I[structural_identifiers]
    I --> M[mol_from_compound]
    I --> S[smiles_from_compound]
    M --> K[canonical_smiles]
    S --> K
    R[resolver SMILES] --> RC[resolvers.canonicalize_smiles]
    RC --> K
    K --> X[Canonical CXSMILES preserving stereo and coordinate bonds]
    X --> D[Derived data, validation, and structure search]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Keep coordinate bonds, and canonicalize ..."](https://github.com/open-reaction-database/ord-schema/commit/82806e0cc58e4c4a09f909c7e3e54e9913df8e13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51048377)</sub>

**Context used:**

- Knowledge Base — [Validation, Resolution, and Update Pipeline](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/validation-pipeline.md)
- Knowledge Base — [ORM and Database Loading](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/orm-database.md)

<!-- /greptile_comment -->