### PR TITLE
Parse structural values before handing them on

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -514,6 +514,12 @@ def molblock_from_compound(
     MolBlock, and returning it verbatim would hand the caller something no MolBlock
     reader accepts while a usable structure sat in another identifier.
 
+    That check skips sanitization, because the question is whether the value is a
+    MolBlock rather than whether it describes a sanitizable molecule. ORD carries
+    structures RDKit reads but will not sanitize -- organometallics and charged-N rings,
+    which validation warns about rather than rejecting -- and regenerating those from
+    another identifier would discard the coordinates for a value that was fine.
+
     Args:
         compound: reaction_pb2.Compound or ProductCompound message.
 
@@ -526,7 +532,7 @@ def molblock_from_compound(
         ValueError: if no structural identifier reads as a Mol.
     """
     molblock = get_compound_molblock(compound)
-    if molblock and Chem.MolFromMolBlock(molblock) is not None:
+    if molblock and Chem.MolFromMolBlock(molblock, sanitize=False) is not None:
         return molblock
     return Chem.MolToMolBlock(mol_from_compound(compound))
 

--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -509,18 +509,26 @@ def molblock_from_compound(
 ) -> str:
     """Fetches or generates a MolBlock identifier for a compound.
 
+    A recorded MOLBLOCK is returned as deposited, keeping the atom coordinates that are
+    the reason to record one, but only once it parses: an unreadable value is not a
+    MolBlock, and returning it verbatim would hand the caller something no MolBlock
+    reader accepts while a usable structure sat in another identifier.
+
     Args:
         compound: reaction_pb2.Compound or ProductCompound message.
 
     Returns:
-        molblock: MolBlock identifier.
+        molblock: MolBlock identifier, generated from the best structural identifier
+        (see :func:`structural_identifiers`) when none is recorded or the recorded one
+        cannot be read.
 
     Raises:
-        ValueError: if no structural identifiers are defined.
+        ValueError: if no structural identifier reads as a Mol.
     """
-    return get_compound_molblock(compound) or Chem.MolToMolBlock(
-        mol_from_compound(compound)
-    )
+    molblock = get_compound_molblock(compound)
+    if molblock and Chem.MolFromMolBlock(molblock) is not None:
+        return molblock
+    return Chem.MolToMolBlock(mol_from_compound(compound))
 
 
 def canonical_smiles(mol: Chem.Mol) -> str:

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -1261,3 +1261,32 @@ def test_molblock_from_compound_keeps_a_readable_recorded_value():
 def test_molblock_from_compound_raises_without_a_readable_structure():
     with pytest.raises(ValueError, match="no valid structural identifier"):
         message_helpers.molblock_from_compound(_compound(name="benzene"))
+
+
+# A carbon with five single bonds: RDKit reads the connection table but refuses to
+# sanitize the valence. ORD carries structures like this (organometallics, charged-N
+# rings), and validation warns about them rather than rejecting them.
+_UNSANITIZABLE_MOLBLOCK = """penta
+  test
+
+  6  5  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    1.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+   -1.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    1.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000   -1.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    0.0000    1.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+  1  2  1  0  0  0  0
+  1  3  1  0  0  0  0
+  1  4  1  0  0  0  0
+  1  5  1  0  0  0  0
+  1  6  1  0  0  0  0
+M  END"""
+
+
+def test_molblock_from_compound_keeps_an_unsanitizable_recorded_value():
+    # The check asks whether the value is a MolBlock, not whether it describes a
+    # sanitizable molecule; regenerating here would discard deposited coordinates.
+    assert Chem.MolFromMolBlock(_UNSANITIZABLE_MOLBLOCK) is None
+    compound = _compound(molblock=_UNSANITIZABLE_MOLBLOCK)
+    assert message_helpers.molblock_from_compound(compound) == _UNSANITIZABLE_MOLBLOCK

--- a/ord_schema/message_helpers_test.py
+++ b/ord_schema/message_helpers_test.py
@@ -1241,3 +1241,23 @@ def test_reaction_from_smiles_strips_atom_maps_from_agents_too():
     )
     assert ("REAGENT", "SMILES", "CO") in _identifiers(reaction)
     assert all(":" not in value for _, _, value in _identifiers(reaction))
+
+
+def test_molblock_from_compound_regenerates_an_unreadable_recorded_value():
+    # A MOLBLOCK that will not parse is not a MolBlock; the readable SMILES recorded
+    # alongside it describes the compound and can produce one.
+    compound = _compound(molblock="not a molblock", smiles="c1ccccc1")
+    molblock = message_helpers.molblock_from_compound(compound)
+    assert "M  END" in molblock
+    assert Chem.MolToSmiles(Chem.MolFromMolBlock(molblock)) == "c1ccccc1"
+
+
+def test_molblock_from_compound_keeps_a_readable_recorded_value():
+    # Returned as deposited, so the atom coordinates a MolBlock exists to carry survive.
+    compound = _compound(molblock=_BENZENE_MOLBLOCK, smiles="c1ccccc1")
+    assert message_helpers.molblock_from_compound(compound) == _BENZENE_MOLBLOCK
+
+
+def test_molblock_from_compound_raises_without_a_readable_structure():
+    with pytest.raises(ValueError, match="no valid structural identifier"):
+        message_helpers.molblock_from_compound(_compound(name="benzene"))

--- a/ord_schema/resolvers.py
+++ b/ord_schema/resolvers.py
@@ -88,11 +88,18 @@ def resolve_name(value_type: str, value: str) -> tuple[str, str]:
     for resolver, resolver_func in _NAME_RESOLVERS.items():
         try:
             smiles = resolver_func(value_type, value)
-            # An empty body reaches here as "", which would otherwise be written out as
-            # a SMILES identifier holding nothing -- and would then mask the compound
-            # from a later resolution pass, since it counts as structural.
-            if smiles:
+            # A resolver that answers with something RDKit cannot read is no more use
+            # than one that answers with nothing, and worse to keep: written out as a
+            # SMILES identifier it counts as structural, which masks the compound from
+            # every later resolution pass, so a working resolver never gets to correct
+            # it. An empty body arrives here as "" and is the same problem. Both fall
+            # through to the next resolver.
+            if smiles and Chem.MolFromSmiles(smiles) is not None:
                 return smiles, resolver
+            logger.info(
+                f"{resolver} returned no usable structure for {value_type} {value}: "
+                f"{smiles!r}"
+            )
         except _ResolverError as error:
             logger.info(f"{resolver} could not resolve {value_type} {value}: {error}")
     raise ValueError(f"Could not resolve {value_type} {value} to SMILES")

--- a/ord_schema/resolvers_test.py
+++ b/ord_schema/resolvers_test.py
@@ -476,3 +476,48 @@ class TestResolveInputBadFormat:
     def test_missing_of_separator(self):
         with pytest.raises(ValueError, match="does not match template"):
             resolvers.resolve_input("just a description")
+
+
+class TestResolverRejectsUnusableAnswers:
+    def test_falls_through_to_the_next_resolver(self, monkeypatch, caplog):
+        # A junk answer stored as a SMILES identifier counts as structural, which would
+        # mask the compound from every later pass; the next resolver has to get a turn.
+        monkeypatch.setattr(
+            resolvers,
+            "_NAME_RESOLVERS",
+            {
+                "broken": lambda _t, _v: "not a smiles",
+                "working": lambda _t, _v: "CC(=O)Oc1ccccc1C(=O)O",
+            },
+        )
+        with caplog.at_level(logging.INFO, logger="ord_schema.resolvers"):
+            smiles, resolver = resolvers.resolve_name("name", "aspirin")
+        assert (smiles, resolver) == ("CC(=O)Oc1ccccc1C(=O)O", "working")
+        assert "no usable structure" in caplog.text
+
+    def test_raises_when_every_answer_is_unusable(self, monkeypatch):
+        monkeypatch.setattr(
+            resolvers,
+            "_NAME_RESOLVERS",
+            {"broken": lambda _t, _v: "not a smiles", "empty": lambda _t, _v: ""},
+        )
+        with pytest.raises(ValueError, match="Could not resolve"):
+            resolvers.resolve_name("name", "aspirin")
+
+    def test_a_bad_answer_does_not_block_a_later_pass(self, monkeypatch):
+        # The end-to-end consequence: nothing structural is recorded, so resolve_names
+        # still has work to do the next time it runs.
+        monkeypatch.setattr(
+            resolvers, "_NAME_RESOLVERS", {"broken": lambda _t, _v: "not a smiles"}
+        )
+        message = reaction_pb2.Reaction()
+        message.inputs["x"].components.add().identifiers.add(
+            type="NAME", value="aspirin"
+        )
+        assert not resolvers.resolve_names(message)
+        monkeypatch.setattr(
+            resolvers,
+            "_NAME_RESOLVERS",
+            {"working": lambda _t, _v: "CC(=O)Oc1ccccc1C(=O)O"},
+        )
+        assert resolvers.resolve_names(message)


### PR DESCRIPTION
## Summary

Two places accept a structural value without ever checking it parses. Both then hand that value on as though it described a molecule.

- `molblock_from_compound` returns a recorded `MOLBLOCK` verbatim, so a malformed one comes back as a MolBlock no reader accepts — while a readable SMILES sat in the next identifier.
- `resolve_name` accepts whatever a resolver's HTTP body contains as long as it is non-empty, so an error page or a truncated response becomes a `SMILES` identifier.

## Changes

- `molblock_from_compound` returns a recorded MOLBLOCK only once `MolFromMolBlock` reads it, and otherwise generates one from the best structural identifier. A readable value is still returned as deposited, keeping the atom coordinates that are the reason to record a MolBlock at all.
- `resolve_name` requires a resolver's answer to parse before accepting it, and falls through to the next resolver otherwise, logging what was rejected.

## Testing

- `uv run pytest -n auto`: 867 pass, 2 skipped, including the 56 ORM tests against a live Postgres. `ruff`, `ty`, and all pre-commit hooks clean; `ty` reports the same 42 diagnostics as `main`.
- New coverage: a malformed MOLBLOCK regenerating from a SMILES recorded alongside it, a readable MOLBLOCK returned byte-identical, a compound with no readable structure still raising, a junk resolver answer falling through to a working resolver, every resolver failing still raising, and the end-to-end case below.
- Validated all 53 published datasets with `--validate_ids`: clean.

## Notes

The resolver case is self-poisoning, which is what makes it worth fixing rather than tolerating. A junk answer stored as a SMILES identifier counts as structural, so `resolve_names` skips that compound on every later pass and a working resolver never gets to correct it:

```text
stored          [(NAME, 'aspirin'), (SMILES, 'not a smiles')]
smiles_from_compound -> None
second pass with a working resolver modified anything? False
```

The comment at that call site already described this hazard for empty bodies; it just did not cover unreadable ones.

Deliberately not changed: `build_compound` and the `macros` helpers take a SMILES argument from a depositor, where parsing would reject a work-in-progress message and validation is the right gate; `parse_uspto.parse_identifier` records identifiers as the source CML states them, which is the point of a corpus parser; and `get_reaction_smiles` in `validations.py` is only a truthiness test there, with `_validate_reaction_identifier` parsing the value separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR prevents malformed structural values from being returned or stored while preserving readable deposited MolBlocks.
- Validates recorded MolBlocks with sanitization disabled before returning them, falling back to another structural identifier only when unreadable.
- Validates resolver responses as SMILES and continues to later resolvers when a response is empty or unparsable.
- Adds regression coverage for malformed, readable, and unsanitizable MolBlocks and unusable resolver responses.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/message_helpers.py | Validates deposited MolBlocks with `sanitize=False`, fully addressing the prior coordinate-loss issue for structurally readable but unsanitizable values. |
| ord_schema/message_helpers_test.py | Adds direct regression coverage proving unsanitizable MolBlocks are returned byte-identically while genuinely unreadable values fall back or raise. |
| ord_schema/resolvers.py | Rejects empty or unparsable resolver responses and falls through instead of persisting unusable SMILES identifiers. |
| ord_schema/resolvers_test.py | Covers resolver fallthrough, total resolution failure, and successful retry on a later resolution pass. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Check a recorded MolBlock without saniti..."](https://github.com/open-reaction-database/ord-schema/commit/beeda8572731c1ee1a46f3f996762e23fa3723b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51056062)</sub>

**Context used:**

- Knowledge Base — [Validation, Resolution, and Update Pipeline](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/validation-pipeline.md)

<!-- /greptile_comment -->