### PR TITLE
Add --rederive so derived data can be rebuilt in place

### DIFF
--- a/.claude/skills/orm-database-load/SKILL.md
+++ b/.claude/skills/orm-database-load/SKILL.md
@@ -59,14 +59,43 @@ unless you actually want to (re)classify.
 
 ## Backfill
 
-`--stages derived` re-derives over already-ingested datasets. It runs the same per-dataset,
-per-shard RDKit passes as an end-to-end load, so nothing special is required:
+`--stages derived` fills in derived rows over already-ingested datasets. It runs the same
+per-dataset, per-shard RDKit passes as an end-to-end load, so nothing special is required:
 
 ```sh
 python -u -m ord_schema.orm.scripts.add_datasets \
   --pattern "$ORD_DATA/data/*/*.parquet" --stages derived \
   --dsn "postgresql+psycopg://" --n_jobs 16
 ```
+
+### Backfilling is not rebuilding
+
+Every derived pass is guarded by `NOT EXISTS`. That is what makes the load idempotent, and it
+also means an existing row is **never revisited**: after a change to how SMILES are derived,
+the command above writes nothing and exits clean, leaving every stale row in place. Silence
+here is not success.
+
+`--rederive` deletes a dataset's derived SMILES rows before deriving them, which is what turns
+the idempotent passes into a rebuild:
+
+```sh
+python -u -m ord_schema.orm.scripts.add_datasets \
+  --pattern "$ORD_DATA/data/*/*.parquet" --stages derived --rederive \
+  --dsn "postgresql+psycopg://" --n_jobs 16
+```
+
+Do not confuse it with `--overwrite`, which is an *ingest* flag meaning "re-ingest a dataset
+whose MD5 changed."
+
+Two things it deliberately leaves alone. `rdkit.mols` and `rdkit.reactions` are shared and
+deduplicated by structure, so deleting one dataset's share would break every other dataset;
+the link columns live on the deleted rows, so the RDKit pass re-links from scratch, reusing
+structures already present. A rebuild that changes SMILES therefore leaves unreferenced
+structures behind — space, not correctness. And `derived.reaction_classes` survives, because
+classification is a slow opt-in pass that a rebuild should not silently redo.
+
+Verify with counts before and after: a rebuild should end with the row counts it started with,
+plus a spot-check of a value you expect to have changed.
 
 ### If you are on an ord-schema without the #895 fix
 

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -214,11 +214,14 @@ def update_derived_data(
     *,
     rdkit_cartridge: bool = True,
     classify_reactions: bool = False,
+    rederive: bool = False,
 ) -> None:
     """Populates the derived tables for an already-ingested dataset.
 
-    Idempotent (NOT EXISTS guards), so it is safe to re-run to backfill or recompute
-    derived data over datasets that are already present.
+    Idempotent (NOT EXISTS guards), so it is safe to re-run to backfill derived data
+    over datasets that are already present. Backfilling is not the same as rebuilding:
+    the guards mean an existing row is never revisited, so use ``rederive`` when the
+    derivation itself has changed.
 
     Args:
         dataset_id: Dataset to derive.
@@ -226,8 +229,9 @@ def update_derived_data(
         rdkit_cartridge: Whether to populate RDKit cartridge tables and links.
         classify_reactions: Whether to assign reaction class/name labels; requires the
             optional ``reaction-class`` extra.
+        rederive: Whether to delete existing derived rows first so they are recomputed.
     """
-    update_derived_tables(dataset_id, session)
+    update_derived_tables(dataset_id, session, rederive=rederive)
     if rdkit_cartridge:
         session.flush()
         update_rdkit_tables(dataset_id, session)
@@ -651,8 +655,92 @@ def _resolve_dataset_pk(dataset_id: str, session: Session) -> Any:
     ).scalar_one()
 
 
