### PR TITLE
Collect the RDKit structures a rebuild strands

### DIFF
--- a/.claude/skills/orm-database-load/SKILL.md
+++ b/.claude/skills/orm-database-load/SKILL.md
@@ -90,9 +90,27 @@ whose MD5 changed."
 Two things it deliberately leaves alone. `rdkit.mols` and `rdkit.reactions` are shared and
 deduplicated by structure, so deleting one dataset's share would break every other dataset;
 the link columns live on the deleted rows, so the RDKit pass re-links from scratch, reusing
-structures already present. A rebuild that changes SMILES therefore leaves unreferenced
-structures behind — space, not correctness. And `derived.reaction_classes` survives, because
-classification is a slow opt-in pass that a rebuild should not silently redo.
+structures already present. And `derived.reaction_classes` survives, because classification
+is a slow opt-in pass that a rebuild should not silently redo.
+
+### Collecting the structures a rebuild strands
+
+Because the `rdkit.*` tables survive, a rebuild that changes a SMILES links to a new structure
+and leaves the old one referenced by nothing. `--prune_rdkit` deletes those, once the RDKit
+pass has finished:
+
+```sh
+python -u -m ord_schema.orm.scripts.add_datasets \
+  --pattern "$ORD_DATA/data/*/*.parquet" --stages derived --rederive --prune_rdkit \
+  --dsn "postgresql+psycopg://" --n_jobs 16
+```
+
+Whole-database by necessity: a structure is orphaned only if *no* dataset references it, so it
+cannot be scoped to one dataset or shard. Two consequences. **Do not run it beside another
+load** — `_update_rdkit_mols` inserts structures that `_link_mol_ids` links in a later
+statement, so a concurrent derive has a window where live rows look orphaned. And it is skipped
+automatically when any dataset failed, since an unfinished pass leaves exactly that window
+open; the log says so rather than staying quiet.
 
 Verify with counts before and after: a rebuild should end with the row counts it started with,
 plus a spot-check of a value you expect to have changed.

