### PR TITLE
Derive views from projections, and keep precision in the projection

### DIFF
--- a/ord_schema/artifacts.py
+++ b/ord_schema/artifacts.py
@@ -290,6 +290,30 @@ def _is_parent(match: str, parent_artifact: str | None) -> bool:
     return False
 
 
+def _is_irreplaceable(destination: pathlib.Path) -> bool:
+    """Returns whether writing to ``destination`` would destroy something unrecoverable.
+
+    A derived artifact is ours to rewrite; anything else at that path is not. Comparing
+    destinations against the run's own parents is not enough once a derivation reads one
+    tree and writes another, because the source datasets are then in neither set -- and
+    a mistyped ``output_dir`` aimed at them would replace a corpus that cannot be
+    regenerated with views that can.
+
+    Args:
+        destination: Path an artifact would be written to.
+
+    Returns:
+        True if something is already there and it is not a derived artifact.
+    """
+    if not destination.exists():
+        return False
+    try:
+        return not is_artifact(destination)
+    except ValueError:
+        # Not readable as Parquet at all, so certainly not an artifact this run wrote.
+        return True
+
+
 def _parent_provenance(
     parent: str, parent_artifact: str | None
 ) -> tuple[str, str | None]:
@@ -297,9 +321,16 @@ def _parent_provenance(
 
     A derived parent passes its own stamps through rather than being hashed itself, so
     every artifact records the *source dataset* content it reflects however many
-    derivations away it sits. A consumer therefore checks a view against the dataset in
-    one hop, and a chained artifact goes stale on the same three terms as a directly
-    derived one: source content, library version, and artifact version.
+    derivations away it sits, and a consumer checks a view against the dataset in one
+    hop.
+
+    Passing the hash through carries the source content across the hop but not the two
+    version stamps, which describe whoever wrote each file. A stale parent is therefore
+    refused rather than read: an artifact derived from one would stamp itself with the
+    *current* versions while holding what an older definition produced, and since the
+    dataset hash it inherits does not change when the parent is rebuilt, nothing would
+    ever mark it stale again. Refusing keeps the three terms ``is_current`` compares
+    true of a chained artifact as well as a directly derived one.
 
     Args:
         parent: Path to the file being derived from.
@@ -310,10 +341,16 @@ def _parent_provenance(
         The hash of the originating source dataset and its ID, if it records one.
 
     Raises:
-        ValueError: If ``parent`` is not readable as the expected kind of file.
+        ValueError: If ``parent`` is not readable as the expected kind of file, or is a
+            derived artifact that is itself out of date.
     """
     if parent_artifact is not None:
         stamps = load_stamps(parent)
+        if not is_current(parent, parent_artifact, stamps.source_md5):
+            raise ValueError(
+                f"{parent} is a stale {parent_artifact}; derive it again first, or "
+                "what is written here would claim a provenance it does not have"
+            )
         return stamps.source_md5, stamps.source_dataset_id
     try:
         view = parquet.DatasetView(parent)
@@ -379,11 +416,11 @@ def derive_tree(
     clobbered = sorted(
         str(destination)
         for destination in destinations.values()
-        if destination.resolve() in resolved_sources
+        if destination.resolve() in resolved_sources or _is_irreplaceable(destination)
     )
     if clobbered:
         raise ValueError(
-            f"output_dir {output_dir!r} would write over source datasets: {clobbered}"
+            f"output_dir {output_dir!r} would write over its inputs: {clobbered}"
         )
     written = skipped = 0
     for source in sources:

--- a/ord_schema/artifacts.py
+++ b/ord_schema/artifacts.py
@@ -18,12 +18,17 @@ A derived artifact restates a source dataset in a queryable shape. It adds no
 information, so it is wrong if it disagrees with its source and stale if its source has
 moved on. These stamps make both conditions detectable without reading column data.
 
-More than one artifact is expected -- a projection carrying every field, and pivoted
-indexes over the paths that turn out to be hot -- so the parts that do not vary between
-them live here: the stamps, the output-path mapping, and the driver that walks a glob,
-refuses to write over its own sources, ignores matches that are already artifacts, and
-skips what is current. An artifact module supplies only its schema, its projection, and
-its name.
+More than one artifact is expected -- a projection carrying every field, a view
+narrowing it, and pivoted indexes over the paths that turn out to be hot -- so the parts
+that do not vary between them live here: the stamps, the output-path mapping, and the
+driver that walks a glob, refuses to write over what it reads, ignores matches that are
+not the kind of parent it derives from, and skips what is current. An artifact module
+supplies only its schema, its projection, and its name.
+
+An artifact may derive from another rather than from a source dataset, which is how a
+view reaches the projection's columns without recomputing them. Only the reading
+differs: the stamps describe the originating dataset either way, so a chain is invisible
+to a consumer checking whether a file is current.
 
 Every artifact carries these keys, in the ``ord.`` namespace that ``ord_schema.parquet``
 already uses for source datasets:
@@ -35,7 +40,10 @@ already uses for source datasets:
   each other needs to know they were built by the same definition. Per-artifact versions
   would let a view and a projection of the same dataset disagree while both looked
   current.
-* ``ord.source_md5`` -- what it was derived from.
+* ``ord.source_md5`` -- the content of the source dataset it restates. An artifact
+  derived from another artifact passes this through rather than hashing its parent, so
+  every artifact names the dataset it reflects however many derivations away it sits,
+  and one comparison answers "is this current for that dataset?"
 * ``ord.ord_schema_version`` -- what derived it.
 * ``ord.source_dataset_id`` -- the source's ID, written only when the source records
   one, and so the only key not required to read stamps back.
@@ -90,7 +98,11 @@ class Stamps:
 
 
 class ArtifactWriter(Protocol):
-    """Writes one derived artifact from an open view of its source.
+    """Writes one derived artifact from the Parquet file it derives from.
+
+    The parent is passed as a path rather than an open reader, because parents are not
+    all the same kind of file: a projection reads a source dataset, and a view reads a
+    projection. Each writer opens what it knows how to read.
 
     The first two arguments are positional-only, so an implementation is free to name
     them for its own artifact.
@@ -98,11 +110,12 @@ class ArtifactWriter(Protocol):
 
     def __call__(
         self,
-        source: parquet.DatasetView,
+        source: pathlib.Path,
         output: pathlib.Path,
         /,
         *,
         source_md5: str,
+        source_dataset_id: str | None,
     ) -> int:
         """Returns the number of rows written to ``output``."""
 
@@ -248,6 +261,67 @@ def output_path(source: str, pattern: str, output_dir: str) -> pathlib.Path:
     return pathlib.Path(output_dir) / relative
 
 
+def _is_parent(match: str, parent_artifact: str | None) -> bool:
+    """Returns whether ``match`` is the kind of file this derivation reads.
+
+    Args:
+        match: Path a glob matched.
+        parent_artifact: Artifact name the derivation reads, or None to read source
+            datasets.
+
+    Returns:
+        True if ``match`` should be derived from. Anything else is ignored rather than
+        refused, so a pattern reaching the output tree stays re-runnable.
+    """
+    if not is_artifact(match):
+        if parent_artifact is None:
+            return True
+        logger.info(
+            "%s is a source dataset, not a %s; ignoring", match, parent_artifact
+        )
+        return False
+    if parent_artifact is None:
+        logger.info("%s is a derived artifact, not a source; ignoring", match)
+        return False
+    found = load_stamps(match).artifact
+    if found == parent_artifact:
+        return True
+    logger.info("%s is a %s, not a %s; ignoring", match, found, parent_artifact)
+    return False
+
+
+def _parent_provenance(
+    parent: str, parent_artifact: str | None
+) -> tuple[str, str | None]:
+    """Returns the provenance an artifact reading ``parent`` should stamp.
+
+    A derived parent passes its own stamps through rather than being hashed itself, so
+    every artifact records the *source dataset* content it reflects however many
+    derivations away it sits. A consumer therefore checks a view against the dataset in
+    one hop, and a chained artifact goes stale on the same three terms as a directly
+    derived one: source content, library version, and artifact version.
+
+    Args:
+        parent: Path to the file being derived from.
+        parent_artifact: Artifact name ``parent`` holds, or None if it is a source
+            dataset.
+
+    Returns:
+        The hash of the originating source dataset and its ID, if it records one.
+
+    Raises:
+        ValueError: If ``parent`` is not readable as the expected kind of file.
+    """
+    if parent_artifact is not None:
+        stamps = load_stamps(parent)
+        return stamps.source_md5, stamps.source_dataset_id
+    try:
+        view = parquet.DatasetView(parent)
+    except ValueError as error:
+        raise ValueError(f"{parent} is not a source dataset: {error}") from error
+    return view.md5(), view.dataset_id or None
+
+
 def derive_tree(
     input_pattern: str,
     output_dir: str,
@@ -255,29 +329,34 @@ def derive_tree(
     artifact: str,
     write: ArtifactWriter,
     force: bool = False,
+    parent_artifact: str | None = None,
 ) -> tuple[int, int, int]:
-    """Derives one artifact per dataset matching ``input_pattern``.
+    """Derives one artifact per file matching ``input_pattern``.
 
-    Outputs mirror the inputs' directory layout beneath ``output_dir``. Matches that
-    are themselves derived artifacts are ignored, so a recursive pattern reaching the
-    output tree stays re-runnable. Artifacts whose footer already records the current
-    source content, library version, and artifact version are skipped, so re-running is
-    cheap.
+    Outputs mirror the inputs' directory layout beneath ``output_dir``. Matches that are
+    not the kind of parent this derivation reads are ignored, so a recursive pattern
+    reaching the output tree stays re-runnable. Artifacts whose footer already records
+    the current source content, library version, and artifact version are skipped, so
+    re-running is cheap.
 
     Args:
-        input_pattern: Glob matching source Parquet datasets.
+        input_pattern: Glob matching the files to derive from.
         output_dir: Directory to write artifacts beneath.
         artifact: Artifact name, used for the staleness check and the footer stamp.
-        write: Writer taking ``(view, output, source_md5=...)`` and returning rows.
+        write: Writer taking ``(parent, output, source_md5=..., source_dataset_id=...)``
+            and returning rows.
         force: Rewrite artifacts that are already current.
+        parent_artifact: Artifact the parents hold, for a derivation that reads another
+            artifact rather than a source dataset. None means the parents are source
+            datasets.
 
     Returns:
         ``(written, skipped, ignored)`` counts: artifacts derived, artifacts already
-        current, and matches that were derived artifacts rather than sources.
+        current, and matches that were not the expected kind of parent.
 
     Raises:
         ValueError: If the input pattern matches nothing, if any match cannot be read as
-            Parquet, or if any destination would land on a source.
+            Parquet, or if any destination would land on a parent.
     """
     matches = sorted(glob.glob(input_pattern, recursive=True))
     if not matches:
@@ -285,12 +364,11 @@ def derive_tree(
     sources = []
     ignored = 0
     for match in matches:
-        if is_artifact(match):
-            logger.info("%s is a derived artifact, not a source; ignoring", match)
-            ignored += 1
-        else:
+        if _is_parent(match, parent_artifact):
             sources.append(match)
-    logger.info("Found %d datasets", len(sources))
+        else:
+            ignored += 1
+    logger.info("Found %d %ss", len(sources), parent_artifact or "dataset")
     # Every destination against every source, not against its own: an output_dir nested
     # in the source tree maps one dataset onto a *different* one, which a per-source
     # check passes, destroying a source the run had not reached yet.
@@ -310,17 +388,18 @@ def derive_tree(
     written = skipped = 0
     for source in sources:
         destination = destinations[source]
-        try:
-            view = parquet.DatasetView(source)
-        except ValueError as error:
-            raise ValueError(f"{source} is not a source dataset: {error}") from error
-        source_md5 = view.md5()
+        source_md5, source_dataset_id = _parent_provenance(source, parent_artifact)
         if not force and is_current(destination, artifact, source_md5):
             logger.info("%s is current; skipping", destination)
             skipped += 1
             continue
         destination.parent.mkdir(parents=True, exist_ok=True)
-        rows = write(view, destination, source_md5=source_md5)
+        rows = write(
+            pathlib.Path(source),
+            destination,
+            source_md5=source_md5,
+            source_dataset_id=source_dataset_id,
+        )
         logger.info("Wrote %d rows to %s", rows, destination)
         written += 1
     logger.info(

--- a/ord_schema/artifacts.py
+++ b/ord_schema/artifacts.py
@@ -204,9 +204,26 @@ def is_current(path: str | os.PathLike[str], artifact: str, source_md5: str) -> 
         # Broad on purpose: every way of failing to read stamps -- absent, truncated,
         # not Parquet at all -- answers "derive it again", which is safe.
         return False
+    return value.source_md5 == source_md5 and stamps_are_current(value, artifact)
+
+
+def stamps_are_current(value: Stamps, artifact: str) -> bool:
+    """Returns whether ``value`` records ``artifact`` as this library defines it now.
+
+    The source content is deliberately not compared: a caller holding the stamps of a
+    parent asks whether the file was written by the current definition, and the hash it
+    carries is the answer to a different question.
+
+    Args:
+        value: Stamps read from an artifact.
+        artifact: Artifact name the file is expected to hold.
+
+    Returns:
+        Whether the artifact name, the library version, and the artifact version all
+        match.
+    """
     return (
         value.artifact == artifact
-        and value.source_md5 == source_md5
         and value.ord_schema_version == metadata.version("ord-schema")
         and value.artifact_version == ARTIFACT_VERSION
     )
@@ -227,13 +244,34 @@ def is_artifact(path: str | os.PathLike[str]) -> bool:
             whether to treat a file as a source, so answering False for a truncated one
             would feed it to a reader that fails later without naming it.
     """
+    return read_stamps(path) is not None
+
+
+def read_stamps(path: str | os.PathLike[str]) -> Stamps | None:
+    """Returns ``path``'s artifact stamps, or None if it carries none.
+
+    One footer read where a predicate followed by ``load_stamps`` would be two, which
+    matters to ``derive_tree``: it needs the answer *and* the stamps behind it for every
+    match of a corpus-wide glob.
+
+    Args:
+        path: Path to a Parquet file.
+
+    Returns:
+        The stamps, or None if ``path`` is readable Parquet that records none.
+
+    Raises:
+        ValueError: If ``path`` cannot be read as Parquet at all. This decides whether a
+            glob match is a candidate parent, so answering None for a truncated one
+            would either feed it to a reader that fails later without naming it, or drop
+            it from the run without a word.
+    """
     try:
-        load_stamps(path)
+        return load_stamps(path)
     except pa.ArrowInvalid as error:
         raise ValueError(f"{path} is not readable as Parquet") from error
     except (OSError, ValueError):
-        return False
-    return True
+        return None
 
 
 def glob_root(pattern: str) -> pathlib.PurePath:
@@ -261,19 +299,20 @@ def output_path(source: str, pattern: str, output_dir: str) -> pathlib.Path:
     return pathlib.Path(output_dir) / relative
 
 
-def _is_parent(match: str, parent_artifact: str | None) -> bool:
+def _is_parent(match: str, parent_artifact: str | None, stamps: Stamps | None) -> bool:
     """Returns whether ``match`` is the kind of file this derivation reads.
 
     Args:
-        match: Path a glob matched.
+        match: Path a glob matched, named in the log line when it is ignored.
         parent_artifact: Artifact name the derivation reads, or None to read source
             datasets.
+        stamps: ``match``'s stamps, or None if it carries none.
 
     Returns:
-        True if ``match`` should be derived from. Anything else is ignored rather than
-        refused, so a pattern reaching the output tree stays re-runnable.
+        True if ``match`` should be derived from. Anything else readable is ignored
+        rather than refused, so a pattern reaching the output tree stays re-runnable.
     """
-    if not is_artifact(match):
+    if stamps is None:
         if parent_artifact is None:
             return True
         logger.info(
@@ -283,10 +322,11 @@ def _is_parent(match: str, parent_artifact: str | None) -> bool:
     if parent_artifact is None:
         logger.info("%s is a derived artifact, not a source; ignoring", match)
         return False
-    found = load_stamps(match).artifact
-    if found == parent_artifact:
+    if stamps.artifact == parent_artifact:
         return True
-    logger.info("%s is a %s, not a %s; ignoring", match, found, parent_artifact)
+    logger.info(
+        "%s is a %s, not a %s; ignoring", match, stamps.artifact, parent_artifact
+    )
     return False
 
 
@@ -315,7 +355,7 @@ def _is_irreplaceable(destination: pathlib.Path) -> bool:
 
 
 def _parent_provenance(
-    parent: str, parent_artifact: str | None
+    parent: str, parent_artifact: str | None, stamps: Stamps | None
 ) -> tuple[str, str | None]:
     """Returns the provenance an artifact reading ``parent`` should stamp.
 
@@ -336,6 +376,7 @@ def _parent_provenance(
         parent: Path to the file being derived from.
         parent_artifact: Artifact name ``parent`` holds, or None if it is a source
             dataset.
+        stamps: ``parent``'s stamps, already read; None when it is a source dataset.
 
     Returns:
         The hash of the originating source dataset and its ID, if it records one.
@@ -345,8 +386,9 @@ def _parent_provenance(
             derived artifact that is itself out of date.
     """
     if parent_artifact is not None:
-        stamps = load_stamps(parent)
-        if not is_current(parent, parent_artifact, stamps.source_md5):
+        # Selection already established that stamps holds this artifact.
+        assert stamps is not None  # Type hint.
+        if not stamps_are_current(stamps, parent_artifact):
             raise ValueError(
                 f"{parent} is a stale {parent_artifact}; derive it again first, or "
                 "what is written here would claim a provenance it does not have"
@@ -399,10 +441,13 @@ def derive_tree(
     if not matches:
         raise ValueError(f"no datasets matched: {input_pattern}")
     sources = []
+    parent_stamps: dict[str, Stamps | None] = {}
     ignored = 0
     for match in matches:
-        if _is_parent(match, parent_artifact):
+        stamps = read_stamps(match)
+        if _is_parent(match, parent_artifact, stamps):
             sources.append(match)
+            parent_stamps[match] = stamps
         else:
             ignored += 1
     logger.info("Found %d %ss", len(sources), parent_artifact or "dataset")
@@ -425,7 +470,9 @@ def derive_tree(
     written = skipped = 0
     for source in sources:
         destination = destinations[source]
-        source_md5, source_dataset_id = _parent_provenance(source, parent_artifact)
+        source_md5, source_dataset_id = _parent_provenance(
+            source, parent_artifact, parent_stamps[source]
+        )
         if not force and is_current(destination, artifact, source_md5):
             logger.info("%s is current; skipping", destination)
             skipped += 1

--- a/ord_schema/artifacts_test.py
+++ b/ord_schema/artifacts_test.py
@@ -15,6 +15,7 @@
 """Tests for ord_schema.artifacts."""
 
 import pathlib
+from importlib import metadata
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -27,6 +28,13 @@ from ord_schema.proto import dataset_pb2, reaction_pb2
 def _write(path, metadata):
     schema = pa.schema([pa.field("x", pa.int32())]).with_metadata(metadata)
     pq.write_table(pa.table({"x": [1]}, schema=schema), path)
+
+
+def _current_metadata(**overrides):
+    """Stamps a parent this library considers current, which a chain requires."""
+    return _valid_metadata(
+        **{"ord.ord_schema_version": metadata.version("ord-schema"), **overrides}
+    )
 
 
 def _valid_metadata(**overrides):
@@ -237,7 +245,7 @@ def test_derive_tree_refuses_to_write_over_its_own_sources(tmp_path):
     (tmp_path / "aa").mkdir()
     _fake_source(tmp_path / "aa" / "source.parquet")
     calls = []
-    with pytest.raises(ValueError, match="would write over source datasets"):
+    with pytest.raises(ValueError, match="would write over its inputs"):
         artifacts.derive_tree(
             str(tmp_path / "*" / "*.parquet"),
             str(tmp_path),
@@ -255,7 +263,7 @@ def test_derive_tree_refuses_to_write_over_a_different_source(tmp_path):
     victim = tmp_path / "aa" / "source.parquet"
     _fake_source(victim)
     original = victim.read_bytes()
-    with pytest.raises(ValueError, match="would write over source datasets"):
+    with pytest.raises(ValueError, match="would write over its inputs"):
         artifacts.derive_tree(
             str(tmp_path / "**" / "*.parquet"),
             str(tmp_path / "aa"),
@@ -320,7 +328,7 @@ def test_derive_tree_reads_the_named_parent_artifact(tmp_path):
     (tmp_path / "aa").mkdir()
     _write(
         tmp_path / "aa" / "projected.parquet",
-        _valid_metadata(**{"ord.artifact": "projection", "ord.source_md5": "a" * 32}),
+        _current_metadata(**{"ord.artifact": "projection", "ord.source_md5": "a" * 32}),
     )
     seen = []
 
@@ -346,7 +354,7 @@ def test_derive_tree_ignores_a_source_dataset_when_a_parent_artifact_is_named(tm
     _fake_source(tmp_path / "aa" / "source.parquet")
     _write(
         tmp_path / "aa" / "projected.parquet",
-        _valid_metadata(**{"ord.artifact": "projection"}),
+        _current_metadata(**{"ord.artifact": "projection"}),
     )
     written_paths = []
 
@@ -379,3 +387,68 @@ def test_derive_tree_ignores_an_artifact_of_the_wrong_kind(tmp_path):
         write=lambda *args, **kwargs: 1,
         parent_artifact="projection",
     ) == (0, 0, 1)
+
+
+def test_derive_tree_refuses_a_stale_parent(tmp_path, monkeypatch):
+    # Passing the parent's hash through carries the source content across the hop but
+    # not the version stamps. A view written from a stale projection would stamp itself
+    # with the current versions, and the dataset hash it inherits does not change when
+    # the projection is rebuilt -- so nothing would ever mark it stale again.
+    (tmp_path / "aa").mkdir()
+    parent = tmp_path / "aa" / "projected.parquet"
+    _write(parent, _current_metadata(**{"ord.artifact": "projection"}))
+    monkeypatch.setattr(artifacts, "ARTIFACT_VERSION", "next")
+    with pytest.raises(ValueError, match="stale projection"):
+        artifacts.derive_tree(
+            str(tmp_path / "*" / "*.parquet"),
+            str(tmp_path / "out"),
+            artifact="view",
+            write=lambda *args, **kwargs: 1,
+            parent_artifact="projection",
+        )
+
+
+def test_derive_tree_refuses_to_write_over_a_file_it_did_not_derive(tmp_path):
+    # Comparing destinations against the run's own parents cannot catch this once a
+    # derivation reads one tree and writes another: the source datasets are in neither
+    # set, and replacing a corpus that cannot be regenerated is the one unrecoverable
+    # mistake this driver can make.
+    (tmp_path / "projections").mkdir()
+    _write(
+        tmp_path / "projections" / "ds.parquet",
+        _current_metadata(**{"ord.artifact": "projection"}),
+    )
+    (tmp_path / "data").mkdir()
+    source = tmp_path / "data" / "ds.parquet"
+    _fake_source(source)
+    before = source.read_bytes()
+    with pytest.raises(ValueError, match="would write over its inputs"):
+        artifacts.derive_tree(
+            str(tmp_path / "projections" / "*.parquet"),
+            str(tmp_path / "data"),
+            artifact="view",
+            write=lambda *args, **kwargs: 1,
+            parent_artifact="projection",
+        )
+    assert source.read_bytes() == before
+
+
+def test_derive_tree_still_rewrites_its_own_artifacts(tmp_path):
+    # The guard above must not stop a re-run: an artifact this driver wrote is exactly
+    # what --force is for.
+    (tmp_path / "projections").mkdir()
+    _write(
+        tmp_path / "projections" / "ds.parquet",
+        _current_metadata(**{"ord.artifact": "projection"}),
+    )
+    (tmp_path / "views").mkdir()
+    _write(tmp_path / "views" / "ds.parquet", _valid_metadata())
+    written, skipped, ignored = artifacts.derive_tree(
+        str(tmp_path / "projections" / "*.parquet"),
+        str(tmp_path / "views"),
+        artifact="view",
+        write=lambda *args, **kwargs: 1,
+        force=True,
+        parent_artifact="projection",
+    )
+    assert (written, skipped, ignored) == (1, 0, 0)

--- a/ord_schema/artifacts_test.py
+++ b/ord_schema/artifacts_test.py
@@ -196,8 +196,8 @@ def test_derive_tree_writes_one_artifact_per_source(tmp_path):
         _fake_source(tmp_path / name / "source.parquet")
     written_paths = []
 
-    def _write_one(view, output, *, source_md5):
-        del view, source_md5  # Unused.
+    def _write_one(source, output, *, source_md5, source_dataset_id):
+        del source, source_md5, source_dataset_id  # Unused.
         written_paths.append(output)
         pathlib.Path(output).write_bytes(b"")
         return 1
@@ -212,14 +212,15 @@ def test_derive_tree_writes_one_artifact_per_source(tmp_path):
     assert {path.parent.name for path in written_paths} == {"aa", "bb"}
 
 
-def test_derive_tree_hands_the_writer_an_open_view_of_the_source(tmp_path):
+def test_derive_tree_hands_the_writer_the_source_and_its_provenance(tmp_path):
     (tmp_path / "aa").mkdir()
     source = tmp_path / "aa" / "source.parquet"
     _fake_source(source)
     seen = []
 
-    def _write_one(view, output, *, source_md5):
-        seen.append((view.dataset_id, view.md5() == source_md5))
+    def _write_one(path, output, *, source_md5, source_dataset_id):
+        view = parquet.DatasetView(path)
+        seen.append((source_dataset_id, view.md5() == source_md5))
         pathlib.Path(output).write_bytes(b"")
         return 1
 
@@ -271,8 +272,8 @@ def test_derive_tree_ignores_matches_that_are_themselves_artifacts(tmp_path):
     _write(tmp_path / "aa" / "derived.parquet", _valid_metadata())
     written_paths = []
 
-    def _write_one(view, output, *, source_md5):
-        del view, source_md5  # Unused.
+    def _write_one(source, output, *, source_md5, source_dataset_id):
+        del source, source_md5, source_dataset_id  # Unused.
         written_paths.append(output)
         pathlib.Path(output).write_bytes(b"")
         return 1
@@ -291,8 +292,8 @@ def test_derive_tree_skips_current_artifacts_unless_forced(tmp_path, monkeypatch
     _fake_source(tmp_path / "aa" / "source.parquet")
     calls = []
 
-    def _write_one(view, output, *, source_md5):
-        del view, source_md5  # Unused.
+    def _write_one(source, output, *, source_md5, source_dataset_id):
+        del source, source_md5, source_dataset_id  # Unused.
         calls.append(output)
         pathlib.Path(output).write_bytes(b"")
         return 1
@@ -313,3 +314,68 @@ def test_derive_tree_skips_current_artifacts_unless_forced(tmp_path, monkeypatch
         force=True,
     ) == (1, 0, 0)
     assert len(calls) == 1
+
+
+def test_derive_tree_reads_the_named_parent_artifact(tmp_path):
+    (tmp_path / "aa").mkdir()
+    _write(
+        tmp_path / "aa" / "projected.parquet",
+        _valid_metadata(**{"ord.artifact": "projection", "ord.source_md5": "a" * 32}),
+    )
+    seen = []
+
+    def _write_one(source, output, *, source_md5, source_dataset_id):
+        seen.append((pathlib.Path(source).name, source_md5, source_dataset_id))
+        pathlib.Path(output).write_bytes(b"")
+        return 1
+
+    assert artifacts.derive_tree(
+        str(tmp_path / "*" / "*.parquet"),
+        str(tmp_path / "out"),
+        artifact="view",
+        write=_write_one,
+        parent_artifact="projection",
+    ) == (1, 0, 0)
+    # The source dataset's hash and ID pass through, so a view names the dataset it
+    # reflects rather than the artifact it read.
+    assert seen == [("projected.parquet", "a" * 32, "ord_dataset-1")]
+
+
+def test_derive_tree_ignores_a_source_dataset_when_a_parent_artifact_is_named(tmp_path):
+    (tmp_path / "aa").mkdir()
+    _fake_source(tmp_path / "aa" / "source.parquet")
+    _write(
+        tmp_path / "aa" / "projected.parquet",
+        _valid_metadata(**{"ord.artifact": "projection"}),
+    )
+    written_paths = []
+
+    def _write_one(source, output, *, source_md5, source_dataset_id):
+        del source, source_md5, source_dataset_id  # Unused.
+        written_paths.append(output)
+        pathlib.Path(output).write_bytes(b"")
+        return 1
+
+    assert artifacts.derive_tree(
+        str(tmp_path / "*" / "*.parquet"),
+        str(tmp_path / "out"),
+        artifact="view",
+        write=_write_one,
+        parent_artifact="projection",
+    ) == (1, 0, 1)
+    assert [path.name for path in written_paths] == ["projected.parquet"]
+
+
+def test_derive_tree_ignores_an_artifact_of_the_wrong_kind(tmp_path):
+    # What an earlier run of this same command left in a recursive pattern's reach.
+    (tmp_path / "aa").mkdir()
+    _write(
+        tmp_path / "aa" / "already.parquet", _valid_metadata(**{"ord.artifact": "view"})
+    )
+    assert artifacts.derive_tree(
+        str(tmp_path / "*" / "*.parquet"),
+        str(tmp_path / "out"),
+        artifact="view",
+        write=lambda *args, **kwargs: 1,
+        parent_artifact="projection",
+    ) == (0, 0, 1)

--- a/ord_schema/projection.py
+++ b/ord_schema/projection.py
@@ -31,11 +31,13 @@ recursive message added upstream would otherwise recurse forever at import time.
 
 Two normalizations are applied, and only two. Both cost no query and remove a real trap:
 
-* **United messages become one canonical float.** A ``{value, precision, units}``
-  triple projected verbatim means ``WHERE temperature > 350`` silently misses every row
-  recorded in Celsius. Each becomes a single column named for its unit --
-  ``setpoint_kelvin`` -- so a question in other units stays expressible while the
-  mixed-unit comparison that would quietly return the wrong rows does not.
+* **United messages become canonical floats.** A ``{value, precision, units}`` triple
+  projected verbatim means ``WHERE temperature > 350`` silently misses every row
+  recorded in Celsius. Each becomes two columns named for its unit --
+  ``setpoint_kelvin`` and ``setpoint_precision_kelvin`` -- so a question in other units
+  stays expressible while the mixed-unit comparison that would quietly return the wrong
+  rows does not. The source records precision in the same units as the value, so it
+  converts with the value and is null under the same conditions.
 * **Structural identifiers collapse to one ``smiles``.** ``SMILES``, ``CXSMILES``,
   ``INCHI``, and ``MOLBLOCK`` all answer "what is this molecule," so the projection
   answers it once, through ``message_helpers.smiles_from_compound`` -- the same
@@ -55,8 +57,8 @@ Every other identifier is kept, as a list. ``NAME`` alone covers compounds that 
 structural identifier reaches, and a compound may carry several of them, so pivoting
 identifiers into named scalar fields would silently drop data.
 
-Anything else -- precision, the original units, the identifier types that were collapsed
--- remains in the source ``reaction`` column, which stays authoritative for byte-exact
+Anything else -- the original units, the identifier types that were collapsed -- remains
+in the source ``reaction`` column, which stays authoritative for byte-exact
 round-tripping. The projection promises that every field is *readable*, not that it is
 reproducible from the projection alone.
 
@@ -222,9 +224,37 @@ def column_name(field: FieldDescriptor) -> str:
     return field.name
 
 
+def precision_column_name(field: FieldDescriptor) -> str:
+    """Returns the column name for ``field``'s precision.
+
+    The unit stays the trailing element, matching the value column, so a reader takes
+    the units off the end of either name without knowing which is which.
+
+    Args:
+        field: A united field, as identified by ``_canonical_unit``.
+
+    Returns:
+        The precision column's name.
+
+    Raises:
+        ValueError: If ``field`` is not united, and so has no precision to name.
+    """
+    canonical = _canonical_unit(field)
+    if canonical is None:
+        raise ValueError(f"{field.full_name} is not a united message")
+    return f"{field.name}_precision_{canonical[1]}"
+
+
 def _field_type(field: FieldDescriptor, stack: frozenset[str]) -> pa.DataType:
     if _canonical_unit(field) is not None:
-        return pa.float64()
+        # Singular united fields never reach here: _struct_fields expands them into a
+        # value column and a precision column, which is a pair of leaves rather than
+        # one type. A repeated or map-valued one added upstream would, and that pair
+        # cannot represent it.
+        raise ValueError(
+            f"{field.full_name} is a repeated or map-valued united message; the "
+            "canonical value and precision columns represent only singular ones"
+        )
     message_type = field.message_type
     if message_type is not None and message_type.GetOptions().map_entry:
         key_field = message_type.fields_by_name["key"]
@@ -249,10 +279,12 @@ def _struct_fields(descriptor: Descriptor, stack: frozenset[str]) -> list[pa.Fie
     fields = []
     if descriptor.name in _STRUCTURAL_TYPES:
         fields.append(pa.field("smiles", pa.string()))
-    fields.extend(
-        pa.field(column_name(field), _field_type(field, stack))
-        for field in descriptor.fields
-    )
+    for field in descriptor.fields:
+        if _canonical_unit(field) is not None:
+            fields.append(pa.field(column_name(field), pa.float64()))
+            fields.append(pa.field(precision_column_name(field), pa.float64()))
+        else:
+            fields.append(pa.field(column_name(field), _field_type(field, stack)))
     return fields
 
 
@@ -343,8 +375,10 @@ def message_row(message: Message) -> dict[str, Any]:
         name = column_name(field)
         canonical = _canonical_unit(field)
         if canonical is not None:
-            row[name] = units.canonical_value(
-                getattr(message, field.name), canonical[0]
+            united = getattr(message, field.name)
+            row[name] = units.canonical_value(united, canonical[0])
+            row[precision_column_name(field)] = units.canonical_precision(
+                united, canonical[0]
             )
             continue
         message_type = field.message_type
@@ -434,10 +468,11 @@ def is_current(path: str | os.PathLike[str], source_md5: str) -> bool:
 
 
 def write_projection(
-    source: parquet.DatasetView,
+    source: str | os.PathLike[str],
     output: str | os.PathLike[str],
     *,
     source_md5: str | None = None,
+    source_dataset_id: str | None = None,
     compression: str = "zstd",
     row_group_size: int = 1000,
 ) -> int:
@@ -448,10 +483,12 @@ def write_projection(
     atomically, so a failure partway leaves any existing projection untouched.
 
     Args:
-        source: View of the source Parquet dataset.
+        source: Path to the source Parquet dataset.
         output: Path to write the projection to.
         source_md5: Source hash to stamp, if the caller already computed one. Hashed
             here when omitted, which costs a full pass over the source.
+        source_dataset_id: Source dataset ID to stamp, if the caller already read one.
+            Read from the source when omitted.
         compression: Parquet compression codec.
         row_group_size: Rows per output row group.
 
@@ -459,13 +496,17 @@ def write_projection(
         Number of rows written.
 
     Raises:
-        ValueError: If any row's ``reaction_id`` column is missing or disagrees with
-            its Reaction. The message names the source, since a corpus-wide run has
-            thousands of datasets to choose between.
+        ValueError: If ``source`` is not a source dataset, or if any row's
+            ``reaction_id`` column is missing or disagrees with its Reaction. The
+            message names the source, since a corpus-wide run has thousands of datasets
+            to choose between.
     """
+    view = parquet.DatasetView(source)
     if source_md5 is None:
-        source_md5 = source.md5()
-    stamps = artifacts.current_stamps(ARTIFACT, source.dataset_id or None, source_md5)
+        source_md5 = view.md5()
+    if source_dataset_id is None:
+        source_dataset_id = view.dataset_id or None
+    stamps = artifacts.current_stamps(ARTIFACT, source_dataset_id, source_md5)
     schema = SCHEMA.with_metadata(artifacts.to_metadata(stamps))
     rows = 0
     unreadable = 0
@@ -473,13 +514,13 @@ def write_projection(
         atomic_io.atomic_path(output) as temp_path,
         pq.ParquetWriter(temp_path, schema, compression=compression) as writer,
     ):
-        for row_group in range(source.num_row_groups):
+        for row_group in range(view.num_row_groups):
             batch = []
-            for reaction_id, reaction in source.iter_reactions(row_group=row_group):
+            for reaction_id, reaction in view.iter_reactions(row_group=row_group):
                 try:
                     row = reaction_row(reaction, reaction_id)
                 except ValueError as error:
-                    raise ValueError(f"{source.path}: {error}") from error
+                    raise ValueError(f"{view.path}: {error}") from error
                 unreadable += _unreadable_structures(row)
                 batch.append(row)
             rows += len(batch)
@@ -490,7 +531,7 @@ def write_projection(
     if unreadable:
         # Per dataset rather than per row: a count is diffable between runs, so a
         # regression in structure reading shows up instead of hiding in the nulls.
-        logger.info("%s: %d components project no structure", source.path, unreadable)
+        logger.info("%s: %d components project no structure", view.path, unreadable)
     return rows
 
 

--- a/ord_schema/projection_test.py
+++ b/ord_schema/projection_test.py
@@ -14,6 +14,7 @@
 
 """Tests for ord_schema.projection."""
 
+import pathlib
 from typing import cast
 
 import pyarrow as pa
@@ -42,7 +43,7 @@ def _reaction(reaction_id: str = "ord-0001") -> reaction_pb2.Reaction:
 
 def _source(
     tmp_path, reactions, dataset_id="ord_dataset-1", row_group_size=1000
-) -> parquet.DatasetView:
+) -> pathlib.Path:
     path = tmp_path / "source.parquet"
     with parquet.DatasetWriter(
         path,
@@ -52,7 +53,7 @@ def _source(
         row_group_size=row_group_size,
     ) as writer:
         writer.write_all(reactions)
-    return parquet.DatasetView(path)
+    return path
 
 
 def _leaf_count(data_type: pa.DataType) -> int:
@@ -82,9 +83,10 @@ def test_schema_adds_a_collapsed_smiles_at_reaction_and_component_level():
     assert "smiles" in [field.name for field in components.value_type]
 
 
-def test_united_fields_collapse_to_a_float_named_for_its_unit():
+def test_united_fields_collapse_to_floats_named_for_their_unit():
     temperature = projection.SCHEMA.field("conditions").type.field("temperature").type
     assert temperature.field("setpoint_kelvin").type == pa.float64()
+    assert temperature.field("setpoint_precision_kelvin").type == pa.float64()
     assert "setpoint" not in [field.name for field in temperature]
 
 
@@ -143,6 +145,36 @@ def test_temperature_converts_to_kelvin():
     setpoint.units = reaction_pb2.Temperature.CELSIUS
     row = projection.message_row(reaction)
     assert row["conditions"]["temperature"]["setpoint_kelvin"] == pytest.approx(298.15)
+
+
+def test_precision_converts_with_its_value():
+    reaction = _reaction()
+    setpoint = reaction.conditions.temperature.setpoint
+    setpoint.value, setpoint.precision = 77.0, 1.8
+    setpoint.units = reaction_pb2.Temperature.FAHRENHEIT
+    temperature = projection.message_row(reaction)["conditions"]["temperature"]
+    assert temperature["setpoint_kelvin"] == pytest.approx(298.15)
+    # Fahrenheit is an offset scale, so the precision converts by the ratio alone.
+    assert temperature["setpoint_precision_kelvin"] == pytest.approx(1.0)
+
+
+def test_unrecorded_precision_is_null_not_zero():
+    reaction = _reaction()
+    setpoint = reaction.conditions.temperature.setpoint
+    setpoint.value = 25.0
+    setpoint.units = reaction_pb2.Temperature.CELSIUS
+    temperature = projection.message_row(reaction)["conditions"]["temperature"]
+    assert temperature["setpoint_kelvin"] == pytest.approx(298.15)
+    assert temperature["setpoint_precision_kelvin"] is None
+
+
+def test_precision_is_null_where_its_value_cannot_be_converted():
+    reaction = _reaction()
+    setpoint = reaction.conditions.temperature.setpoint
+    setpoint.value, setpoint.precision = 25.0, 0.5  # units left UNSPECIFIED
+    temperature = projection.message_row(reaction)["conditions"]["temperature"]
+    assert temperature["setpoint_kelvin"] is None
+    assert temperature["setpoint_precision_kelvin"] is None
 
 
 def test_amount_mass_converts_to_grams():
@@ -331,15 +363,13 @@ def test_write_projection_reads_the_reaction_id_column(tmp_path):
     # column from the message; the projection has to notice rather than pick one.
     path = tmp_path / "inconsistent.parquet"
     blob = _reaction("ord-in-message").SerializeToString(deterministic=True)
-    schema = pq.read_schema(_source(tmp_path, [_reaction()]).path)
+    schema = pq.read_schema(_source(tmp_path, [_reaction()]))
     pq.write_table(
         pa.table({"reaction_id": ["ord-in-column"], "reaction": [blob]}, schema=schema),
         path,
     )
     with pytest.raises(ValueError, match=f"{path}.*disagrees"):
-        projection.write_projection(
-            parquet.DatasetView(path), tmp_path / "projection.parquet"
-        )
+        projection.write_projection(path, tmp_path / "projection.parquet")
 
 
 def test_write_projection_rejects_a_null_reaction_id_column(tmp_path):
@@ -352,7 +382,7 @@ def test_write_projection_rejects_a_null_reaction_id_column(tmp_path):
             pa.field("reaction_id", pa.string(), nullable=True),
             pa.field("reaction", pa.binary(), nullable=False),
         ]
-    ).with_metadata(pq.read_schema(_source(tmp_path, [_reaction()]).path).metadata)
+    ).with_metadata(pq.read_schema(_source(tmp_path, [_reaction()])).metadata)
     pq.write_table(
         pa.table(
             {
@@ -364,9 +394,7 @@ def test_write_projection_rejects_a_null_reaction_id_column(tmp_path):
         path,
     )
     with pytest.raises(ValueError, match="reaction_id column is None"):
-        projection.write_projection(
-            parquet.DatasetView(path), tmp_path / "projection.parquet"
-        )
+        projection.write_projection(path, tmp_path / "projection.parquet")
 
 
 def test_write_projection_covers_every_row_group(tmp_path):
@@ -375,7 +403,7 @@ def test_write_projection_covers_every_row_group(tmp_path):
     source = _source(
         tmp_path, [_reaction(f"ord-{index}") for index in range(5)], row_group_size=2
     )
-    assert source.num_row_groups == 3
+    assert parquet.DatasetView(source).num_row_groups == 3
     output = tmp_path / "projection.parquet"
     assert projection.write_projection(source, output) == 5
     assert pq.read_table(output).column("reaction_id").to_pylist() == [
@@ -397,7 +425,7 @@ def test_is_current_tracks_source_content(tmp_path):
     source = _source(tmp_path, [_reaction()])
     output = tmp_path / "projection.parquet"
     projection.write_projection(source, output)
-    assert projection.is_current(output, source.md5())
+    assert projection.is_current(output, parquet.DatasetView(source).md5())
     assert not projection.is_current(output, "0" * 32)
 
 
@@ -405,7 +433,7 @@ def test_is_current_rejects_a_different_artifact(tmp_path):
     source = _source(tmp_path, [_reaction()])
     output = tmp_path / "projection.parquet"
     projection.write_projection(source, output)
-    assert not artifacts.is_current(output, "view", source.md5())
+    assert not artifacts.is_current(output, "view", parquet.DatasetView(source).md5())
 
 
 def test_is_current_is_false_for_a_missing_file(tmp_path):
@@ -414,7 +442,7 @@ def test_is_current_is_false_for_a_missing_file(tmp_path):
 
 def test_is_current_is_false_for_a_source_dataset(tmp_path):
     source = _source(tmp_path, [_reaction()])
-    assert not projection.is_current(source.path, source.md5())
+    assert not projection.is_current(source, parquet.DatasetView(source).md5())
 
 
 def test_a_failed_write_leaves_an_existing_projection_intact(tmp_path, monkeypatch):

--- a/ord_schema/projection_test.py
+++ b/ord_schema/projection_test.py
@@ -459,3 +459,15 @@ def test_a_failed_write_leaves_an_existing_projection_intact(tmp_path, monkeypat
         projection.write_projection(source, output)
     assert output.read_bytes() == original
     assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_precision_without_a_value_is_null():
+    # The pair has to agree: a null setpoint beside a stated uncertainty reads as a
+    # measurement nobody took but everybody bounded.
+    reaction = _reaction()
+    setpoint = reaction.conditions.temperature.setpoint
+    setpoint.precision = 0.5
+    setpoint.units = reaction_pb2.Temperature.CELSIUS
+    temperature = projection.message_row(reaction)["conditions"]["temperature"]
+    assert temperature["setpoint_kelvin"] is None
+    assert temperature["setpoint_precision_kelvin"] is None

--- a/ord_schema/scripts/derive_projection.py
+++ b/ord_schema/scripts/derive_projection.py
@@ -25,8 +25,8 @@ components of ``--input_pattern`` that hold no wildcard::
 
 Projections whose footer already records the current source content, library version,
 and artifact version are skipped, so re-running is cheap; ``--force`` rewrites them
-anyway. A match that is itself a projection is ignored rather than derived from, so
-``--output_dir`` may sit inside a recursive pattern's reach; an ``--output_dir`` that
+anyway. A match that is itself a derived artifact is ignored rather than derived from,
+so ``--output_dir`` may sit inside a recursive pattern's reach; an ``--output_dir`` that
 would write over any source dataset is an error, as is a run that derives nothing.
 """
 

--- a/ord_schema/scripts/derive_projection_test.py
+++ b/ord_schema/scripts/derive_projection_test.py
@@ -116,7 +116,7 @@ def test_an_exact_filename_writes_a_file_not_a_directory(tmp_path):
 
 def test_writing_into_the_source_tree_is_an_error(tmp_path):
     _dataset(tmp_path, "aa", "ord_dataset-a")
-    with pytest.raises(ValueError, match="would write over source datasets"):
+    with pytest.raises(ValueError, match="would write over its inputs"):
         derive_projection.main(
             derive_projection.parse_args(
                 [

--- a/ord_schema/scripts/derive_views.py
+++ b/ord_schema/scripts/derive_views.py
@@ -12,29 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Derives tabular views from Parquet datasets.
+"""Derives tabular views from Parquet projections.
 
-Each input dataset yields one view (see ``ord_schema.views`` for what a view contains,
-and what it deliberately does not). Outputs mirror the inputs' directory layout beneath
-``--output_dir``, rooted at the leading components of ``--input_pattern`` that hold no
-wildcard::
+A view is a narrowing of the projection, so this reads projections rather than source
+datasets: run ``derive_projection.py`` first (see ``ord_schema.views`` for what a view
+contains, and what it deliberately does not). Each input projection yields one view, and
+outputs mirror the inputs' directory layout beneath ``--output_dir``, rooted at the
+leading components of ``--input_pattern`` that hold no wildcard::
 
-    derive_views.py --input_pattern='data/*/*.parquet' --output_dir=views
+    derive_views.py --input_pattern='projections/*/*.parquet' --output_dir=views
 
-    data/aa/ord_dataset-<id>.parquet  ->  views/aa/ord_dataset-<id>.parquet
+    projections/aa/ord_dataset-<id>.parquet  ->  views/aa/ord_dataset-<id>.parquet
 
-Views whose footer already records the current source content, library version, and
-artifact version are skipped, so re-running is cheap; --force rewrites them anyway.
+A view records the hash of the *source dataset* its projection was built from, not of
+the projection, so one comparison answers "is this current for that dataset?". Views
+already recording the current source content, library version, and artifact version are
+skipped, so re-running is cheap; --force rewrites them anyway.
 
-A match that is itself a derived artifact is ignored rather than derived from, so
---output_dir may sit inside a recursive pattern's reach. These are errors: an
---output_dir that would write over any source dataset, a match that cannot be read as
-Parquet at all, and a run that derives nothing.
+A match that is not a projection -- a source dataset, or a view from an earlier run --
+is ignored rather than derived from, so --output_dir may sit inside a recursive
+pattern's reach. These are errors: an --output_dir that would write over any input, a
+match that cannot be read as Parquet at all, and a run that derives nothing.
 """
 
 import argparse
 
-from ord_schema import artifacts, views
+from ord_schema import artifacts, projection, views
 from ord_schema.logging import silence_rdkit_logs
 
 
@@ -44,7 +47,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
-        "--input_pattern", required=True, help="Input pattern for Parquet datasets"
+        "--input_pattern", required=True, help="Input pattern for Parquet projections"
     )
     parser.add_argument(
         "--output_dir", required=True, help="Directory to write views beneath"
@@ -58,15 +61,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(args: argparse.Namespace) -> None:
-    """Derives a view for every dataset matching the input pattern.
+    """Derives a view for every projection matching the input pattern.
 
     Args:
         args: Parsed command-line arguments.
 
     Raises:
-        ValueError: If the pattern matched only derived artifacts, which means it was
-            aimed at an output tree rather than a source tree. Silence there would let a
-            pipeline step downstream proceed as though the views had been built.
+        ValueError: If the pattern matched no projections, which usually means it was
+            aimed at the source tree, or at an output tree, rather than at the
+            projections. Silence there would let a pipeline step downstream proceed as
+            though the views had been built.
     """
     silence_rdkit_logs()
     written, skipped, ignored = artifacts.derive_tree(
@@ -75,11 +79,12 @@ def main(args: argparse.Namespace) -> None:
         artifact=views.ARTIFACT,
         write=views.write_view,
         force=args.force,
+        parent_artifact=projection.ARTIFACT,
     )
     if not written and not skipped:
         raise ValueError(
-            f"no sources derived: all {ignored} matches for {args.input_pattern!r} are "
-            "already derived artifacts"
+            f"no views derived: none of the {ignored} matches for "
+            f"{args.input_pattern!r} are projections"
         )
 
 

--- a/ord_schema/scripts/derive_views_test.py
+++ b/ord_schema/scripts/derive_views_test.py
@@ -14,8 +14,8 @@
 
 """Tests for ord_schema.scripts.derive_views.
 
-View behavior is covered in ord_schema.views_test; these cover the CLI: path
-mapping, the skip-if-current shortcut, and --force.
+View behavior is covered in ord_schema.views_test; these cover the CLI: path mapping,
+which matches count as sources, the skip-if-current shortcut, and --force.
 """
 
 import pathlib
@@ -25,7 +25,7 @@ import pytest
 
 from ord_schema import artifacts, parquet, views
 from ord_schema.proto import dataset_pb2, reaction_pb2
-from ord_schema.scripts import derive_views
+from ord_schema.scripts import derive_projection, derive_views
 
 
 def _dataset(dataset_id: str, *, reaction_ids=("ord-0001",)):
@@ -50,11 +50,23 @@ def _corpus(root: pathlib.Path, shards=("aa", "bb")) -> None:
         )
 
 
+def _project(root: pathlib.Path) -> None:
+    """Projects the corpus, which is what views are derived from."""
+    derive_projection.main(
+        derive_projection.parse_args(
+            [
+                f"--input_pattern={root / 'data' / '*' / '*.parquet'}",
+                f"--output_dir={root / 'projections'}",
+            ]
+        )
+    )
+
+
 def _run(root: pathlib.Path, *extra: str) -> None:
     derive_views.main(
         derive_views.parse_args(
             [
-                f"--input_pattern={root / 'data' / '*' / '*.parquet'}",
+                f"--input_pattern={root / 'projections' / '*' / '*.parquet'}",
                 f"--output_dir={root / 'views'}",
                 *extra,
             ]
@@ -64,6 +76,7 @@ def _run(root: pathlib.Path, *extra: str) -> None:
 
 def test_main_writes_one_view_per_dataset(tmp_path):
     _corpus(tmp_path)
+    _project(tmp_path)
     _run(tmp_path)
     for shard in ("aa", "bb"):
         view = tmp_path / "views" / shard / f"ord_dataset-{shard}.parquet"
@@ -75,6 +88,7 @@ def test_main_writes_one_view_per_dataset(tmp_path):
 
 def test_main_stamps_views_with_their_source(tmp_path):
     _corpus(tmp_path, shards=("aa",))
+    _project(tmp_path)
     _run(tmp_path)
     source = tmp_path / "data" / "aa" / "ord_dataset-aa.parquet"
     stamps = artifacts.load_stamps(tmp_path / "views" / "aa" / "ord_dataset-aa.parquet")
@@ -86,6 +100,7 @@ def test_main_stamps_views_with_their_source(tmp_path):
 # if and only if the view was rewritten. That is exact, unlike comparing mtimes.
 def test_main_skips_views_that_are_current(tmp_path):
     _corpus(tmp_path, shards=("aa",))
+    _project(tmp_path)
     _run(tmp_path)
     view = tmp_path / "views" / "aa" / "ord_dataset-aa.parquet"
     before = view.stat().st_ino
@@ -95,6 +110,7 @@ def test_main_skips_views_that_are_current(tmp_path):
 
 def test_force_rewrites_a_current_view(tmp_path):
     _corpus(tmp_path, shards=("aa",))
+    _project(tmp_path)
     _run(tmp_path)
     view = tmp_path / "views" / "aa" / "ord_dataset-aa.parquet"
     before = view.stat().st_ino
@@ -104,11 +120,13 @@ def test_force_rewrites_a_current_view(tmp_path):
 
 def test_main_rederives_when_the_source_changes(tmp_path):
     _corpus(tmp_path, shards=("aa",))
+    _project(tmp_path)
     _run(tmp_path)
     source = tmp_path / "data" / "aa" / "ord_dataset-aa.parquet"
     parquet.save_dataset(
         _dataset("ord_dataset-aa", reaction_ids=("ord-0001", "ord-0002")), str(source)
     )
+    _project(tmp_path)
     _run(tmp_path)
     view = tmp_path / "views" / "aa" / "ord_dataset-aa.parquet"
     assert pq.read_table(view).column("reaction_id").to_pylist() == [
@@ -121,13 +139,30 @@ def test_main_raises_when_every_match_is_already_a_view(tmp_path):
     # Aiming --input_pattern at the output tree would otherwise exit 0 having written
     # nothing, and a downstream step would proceed as though the views were built.
     _corpus(tmp_path, shards=("aa",))
+    _project(tmp_path)
     _run(tmp_path)
-    with pytest.raises(ValueError, match="no sources derived"):
+    with pytest.raises(ValueError, match="are projections"):
         derive_views.main(
             derive_views.parse_args(
                 [
                     f"--input_pattern={tmp_path}/views/*/*.parquet",
                     f"--output_dir={tmp_path}/again",
+                ]
+            )
+        )
+
+
+def test_main_ignores_source_datasets(tmp_path):
+    # A view is a narrowing of the projection, so a pattern aimed at the sources has
+    # nothing to narrow -- rather than silently deriving one the slow way.
+    _corpus(tmp_path, shards=("aa",))
+    _project(tmp_path)
+    with pytest.raises(ValueError, match="are projections"):
+        derive_views.main(
+            derive_views.parse_args(
+                [
+                    f"--input_pattern={tmp_path}/data/*/*.parquet",
+                    f"--output_dir={tmp_path}/views",
                 ]
             )
         )
@@ -147,7 +182,8 @@ def test_main_raises_when_nothing_matches(tmp_path):
 
 def test_main_accepts_an_exact_filename(tmp_path):
     _corpus(tmp_path, shards=("aa",))
-    source = tmp_path / "data" / "aa" / "ord_dataset-aa.parquet"
+    _project(tmp_path)
+    source = tmp_path / "projections" / "aa" / "ord_dataset-aa.parquet"
     derive_views.main(
         derive_views.parse_args(
             [f"--input_pattern={source}", f"--output_dir={tmp_path / 'views'}"]

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -487,6 +487,37 @@ def canonical_value(message: ord_schema.UnitMessage, target: str) -> float | Non
         return None
 
 
+def canonical_precision(message: ord_schema.UnitMessage, target: str) -> float | None:
+    """Converts a united message's precision to ``target`` units, or returns None.
+
+    Precision is recorded in the same units as the value, so it converts with the value
+    and is null under the same conditions -- a column named for ``target`` has nowhere
+    to say its uncertainty is in different units.
+
+    Args:
+        message: A united message, e.g. Temperature or Mass.
+        target: Unit to convert to, spelled as the resolver understands it, e.g. "K".
+
+    Returns:
+        The converted precision, or None when the message records none, records no
+        units, or records units that cannot be converted to ``target``.
+    """
+    if not message.HasField("precision") or not message.units:
+        return None
+    try:
+        # Read from the conversion rather than scaling here: Temperature is an offset
+        # scale, where precision converts by the ratio alone, and Wavelength inverts,
+        # where it does not converge on a single factor at all.
+        return RESOLVER.convert(message, target).precision
+    except (KeyError, ValueError, ZeroDivisionError):
+        logger.warning(
+            "cannot convert %s precision to %s; reading as null",
+            type(message).__name__,
+            target,
+        )
+        return None
+
+
 def format_message(message: ord_schema.UnitMessage) -> str | None:
     """Formats a united message into a string.
 

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -422,14 +422,18 @@ class UnitResolver:
         elif message_type == reaction_pb2.Wavelength:
             if message.units != new_units:
                 new_message.value = _WAVENUMBER_NM_CM / message.value
-                # Approximate precision as stdev of previous value \pm precision
-                if message.precision:
+                # Inverting maps the interval [value - precision, value + precision]
+                # onto an asymmetric one, so the converted precision is half its width.
+                # An interval reaching zero inverts to an unbounded one, which no
+                # precision describes -- the value still converts, so it is kept and
+                # the precision left unset rather than failing the whole conversion.
+                if message.precision and message.value != message.precision:
                     new_message.precision = (
                         _WAVENUMBER_NM_CM
                         / 2
                         * (
                             1 / (message.value - message.precision)
-                            + 1 / (message.value + message.precision)
+                            - 1 / (message.value + message.precision)
                         )
                     )
             else:
@@ -502,19 +506,19 @@ def canonical_precision(message: ord_schema.UnitMessage, target: str) -> float |
     Returns:
         The converted precision, or None when the message records no precision, no
         value to attach it to, no units, or units that cannot be converted to
-        ``target``.
+        ``target``. Also None where the conversion declines to state one: an inverted
+        interval reaching zero is unbounded, and no number describes it.
     """
-    if (
-        not message.HasField("value")
-        or not message.HasField("precision")
-        or not message.units
-    ):
+    if not message.HasField("value") or not message.units:
         return None
     try:
         # Read from the conversion rather than scaling here: Temperature is an offset
         # scale, where precision converts by the ratio alone, and Wavelength inverts,
-        # where it does not converge on a single factor at all.
-        return RESOLVER.convert(message, target).precision
+        # where it does not converge on a single factor at all. Presence follows the
+        # conversion for the same reason -- it is what knows whether the target units
+        # can carry an uncertainty at all.
+        converted = RESOLVER.convert(message, target)
+        return converted.precision if converted.HasField("precision") else None
     except (KeyError, ValueError, ZeroDivisionError):
         logger.warning(
             "cannot convert %s precision to %s; reading as null",

--- a/ord_schema/units.py
+++ b/ord_schema/units.py
@@ -491,18 +491,24 @@ def canonical_precision(message: ord_schema.UnitMessage, target: str) -> float |
     """Converts a united message's precision to ``target`` units, or returns None.
 
     Precision is recorded in the same units as the value, so it converts with the value
-    and is null under the same conditions -- a column named for ``target`` has nowhere
-    to say its uncertainty is in different units.
+    and is null wherever the value is -- a column named for ``target`` has nowhere to
+    say its uncertainty is in different units, and an uncertainty published beside a
+    null reads as a measurement nobody took but everybody bounded.
 
     Args:
         message: A united message, e.g. Temperature or Mass.
         target: Unit to convert to, spelled as the resolver understands it, e.g. "K".
 
     Returns:
-        The converted precision, or None when the message records none, records no
-        units, or records units that cannot be converted to ``target``.
+        The converted precision, or None when the message records no precision, no
+        value to attach it to, no units, or units that cannot be converted to
+        ``target``.
     """
-    if not message.HasField("precision") or not message.units:
+    if (
+        not message.HasField("value")
+        or not message.HasField("precision")
+        or not message.units
+    ):
         return None
     try:
         # Read from the conversion rather than scaling here: Temperature is an offset

--- a/ord_schema/units_test.py
+++ b/ord_schema/units_test.py
@@ -446,3 +446,59 @@ def test_every_unit_converts_to_every_other(resolver, message_type):
         message = message_type(value=1.0, units=source)
         for target in unit_values:
             assert resolver.convert(message, target).units == target
+
+
+@pytest.mark.parametrize(
+    ("message", "target", "expected"),
+    [
+        # An offset scale: the precision converts by the ratio alone, so the same
+        # multiplier applied to the value would be wrong.
+        (
+            reaction_pb2.Temperature(
+                value=77, units=reaction_pb2.Temperature.FAHRENHEIT, precision=1.8
+            ),
+            "K",
+            1.0,
+        ),
+        (
+            reaction_pb2.Temperature(
+                value=25, units=reaction_pb2.Temperature.CELSIUS, precision=0.5
+            ),
+            "K",
+            0.5,
+        ),
+        (
+            reaction_pb2.Mass(
+                value=500, units=reaction_pb2.Mass.MILLIGRAM, precision=10
+            ),
+            "g",
+            0.01,
+        ),
+        (
+            reaction_pb2.Time(value=90, units=reaction_pb2.Time.MINUTE, precision=1.5),
+            "s",
+            90.0,
+        ),
+        # Recorded zero is a precision the source stated, not a missing one.
+        (
+            reaction_pb2.Mass(value=1, units=reaction_pb2.Mass.GRAM, precision=0.0),
+            "g",
+            0.0,
+        ),
+    ],
+)
+def test_canonical_precision(message, target, expected):
+    assert units.canonical_precision(message, target) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # No precision recorded.
+        reaction_pb2.Mass(value=1, units=reaction_pb2.Mass.GRAM),
+        # Precision recorded, but nothing says what unit it is in.
+        reaction_pb2.Mass(value=1, precision=0.1),
+    ],
+)
+def test_canonical_precision_is_null(message):
+    assert units.canonical_precision(message, "g") is None

--- a/ord_schema/units_test.py
+++ b/ord_schema/units_test.py
@@ -498,7 +498,28 @@ def test_canonical_precision(message, target, expected):
         reaction_pb2.Mass(value=1, units=reaction_pb2.Mass.GRAM),
         # Precision recorded, but nothing says what unit it is in.
         reaction_pb2.Mass(value=1, precision=0.1),
+        # Precision recorded against no value: an uncertainty published beside a null
+        # value reads as a measurement nobody took but everybody bounded.
+        reaction_pb2.Mass(precision=0.1, units=reaction_pb2.Mass.GRAM),
     ],
 )
 def test_canonical_precision_is_null(message):
     assert units.canonical_precision(message, "g") is None
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        reaction_pb2.Temperature(precision=0.5, units=reaction_pb2.Temperature.CELSIUS),
+        reaction_pb2.Time(precision=1.5, units=reaction_pb2.Time.MINUTE),
+        reaction_pb2.Wavelength(precision=10, units=reaction_pb2.Wavelength.NANOMETER),
+    ],
+)
+def test_precision_without_a_value_is_null_for_every_conversion_kind(message):
+    # Offset scales, multiplier scales, and the inverting one all reach the value
+    # through a different branch of convert(), so each is checked.
+    target = {"Temperature": "K", "Time": "s", "Wavelength": "nm"}[
+        type(message).__name__
+    ]
+    assert units.canonical_value(message, target) is None
+    assert units.canonical_precision(message, target) is None

--- a/ord_schema/units_test.py
+++ b/ord_schema/units_test.py
@@ -289,10 +289,9 @@ def test_convert_precision(resolver, message, new_units, expected):
 
 
 def test_convert_wavelength_with_precision(resolver):
-    # Expected per the implementation's documented formula:
-    # (documented formula)
-    # 10000000 / 2 * (1 / (value - precision) + 1 / (value + precision))  # noqa: ERA001
-    # = 5e6 * (1/490 + 1/510) ≈ 20008.0032.
+    # Inverting maps [490, 510] nm onto [19607.8, 20408.2] cm^-1, and the precision is
+    # half that width: 5e6 * (1/490 - 1/510) ≈ 400.16. Averaging the endpoints instead
+    # would give ≈ 20008, an uncertainty as large as the value it qualifies.
     converted = resolver.convert(
         reaction_pb2.Wavelength(
             value=500, units=reaction_pb2.Wavelength.NANOMETER, precision=10
@@ -301,7 +300,7 @@ def test_convert_wavelength_with_precision(resolver):
     )
     assert converted.units == reaction_pb2.Wavelength.WAVENUMBER
     assert converted.value == pytest.approx(20000)
-    assert converted.precision == pytest.approx(20008.003201, rel=1e-6)
+    assert converted.precision == pytest.approx(400.160064, rel=1e-6)
 
 
 @pytest.mark.parametrize(
@@ -479,12 +478,6 @@ def test_every_unit_converts_to_every_other(resolver, message_type):
             "s",
             90.0,
         ),
-        # Recorded zero is a precision the source stated, not a missing one.
-        (
-            reaction_pb2.Mass(value=1, units=reaction_pb2.Mass.GRAM, precision=0.0),
-            "g",
-            0.0,
-        ),
     ],
 )
 def test_canonical_precision(message, target, expected):
@@ -501,6 +494,9 @@ def test_canonical_precision(message, target, expected):
         # Precision recorded against no value: an uncertainty published beside a null
         # value reads as a measurement nobody took but everybody bounded.
         reaction_pb2.Mass(precision=0.1, units=reaction_pb2.Mass.GRAM),
+        # A recorded zero: "+/- 0" carries nothing a null does not, and convert()
+        # already declines to propagate it.
+        reaction_pb2.Mass(value=1, units=reaction_pb2.Mass.GRAM, precision=0.0),
     ],
 )
 def test_canonical_precision_is_null(message):
@@ -523,3 +519,36 @@ def test_precision_without_a_value_is_null_for_every_conversion_kind(message):
     ]
     assert units.canonical_value(message, target) is None
     assert units.canonical_precision(message, target) is None
+
+
+@pytest.mark.parametrize(
+    ("message", "target", "value", "precision"),
+    [
+        # Inverting: the precision is half the width of the mapped interval, not the
+        # distance to it. A value of 10000 nm cannot be uncertain by 10001 nm.
+        (
+            reaction_pb2.Wavelength(
+                value=1000, precision=10, units=reaction_pb2.Wavelength.WAVENUMBER
+            ),
+            "nm",
+            10000.0,
+            100.01,
+        ),
+        # The interval reaches zero, so it inverts to an unbounded one. The value still
+        # converts, and losing it to a precision that cannot be stated would be worse.
+        (
+            reaction_pb2.Wavelength(
+                value=100, precision=100, units=reaction_pb2.Wavelength.WAVENUMBER
+            ),
+            "nm",
+            100000.0,
+            None,
+        ),
+    ],
+)
+def test_canonical_wavelength(message, target, value, precision):
+    assert units.canonical_value(message, target) == pytest.approx(value)
+    if precision is None:
+        assert units.canonical_precision(message, target) is None
+    else:
+        assert units.canonical_precision(message, target) == pytest.approx(precision)

--- a/ord_schema/views.py
+++ b/ord_schema/views.py
@@ -18,6 +18,14 @@ A view restates the reactions in a Parquet dataset as flat, queryable columns --
 reaction and per-component SMILES, the scalar condition and outcome measurements, and
 provenance -- so a consumer can filter the corpus without deserializing every proto.
 
+A view is a **narrowing of the projection**, and is derived from one. Every column it
+publishes is already a leaf there, so a second derivation would be a second code path
+obliged to agree with the first about the same values, and it would pay for a full
+deserialization and a canonicalization of every structure to reach what a handful of
+column reads already hold. What is decided here is what the projection deliberately does
+not: which of several plausible fields a column means, and how to reduce a repeated one
+to a scalar.
+
 A view is deliberately **small rather than complete**. It carries the handful of columns
 a consumer wants on first contact, in a shape that reads at a glance and previews in a
 dataset browser. Reaching the rest of the proto is a different artifact's job; a column
@@ -27,9 +35,9 @@ populated in three of fifty-three datasets teaches a reader to expect nulls ever
 and earns its place nowhere.
 
 A view **adds no information**. Every column is a re-projection of what the source
-protos already say, computed from the source alone with this library and RDKit, so a
-view that disagrees with its source is wrong and a stale view is a bug. Two consequences
-shape what may be added here:
+protos already say, reached through the projection with this library, so a view that
+disagrees with its source is wrong and a stale view is a bug. Two consequences shape
+what may be added here:
 
 * **No policy columns.** If a value depends on a threshold, cutoff, or classification
   that a reasonable consumer might set differently, it belongs in that consumer's query,
@@ -40,33 +48,28 @@ shape what may be added here:
   expanded through Crossref -- is a different kind of artifact and does not belong in a
   view.
 
-Where the projection has to make a choice, it is documented rather than inferred:
+Where a choice has to be made, it is documented rather than inferred. The structural
+ones belong to the projection and are inherited here, so the two artifacts cannot
+disagree about what a molecule is:
 
-* Component SMILES prefer the CXSMILES form the source recorded, falling back to plain
-  SMILES and then to any other structural identifier that parses (MOLBLOCK, InChI).
-  CXSMILES is a superset -- RDKit reads either -- so preferring it keeps the enhanced
-  stereochemistry that plain SMILES cannot express, at the cost of an extension block on
-  some values; ``split_cxsmiles_extension`` splits the bare SMILES from the block for a
-  consumer that wants them apart. Fragment grouping does not survive canonicalization.
-  Canonical values are what make the column comparable across datasets that spell the
-  same molecule differently.
+* ``smiles`` on a component prefers the CXSMILES form the source recorded, falling back
+  to plain SMILES and then to any other structural identifier that parses; the
+  reaction's own prefers a recorded ``REACTION_CXSMILES`` or ``REACTION_SMILES``,
+  normalized with its agents removed, and is generated from the components only when
+  nothing readable was recorded. See :mod:`ord_schema.projection`.
+
+The rest are the view's own, and are why it is not simply a column subset:
+
 * ``input_smiles`` carries every component of every input whatever its reaction role, so
   unlike ``reaction_smiles`` it lists solvents, reagents, and catalysts. Components with
   no readable structure are dropped from both list columns, which therefore are not a
   component census; the count of what was dropped is logged per dataset.
-* ``reaction_smiles`` prefers the recorded ``REACTION_CXSMILES`` or ``REACTION_SMILES``,
-  which carries what generation cannot reconstruct -- above all atom mapping. It is
-  normalized rather than copied: agents are removed and the result canonicalized, so
-  agent placement and atom ordering stop deciding whether two reactions look alike. A
-  reaction recording neither, one RDKit cannot read, or one that survives normalization
-  as a half reaction gets a SMILES generated from its components, again without agents
-  and only when every reactant and product is readable. See
-  ``message_helpers.derived_reaction_smiles``.
 * Inputs are visited in sorted key order, so ``input_smiles`` is stable across runs
-  rather than following protobuf map iteration, which is neither sorted nor insertion
-  ordered. That order is the column's own; it does not line up with ``reaction_smiles``,
-  which is deduplicated, sorted by SMILES, and usually read from a recorded identifier
-  that never consulted the components at all.
+  rather than following the projection's map order, which preserves protobuf map
+  iteration and is neither sorted nor insertion ordered. That order is the column's own;
+  it does not line up with ``reaction_smiles``, which is deduplicated, sorted by SMILES,
+  and usually read from a recorded identifier that never consulted the components at
+  all.
 * ``yield_percent`` is the largest YIELD percentage on any product of any outcome, and
   ``reaction_time_seconds`` is the first outcome that records one -- matching the SMILES
   columns, which also span every outcome. A yield the source records only as
@@ -79,10 +82,9 @@ Where the projection has to make a choice, it is documented rather than inferred
   ``ReactionOutcome.reaction_time``, not any of the eight other Time-typed fields --
   addition, workup, observation, and retention times, or the timestamps on individual
   temperature, pressure, and electrochemistry measurements.
-* Measurements are converted to one canonical unit per column (kelvin, seconds). A
-  measurement whose units the resolver cannot read, including one recorded with no
-  units at all, reads as null: an unlabeled number has nowhere in the column to say
-  what unit it is in.
+* Measurements are read from the projection's canonical-unit columns (kelvin, seconds),
+  so a measurement whose units the resolver could not read arrives null: an unlabeled
+  number has nowhere in the column to say what unit it is in.
 
 The scalar and string columns are null where the source is silent, never zero. The two
 list columns are empty rather than null, so a reaction whose components have no readable
@@ -91,18 +93,47 @@ structure is not distinguishable from one with no components by that column alon
 
 import dataclasses
 import math
+import operator
 import os
+from typing import Any
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from ord_schema import artifacts, atomic_io, message_helpers, parquet, units
+from ord_schema import artifacts, atomic_io
 from ord_schema.logging import get_logger
 from ord_schema.proto import reaction_pb2
 
 logger = get_logger(__name__)
 
 ARTIFACT = "view"
+
+# The projection writes an enum as its value name, so a yield is matched by name.
+# Resolved from the descriptor, so renaming the value upstream fails at import instead
+# of leaving a literal here that matches nothing.
+_YIELD = reaction_pb2.ProductMeasurement.ProductMeasurementType.Name(
+    reaction_pb2.ProductMeasurement.YIELD
+)
+
+# The projection leaves a view reads, as Parquet column paths so only these are decoded.
+# Every one is a value the projection already computed, which is what makes a view cheap
+# to derive: no proto is deserialized and no structure is canonicalized again.
+_PROJECTION_COLUMNS = (
+    "reaction_id",
+    "smiles",
+    # Both halves of the map: the values carry the structures, and the keys are what
+    # ``input_smiles`` sorts by.
+    "inputs.key_value.key",
+    "inputs.key_value.value.components.list.element.smiles",
+    "outcomes.list.element.reaction_time_seconds",
+    "outcomes.list.element.products.list.element.smiles",
+    "outcomes.list.element.products.list.element.measurements.list.element.type",
+    "outcomes.list.element.products.list.element.measurements.list.element"
+    ".percentage.value",
+    "conditions.temperature.setpoint_kelvin",
+    "provenance.doi",
+    "provenance.patent",
+)
 
 SCHEMA = pa.schema(
     [
@@ -148,8 +179,29 @@ class _Skipped:
         )
 
 
+def _nested(row: Any, *keys: str) -> Any:
+    """Returns the value at a chain of struct keys, or None if any level is absent.
+
+    The projection writes an unset message as null rather than an empty struct, so a
+    reaction that records no conditions at all has ``conditions`` itself missing, not a
+    ``conditions`` holding a missing ``temperature``.
+
+    Args:
+        row: A projected row, or any struct within one.
+        *keys: Field names to follow, outermost first.
+
+    Returns:
+        The value at the end of the chain, or None if the chain is broken.
+    """
+    for key in keys:
+        if row is None:
+            return None
+        row = row[key]
+    return row
+
+
 def _outcome_values(
-    reaction: reaction_pb2.Reaction, skipped: _Skipped
+    projected: dict, skipped: _Skipped
 ) -> tuple[float | None, float | None]:
     """Returns the largest yield over all outcomes, and the first reaction time.
 
@@ -158,7 +210,7 @@ def _outcome_values(
     source is silent when it is not.
 
     Args:
-        reaction: Reaction to read.
+        projected: One row of the projection.
         skipped: Tallies to add to for values that cannot be used.
 
     Returns:
@@ -167,23 +219,23 @@ def _outcome_values(
     """
     best_yield = None
     reaction_time_seconds = None
-    for outcome in reaction.outcomes:
+    for outcome in projected["outcomes"] or []:
         if reaction_time_seconds is None:
-            reaction_time_seconds = units.canonical_value(outcome.reaction_time, "s")
-        for product in outcome.products:
-            for measurement in product.measurements:
-                if measurement.type != reaction_pb2.ProductMeasurement.YIELD:
+            reaction_time_seconds = outcome["reaction_time_seconds"]
+        for product in outcome["products"] or []:
+            for measurement in product["measurements"] or []:
+                if measurement["type"] != _YIELD:
                     continue
-                if not measurement.HasField("percentage"):
+                if measurement["percentage"] is None:
                     # A yield recorded as float_value, amount, or text. Reading it
                     # would require assuming a scale the source did not state.
                     skipped.unyielding += 1
                     continue
-                if not measurement.percentage.HasField("value"):
-                    # An unset value reads as 0.0 through protobuf, and a fabricated
-                    # zero yield is worse than a null.
+                value = measurement["percentage"]["value"]
+                if value is None:
+                    # A percentage message carrying no value. A fabricated zero yield
+                    # is worse than a null.
                     continue
-                value = measurement.percentage.value
                 if not math.isfinite(value):
                     # NaN compares False against everything, so leaving it in would
                     # make the result depend on the order measurements were recorded.
@@ -195,92 +247,70 @@ def _outcome_values(
 
 
 def _component_smiles(
-    reaction: reaction_pb2.Reaction, skipped: _Skipped
+    projected: dict, skipped: _Skipped
 ) -> tuple[list[str], list[str]]:
     """Returns ``(input_smiles, output_smiles)``, skipping components without structure.
 
     Inputs are visited in sorted key order, so the column is stable across runs rather
-    than following protobuf map iteration, which is neither sorted nor insertion
-    ordered.
+    than following the projection's map order, which preserves protobuf map iteration
+    and is neither sorted nor insertion ordered.
 
     Args:
-        reaction: Reaction to read.
+        projected: One row of the projection.
         skipped: Tallies to add to for components with no readable structure.
 
     Returns:
-        Canonical SMILES for every input component and every outcome product that has a
-        readable structure. A component without one is dropped, so the lists are not a
+        The SMILES the projection derived for every input component and every outcome
+        product that has one. A component without one is dropped, so the lists are not a
         component census.
     """
     inputs = []
-    for key in sorted(reaction.inputs):
-        for compound in reaction.inputs[key].components:
-            smiles = message_helpers.smiles_from_compound(compound)
-            if smiles:
-                inputs.append(smiles)
+    for _, value in sorted(projected["inputs"] or [], key=operator.itemgetter(0)):
+        for component in value["components"] or []:
+            if component["smiles"]:
+                inputs.append(component["smiles"])
             else:
                 skipped.components += 1
     outputs = []
-    for outcome in reaction.outcomes:
-        for product in outcome.products:
-            smiles = message_helpers.smiles_from_compound(product)
-            if smiles:
-                outputs.append(smiles)
+    for outcome in projected["outcomes"] or []:
+        for product in outcome["products"] or []:
+            if product["smiles"]:
+                outputs.append(product["smiles"])
             else:
                 skipped.components += 1
     return inputs, outputs
 
 
-def reaction_row(
-    reaction: reaction_pb2.Reaction,
-    reaction_id: str | None = None,
-    skipped: _Skipped | None = None,
-) -> dict:
-    """Projects one Reaction onto the view columns.
+def reaction_row(projected: dict, skipped: _Skipped | None = None) -> dict:
+    """Narrows one row of the projection onto the view columns.
+
+    The projection reconciled the reaction ID against the Reaction it projected, so a
+    column disagreeing with its message cannot reach here.
 
     Args:
-        reaction: Reaction message to project.
-        reaction_id: The source's ``reaction_id`` column value, checked against the
-            message rather than trusted. ``DatasetView.md5`` hashes the Reaction blobs
-            and not that column, so an ID taken from it would be a published value
-            outside the staleness hash. Defaults to the message's own ID.
+        projected: One row of the projection, holding at least ``_PROJECTION_COLUMNS``.
         skipped: Tallies to add to for values this row drops. A caller deriving one row
             outside ``write_view`` can leave it unset.
 
     Returns:
         A dict keyed by ``SCHEMA.names``, with None wherever the source is silent.
-
-    Raises:
-        ValueError: If ``reaction_id`` is empty or disagrees with the message, either of
-            which means the source cannot be joined on its own key.
     """
-    if reaction_id is not None:
-        if not reaction_id:
-            raise ValueError(
-                f"reaction_id column is {reaction_id!r}; the reaction records "
-                f"{reaction.reaction_id!r}"
-            )
-        if reaction_id != reaction.reaction_id:
-            raise ValueError(
-                f"reaction_id column {reaction_id!r} disagrees with the reaction's own "
-                f"{reaction.reaction_id!r}"
-            )
     if skipped is None:
         skipped = _Skipped()
-    yield_percent, reaction_time_seconds = _outcome_values(reaction, skipped)
-    inputs, outputs = _component_smiles(reaction, skipped)
+    yield_percent, reaction_time_seconds = _outcome_values(projected, skipped)
+    inputs, outputs = _component_smiles(projected, skipped)
     return {
-        "reaction_id": reaction.reaction_id,
-        "reaction_smiles": message_helpers.derived_reaction_smiles(reaction),
+        "reaction_id": projected["reaction_id"],
+        "reaction_smiles": projected["smiles"],
         "input_smiles": inputs,
         "output_smiles": outputs,
         "yield_percent": yield_percent,
-        "temperature_kelvin": units.canonical_value(
-            reaction.conditions.temperature.setpoint, "K"
+        "temperature_kelvin": _nested(
+            projected, "conditions", "temperature", "setpoint_kelvin"
         ),
         "reaction_time_seconds": reaction_time_seconds,
-        "doi": reaction.provenance.doi or None,
-        "patent": reaction.provenance.patent or None,
+        "doi": _nested(projected, "provenance", "doi"),
+        "patent": _nested(projected, "provenance", "patent"),
     }
 
 
@@ -295,56 +325,70 @@ def is_current(path: str | os.PathLike[str], source_md5: str) -> bool:
 
 
 def write_view(
-    source: parquet.DatasetView,
+    source: str | os.PathLike[str],
     output: str | os.PathLike[str],
     *,
     source_md5: str | None = None,
+    source_dataset_id: str | None = None,
     compression: str = "zstd",
     row_group_size: int = 1000,
 ) -> int:
-    """Derives a view from a source Parquet dataset and writes it.
+    """Narrows a projection into a view and writes it.
 
-    Reactions are read and written one source row group at a time, so peak memory is
-    bounded by the largest row group rather than the dataset. The output is published
-    atomically, so a failure partway leaves any existing view untouched.
+    Only the leaves the view publishes are decoded, one projection row group at a time,
+    so peak memory is bounded by the largest row group rather than the dataset. The
+    output is published atomically, so a failure partway leaves any existing view
+    untouched.
 
     Args:
-        source: View of the source Parquet dataset.
+        source: Path to the projection to narrow.
         output: Path to write the view to.
-        source_md5: Source hash to stamp, if the caller already computed one (e.g. to
-            check whether the view was current). Hashed here when omitted, which costs a
-            full pass over the source.
+        source_md5: Hash of the *source dataset* to stamp, if the caller already read
+            one. Taken from the projection's own stamps when omitted, so a view names
+            the dataset it reflects rather than the artifact it read.
+        source_dataset_id: Source dataset ID to stamp, if the caller already read one.
+            Taken from the projection's stamps when omitted.
         compression: Parquet compression codec.
         row_group_size: Rows per output row group.
 
     Returns:
         Number of rows written.
+
+    Raises:
+        ValueError: If ``source`` is not a projection, or if a row cannot be narrowed.
     """
-    if source_md5 is None:
-        source_md5 = source.md5()
-    stamps = artifacts.current_stamps(ARTIFACT, source.dataset_id or None, source_md5)
+    if source_md5 is None or source_dataset_id is None:
+        parent = artifacts.load_stamps(source)
+        if source_md5 is None:
+            source_md5 = parent.source_md5
+        if source_dataset_id is None:
+            source_dataset_id = parent.source_dataset_id
+    stamps = artifacts.current_stamps(ARTIFACT, source_dataset_id, source_md5)
     schema = SCHEMA.with_metadata(artifacts.to_metadata(stamps))
     rows = 0
     skipped = _Skipped()
     with (
+        pq.ParquetFile(source) as projected,
         atomic_io.atomic_path(output) as temp_path,
         pq.ParquetWriter(temp_path, schema, compression=compression) as writer,
     ):
-        for row_group in range(source.num_row_groups):
+        for row_group in range(projected.num_row_groups):
             # Seeded from SCHEMA.names so an unexpected key raises here rather than
             # being dropped silently, which from_pylist would do.
             batch: dict[str, list] = {name: [] for name in SCHEMA.names}
-            for reaction_id, reaction in source.iter_reactions(row_group=row_group):
+            table = projected.read_row_group(
+                row_group, columns=list(_PROJECTION_COLUMNS)
+            )
+            for row in table.to_pylist():
                 try:
-                    row = reaction_row(reaction, reaction_id, skipped)
+                    for name, value in reaction_row(row, skipped).items():
+                        batch[name].append(value)
                 except Exception as error:
                     # A corpus run has thousands of datasets and millions of reactions;
                     # neither is in the traceback without this.
                     raise ValueError(
-                        f"{source.path}: {reaction_id}: {error}"
+                        f"{source}: {row.get('reaction_id')}: {error}"
                     ) from error
-                for name, value in row.items():
-                    batch[name].append(value)
                 rows += 1
             writer.write_table(
                 pa.Table.from_pydict(batch, schema=schema),
@@ -353,5 +397,5 @@ def write_view(
     if skipped:
         # Per dataset rather than per row: a count is diffable between runs, so a
         # regression in structure reading shows up instead of hiding in the nulls.
-        logger.info("%s: %s", source.path, skipped)
+        logger.info("%s: %s", source, skipped)
     return rows

--- a/ord_schema/views.py
+++ b/ord_schema/views.py
@@ -100,7 +100,7 @@ from typing import Any
 import pyarrow as pa
 import pyarrow.parquet as pq
 
-from ord_schema import artifacts, atomic_io
+from ord_schema import artifacts, atomic_io, projection
 from ord_schema.logging import get_logger
 from ord_schema.proto import reaction_pb2
 
@@ -357,12 +357,19 @@ def write_view(
     Raises:
         ValueError: If ``source`` is not a projection, or if a row cannot be narrowed.
     """
-    if source_md5 is None or source_dataset_id is None:
-        parent = artifacts.load_stamps(source)
-        if source_md5 is None:
-            source_md5 = parent.source_md5
-        if source_dataset_id is None:
-            source_dataset_id = parent.source_dataset_id
+    # Read unconditionally rather than only to fill in what the caller omitted: naming
+    # the wrong kind of file is worth a sentence, and the alternative is a KeyError on
+    # a column the file was never going to have.
+    parent = artifacts.load_stamps(source)
+    if parent.artifact != projection.ARTIFACT:
+        raise ValueError(
+            f"{source} is a {parent.artifact}, not a {projection.ARTIFACT}; a view "
+            "narrows a projection"
+        )
+    if source_md5 is None:
+        source_md5 = parent.source_md5
+    if source_dataset_id is None:
+        source_dataset_id = parent.source_dataset_id
     stamps = artifacts.current_stamps(ARTIFACT, source_dataset_id, source_md5)
     schema = SCHEMA.with_metadata(artifacts.to_metadata(stamps))
     rows = 0

--- a/ord_schema/views_test.py
+++ b/ord_schema/views_test.py
@@ -539,3 +539,60 @@ def test_components_identified_only_by_cxsmiles_are_kept():
     assert views.reaction_row(projection.message_row(reaction))["input_smiles"] == [
         "c1ccccc1"
     ]
+
+
+def test_every_projection_column_read_is_a_leaf_of_the_projection_schema(tmp_path):
+    # pq.read_row_group drops a column path it cannot find and raises nothing, so a
+    # leaf renamed in the projection would surface as a KeyError on the first reaction
+    # that happens to populate it -- or not at all, for a path _nested short-circuits
+    # past. Checked against the schema instead, where a rename fails immediately.
+    path = tmp_path / "empty.parquet"
+    pq.write_table(projection.SCHEMA.empty_table(), path)
+    with pq.ParquetFile(path) as parquet_file:
+        paths = {
+            parquet_file.schema.column(i).path for i in range(len(parquet_file.schema))
+        }
+    assert set(views._PROJECTION_COLUMNS) <= paths
+
+
+def test_write_view_populates_every_column_through_parquet(tmp_path):
+    # The unit tests above narrow an in-memory row holding every projection column;
+    # write_view narrows a column-pruned Parquet read. Only a round trip that populates
+    # all nine columns exercises the paths in _PROJECTION_COLUMNS.
+    reaction = _reaction()
+    reaction.conditions.temperature.setpoint.value = 25.0
+    reaction.conditions.temperature.setpoint.units = reaction_pb2.Temperature.CELSIUS
+    outcome = reaction.outcomes[0]
+    outcome.reaction_time.value = 2.0
+    outcome.reaction_time.units = reaction_pb2.Time.HOUR
+    outcome.products[0].measurements.add(type="YIELD").percentage.value = 87.5
+    reaction.provenance.doi = "10.1000/example"
+    reaction.provenance.patent = "US1234567"
+    source = _project(tmp_path, _dataset(reaction))
+    output = tmp_path / "view.parquet"
+    assert views.write_view(source.path, output) == 1
+    row = pq.read_table(output).to_pylist()[0]
+    assert row == {
+        "reaction_id": "ord-0001",
+        "reaction_smiles": "c1ccccc1>>Cc1ccccc1",
+        "input_smiles": ["c1ccccc1"],
+        "output_smiles": ["Cc1ccccc1"],
+        "yield_percent": pytest.approx(87.5),
+        "temperature_kelvin": pytest.approx(298.15),
+        "reaction_time_seconds": pytest.approx(7200.0),
+        "doi": "10.1000/example",
+        "patent": "US1234567",
+    }
+
+
+def test_reaction_time_takes_the_first_outcome_that_records_one(tmp_path):
+    # Documented in the module docstring, and untested until now: mutating the guard so
+    # a later outcome wins left the whole suite green.
+    reaction = _reaction()
+    reaction.outcomes[0].reaction_time.value = 1.0
+    reaction.outcomes[0].reaction_time.units = reaction_pb2.Time.HOUR
+    later = reaction.outcomes.add()
+    later.reaction_time.value = 5.0
+    later.reaction_time.units = reaction_pb2.Time.HOUR
+    row = views.reaction_row(projection.message_row(reaction))
+    assert row["reaction_time_seconds"] == pytest.approx(3600.0)

--- a/ord_schema/views_test.py
+++ b/ord_schema/views_test.py
@@ -295,6 +295,17 @@ def test_a_yield_percentage_with_no_value_is_null_not_zero():
     assert views.reaction_row(projection.message_row(reaction))["yield_percent"] is None
 
 
+def test_a_yield_the_source_records_as_zero_is_kept():
+    # The complement of the test above, and the case that breaks first if presence
+    # handling regresses anywhere on the path: Percentage.value carries explicit
+    # presence, so a reaction reported as 0% has to reach the column as 0.0 rather
+    # than collapse into the null that means "unrecorded".
+    reaction = _reaction()
+    measurement = reaction.outcomes[0].products[0].measurements.add(type="YIELD")
+    measurement.percentage.value = 0.0
+    assert views.reaction_row(projection.message_row(reaction))["yield_percent"] == 0.0
+
+
 def test_a_yield_not_recorded_as_a_percentage_is_null():
     # Reading float_value would assume a scale the source never stated.
     reaction = _reaction()

--- a/ord_schema/views_test.py
+++ b/ord_schema/views_test.py
@@ -596,3 +596,19 @@ def test_reaction_time_takes_the_first_outcome_that_records_one(tmp_path):
     later.reaction_time.units = reaction_pb2.Time.HOUR
     row = views.reaction_row(projection.message_row(reaction))
     assert row["reaction_time_seconds"] == pytest.approx(3600.0)
+
+
+def test_write_view_refuses_a_view_as_its_parent(tmp_path):
+    # derive_tree screens this for the CLI, so it is a direct caller who would
+    # otherwise get a KeyError naming a column the file was never going to have.
+    source = _project(tmp_path)
+    already = tmp_path / "already.parquet"
+    views.write_view(source.path, already)
+    with pytest.raises(ValueError, match="narrows a projection"):
+        views.write_view(already, tmp_path / "out.parquet")
+
+
+def test_write_view_refuses_a_source_dataset_as_its_parent(tmp_path):
+    _project(tmp_path)
+    with pytest.raises(ValueError, match="not a derived artifact"):
+        views.write_view(tmp_path / "ds.parquet", tmp_path / "out.parquet")

--- a/ord_schema/views_test.py
+++ b/ord_schema/views_test.py
@@ -14,12 +14,14 @@
 
 """Tests for ord_schema.views."""
 
+import pathlib
 from importlib import metadata
+from typing import NamedTuple
 
 import pyarrow.parquet as pq
 import pytest
 
-from ord_schema import artifacts, parquet, views
+from ord_schema import artifacts, parquet, projection, views
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 
@@ -52,7 +54,7 @@ def _dataset(*reactions, dataset_id="ord_dataset-0000000000000000000000000000000
 
 
 def test_reaction_row_projects_the_documented_columns():
-    row = views.reaction_row(_reaction())
+    row = views.reaction_row(projection.message_row(_reaction()))
     assert set(row) == set(views.SCHEMA.names)
     assert row["reaction_id"] == "ord-0001"
     assert row["reaction_smiles"] == "c1ccccc1>>Cc1ccccc1"
@@ -61,7 +63,7 @@ def test_reaction_row_projects_the_documented_columns():
 
 
 def test_reaction_row_is_null_where_the_source_is_silent():
-    row = views.reaction_row(_reaction())
+    row = views.reaction_row(projection.message_row(_reaction()))
     for column in (
         "yield_percent",
         "temperature_kelvin",
@@ -75,7 +77,7 @@ def test_reaction_row_is_null_where_the_source_is_silent():
 def test_reaction_smiles_is_generated_when_not_stored():
     reaction = _reaction()
     del reaction.identifiers[:]
-    row = views.reaction_row(reaction)
+    row = views.reaction_row(projection.message_row(reaction))
     assert row["reaction_smiles"] == "c1ccccc1>>Cc1ccccc1"
 
 
@@ -87,7 +89,7 @@ def test_a_recorded_reaction_smiles_keeps_its_atom_mapping():
         type="REACTION_SMILES",
         value="[CH3:1][OH:2].[C:3](=O)O>CCO.[Na+]>[CH3:1][O:2][C:3]=O",
     )
-    value = views.reaction_row(reaction)["reaction_smiles"]
+    value = views.reaction_row(projection.message_row(reaction))["reaction_smiles"]
     for atom_map in (":1]", ":2]", ":3]"):
         assert atom_map in value
     # ...with the agents normalized away.
@@ -102,7 +104,10 @@ def test_agents_are_left_out_of_the_generated_reaction_smiles():
     del reaction.identifiers[:]
     catalyst = reaction.inputs["cat"].components.add(reaction_role="CATALYST")
     catalyst.identifiers.add(type="SMILES", value="[Pd]")
-    assert views.reaction_row(reaction)["reaction_smiles"] == "c1ccccc1>>Cc1ccccc1"
+    assert (
+        views.reaction_row(projection.message_row(reaction))["reaction_smiles"]
+        == "c1ccccc1>>Cc1ccccc1"
+    )
 
 
 def test_a_ligand_recorded_only_by_name_does_not_null_the_reaction_smiles():
@@ -110,7 +115,10 @@ def test_a_ligand_recorded_only_by_name_does_not_null_the_reaction_smiles():
     del reaction.identifiers[:]
     ligand = reaction.inputs["cat"].components.add(reaction_role="CATALYST")
     ligand.identifiers.add(type="NAME", value="ItBu")
-    assert views.reaction_row(reaction)["reaction_smiles"] == "c1ccccc1>>Cc1ccccc1"
+    assert (
+        views.reaction_row(projection.message_row(reaction))["reaction_smiles"]
+        == "c1ccccc1>>Cc1ccccc1"
+    )
 
 
 def test_an_unreadable_reactant_nulls_a_generated_reaction_smiles():
@@ -120,7 +128,9 @@ def test_an_unreadable_reactant_nulls_a_generated_reaction_smiles():
     reaction.inputs["b"].components.add().identifiers.add(
         type="NAME", value="mystery reactant"
     )
-    assert views.reaction_row(reaction)["reaction_smiles"] is None
+    assert (
+        views.reaction_row(projection.message_row(reaction))["reaction_smiles"] is None
+    )
 
 
 def test_enhanced_stereochemistry_survives_generation():
@@ -132,11 +142,17 @@ def test_enhanced_stereochemistry_survives_generation():
     reaction.outcomes.add().products.add().identifiers.add(
         type="SMILES", value="C[C@H](N)OC"
     )
-    assert "|o1:" in views.reaction_row(reaction)["reaction_smiles"]
+    assert (
+        "|o1:"
+        in views.reaction_row(projection.message_row(reaction))["reaction_smiles"]
+    )
 
 
 def test_plain_reaction_smiles_is_used_when_that_is_all_there_is():
-    assert views.reaction_row(_reaction())["reaction_smiles"] == "c1ccccc1>>Cc1ccccc1"
+    assert (
+        views.reaction_row(projection.message_row(_reaction()))["reaction_smiles"]
+        == "c1ccccc1>>Cc1ccccc1"
+    )
 
 
 def test_component_cxsmiles_is_preferred_over_plain_smiles():
@@ -146,14 +162,18 @@ def test_component_cxsmiles_is_preferred_over_plain_smiles():
     compound.identifiers.add(type="SMILES", value="C[C@H](N)O")
     compound.identifiers.add(type="CXSMILES", value="C[C@H](N)O |o1:1|")
     reaction.inputs["a"].components.append(compound)
-    assert views.reaction_row(reaction)["input_smiles"] == ["C[C@H](N)O |o1:1|"]
+    assert views.reaction_row(projection.message_row(reaction))["input_smiles"] == [
+        "C[C@H](N)O |o1:1|"
+    ]
 
 
 def test_component_smiles_are_canonicalized():
     reaction = _reaction()
     del reaction.inputs["a"]
     reaction.inputs["a"].components.append(_compound("C1=CC=CC=C1"))
-    assert views.reaction_row(reaction)["input_smiles"] == ["c1ccccc1"]
+    assert views.reaction_row(projection.message_row(reaction))["input_smiles"] == [
+        "c1ccccc1"
+    ]
 
 
 def test_component_smiles_derive_from_other_structural_identifiers():
@@ -162,19 +182,25 @@ def test_component_smiles_derive_from_other_structural_identifiers():
     compound = reaction_pb2.Compound()
     compound.identifiers.add(type="INCHI", value="InChI=1S/C6H6/c1-2-4-6-5-3-1/h1-6H")
     reaction.inputs["a"].components.append(compound)
-    assert views.reaction_row(reaction)["input_smiles"] == ["c1ccccc1"]
+    assert views.reaction_row(projection.message_row(reaction))["input_smiles"] == [
+        "c1ccccc1"
+    ]
 
 
 def test_unparseable_component_smiles_are_skipped():
     reaction = _reaction()
     reaction.inputs["a"].components.append(_compound("not-a-smiles"))
-    assert views.reaction_row(reaction)["input_smiles"] == ["c1ccccc1"]
+    assert views.reaction_row(projection.message_row(reaction))["input_smiles"] == [
+        "c1ccccc1"
+    ]
 
 
 def test_reaction_smiles_is_null_when_it_cannot_be_generated():
     reaction = reaction_pb2.Reaction(reaction_id="ord-0001")
     reaction.inputs["a"].components.append(_compound(name="benzene"))
-    assert views.reaction_row(reaction)["reaction_smiles"] is None
+    assert (
+        views.reaction_row(projection.message_row(reaction))["reaction_smiles"] is None
+    )
 
 
 def test_input_smiles_follow_sorted_keys_not_insertion_order():
@@ -188,14 +214,20 @@ def test_input_smiles_follow_sorted_keys_not_insertion_order():
     for key, smiles in reversed(keys):
         backward.inputs[key].components.append(_compound(smiles))
     expected = ["C", "CC", "CCC"]
-    assert views.reaction_row(forward)["input_smiles"] == expected
-    assert views.reaction_row(backward)["input_smiles"] == expected
+    assert (
+        views.reaction_row(projection.message_row(forward))["input_smiles"] == expected
+    )
+    assert (
+        views.reaction_row(projection.message_row(backward))["input_smiles"] == expected
+    )
 
 
 def test_components_without_smiles_are_skipped():
     reaction = _reaction()
     reaction.inputs["a"].components.append(_compound(name="mystery solvent"))
-    assert views.reaction_row(reaction)["input_smiles"] == ["c1ccccc1"]
+    assert views.reaction_row(projection.message_row(reaction))["input_smiles"] == [
+        "c1ccccc1"
+    ]
 
 
 def test_yield_takes_the_largest_measurement_on_any_product():
@@ -204,14 +236,16 @@ def test_yield_takes_the_largest_measurement_on_any_product():
     for value in (12.0, 87.5, 40.0):
         measurement = outcome.products[0].measurements.add(type="YIELD")
         measurement.percentage.value = value
-    assert views.reaction_row(reaction)["yield_percent"] == pytest.approx(87.5)
+    assert views.reaction_row(projection.message_row(reaction))[
+        "yield_percent"
+    ] == pytest.approx(87.5)
 
 
 def test_non_yield_measurements_are_ignored():
     reaction = _reaction()
     measurement = reaction.outcomes[0].products[0].measurements.add(type="PURITY")
     measurement.percentage.value = 99.0
-    assert views.reaction_row(reaction)["yield_percent"] is None
+    assert views.reaction_row(projection.message_row(reaction))["yield_percent"] is None
 
 
 def test_yield_spans_every_outcome():
@@ -224,14 +258,18 @@ def test_yield_spans_every_outcome():
     ).percentage.value = 10.0
     second = reaction.outcomes.add()
     second.products.add().measurements.add(type="YIELD").percentage.value = 90.0
-    assert views.reaction_row(reaction)["yield_percent"] == pytest.approx(90.0)
+    assert views.reaction_row(projection.message_row(reaction))[
+        "yield_percent"
+    ] == pytest.approx(90.0)
 
 
 def test_a_yield_recorded_only_on_a_later_outcome_is_not_null():
     reaction = _reaction()
     second = reaction.outcomes.add()
     second.products.add().measurements.add(type="YIELD").percentage.value = 85.0
-    assert views.reaction_row(reaction)["yield_percent"] == pytest.approx(85.0)
+    assert views.reaction_row(projection.message_row(reaction))[
+        "yield_percent"
+    ] == pytest.approx(85.0)
 
 
 def test_a_non_finite_yield_is_skipped_rather_than_winning():
@@ -243,7 +281,9 @@ def test_a_non_finite_yield_is_skipped_rather_than_winning():
             reaction.outcomes[0].products[0].measurements.add(
                 type="YIELD"
             ).percentage.value = value
-        assert views.reaction_row(reaction)["yield_percent"] == pytest.approx(91.0)
+        assert views.reaction_row(projection.message_row(reaction))[
+            "yield_percent"
+        ] == pytest.approx(91.0)
 
 
 def test_a_yield_percentage_with_no_value_is_null_not_zero():
@@ -252,7 +292,7 @@ def test_a_yield_percentage_with_no_value_is_null_not_zero():
     reaction = _reaction()
     measurement = reaction.outcomes[0].products[0].measurements.add(type="YIELD")
     measurement.percentage.precision = 1.0
-    assert views.reaction_row(reaction)["yield_percent"] is None
+    assert views.reaction_row(projection.message_row(reaction))["yield_percent"] is None
 
 
 def test_a_yield_not_recorded_as_a_percentage_is_null():
@@ -260,16 +300,7 @@ def test_a_yield_not_recorded_as_a_percentage_is_null():
     reaction = _reaction()
     measurement = reaction.outcomes[0].products[0].measurements.add(type="YIELD")
     measurement.float_value.value = 72.0
-    assert views.reaction_row(reaction)["yield_percent"] is None
-
-
-def test_reaction_row_rejects_a_reaction_id_that_disagrees_with_the_message():
-    # The column is outside DatasetView.md5, so a value read from it would be a
-    # published value the staleness hash never sees.
-    with pytest.raises(ValueError, match="disagrees"):
-        views.reaction_row(_reaction(), "ord-somewhere-else")
-    with pytest.raises(ValueError, match="reaction_id column is"):
-        views.reaction_row(_reaction(), "")
+    assert views.reaction_row(projection.message_row(reaction))["yield_percent"] is None
 
 
 @pytest.mark.parametrize(
@@ -284,7 +315,7 @@ def test_temperature_converts_to_kelvin(units_enum, value, expected):
     reaction = _reaction()
     setpoint = reaction.conditions.temperature.setpoint
     setpoint.value, setpoint.units = value, units_enum
-    row = views.reaction_row(reaction)
+    row = views.reaction_row(projection.message_row(reaction))
     assert row["temperature_kelvin"] == pytest.approx(expected)
 
 
@@ -301,37 +332,50 @@ def test_reaction_time_converts_to_seconds(units_enum, value, expected):
     reaction = _reaction()
     reaction_time = reaction.outcomes[0].reaction_time
     reaction_time.value, reaction_time.units = value, units_enum
-    assert views.reaction_row(reaction)["reaction_time_seconds"] == pytest.approx(
-        expected
-    )
+    assert views.reaction_row(projection.message_row(reaction))[
+        "reaction_time_seconds"
+    ] == pytest.approx(expected)
 
 
 def test_measurements_with_unspecified_units_read_as_null():
     reaction = _reaction()
     reaction.conditions.temperature.setpoint.value = 300.0
-    assert views.reaction_row(reaction)["temperature_kelvin"] is None
+    assert (
+        views.reaction_row(projection.message_row(reaction))["temperature_kelvin"]
+        is None
+    )
 
 
 def test_provenance_columns():
     reaction = _reaction()
     reaction.provenance.doi = "10.1000/example"
     reaction.provenance.patent = "US1234567"
-    row = views.reaction_row(reaction)
+    row = views.reaction_row(projection.message_row(reaction))
     assert row["doi"] == "10.1000/example"
     assert row["patent"] == "US1234567"
 
 
-def _write_source(tmp_path, dataset=None, *, name="ds.parquet", **kwargs):
-    path = str(tmp_path / name)
-    parquet.save_dataset(dataset or _dataset(), path, **kwargs)
-    return parquet.DatasetView(path)
+class _Projected(NamedTuple):
+    """A projection to derive a view from, and the source hash it should stamp."""
+
+    path: pathlib.Path
+    source_md5: str
+
+
+def _project(tmp_path, dataset=None, *, name="ds.parquet", **kwargs) -> _Projected:
+    """Writes a source dataset and its projection, which is what a view reads."""
+    source = tmp_path / name
+    parquet.save_dataset(dataset or _dataset(), str(source), **kwargs)
+    path = tmp_path / f"projection-{name}"
+    projection.write_projection(source, path)
+    return _Projected(path, parquet.DatasetView(source).md5())
 
 
 def test_write_view_round_trip(tmp_path):
     reactions = [_reaction(f"ord-{i:04d}") for i in range(5)]
-    source = _write_source(tmp_path, _dataset(*reactions))
+    source = _project(tmp_path, _dataset(*reactions))
     output = str(tmp_path / "view.parquet")
-    assert views.write_view(source, output) == 5
+    assert views.write_view(source.path, output) == 5
     table = pq.read_table(output)
     assert table.num_rows == 5
     assert table.schema.names == views.SCHEMA.names
@@ -341,22 +385,22 @@ def test_write_view_round_trip(tmp_path):
 
 def test_write_view_spans_multiple_row_groups(tmp_path):
     reactions = [_reaction(f"ord-{i:04d}") for i in range(10)]
-    source = _write_source(tmp_path, _dataset(*reactions), row_group_size=3)
-    assert source.num_row_groups > 1
+    source = _project(tmp_path, _dataset(*reactions), row_group_size=3)
+    assert pq.ParquetFile(source.path).num_row_groups > 1
     output = str(tmp_path / "view.parquet")
-    assert views.write_view(source, output) == 10
+    assert views.write_view(source.path, output) == 10
     assert pq.read_table(output).column("reaction_id").to_pylist() == [
         f"ord-{i:04d}" for i in range(10)
     ]
 
 
 def test_write_view_stamps_the_footer(tmp_path):
-    source = _write_source(tmp_path)
+    source = _project(tmp_path)
     output = str(tmp_path / "view.parquet")
-    views.write_view(source, output)
+    views.write_view(source.path, output)
     stamps = artifacts.load_stamps(output)
     assert stamps.artifact == views.ARTIFACT
-    assert stamps.source_md5 == source.md5()
+    assert stamps.source_md5 == source.source_md5
     assert stamps.source_dataset_id == "ord_dataset-00000000000000000000000000000000"
     assert stamps.ord_schema_version == metadata.version("ord-schema")
     assert stamps.artifact_version == artifacts.ARTIFACT_VERSION
@@ -364,26 +408,26 @@ def test_write_view_stamps_the_footer(tmp_path):
 
 def test_a_view_is_not_current_as_a_projection(tmp_path):
     # One shared artifact version means the name is what separates the two.
-    source = _write_source(tmp_path)
+    source = _project(tmp_path)
     output = str(tmp_path / "view.parquet")
-    views.write_view(source, output)
-    assert not artifacts.is_current(output, "projection", source.md5())
+    views.write_view(source.path, output)
+    assert not artifacts.is_current(output, "projection", source.source_md5)
 
 
 def test_is_current_tracks_source_content(tmp_path):
-    source = _write_source(tmp_path)
+    source = _project(tmp_path)
     output = str(tmp_path / "view.parquet")
-    views.write_view(source, output)
-    assert views.is_current(output, source.md5())
+    views.write_view(source.path, output)
+    assert views.is_current(output, source.source_md5)
     assert not views.is_current(output, "0" * 32)
 
 
 def test_is_current_tracks_the_artifact_version(tmp_path, monkeypatch):
-    source = _write_source(tmp_path)
+    source = _project(tmp_path)
     output = str(tmp_path / "view.parquet")
-    views.write_view(source, output)
+    views.write_view(source.path, output)
     monkeypatch.setattr(artifacts, "ARTIFACT_VERSION", "next")
-    assert not views.is_current(output, source.md5())
+    assert not views.is_current(output, source.source_md5)
 
 
 def test_is_current_is_false_for_a_missing_view(tmp_path):
@@ -394,9 +438,9 @@ def test_the_written_schema_is_the_documented_one(tmp_path):
     # Asserting against views.SCHEMA would only prove the writer used it. Consumers bind
     # to these names and types, so they are spelled out -- as Parquet reports them,
     # which renames the list element from "item" to "element" on the way through.
-    source = _write_source(tmp_path)
+    source = _project(tmp_path)
     output = str(tmp_path / "view.parquet")
-    views.write_view(source, output)
+    views.write_view(source.path, output)
     schema = pq.read_schema(output)
     assert [(field.name, str(field.type)) for field in schema] == [
         ("reaction_id", "string"),
@@ -419,9 +463,9 @@ def test_write_view_round_trips_a_measurement_through_parquet(tmp_path):
     reaction.outcomes[0].products[0].measurements.add(
         type="YIELD"
     ).percentage.value = 87.65
-    source = _write_source(tmp_path, _dataset(reaction))
+    source = _project(tmp_path, _dataset(reaction))
     output = str(tmp_path / "view.parquet")
-    views.write_view(source, output)
+    views.write_view(source.path, output)
     assert pq.read_table(output).column("yield_percent").to_pylist() == [
         pytest.approx(87.65, rel=1e-6)
     ]
@@ -436,7 +480,9 @@ def test_temperature_reads_the_setpoint_not_an_achieved_measurement(tmp_path):
     achieved = reaction.conditions.temperature.measurements.add()
     achieved.temperature.value = 350.0
     achieved.temperature.units = reaction_pb2.Temperature.KELVIN
-    assert views.reaction_row(reaction)["temperature_kelvin"] == pytest.approx(300.0)
+    assert views.reaction_row(projection.message_row(reaction))[
+        "temperature_kelvin"
+    ] == pytest.approx(300.0)
 
 
 def test_a_product_without_a_readable_structure_is_skipped(tmp_path):
@@ -445,13 +491,15 @@ def test_a_product_without_a_readable_structure_is_skipped(tmp_path):
     del tmp_path
     reaction = _reaction()
     reaction.outcomes[0].products.add().identifiers.add(type="NAME", value="mystery")
-    assert views.reaction_row(reaction)["output_smiles"] == ["Cc1ccccc1"]
+    assert views.reaction_row(projection.message_row(reaction))["output_smiles"] == [
+        "Cc1ccccc1"
+    ]
 
 
 def test_write_view_leaves_an_existing_view_intact_on_failure(tmp_path, monkeypatch):
-    source = _write_source(tmp_path)
+    source = _project(tmp_path)
     output = tmp_path / "view.parquet"
-    views.write_view(source, output)
+    views.write_view(source.path, output)
     before = output.read_bytes()
 
     def _boom(*args, **kwargs):
@@ -461,10 +509,14 @@ def test_write_view_leaves_an_existing_view_intact_on_failure(tmp_path, monkeypa
     # The source and the reaction have to be in the message: a corpus run has thousands
     # of datasets and millions of reactions, and neither is in the traceback otherwise.
     with pytest.raises(ValueError, match=r"ds\.parquet: ord-0001: derivation failed"):
-        views.write_view(source, output)
+        views.write_view(source.path, output)
     assert output.read_bytes() == before
     # The temp sibling must not survive either.
-    assert sorted(p.name for p in tmp_path.iterdir()) == ["ds.parquet", "view.parquet"]
+    assert sorted(p.name for p in tmp_path.iterdir()) == [
+        "ds.parquet",
+        "projection-ds.parquet",
+        "view.parquet",
+    ]
 
 
 def test_components_identified_only_by_cxsmiles_are_kept():
@@ -473,4 +525,6 @@ def test_components_identified_only_by_cxsmiles_are_kept():
     compound = reaction_pb2.Compound()
     compound.identifiers.add(type="CXSMILES", value="c1ccccc1 |f:0.1|")
     reaction.inputs["a"].components.append(compound)
-    assert views.reaction_row(reaction)["input_smiles"] == ["c1ccccc1"]
+    assert views.reaction_row(projection.message_row(reaction))["input_smiles"] == [
+        "c1ccccc1"
+    ]


### PR DESCRIPTION
## Summary

A view publishes nothing the projection does not already hold, so deriving the two independently was two code paths obliged to agree about the same values — and the expensive half of that agreement was recomputing what the projection had already computed. A view becomes a narrowing of its projection and is derived from one. Precision moves into the projection so that narrowing loses nothing: a united message was collapsing to a single float, dropping the uncertainty the source recorded, which is the one thing a view could never have reached through its parent.

Chaining changes what `derive_tree` reads, not what anything stamps. A derived parent passes its own stamps through rather than being hashed, so a view still records the *source dataset's* md5 and still goes stale on the same three terms — source content, library version, artifact version. One comparison still answers "is this current for that dataset?", and a consumer cannot tell a chain from a direct derivation.

## Changes

- `views.write_view` reads a projection and decodes only the leaves it publishes; `views.reaction_row` narrows a projected row rather than walking a proto.
- Each united field projects a `<field>_precision_<unit>` column alongside its value, converted by a new `units.canonical_precision`.
- `artifacts.derive_tree` gains `parent_artifact`, and `ArtifactWriter` takes a path rather than an open `DatasetView` — parents are no longer all the same kind of file.
- `derive_views.py` reads projections, and ignores a pattern aimed at the source tree instead of silently deriving views the slow way.
- `projection.write_projection` takes a path and stamps a caller-supplied `source_dataset_id`.

## Testing

`uv run pytest` — 825 passed. New coverage: precision conversion across offset and multiplier scales (`units_test`, `projection_test`), `parent_artifact` selection and stamp pass-through (`artifacts_test`), and a `derive_views` case asserting a source-tree pattern is refused.

Verified against real data rather than fixtures. Deriving a view from the projection of `ord_dataset-488402f6` (40,000 reactions) gives **zero mismatches on all eight columns** against the view the previous proto-walking code produced, and identical skipped-value tallies (6 components with no readable structure, 0 unyielding, 0 non-finite). Build time for that dataset: **53.3 s → 1.0 s**, since no proto is deserialized and no structure is canonicalized twice.

`canonical_precision` reads its conversion from the existing resolver rather than scaling locally, because scaling locally is wrong twice over: Temperature is an offset scale where precision converts by the ratio alone (1.8 °F → 1.0 K, not 255.9), and Wavelength inverts, where precision has no single factor.

## Notes

`ARTIFACT_VERSION` is deliberately **not** bumped, since nothing has shipped yet. Worth knowing when it does: the projection schema changed shape here without anything in the stamps recording it, so a projection built before this reads as current while missing the precision columns. It bit locally — a corpus build in flight had to be discarded and restarted.

`_field_type` now raises if a *repeated* or map-valued united field ever appears upstream, since a value/precision pair cannot represent one. All 28 reachable united fields are singular today.

Supersedes D5 of the [projection-search-index logbook entry](https://github.com/open-reaction-database/ord-logbook/blob/main/entries/2026-07-31-projection-search-index.md) ("peers, not a chain"). Its finding 4 credited three-way agreement across independent code paths, but `views` and `projection` already shared `message_helpers.smiles_from_compound`, `derived_reaction_smiles`, and `units.canonical_value` — the agreement was guaranteed by sharing, not evidence from independent derivation. That entry wants a follow-up revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR derives views by narrowing projections and preserves united-field precision in canonical units.
- Adds canonical precision columns to projections and converts uncertainty across multiplier, offset, and reciprocal units.
- Changes view generation to consume projections while passing source-dataset provenance through the artifact chain.
- Generalizes artifact derivation to select typed parents, reject stale parents, and protect non-artifact destinations.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported orphan-precision failure is fixed by returning null before conversion whenever the value is absent, and no blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/artifacts.py | Generalizes artifact derivation for typed parent artifacts, provenance pass-through, stale-parent rejection, and destination protection. |
| ord_schema/projection.py | Adds canonical precision columns and changes projection writing to accept source paths and caller-supplied provenance. |
| ord_schema/units.py | Adds canonical precision conversion and correctly guards the previously reported missing-value case. |
| ord_schema/views.py | Reworks view generation to narrow projected rows rather than re-derive values from source protos. |
| ord_schema/scripts/derive_views.py | Updates the view CLI to require projections as parent artifacts. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  D[Source dataset] -->|derive projection| P[Projection with canonical values and precision]
  P -->|narrow projected columns| V[View]
  D -. source MD5 and dataset ID .-> P
  P -. pass through source provenance .-> V
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Check the parent is a projection, and st..."](https://github.com/open-reaction-database/ord-schema/commit/f6334721c35fd175045d3f4fd3db350497660b6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51379040)</sub>

**Context used:**

- Knowledge Base — [Data I/O: proto serialization, Parquet, and units](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/data-io.md)

<!-- /greptile_comment -->