-def update_derived_tables(
+def delete_derived_data(
     dataset_id: str, session: Session, *, shard: tuple[int, int] | None = None
+) -> None:
+    """Deletes a dataset's derived SMILES rows so the derived passes recompute them.
+
+    Every derived pass is guarded by ``NOT EXISTS``, which makes re-running cheap but
+    means an existing row is never revisited: a change to how SMILES are derived reaches
+    only rows that do not exist yet. Deleting first is what turns the idempotent passes
+    into a rebuild, so a database can be updated in place instead of reloaded.
+
+    ``rdkit.mols`` and ``rdkit.reactions`` are deliberately left alone. They are shared,
+    deduplicated by structure, and referenced by every dataset, so deleting this
+    dataset's share of them would break others. The link columns live on the rows
+    removed here, so the RDKit pass re-links from scratch, reusing structures that are
+    already present and inserting the ones that are not. A rebuild that changes SMILES
+    therefore leaves unreferenced structures behind; they cost space, not correctness.
+
+    ``derived.reaction_classes`` is also left alone: classification is a separate opt-in
+    pass, and discarding it here would silently make every rebuild pay for it again.
+
+    Args:
+        dataset_id: Dataset whose derived rows to delete.
+        session: SQLAlchemy session.
+        shard: ``(index, num_shards)`` to restrict to one disjoint hash-partition, using
+            the same partitioning as the derived passes, so a sharded rebuild deletes
+            exactly the rows that shard is about to recompute.
+    """
+    logger.debug(f"Deleting derived data for {dataset_id=}")
+    start = time.time()
+    dataset_pk = _resolve_dataset_pk(dataset_id, session)
+    reaction_shard_sql, reaction_shard_params = _shard_predicate(
+        "ord.reaction.id", shard
+    )
+    session.execute(
+        text(f"""
+        DELETE FROM derived.reaction_smiles
+        WHERE derived.reaction_smiles.reaction_id IN (
+            SELECT ord.reaction.id
+            FROM ord.reaction
+            WHERE ord.reaction.dataset_id = :id
+              {reaction_shard_sql}
+        )
+        """),  # noqa: S608  (table/column names are internal constants, not user input)
+        {"id": dataset_pk, **reaction_shard_params},
+    )
+    for compound_table, reaction_joins, derived_table, derived_id in (
+        (
+            "ord.compound",
+            _COMPOUND_REACTION_JOINS,
+            "derived.compound_smiles",
+            "compound_id",
+        ),
+        (
+            "ord.product_compound",
+            _PRODUCT_COMPOUND_REACTION_JOINS,
+            "derived.product_compound_smiles",
+            "product_compound_id",
+        ),
+    ):
+        shard_sql, shard_params = _shard_predicate(f"{compound_table}.id", shard)
+        select_ids = "\nUNION ALL\n".join(
+            f"""
+                SELECT {compound_table}.id
+                FROM {compound_table}
+                {reaction_join}
+                WHERE ord.reaction.dataset_id = :id
+                  {shard_sql}
+            """  # noqa: S608
+            for reaction_join in reaction_joins
+        )
+        session.execute(
+            text(f"""
+            DELETE FROM {derived_table}
+            WHERE {derived_table}.{derived_id} IN ({select_ids})
+            """),  # noqa: S608
+            {"id": dataset_pk, **shard_params},
+        )
+    logger.debug(f"Deleting derived data took {time.time() - start:g}s")
+
+
+def update_derived_tables(
+    dataset_id: str,
+    session: Session,
+    *,
+    shard: tuple[int, int] | None = None,
+    rederive: bool = False,
 ) -> None:
     """Populates the derived SMILES tables from the search index.
 
@@ -667,9 +755,20 @@ def update_derived_tables(
     dataset's reaction/compound ids is derived, so a large dataset can be split across
     worker processes (the derived-stage analog of the row-group sharding used for
     ingest). Idempotency makes the shards safe to run in any order or overlap.
+
+    Args:
+        dataset_id: Dataset to derive.
+        session: SQLAlchemy session.
+        shard: ``(index, num_shards)`` to derive one disjoint hash-partition.
+        rederive: If True, delete this dataset's existing derived rows first, so rows
+            written by an earlier version of the derivation are recomputed rather than
+            skipped by the ``NOT EXISTS`` guards. Sharded runs delete only their own
+            partition, so workers stay disjoint. See :func:`delete_derived_data`.
     """
     logger.debug(f"Updating derived tables for {dataset_id=}")
     start = time.time()
+    if rederive:
+        delete_derived_data(dataset_id, session, shard=shard)
     # dataset_id and the compound link columns live on the polymorphic child mappers, so
     # rows are scoped to the dataset via raw SQL (like the RDKit pass).
     dataset_pk = _resolve_dataset_pk(dataset_id, session)

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -32,6 +32,7 @@ from ord_schema.orm.database import (
     backfill_submission_times,
     classify_dataset,
     delete_dataset,
+    delete_derived_data,
     get_dataset_md5,
     get_dataset_size,
     update_derived_data,
@@ -710,3 +711,139 @@ def test_backfill_submission_times(test_session):
         select(DatasetMetadata.submitted_at)
     ).scalar_one()
     assert submitted_at is not None
+
+
+def _derived_smiles(session):
+    """Returns the derived SMILES for the compound _derive_with_identifiers marks."""
+    return (
+        session.execute(
+            text(
+                "SELECT cs.smiles FROM derived.compound_smiles cs "
+                "JOIN ord.compound_identifier ci ON ci.compound_id = cs.compound_id "
+                "WHERE ci.type = 'NAME' AND ci.value = 'the compound under test'"
+            )
+        )
+        .scalars()
+        .one_or_none()
+    )
+
+
+def test_rederive_recomputes_a_stale_row(prepared_engine):
+    """A stale derived row is corrected only when the rows are deleted first.
+
+    The NOT EXISTS guards make a plain re-run cheap but blind to a row that already
+    exists, which is what makes a derivation change invisible without this.
+    """
+    dataset = load_dataset(
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt",
+        as_dataset=True,
+    )
+    compound = next(
+        component
+        for reaction in dataset.reactions
+        for reaction_input in reaction.inputs.values()
+        for component in reaction_input.components
+    )
+    del compound.identifiers[:]
+    compound.identifiers.add(type="SMILES", value="c1ccccc1")
+    compound.identifiers.add(type="NAME", value="the compound under test")
+    with Session(prepared_engine) as session:
+        with session.begin():
+            add_dataset(dataset, session)
+        with session.begin():
+            update_derived_tables(dataset.dataset_id, session)
+        with session.begin():
+            assert _derived_smiles(session) == "c1ccccc1"
+        # Stand in for a change in how SMILES are derived.
+        with session.begin():
+            session.execute(
+                text(
+                    "UPDATE derived.compound_smiles SET smiles = 'stale' "
+                    "WHERE compound_id IN (SELECT compound_id "
+                    "FROM ord.compound_identifier "
+                    "WHERE type = 'NAME' AND value = 'the compound under test')"
+                )
+            )
+        with session.begin():
+            update_derived_tables(dataset.dataset_id, session)
+        with session.begin():
+            assert _derived_smiles(session) == "stale", "NOT EXISTS should skip the row"
+        with session.begin():
+            update_derived_tables(dataset.dataset_id, session, rederive=True)
+        with session.begin():
+            assert _derived_smiles(session) == "c1ccccc1"
+
+
+def test_rederive_leaves_reaction_classes_alone(prepared_engine):
+    # Classification is a separate opt-in pass; discarding it would make every rebuild
+    # silently pay to redo work the caller did not ask to redo.
+    dataset = load_dataset(
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt",
+        as_dataset=True,
+    )
+    with Session(prepared_engine) as session:
+        with session.begin():
+            add_dataset(dataset, session)
+        with session.begin():
+            update_derived_tables(dataset.dataset_id, session)
+        with session.begin():
+            session.execute(
+                text(
+                    "INSERT INTO derived.reaction_classes "
+                    "(reaction_id, reaction_class) "
+                    "SELECT id, 'test class' FROM ord.reaction LIMIT 1"
+                )
+            )
+        with session.begin():
+            update_derived_tables(dataset.dataset_id, session, rederive=True)
+        with session.begin():
+            surviving = session.execute(
+                text("SELECT count(*) FROM derived.reaction_classes")
+            ).scalar_one()
+        assert surviving == 1
+
+
+def test_rederive_deletes_every_derived_smiles_table(prepared_engine):
+    # Product compounds hang off a different join path than input compounds; a delete
+    # that missed one would leave half the rebuild stale.
+    dataset = load_dataset(
+        pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt",
+        as_dataset=True,
+    )
+    with Session(prepared_engine) as session:
+        with session.begin():
+            add_dataset(dataset, session)
+        with session.begin():
+            update_derived_tables(dataset.dataset_id, session)
+        with session.begin():
+            before = {
+                table: session.execute(
+                    text(f"SELECT count(*) FROM {table}")  # noqa: S608  (constant)
+                ).scalar_one()
+                for table in (
+                    "derived.reaction_smiles",
+                    "derived.compound_smiles",
+                    "derived.product_compound_smiles",
+                )
+            }
+        assert all(before.values()), before
+        with session.begin():
+            delete_derived_data(dataset.dataset_id, session)
+        with session.begin():
+            after = {
+                table: session.execute(
+                    text(f"SELECT count(*) FROM {table}")  # noqa: S608  (constant)
+                ).scalar_one()
+                for table in before
+            }
+        assert after == dict.fromkeys(before, 0), after
+        with session.begin():
+            update_derived_tables(dataset.dataset_id, session)
+        with session.begin():
+            rebuilt = {
+                table: session.execute(
+                    text(f"SELECT count(*) FROM {table}")  # noqa: S608  (constant)
+                ).scalar_one()
+                for table in before
+            }
+        assert rebuilt == before

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -147,7 +147,9 @@ def ingest_dataset(filename: str, *, dsn: str, overwrite: bool) -> str:
     return dataset_id
 
 
-def derive_dataset(dataset_id: str, *, dsn: str, classify_reactions: bool) -> str:
+def derive_dataset(
+    dataset_id: str, *, dsn: str, classify_reactions: bool, rederive: bool = False
+) -> str:
     """Runs the parallel-safe derived passes (SMILES + optional classification).
 
     The RDKit linking pass is excluded here and run serially in ``add_rdkit`` to avoid
@@ -157,6 +159,7 @@ def derive_dataset(dataset_id: str, *, dsn: str, classify_reactions: bool) -> st
         dataset_id: Dataset to derive.
         dsn: Database connection string.
         classify_reactions: Whether to assign reaction class/name labels.
+        rederive: Whether to delete existing derived rows first so they are recomputed.
 
     Returns:
         Dataset ID.
@@ -170,6 +173,7 @@ def derive_dataset(dataset_id: str, *, dsn: str, classify_reactions: bool) -> st
                 # Done serially in add_rdkit() to avoid deadlocks.
                 rdkit_cartridge=False,
                 classify_reactions=classify_reactions,
+                rederive=rederive,
             )
     finally:
         engine.dispose()
@@ -211,7 +215,7 @@ def _derive_shard_items(
 
 
 def _derive_smiles_shard(
-    item: tuple[str, int, int], *, dsn: str
+    item: tuple[str, int, int], *, dsn: str, rederive: bool = False
 ) -> tuple[str, int, int]:
     """Derive a hash-partition of a dataset's SMILES; parallel-safe and shardable."""
     dataset_id, shard_index, num_shards = item
@@ -219,7 +223,10 @@ def _derive_smiles_shard(
     try:
         with Session(engine) as session, session.begin():
             database.update_derived_tables(
-                dataset_id, session, shard=(shard_index, num_shards)
+                dataset_id,
+                session,
+                shard=(shard_index, num_shards),
+                rederive=rederive,
             )
     finally:
         engine.dispose()
@@ -471,6 +478,7 @@ def load_datasets(
     stages: Iterable[str] = STAGES,
     overwrite: bool = False,
     classify_reactions: bool = False,
+    rederive: bool = False,
     n_jobs: int = 1,
     classify_jobs: int | None = None,
 ) -> None:
@@ -487,6 +495,9 @@ def load_datasets(
         overwrite: If True, update changed datasets during ingest.
         classify_reactions: If True, assign reaction class/name labels during
             derivation.
+        rederive: If True, delete existing derived rows before deriving, so rows written
+            by an earlier version of the derivation are recomputed rather than skipped.
+            Without it the derived stage backfills gaps but never revisits a row.
         n_jobs: Number of parallel workers.
         classify_jobs: Worker count for the classification pass; each worker loads a
             transformer model, so this is bounded separately from ``n_jobs``. Defaults
@@ -551,7 +562,7 @@ def load_datasets(
         # datasets.
         shard_items = _derive_shard_items(dataset_ids, dsn)
         _, shard_failures = _run_parallel(
-            partial(_derive_smiles_shard, dsn=dsn),
+            partial(_derive_smiles_shard, dsn=dsn, rederive=rederive),
             shard_items,
             n_jobs=n_jobs,
             desc="Derive",

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -51,6 +51,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--overwrite", action="store_true", help="Update changed datasets"
     )
+    parser.add_argument(
+        "--rederive",
+        action="store_true",
+        help="Recompute derived.* SMILES that already exist, instead of only filling "
+        "in missing ones. Use after a change to how SMILES are derived; without it "
+        "the derived stage skips every row it already wrote. Does not touch reaction "
+        "classes.",
+    )
     parser.add_argument("--dsn", default=None, help="Postgres connection string")
     parser.add_argument("--database", default="orm", help="Database")
     parser.add_argument("--username", default="postgres", help="Database username")
@@ -107,6 +115,7 @@ def main(args: argparse.Namespace) -> None:
         stages=stages,
         overwrite=args.overwrite,
         classify_reactions=args.classify_reactions,
+        rederive=args.rederive,
         n_jobs=args.n_jobs,
         classify_jobs=args.classify_jobs,
     )


### PR DESCRIPTION
## Summary

Part of #937. Every derived pass is guarded by `NOT EXISTS`, which is what makes the load idempotent — and also means an existing row is never revisited. After a change to how SMILES are derived, `--stages derived` writes nothing and exits clean, leaving every stale row in place. Rebuilding meant loading a whole new database or hand-writing DELETEs.

`--rederive` deletes a dataset's derived SMILES rows before deriving them, turning the idempotent passes into a rebuild.

## Changes

- `database.delete_derived_data` removes a dataset's rows from the three `derived.*` SMILES tables, scoped by the same hash partition as the derive passes so a sharded rebuild deletes exactly the rows that shard is about to recompute.
- `update_derived_tables`, `update_derived_data`, `derive_dataset`, and `load_datasets` take `rederive`; `add_datasets.py` exposes `--rederive`.
- The `orm-database-load` skill gets a "Backfilling is not rebuilding" section, since it previously implied `--stages derived` was enough to pick up a derivation change.

## Testing

- `uv run pytest -n auto`: 864 pass, 2 skipped, including the 56 ORM tests against a live Postgres. `ruff`, `ty`, and all pre-commit hooks clean; `ty` reports the same 42 diagnostics as `main`.
- Three new ORM tests, each against a real database: a row corrupted to stand in for a derivation change survives a plain re-run and is corrected by `--rederive`; `derived.reaction_classes` survives a rebuild; and all three SMILES tables empty and refill to their original counts, which catches a delete that missed the product-compound join path.

## Notes

Named `--rederive` rather than reusing `--overwrite`, which is an *ingest* flag meaning "re-ingest a dataset whose MD5 changed". Overloading it would couple the two stages' semantics.

Two things are deliberately left alone. `rdkit.mols` and `rdkit.reactions` are shared and deduplicated by structure, so deleting one dataset's share would break every other dataset; the link columns live on the deleted rows, so the RDKit pass re-links from scratch and reuses structures already present. A rebuild that changes SMILES therefore leaves unreferenced structures behind — space, not correctness. And `derived.reaction_classes` survives, because classification is a slow opt-in pass a rebuild should not silently redo.

This is the tooling half of #937. The rebuilds themselves — the agent-free normalization from #935, the coordinate bonds from #939, and the compound SMILES from #936/#943 — are still to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds an in-place rebuild mode for derived SMILES while preserving shared RDKit structures and opt-in reaction classifications.

- Adds dataset- and shard-scoped deletion of derived SMILES rows.
- Threads `rederive` through database and loading orchestration.
- Exposes the behavior through the `--rederive` CLI flag.
- Adds database tests and operational documentation for rebuilding derived data.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Adds transactional, dataset- and shard-scoped deletion and recomputation of the three derived SMILES tables. |
| ord_schema/orm/loading.py | Propagates rebuild behavior through parallel derivation while retaining the existing classification and RDKit orchestration. |
| ord_schema/orm/scripts/add_datasets.py | Exposes rebuild behavior through the documented `--rederive` command-line flag. |
| ord_schema/orm/database_test.py | Tests stale-row recomputation, preservation of reaction classes, and deletion/refill of all derived SMILES tables. |
| .claude/skills/orm-database-load/SKILL.md | Distinguishes backfilling from rebuilding and documents safe operational use of `--rederive`. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  CLI["add_datasets --rederive"] --> Load["load_datasets"]
  Load --> Shards["Derivation shards"]
  Shards --> Delete["Delete shard's derived SMILES"]
  Delete --> Recompute["Recompute derived SMILES"]
  Recompute --> RDKit["Insert/reuse RDKit structures and relink"]
  Recompute --> Classify{"Classification requested?"}
  Classify -->|Yes| Labels["Update reaction classifications"]
  Classify -->|No| Done["Complete"]
  RDKit --> Done
  Labels --> Done
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge main into rederive-flag"](https://github.com/open-reaction-database/ord-schema/commit/2f241b30af0afa2bf9b1fc859f3366c755c3a359) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51058416)</sub>

**Context used:**

- Knowledge Base — [ORM and Database Loading](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/orm-database.md)

<!-- /greptile_comment -->