### PR TITLE
Derive compound SMILES the way the Parquet artifacts do

### DIFF
--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -769,19 +769,24 @@ def _update_compound_smiles(
 ) -> None:
     """Derives SMILES for one (product) compound table's not-yet-derived rows.
 
-    The common case -- a compound with a stored SMILES identifier -- is served
-    set-based: the first SMILES identifier for each compound in the batch is fetched
+    The answer matches ``message_helpers.smiles_from_compound``, which the Parquet view
+    and projection use, so the three artifacts cannot disagree about what a compound is.
+    Getting there without loading a proto per compound is what the two set-based queries
+    below are for.
+
+    The common case -- a compound with a stored SMILES or CXSMILES identifier -- is
+    served set-based: the best such identifier for each compound in the batch is fetched
     from ord.compound_identifier in a single query and canonicalized with RDKit,
-    avoiding a per-compound ORM load. Compounds without a stored SMILES but with some
-    other structural identifier (INCHI/MOLBLOCK) fall back to reconstructing the message
-    via to_proto and computing the SMILES from those identifiers; a second set-based
-    query flags which batch ids carry any structural identifier at all, so a compound
-    with only non-structural identifiers (e.g. NAME) -- which never yields a derived row
-    and is therefore re-selected every run -- is skipped without the ORM load plus
-    to_proto that is certain to raise. Ids are resolved up front and processed in
-    batches of _DERIVED_BATCH so memory stays bounded. ``shard`` (index, num_shards)
-    restricts to one disjoint hash-partition of this table's ids so large datasets can
-    be split across workers.
+    avoiding a per-compound ORM load. Compounds without one, and those whose stored
+    value will not parse, fall back to reconstructing the message via to_proto and
+    deriving from the remaining identifiers (INCHI/MOLBLOCK); a second set-based query
+    flags which batch ids carry any structural identifier at all, so a compound with
+    only non-structural identifiers (e.g. NAME) -- which never yields a derived row and
+    is therefore re-selected every run -- is skipped without the ORM load plus to_proto
+    that is certain to raise. Ids are resolved up front and processed in batches of
+    _DERIVED_BATCH so memory stays bounded. ``shard`` (index, num_shards) restricts to
+    one disjoint hash-partition of this table's ids so large datasets can be split
+    across workers.
 
     ``reaction_joins`` are the disjoint join paths from ``compound_table`` to
     ord.reaction; one id query runs per path and the results are concatenated. See
@@ -812,17 +817,26 @@ def _update_compound_smiles(
         .scalars()
         .all()
     )
-    # The first SMILES identifier (lowest id == proto order) for each requested
-    # compound. The FK column is indexed, so one query per batch replaces an ORM load
-    # plus lazy child fetches per compound. Interpolated names are internal constants
-    # (not user input); see S608 below.
+    # The best SMILES-like identifier for each requested compound. The FK column is
+    # indexed, so one query per batch replaces an ORM load plus lazy child fetches per
+    # compound. Interpolated names are internal constants (not user input); see S608
+    # below.
+    #
+    # CXSMILES sorts ahead of SMILES so this picks what message_helpers
+    # .structural_identifiers picks, and ties break on id (proto order), matching the
+    # first-one-wins rule there. Empty values are excluded rather than being taken and
+    # rejected below: an empty CXSMILES would otherwise win this ordering and push a
+    # compound with a perfectly good SMILES down the reconstruction path.
     select_smiles = text(f"""
         SELECT DISTINCT ON (ord.compound_identifier.{derived_id})
                ord.compound_identifier.{derived_id}, ord.compound_identifier.value
         FROM ord.compound_identifier
         WHERE ord.compound_identifier.{derived_id} IN :ids