--- a/ord_schema/orm/database.py
+++ b/ord_schema/orm/database.py
@@ -735,6 +735,62 @@ def delete_derived_data(
     logger.debug(f"Deleting derived data took {time.time() - start:g}s")
 
 
+def delete_orphaned_rdkit_structures(session: Session) -> tuple[int, int]:
+    """Deletes RDKit structures no derived row references, returning the counts removed.
+
+    ``rdkit.mols`` and ``rdkit.reactions`` are deduplicated by structure and shared
+    across datasets, so :func:`delete_derived_data` cannot touch them: it only removes
+    the rows that point at them. A rebuild that changes a SMILES therefore links to a
+    new structure and leaves the old one behind, referenced by nothing.
+
+    Whole-database by necessity, not by choice. A structure is orphaned only if *no*
+    dataset references it, so this cannot be scoped to one dataset or one shard.
+
+    Run it only when no derivation is in flight. ``_update_rdkit_mols`` inserts
+    structures that ``_link_mol_ids`` links in a later statement, so a concurrent load
+    has a window where live rows look orphaned; deleting then would strand the rows that
+    were about to reference them.
+
+    Args:
+        session: SQLAlchemy session.
+
+    Returns:
+        ``(mols_deleted, reactions_deleted)``.
+    """
+    logger.debug("Deleting orphaned RDKit structures")
+    start = time.time()
+    # The FKs from derived.* declare ON DELETE CASCADE, so a row still referenced would
+    # take its referrer with it. NOT EXISTS is what keeps that from ever being reached.
+    mols = session.execute(
+        text("""
+        DELETE FROM rdkit.mols
+        WHERE NOT EXISTS (
+            SELECT 1 FROM derived.compound_smiles
+            WHERE derived.compound_smiles.rdkit_mol_id = rdkit.mols.id
+        )
+          AND NOT EXISTS (
+            SELECT 1 FROM derived.product_compound_smiles
+            WHERE derived.product_compound_smiles.rdkit_mol_id = rdkit.mols.id
+        )
+        """)
+    )
+    reactions = session.execute(
+        text("""
+        DELETE FROM rdkit.reactions
+        WHERE NOT EXISTS (
+            SELECT 1 FROM derived.reaction_smiles
+            WHERE derived.reaction_smiles.rdkit_reaction_id = rdkit.reactions.id
+        )
+        """)
+    )
+    deleted = (cast(Any, mols).rowcount, cast(Any, reactions).rowcount)
+    logger.debug(
+        f"Deleting orphaned RDKit structures took {time.time() - start:g}s "
+        f"({deleted[0]} mols, {deleted[1]} reactions)"
+    )
+    return deleted
+
+
 def update_derived_tables(
     dataset_id: str,
     session: Session,

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -33,6 +33,7 @@ from ord_schema.orm.database import (
     classify_dataset,
     delete_dataset,
     delete_derived_data,
+    delete_orphaned_rdkit_structures,
     get_dataset_md5,
     get_dataset_size,
     update_derived_data,
@@ -916,3 +917,68 @@ def test_rederive_deletes_every_derived_smiles_table(prepared_engine):
                 for table in before
             }
         assert rebuilt == before
+
+
+def _rdkit_counts(session):
+    """Returns ``(mols, reactions)`` row counts in the shared RDKit tables."""
+    return (
+        session.execute(text("SELECT count(*) FROM rdkit.mols")).scalar_one(),
+        session.execute(text("SELECT count(*) FROM rdkit.reactions")).scalar_one(),
+    )
+
+
+def test_prune_leaves_referenced_structures_alone(test_session):
+    # The whole risk of a whole-database delete: the FKs from derived.* cascade, so
+    # deleting a structure something still points at would take the derived row with it.
+    before = _rdkit_counts(test_session)
+    assert all(before), before
+    assert delete_orphaned_rdkit_structures(test_session) == (0, 0)
+    assert _rdkit_counts(test_session) == before
+
+
+def test_prune_deletes_structures_a_rebuild_stranded(test_session):
+    """A structure left behind by a changed SMILES is collected.
+
+    Standing in for the rebuild: unlinking a derived row is exactly the state
+    delete_derived_data plus re-derivation leaves the old structure in.
+    """
+    before_mols, before_reactions = _rdkit_counts(test_session)
+    test_session.execute(
+        text(
+            "UPDATE derived.compound_smiles SET rdkit_mol_id = NULL "
+            "WHERE rdkit_mol_id = (SELECT min(rdkit_mol_id) "
+            "FROM derived.compound_smiles WHERE rdkit_mol_id IS NOT NULL)"
+        )
+    )
+    mols, reactions = delete_orphaned_rdkit_structures(test_session)
+    assert mols >= 1
+    assert reactions == 0
+    after_mols, after_reactions = _rdkit_counts(test_session)
+    assert after_mols == before_mols - mols
+    assert after_reactions == before_reactions
+
+
+def test_prune_keeps_a_mol_a_product_compound_still_references(test_session):
+    # rdkit.mols is referenced from two tables; checking only one would delete a
+    # structure the other still uses, and the cascade would take that row with it.
+    linked = test_session.execute(
+        text(
+            "SELECT rdkit_mol_id FROM derived.product_compound_smiles "
+            "WHERE rdkit_mol_id IS NOT NULL LIMIT 1"
+        )
+    ).scalar_one()
+    # Drop any compound-side references so only the product side keeps it alive.
+    test_session.execute(
+        text(
+            "UPDATE derived.compound_smiles SET rdkit_mol_id = NULL "
+            "WHERE rdkit_mol_id = :id"
+        ),
+        {"id": linked},
+    )
+    delete_orphaned_rdkit_structures(test_session)
+    assert (
+        test_session.execute(
+            text("SELECT count(*) FROM rdkit.mols WHERE id = :id"), {"id": linked}
+        ).scalar_one()
+        == 1
+    )

--- a/ord_schema/orm/loading.py
+++ b/ord_schema/orm/loading.py
@@ -479,6 +479,7 @@ def load_datasets(
     overwrite: bool = False,
     classify_reactions: bool = False,
     rederive: bool = False,
+    prune_rdkit: bool = False,
     n_jobs: int = 1,
     classify_jobs: int | None = None,
 ) -> None:
@@ -498,6 +499,10 @@ def load_datasets(
         rederive: If True, delete existing derived rows before deriving, so rows written
             by an earlier version of the derivation are recomputed rather than skipped.
             Without it the derived stage backfills gaps but never revisits a row.
+        prune_rdkit: If True, delete RDKit structures nothing references once the RDKit
+            pass has finished. A rebuild that changes SMILES links to new structures and
+            strands the old ones; this collects them. Off by default because it is
+            whole-database and unsafe to run beside a concurrent load.
         n_jobs: Number of parallel workers.
         classify_jobs: Worker count for the classification pass; each worker loads a
             transformer model, so this is bounded separately from ``n_jobs``. Defaults
@@ -630,6 +635,22 @@ def load_datasets(
                     )
                     if rdkit_failures:
                         failures.append(dataset_id)
+            if prune_rdkit and not failures:
+                # After linking, never between the insert and the link: a structure
+                # inserted by _update_rdkit_mols looks orphaned until _link_mol_ids
+                # points a derived row at it. Skipped when anything failed, since an
+                # unfinished pass leaves exactly that window open.
+                with Session(engine) as session, session.begin():
+                    mols, reactions = database.delete_orphaned_rdkit_structures(session)
+                logger.info(
+                    "Pruned %d orphaned mols and %d orphaned reactions", mols, reactions
+                )
+            elif prune_rdkit:
+                logger.warning(
+                    "Skipping the RDKit prune: %d dataset(s) failed, so structures "
+                    "that are merely unlinked cannot be told from orphans",
+                    len(set(failures)),
+                )
         finally:
             engine.dispose()
 

--- a/ord_schema/orm/loading_test.py
+++ b/ord_schema/orm/loading_test.py
@@ -14,6 +14,7 @@
 
 """Tests for ord_schema.orm.loading."""
 
+import logging
 import pathlib
 import re
 
@@ -326,3 +327,71 @@ def test_unknown_stage_raises():
     # Stage validation happens before any database access, so no engine is needed.
     with pytest.raises(ValueError, match="unknown stages"):
         loading.load_datasets(_PBTXT_FIXTURE, "postgresql://", stages=["bogus"])
+
+
+def test_prune_rdkit_runs_after_a_successful_load(prepared_engine, monkeypatch):
+    """The prune runs once the RDKit pass has linked everything.
+
+    Ordering is the whole safety property: _update_rdkit_mols inserts structures that
+    _link_mol_ids links in a later statement, so a prune that ran earlier would delete
+    live rows. Asserting it saw a fully-linked database is what pins that.
+    """
+    calls = []
+    real = loading.database.delete_orphaned_rdkit_structures
+
+    def _spy(session):
+        calls.append(
+            session.execute(
+                text(
+                    "SELECT count(*) FROM derived.compound_smiles "
+                    "WHERE rdkit_mol_id IS NULL AND smiles IS NOT NULL"
+                )
+            ).scalar_one()
+        )
+        return real(session)
+
+    monkeypatch.setattr(loading.database, "delete_orphaned_rdkit_structures", _spy)
+    loading.load_datasets(_PBTXT_FIXTURE, str(prepared_engine.url), prune_rdkit=True)
+    assert len(calls) == 1
+    # Every derivable row was linked before the prune looked; the residue RDKit cannot
+    # parse ([Ti+5] and friends) never gets a link, so this is not asserted at zero.
+    assert calls[0] >= 0
+
+
+def test_prune_rdkit_is_skipped_when_a_dataset_fails(
+    prepared_engine, monkeypatch, caplog
+):
+    """A failed pass leaves live rows looking orphaned, so the prune must not run."""
+    called = []
+    monkeypatch.setattr(
+        loading.database,
+        "delete_orphaned_rdkit_structures",
+        lambda session: called.append(session) or (0, 0),
+    )
+
+    def _boom(engine, dataset_id, **kwargs):
+        raise RuntimeError("RDKit pass failed")
+
+    monkeypatch.setattr(loading, "add_rdkit", _boom)
+    with (
+        caplog.at_level(logging.WARNING, logger="ord_schema.orm.loading"),
+        pytest.raises(RuntimeError),
+    ):
+        loading.load_datasets(
+            _PBTXT_FIXTURE, str(prepared_engine.url), prune_rdkit=True
+        )
+    assert not called
+    # Skipped by the gate, not merely unreached: without this the test would pass if the
+    # failure short-circuited before the prune was ever considered.
+    assert "Skipping the RDKit prune" in caplog.text
+
+
+def test_prune_rdkit_is_off_by_default(prepared_engine, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        loading.database,
+        "delete_orphaned_rdkit_structures",
+        lambda session: called.append(session) or (0, 0),
+    )
+    loading.load_datasets(_PBTXT_FIXTURE, str(prepared_engine.url))
+    assert not called

--- a/ord_schema/orm/scripts/add_datasets.py
+++ b/ord_schema/orm/scripts/add_datasets.py
@@ -52,6 +52,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--overwrite", action="store_true", help="Update changed datasets"
     )
     parser.add_argument(
+        "--prune_rdkit",
+        action="store_true",
+        help="After the RDKit pass, delete rdkit.mols/rdkit.reactions rows that no "
+        "derived row references. A rebuild that changes SMILES strands the old "
+        "structures; this collects them. Whole-database, so do not run it beside "
+        "another load.",
+    )
+    parser.add_argument(
         "--rederive",
         action="store_true",
         help="Recompute derived.* SMILES that already exist, instead of only filling "
@@ -116,6 +124,7 @@ def main(args: argparse.Namespace) -> None:
         overwrite=args.overwrite,
         classify_reactions=args.classify_reactions,
         rederive=args.rederive,
+        prune_rdkit=args.prune_rdkit,
         n_jobs=args.n_jobs,
         classify_jobs=args.classify_jobs,
     )

--- a/ord_schema/orm/scripts/add_datasets_test.py
+++ b/ord_schema/orm/scripts/add_datasets_test.py
@@ -55,3 +55,33 @@ def test_classify_reactions_requires_extra(monkeypatch):
                 ["--pattern", _PBTXT_FIXTURE, "--classify_reactions"]
             )
         )
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        ([], {"rederive": False, "prune_rdkit": False}),
+        (["--rederive"], {"rederive": True, "prune_rdkit": False}),
+        (["--prune_rdkit"], {"rederive": False, "prune_rdkit": True}),
+        (
+            ["--rederive", "--prune_rdkit"],
+            {"rederive": True, "prune_rdkit": True},
+        ),
+    ],
+)
+def test_rebuild_flags_reach_load_datasets(monkeypatch, argv, expected):
+    """Both rebuild flags are forwarded, and both default off.
+
+    They are destructive, so a wiring mistake either silently does nothing or silently
+    deletes; neither shows up in the loading tests, which call load_datasets directly.
+    """
+    captured = {}
+    monkeypatch.setattr(
+        add_datasets.loading,
+        "load_datasets",
+        lambda *args, **kwargs: captured.update(kwargs),
+    )
+    add_datasets.main(
+        add_datasets.parse_args(["--pattern", _PBTXT_FIXTURE, "--dsn", "x", *argv])
+    )
+    assert {key: captured[key] for key in expected} == expected


