### PR TITLE
Keep CXSMILES information when building a Reaction from a reaction SMILES

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -817,42 +817,71 @@ def validate_reaction_smiles(reaction_smiles: str) -> None:
         ) from error
 
 
+_EXTRACTED_FROM_REACTION_SMILES = "Extracted from reaction SMILES"
+
+
+def _add_structural_identifier(
+    component: reaction_pb2.Compound | reaction_pb2.ProductCompound, mol: Chem.Mol
+) -> None:
+    """Adds a canonical structural identifier for ``mol``, typed to match its value.
+
+    The type follows the value rather than being fixed at SMILES: a value carrying an
+    extension block is a CXSMILES, and recording it as SMILES is what
+    ``_check_cxsmiles_type`` warns about.
+
+    Args:
+        component: Compound or ProductCompound to add the identifier to.
+        mol: RDKit Mol to write.
+    """
+    smiles = canonical_smiles(mol)
+    _, extension = split_cxsmiles_extension(smiles)
+    component.identifiers.add(
+        value=smiles,
+        type="CXSMILES" if extension else "SMILES",
+        details=_EXTRACTED_FROM_REACTION_SMILES,
+    )
+
+
 def reaction_from_smiles(reaction_smiles: str) -> reaction_pb2.Reaction:
-    """Builds a Reaction by splitting a reaction SMILES."""
+    """Builds a Reaction by splitting a reaction SMILES.
+
+    Components are written through :func:`canonical_smiles`, so enhanced stereochemistry
+    and coordinate bonds carried by the input reach the components that have them.
+
+    Args:
+        reaction_smiles: A reaction SMILES or CXSMILES.
+
+    Returns:
+        A Reaction with one input holding the reactants and agents, and one outcome
+        holding the products. Amounts are unmeasured; only structure is recovered.
+    """
     reaction = rdChemReactions.ReactionFromSmarts(reaction_smiles, useSmiles=True)
     rdChemReactions.RemoveMappingNumbersFromReactions(reaction)
     message = reaction_pb2.Reaction()
-    message.identifiers.add(value=reaction_smiles, type="REACTION_SMILES")
+    _, extension = split_cxsmiles_extension(reaction_smiles)
+    message.identifiers.add(
+        value=reaction_smiles,
+        type="REACTION_CXSMILES" if extension else "REACTION_SMILES",
+    )
     reaction_input = message.inputs["from_reaction_smiles"]
-    for mol in reaction.GetReactants():
-        component = reaction_input.components.add()
-        component.identifiers.add(
-            value=Chem.MolToSmiles(mol),
-            type="SMILES",
-            details="Extracted from reaction SMILES",
-        )
-        component.reaction_role = reaction_pb2.ReactionRole.REACTANT
-        component.amount.unmeasured.type = component.amount.unmeasured.CUSTOM
-        component.amount.unmeasured.details = "Extracted from reaction SMILES"
-    for smiles in reaction_smiles.split(">")[1].split("."):
-        if not smiles:
-            continue
-        component = reaction_input.components.add()
-        component.identifiers.add(
-            value=smiles, type="SMILES", details="Extracted from reaction SMILES"
-        )
-        component.reaction_role = reaction_pb2.ReactionRole.REAGENT
-        component.amount.unmeasured.type = component.amount.unmeasured.CUSTOM
-        component.amount.unmeasured.details = "Extracted from reaction SMILES"
+    for role, mols in (
+        (reaction_pb2.ReactionRole.REACTANT, reaction.GetReactants()),
+        # Read off the parsed reaction rather than by splitting the string on ">" and
+        # ".", which would cut a CXSMILES extension into pieces and would keep the atom
+        # maps that RemoveMappingNumbersFromReactions has already stripped elsewhere.
+        (reaction_pb2.ReactionRole.REAGENT, reaction.GetAgents()),
+    ):
+        for mol in mols:
+            component = reaction_input.components.add()
+            _add_structural_identifier(component, mol)
+            component.reaction_role = role
+            component.amount.unmeasured.type = component.amount.unmeasured.CUSTOM
+            component.amount.unmeasured.details = _EXTRACTED_FROM_REACTION_SMILES
     outcome = message.outcomes.add()
     for mol in reaction.GetProducts():
-        component = outcome.products.add()
-        component.identifiers.add(
-            value=Chem.MolToSmiles(mol),
-            type="SMILES",
-            details="Extracted from reaction SMILES",
-        )
-        component.reaction_role = reaction_pb2.ReactionRole.PRODUCT
+        product = outcome.products.add()
+        _add_structural_identifier(product, mol)
+        product.reaction_role = reaction_pb2.ReactionRole.PRODUCT
     return message
 
 

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -1189,3 +1189,55 @@ def test_derived_reaction_smiles_is_none_when_a_reactant_cannot_be_read():
     reaction = _reaction_with_components()
     reaction.inputs["b"].components.append(_compound(name="mystery reactant"))
     assert message_helpers.derived_reaction_smiles(reaction) is None