-          AND ord.compound_identifier.type = 'SMILES'
-        ORDER BY ord.compound_identifier.{derived_id}, ord.compound_identifier.id
+          AND ord.compound_identifier.type IN ('CXSMILES', 'SMILES')
+          AND ord.compound_identifier.value <> ''
+        ORDER BY ord.compound_identifier.{derived_id},
+                 (ord.compound_identifier.type = 'CXSMILES') DESC,
+                 ord.compound_identifier.id
         """).bindparams(bindparam("ids", expanding=True))  # noqa: S608
     # Ids in the batch that carry a non-empty structural identifier, i.e. one of the
     # types smiles_from_compound can build a Mol from. A compound with only
@@ -872,27 +886,27 @@ def _update_compound_smiles(
         }
         inserts = []
         for compound_id in batch_ids:
+            smiles = None
             value = stored_smiles.get(compound_id)
-            # An absent or empty SMILES identifier both fall through to the
-            # reconstruction path: an empty string is not a structure to canonicalize.
-            if value:
-                # Canonicalize the stored SMILES. Plain MolToSmiles, so this path
-                # drops the enhanced stereochemistry smiles_from_compound keeps; see
-                # #936, which is about closing that gap.
+            if value is not None:
                 mol = Chem.MolFromSmiles(value)
                 if mol is None:
+                    # Not a dead end: the compound may record an INCHI or MOLBLOCK that
+                    # does parse, which the reconstruction below reaches. Matches
+                    # smiles_from_compound, which looks past a malformed identifier
+                    # rather than letting it decide the compound has no structure.
                     logger.debug(
                         f"Cannot parse SMILES for compound id={compound_id}: {value}"
                     )
+                else:
+                    # canonical_smiles, not MolToSmiles, so this path keeps the enhanced
+                    # stereochemistry and coordinate bonds the Parquet artifacts keep.
+                    smiles = message_helpers.canonical_smiles(mol)
+            if smiles is None:
+                if compound_id not in derivable:
+                    # Only non-structural identifiers, so smiles_from_compound has
+                    # nothing to read; skip the reconstruction (see select_structural).
                     continue
-                smiles = Chem.MolToSmiles(mol)
-            elif compound_id not in derivable:
-                # Only non-structural identifiers, so smiles_from_compound has nothing
-                # to read; skip the reconstruction (see select_structural).
-                continue
-            else:
-                # No stored SMILES: reconstruct the message and derive from other
-                # identifiers.
                 compound = session.get(compound_class, compound_id)
                 assert compound is not None  # Selected by id above.
                 smiles = message_helpers.smiles_from_compound(

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -710,3 +710,84 @@ def test_backfill_submission_times(test_session):
         select(DatasetMetadata.submitted_at)
     ).scalar_one()
     assert submitted_at is not None
+
+
+def _derive_with_identifiers(prepared_engine, identifiers):
+    """Loads the example dataset with one compound's identifiers replaced, and derives.
+
+    Args:
+        prepared_engine: Engine fixture.
+        identifiers: ``(type, value)`` pairs to give the compound.
+
+    Returns:
+        The derived SMILES for that compound, or None if it got no derived row.
+    """
+    dataset = load_dataset(
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt",
+        as_dataset=True,
+    )
+    compound = next(
+        component
+        for reaction in dataset.reactions
+        for reaction_input in reaction.inputs.values()
+        for component in reaction_input.components
+    )
+    del compound.identifiers[:]
+    for identifier_type, value in identifiers:
+        compound.identifiers.add(type=identifier_type, value=value)
+    # Marks the row: no other compound in the fixture carries this name.
+    compound.identifiers.add(type="NAME", value="the compound under test")
+    with Session(prepared_engine) as session:
+        with session.begin():
+            add_dataset(dataset, session)
+        with session.begin():
+            update_derived_tables(dataset.dataset_id, session)
+        return (
+            session.execute(
+                text(
+                    "SELECT cs.smiles FROM derived.compound_smiles cs "
+                    "JOIN ord.compound_identifier ci "
+                    "  ON ci.compound_id = cs.compound_id "
+                    "WHERE ci.type = 'NAME' "
+                    "  AND ci.value = 'the compound under test'"
+                )
+            )
+            .scalars()
+            .one_or_none()
+        )
+
+
+def test_derived_compound_smiles_prefers_cxsmiles(prepared_engine):
+    # The plain SMILES asserts one configuration where the CXSMILES records a group, so
+    # taking the SMILES would make this table disagree with the Parquet artifacts.
+    smiles = _derive_with_identifiers(
+        prepared_engine,
+        [("SMILES", "C[C@H](N)O"), ("CXSMILES", "C[C@H](N)O |o1:1|")],
+    )
+    assert smiles == "C[C@H](N)O |o1:1|"
+
+
+def test_derived_compound_smiles_keeps_coordinate_bonds(prepared_engine):
+    smiles = _derive_with_identifiers(
+        prepared_engine, [("SMILES", "Cl[Pd](Cl)<-P(C)(C)C")]
+    )
+    assert smiles == "C[P](C)(C)[Pd]([Cl])[Cl] |C:1.3|"
+
+
+def test_derived_compound_smiles_looks_past_a_malformed_value(prepared_engine):
+    # A malformed SMILES used to end the attempt, so a compound recording a good InChI
+    # alongside it got no derived row at all.
+    inchi = "InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H"
+    smiles = _derive_with_identifiers(
+        prepared_engine, [("SMILES", "not a smiles"), ("INCHI", inchi)]
+    )
+    assert smiles == "c1ccccc1"
+
+
+def test_derived_compound_smiles_ignores_an_empty_preferred_identifier(prepared_engine):
+    # An empty CXSMILES must not win the preference ordering and push a compound with a
+    # perfectly good SMILES down the reconstruction path.
+    smiles = _derive_with_identifiers(
+        prepared_engine, [("CXSMILES", ""), ("SMILES", "c1ccccc1")]
+    )
+    assert smiles == "c1ccccc1"


### PR DESCRIPTION
## Summary

Closes #936. `derived.compound_smiles` was the one derived artifact not going through `message_helpers`, so it could disagree with the Parquet view and projection about what a compound is. The set-based query that keeps a full corpus load tractable was a good reason to have a separate implementation and a bad reason to have a different answer; it stays set-based.

## Changes

- The fast-path query selects `CXSMILES` alongside `SMILES` and prefers it, matching `message_helpers.structural_identifiers`, with ties breaking on id as they do there. A compound recording both used to lose the enhanced stereochemistry the CXSMILES carries.
- Both paths canonicalize through `message_helpers.canonical_smiles`. The fast path used plain `MolToSmiles` while the reconstruction fallback already used `smiles_from_compound`, so which spelling a compound got depended on which identifier it happened to record — and enhanced stereochemistry and coordinate bonds were dropped either way on the fast path.
- A malformed stored value falls through to reconstruction instead of ending the attempt, so a compound recording a good `INCHI` or `MOLBLOCK` behind a bad `SMILES` gets a derived row. This matches `smiles_from_compound`, which looks past a malformed identifier rather than letting it decide the compound has no structure.
- The fast-path query excludes empty values. This one is not in the issue: without it an empty `CXSMILES` would win the new preference ordering and push a compound with a perfectly good `SMILES` down the reconstruction path.

## Testing

- `uv run pytest -n auto`: 865 pass, 2 skipped, including the 56 ORM tests against a live Postgres. `ruff`, `ty`, and all pre-commit hooks clean; `ty` reports the same 42 diagnostics as `main`.
- Four new ORM tests, each deriving against a real database: CXSMILES preferred over a plain SMILES, coordinate bonds surviving, a malformed SMILES not masking a good InChI, and an empty CXSMILES not beating a usable SMILES.
- `test_compound_smiles_match_reference` already asserted that the derived value equals `smiles_from_compound`. It passed before only because the fixture carries no CXSMILES; it is now backed by cases that would have caught the divergence.

## Notes

This changes stored values, so `derived.compound_smiles` and the `rdkit.mols` links below it need a rebuild — tracked in #937, alongside the reaction-side rebuild and the coordinate-bond change from #939.

Worth knowing for that rebuild: every derived pass is guarded by `NOT EXISTS`, so re-running `--stages derived` fills gaps but never updates an existing row. A rebuild has to delete first, and there is currently no supported way to do that. Follow-up PR adds one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR aligns ORM-derived compound SMILES with the Parquet and projection helper behavior.
- Prefers non-empty CXSMILES over SMILES while retaining stable identifier ordering.
- Uses the shared canonicalization helper to preserve enhanced stereochemistry and coordinate bonds.
- Falls back to compound reconstruction when the selected stored value is malformed.
- Adds live-database coverage for CXSMILES preference, coordinate bonds, malformed-value fallback, and empty preferred identifiers.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking defects identified.

The revised fast path matches the shared helper’s identifier priority and canonicalization behavior, malformed values reach the existing reconstruction fallback, and the new database tests exercise the principal regression cases.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Updates set-based identifier selection and canonicalization while preserving reconstruction fallback and bound data parameters. |
| ord_schema/orm/database_test.py | Adds focused integration tests covering each changed identifier-selection and canonicalization behavior. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Compound awaiting derived SMILES] --> B{Non-empty CXSMILES or SMILES?}
  B -->|Yes| C[Prefer CXSMILES, then lowest identifier id]
  C --> D{RDKit parses value?}
  D -->|Yes| E[canonical_smiles]
  D -->|No| F[Reconstruct compound proto]
  B -->|No| G{Any structural identifier?}
  G -->|Yes| F
  G -->|No| H[Skip compound]
  F --> I[smiles_from_compound]
  I --> J{Canonical SMILES produced?}
  J -->|Yes| K[Insert derived row]
  J -->|No| H
  E --> K
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Derive compound SMILES the way the Parqu..."](https://github.com/open-reaction-database/ord-schema/commit/7ddb205ff0e2b8a5c890b49bf5ff304859a3ebdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51057558)</sub>

**Context used:**

- Knowledge Base — [ORM and Database Loading](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/orm-database.md)

<!-- /greptile_comment -->