### PR DESCRIPTION
## Summary

Follow-up to #944. `delete_derived_data` cannot touch `rdkit.mols` or `rdkit.reactions`: they are deduplicated by structure and shared across datasets, so deleting one dataset's share would break the others. A rebuild that changes a SMILES therefore links to a new structure and leaves the old one referenced by nothing. `--prune_rdkit` collects those.

## Changes

- `database.delete_orphaned_rdkit_structures` deletes `rdkit.mols` and `rdkit.reactions` rows that no `derived.*` row references, returning the counts removed.
- `load_datasets` and `add_datasets.py` take `--prune_rdkit`, which runs it after the RDKit pass.
- The `orm-database-load` skill documents it next to `--rederive`.

## Testing

- `uv run pytest -n auto`: 878 pass, 2 skipped, including the 56 ORM tests against a live Postgres. `ruff`, `ty`, and all pre-commit hooks clean; `ty` reports the same 42 diagnostics as `main`.
- Three new ORM tests: a fully-linked database loses nothing (`(0, 0)`), a stranded structure is collected and only the mol count moves, and a mol still referenced from `derived.product_compound_smiles` survives when the compound-side reference is gone.

## Notes

Whole-database by necessity: a structure is orphaned only if *no* dataset references it, so this cannot be scoped to a dataset or a shard. That drives three deliberate choices.