+
+
+def _identifiers(reaction: reaction_pb2.Reaction) -> list[tuple[str, str, str]]:
+    """Returns ``(role, identifier type name, value)`` for every component."""
+    name = reaction_pb2.CompoundIdentifier.CompoundIdentifierType.Name
+    role_name = reaction_pb2.ReactionRole.ReactionRoleType.Name
+    rows = [
+        (role_name(component.reaction_role), name(identifier.type), identifier.value)
+        for key in sorted(reaction.inputs)
+        for component in reaction.inputs[key].components
+        for identifier in component.identifiers
+    ]
+    rows.extend(
+        ("PRODUCT", name(identifier.type), identifier.value)
+        for outcome in reaction.outcomes
+        for product in outcome.products
+        for identifier in product.identifiers
+    )
+    return rows
+
+
+def test_reaction_from_smiles_keeps_enhanced_stereochemistry():
+    # A component's stereo group is chemistry the reaction SMILES recorded; writing the
+    # component with plain MolToSmiles would assert one configuration instead.
+    reaction = message_helpers.reaction_from_smiles(
+        "C[C@H](N)O.CC(=O)Cl>>C[C@H](NC(C)=O)O |o1:1|"
+    )
+    assert ("REACTANT", "CXSMILES", "C[C@H](N)O |o1:1|") in _identifiers(reaction)
+    # The type follows the value, so validation does not warn about a mistyped block.
+    assert (
+        reaction.identifiers[0].type
+        == reaction_pb2.ReactionIdentifier.REACTION_CXSMILES
+    )
+
+
+def test_reaction_from_smiles_keeps_coordinate_bonds():
+    reaction = message_helpers.reaction_from_smiles("Cl[Pd](Cl)<-P(C)(C)C.CC=O>>CCO")
+    assert (
+        "REACTANT",
+        "CXSMILES",
+        "C[P](C)(C)[Pd]([Cl])[Cl] |C:1.3|",
+    ) in _identifiers(reaction)
+
+
+def test_reaction_from_smiles_strips_atom_maps_from_agents_too():
+    # Every component comes off the parsed reaction, so agents lose their atom maps
+    # along with the reactants and products rather than keeping them.
+    reaction = message_helpers.reaction_from_smiles(
+        "[CH3:1][C:2](=O)O>[CH3:3][OH:4]>[CH3:1][C:2](=O)OC"
+    )
+    assert ("REAGENT", "SMILES", "CO") in _identifiers(reaction)
+    assert all(":" not in value for _, _, value in _identifiers(reaction))


### PR DESCRIPTION
## Summary

A sweep of every `MolToSmiles` call after #939, looking for other places CXSMILES information is dropped. One real gap: `reaction_from_smiles` wrote every component with plain `MolToSmiles`, so a reaction CXSMILES lost its chemistry on the way into the proto.

```text
in   C[C@H](N)O.CC(=O)Cl>>C[C@H](NC(C)=O)O |o1:1|
out  'C[C@H](N)O'                     stereo group gone
in   Cl[Pd](Cl)<-P(C)(C)C.CC=O>>CCO
out  'ClPd(Cl)P(C)(C)C'               dative bond gone
```

## Changes

- Components go through `canonical_smiles`, so enhanced stereochemistry and coordinate bonds reach the components that have them.
- The identifier type follows the value: `CXSMILES` when it carries a block, `SMILES` otherwise, and `REACTION_CXSMILES` for the reaction identifier. Writing a block under a `SMILES` type is what `_check_cxsmiles_type` warns about, so fixing the value without the type would trade one defect for another.
- Agents are read off the parsed reaction rather than by splitting the string on `>` and `.`. That splitting would cut an extension block into fragments, and it kept the atom maps `RemoveMappingNumbersFromReactions` had already taken off the reactants and products (`[CH3:3][OH:4]` now reads as `CO`).

## Testing

- `uv run pytest -n auto`: 875 pass, 2 skipped, including 56 ORM tests against a live Postgres. `ruff`, `ty`, and all pre-commit hooks clean; `ty` reports the same 42 diagnostics as `main`.
- New coverage for an enhanced-stereo reactant, a coordinate-bonded reactant, and agents losing their atom maps, each asserting the identifier type as well as the value.
- Validated all 53 published datasets with `--validate_ids`.

## Notes

The other five `MolToSmiles`/`MolToMolBlock` sites are clean. `sorted(key=Chem.MolToSmiles)` (×2) are sort keys that write nothing; one is an error-message f-string; and `molblock_from_compound` is safe because RDKit auto-upgrades to V3000 when a Mol has stereo groups, which survive the round-trip. The ORM's `Chem.MolToSmiles` is a real divergence but is already scoped in #936, where the fix has to preserve the set-based query and needs a rebuild.

No derived artifact changes here: `reaction_from_smiles` has no caller in ord-schema, ord-interface, or ord-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves structural CXSMILES information when converting reaction SMILES into Reaction protos and aligns identifier types with their serialized values.
- Canonicalizes reactants, agents, and products while retaining enhanced stereochemistry and coordinate bonds.
- Extracts agents from the parsed RDKit reaction so extension blocks are not split and atom mappings are removed consistently.
- Adds focused tests for enhanced stereochemistry, coordinate bonds, identifier typing, and mapped agents.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failures identified.

The new serialization path preserves the intended structural CXSMILES fields, assigns identifier types consistently with their values, and is supported by existing validation and downstream reaction-identifier handling.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/message_helpers.py | Centralizes component serialization through canonical CXSMILES-aware handling and consistently extracts all reaction participants from the parsed reaction. |
| ord_schema/message_helpers_test.py | Adds focused regression coverage for preserved structural extensions, corrected identifier types, and agent atom-map removal. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Keep CXSMILES information when building ..."](https://github.com/open-reaction-database/ord-schema/commit/a21e5fd80070f7d4a341f6a9088eb2786e05842f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51053170)</sub>

**Context used:**

- Knowledge Base — [Validation, Resolution, and Update Pipeline](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/validation-pipeline.md)

<!-- /greptile_comment -->