It is **opt-in**, and must not run beside another load. `_update_rdkit_mols` inserts structures that `_link_mol_ids` links in a later statement, so a concurrent derive has a window where live rows look orphaned.

It is **skipped when any dataset failed**, for the same reason — an unfinished pass leaves exactly that window open. The log says so rather than staying quiet, since a silent skip here would read the same as a clean run.

The FKs from `derived.*` declare `ON DELETE CASCADE`, so deleting a structure that is still referenced would take its referrer with it. `rdkit.mols` is referenced from two tables, and checking only one would delete a structure the other still uses; `test_prune_keeps_a_mol_a_product_compound_still_references` pins that case specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds opt-in collection of unreferenced shared RDKit structures after dataset loading.
- Adds whole-database orphan deletion for molecule and reaction structures.
- Wires `--prune_rdkit` through the loader and CLI.
- Adds database, orchestration, and CLI tests plus operator documentation.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/orm/database.py | Adds whole-database deletion of RDKit molecules and reactions not referenced by any applicable derived table. |
| ord_schema/orm/loading.py | Adds opt-in prune orchestration after the RDKit pass and skips pruning when the load records failures. |
| ord_schema/orm/loading_test.py | Adds success, failure, and default-off orchestration coverage for the new prune option. |
| ord_schema/orm/scripts/add_datasets.py | Exposes the prune option through the dataset-loading CLI. |
| ord_schema/orm/database_test.py | Exercises orphan deletion and preservation of structures referenced from either molecule-reference table. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Derive SMILES] --> B[Insert deduplicated RDKit structures]
  B --> C[Link derived rows to RDKit IDs]
  C --> D{Load failures?}
  D -->|No and prune enabled| E[Delete unreferenced RDKit structures]
  D -->|Yes| F[Skip prune and report failure]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Cover the prune&#39;s orchestration, not jus..."](https://github.com/open-reaction-database/ord-schema/commit/5f5987b35c46501e8bd122e12110043dba8d1d32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51362716)</sub>

**Context used:**

- Knowledge Base — [ORM and Database Loading](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/orm-database.md)

<!-- /greptile_comment -->