### PR TITLE
Compile a query the model emits instead of accepting the SQL it writes

### DIFF
--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -1,0 +1,213 @@
+# Reaching ORD from an agent
+
+The serialized protocol buffers in [ord-data](https://github.com/open-reaction-database/ord-data)
+are the [source of truth](https://en.wikipedia.org/wiki/Single_source_of_truth), and the
+[projection](../projection.py) restates them as nested Parquet so a query engine can read one
+leaf without deserializing the rest. This package is how a language model reaches that
+projection: what the model is told it may query, what it is allowed to emit, and how that
+becomes SQL.
+
+Requires the `agent` extra (`pip install "ord-schema[agent]"`).
+
+## Why the model does not write SQL
+
+The obvious design is to let the model write DuckDB SQL and check it. That was tried, and the
+check cannot be made to hold: **the expensive programs expressible in SQL cannot be
+enumerated.** A validator that refuses `UNNEST` in a `FROM` clause still accepts a self-join
+over 2.4M reactions, a cross join against `range`, a recursive CTE counting to a billion, and a
+predicate-free `SELECT *`. Entries can be added to that blacklist, but it never finishes.
+
+So the model emits a `Query` instead, and the library compiles it. The grammar has one
+relation, no join, no recursion, and no set-returning function, which means the worst program
+expressible in it is **one pass over the corpus plus a sort**. Expensive queries are not
+discouraged; they are unwritable.
+
+The same move settles two other things SQL leaves to whoever writes it:
+
+- **Quantifiers are stated, never assumed.** A path crossing a repeated level is refused unless
+  an `exists` or `forall` binds it. The equivalent SQL is `UNNEST`, which silently means "any"
+  *and* multiplies the row count.
+- **Repeated levels compile to list lambdas**, never to `UNNEST` in a `FROM` clause — measured
+  at 27–200× the cost for identical answers, and the idiom every SQL tutorial teaches. A
+  compiler cannot reach for the wrong one.
+
+It gives up nothing in reach. A column is a *parameter* rather than part of the grammar, so all
+442 leaves of the projection are queryable, and a field added upstream becomes queryable at no
+cost here.
+
+## The grammar
+
+```text
+Query      = { where?: Predicate, aggregate?: Aggregate,
+               order_by?: [Order], limit?: int }
+
+Predicate  = { op: "and" | "or", clauses: [Predicate] }
+           | { op: "not", clause: Predicate }
+           | { op: "exists" | "forall", path: Path, where: Predicate }
+           | { op: "eq"|"ne"|"lt"|"le"|"gt"|"ge", path: Path, value: Value }
+           | { op: "contains"|"starts_with"|"ends_with", path: Path, value: Value }
+           | { op: "is_null" | "not_null", path: Path }
+
+Value      = { literal: <scalar> } | { compound: <name> }
+
+Aggregate  = { group_by: [Path],
+               measures: [{ fn: "count"|"count_distinct"|"sum"|"avg"|"min"|"max",
+                            path?: Path, name: string }] }
+
+Order      = { key: string, descending?: bool }
+```
+
+A `Path` is a dotted column path such as `conditions.temperature.setpoint_kelvin`. Inside an
+`exists` or `forall` it is **relative to the bound element**, which is what lets one component
+be required to satisfy several conditions at once.
+
+Every rule below is enforced against `projection.SCHEMA` before any SQL exists, so a bad query
+is a compile error rather than a wrong answer:
+
+- A comparison path must end at a scalar and must not cross a repeated level.
+- An `exists`/`forall` path must end *at* a repeated level.
+- Operators must suit the leaf type — `contains` is text-only, ordering is numeric-only.
+- `group_by` paths must be scalar, so the number of groups is bounded by the values a column
+  holds rather than by an explosion over a repeated level.
+- A `{"compound": ...}` value is resolved through [`ord_schema.resolvers`](../resolvers.py) and
+  **bound as a parameter**, so the model names compounds and never spells structures.
+
+## Usage
+
+### Tell the model what it may query
+
+```python
+from ord_schema.agent import schema
+
+print(schema.describe())
+```
+
+That renders the projection as an indented type tree in DuckDB's type names — 442 leaves in 537
+lines, small enough to sit in a system prompt whole, which is what lets translation stay a
+single tool call rather than a retrieval loop over column metadata. Units ride along in the
+column names (`setpoint_kelvin`, `mass_grams`), so nothing has to explain them, and each enum
+column carries the values it may hold:
+
+```text
+      reaction_role: VARCHAR  (UNSPECIFIED | REACTANT | REAGENT | SOLVENT | CATALYST | ...)
+```
+
+An enum projects as its value *name*, so without this a model would have the column and no way
+to learn the spelling to compare against. The members ride in Arrow field metadata on the
+projection itself and survive the Parquet round trip at any nesting depth, so a published file
+says what its own enum columns may hold — no type can do that job, since a dictionary column
+carries only the values a batch happened to contain and DuckDB reads it back as `VARCHAR`
+regardless.
+
+`projection_schema.txt` alongside this file is a checked-in snapshot of that output. It is a
+review artifact, never a source: `describe()` generates what actually ships, and a test keeps
+the two identical so a proto field added upstream shows up in a diff rather than in a model's
+behavior.
+
+### Compile a query
+
+```python
+from ord_schema.agent import query
+
+compiled = query.compile_query(
+    query.Query.model_validate(
+        {
+            "where": {
+                "op": "exists",
+                "path": "inputs.components",
+                "where": {"op": "eq", "path": "smiles", "value": {"compound": "thf"}},
+            },
+            "limit": 100,
+        }
+    )
+)
+print(compiled.sql)
+print(compiled.compounds)  # ('thf',) -- resolve and bind these
+```
+
+```sql
+SELECT reaction_id FROM reactions
+WHERE len(list_filter(flatten(list_transform(map_values(inputs), x -> x.components)),
+                      e0 -> e0.smiles = $thf)) > 0
+LIMIT 100
+```
+
+`compiled.compounds` names the parameters still to be bound. Resolve each through
+`ord_schema.resolvers` and pass the SMILES at execution — the name never reaches the SQL as
+text.
+
+### Run it
+
+```python
+import duckdb
+
+from ord_schema.resolvers import resolve_name
+
+connection = duckdb.connect()
+connection.execute(
+    "CREATE VIEW reactions AS SELECT * FROM read_parquet('projections/*/*.parquet')"
+)
+parameters = {name: resolve_name("name", name)[0] for name in compiled.compounds}
+reaction_ids = [row[0] for row in connection.execute(compiled.sql, parameters).fetchall()]
+```
+
+### Ask for the same component, not merely the same reaction
+
+The distinction a reaction-keyed flat table cannot express, and the reason quantifiers bind an
+element rather than a row:
+
+```python
+# One component that is BOTH tetrahydrofuran AND used in quantity.
+{"op": "exists", "path": "inputs.components", "where": {"op": "and", "clauses": [
+    {"op": "eq", "path": "smiles", "value": {"compound": "thf"}},
+    {"op": "gt", "path": "amount.volume_liters", "value": {"literal": 0.005}}]}}
+
+# A reaction containing each, possibly as different components.
+{"op": "and", "clauses": [
+    {"op": "exists", "path": "inputs.components",
+     "where": {"op": "eq", "path": "smiles", "value": {"compound": "thf"}}},
+    {"op": "exists", "path": "inputs.components",
+     "where": {"op": "gt", "path": "amount.volume_liters", "value": {"literal": 0.005}}}]}
+```
+
+### Group and measure
+
+```python
+{
+    "aggregate": {
+        "group_by": ["conditions.stirring.type"],
+        "measures": [
+            {"fn": "avg", "path": "conditions.temperature.setpoint_kelvin", "name": "mean_k"},
+            {"fn": "count", "name": "n"},
+        ],
+    },
+    "order_by": [{"key": "mean_k", "descending": True}],
+    "limit": 10,
+}
+```
+
+An aggregated query orders by a measure name or a `group_by` path, and by nothing else.
+
+## What it deliberately cannot express
+
+Arbitrary expressions (`yield / temperature`), window functions, and joins against anything
+else. That is the line drawn in the design log: lookup and search stay mediated, analysis goes
+direct. An analyst wanting a window function opens the Parquet in DuckDB, where the user is a
+human who is not the injection risk and whose slow query costs only their own session.
+
+## The backstop
+
+[`sql.validate`](sql.py) plans a query against an *empty* Arrow table carrying the projection
+schema, so it needs no corpus. It refuses anything that is not a single `SELECT`, refuses
+`UNNEST` in a `FROM` clause, and runs on a connection with no filesystem access.
+
+It is a check on the compiler's own output, not the guard it once was — the guard is the
+grammar. It still **does not bound cost**, and says so: a caller running arbitrary SQL against
+a real corpus needs its own statement timeout, row cap, or memory limit.
+
+## Not yet solved
+
+Execution has no sandbox. `enable_external_access=false` cannot be combined with a lazy Parquet
+view — only a materialized table survives it — so running against the full corpus needs
+DuckDB's `allowed_directories` or a separate process. Compiling from an IR removes the reasons
+to fear the *query*; it does not remove the reasons to contain the *process*.

--- a/ord_schema/agent/query.py
+++ b/ord_schema/agent/query.py
@@ -1,0 +1,485 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A query a model can emit, and its compilation to DuckDB SQL.
+
+A model emits one of these rather than SQL. The reason is not safety alone -- bound
+parameters already gave that -- but **cost**. SQL's expensive programs cannot be
+enumerated, so every guard on generated SQL is a blacklist someone has to keep adding
+to. This grammar has one relation, no join, no recursion, and no set-returning
+function, so the worst program expressible in it is one pass over the corpus and a
+sort. Expensive queries are not discouraged here; they are unwritable.
+
+It reaches every column the projection has, because a column is a *parameter* rather
+than part of the grammar. That is the difference between this and the per-predicate
+enumeration it replaces: adding a field upstream adds a queryable column and costs
+nothing here.
+
+Two things the compiler settles that SQL leaves to whoever writes it:
+
+* **Quantifiers are stated, never assumed.** A path crossing a repeated level is
+  refused unless an ``exists`` or ``forall`` binds it. The same intent in SQL is spelled
+  ``UNNEST``, which silently means "any" *and* multiplies the row count.
+* **Repeated levels compile to list lambdas**, never to ``UNNEST`` in a ``FROM`` clause
+  -- measured at 27-200x the cost for identical answers, and the idiom every SQL
+  tutorial teaches. A compiler cannot reach for the wrong one.
+
+Co-membership survives, which a reaction-keyed flat table cannot express:
+``exists(components, A and B)`` is one component that is both, while
+``exists(components, A) and exists(components, B)`` is a reaction containing each.
+They are different nodes rather than a subtlety of join keys.
+
+Compounds are named, never spelled. A ``{"compound": "thf"}`` value compiles to a bound
+parameter, so the model never writes a structure and the caller resolves the name
+through :mod:`ord_schema.resolvers` before binding.
+"""
+
+import dataclasses
+import difflib
+import re
+from typing import Annotated, Any, Literal
+
+import pyarrow as pa
+from pydantic import BaseModel, Field, model_validator
+
+from ord_schema import projection
+
+# The relation a compiled query reads. The only one in scope, so nothing else is
+# nameable and a join has nothing to join to.
+TABLE = "reactions"
+
+_COMPARISONS = {"eq": "=", "ne": "<>", "lt": "<", "le": "<=", "gt": ">", "ge": ">="}
+_ORDERED = frozenset({"lt", "le", "gt", "ge"})
+_TEXT = {"contains": "contains", "starts_with": "starts_with", "ends_with": "ends_with"}
+_AGGREGATES = {
+    "count": "count",
+    "count_distinct": "count",
+    "sum": "sum",
+    "avg": "avg",
+    "min": "min",
+    "max": "max",
+}
+
+# Measure names and the bound-parameter names for compounds are the only model-supplied
+# strings that reach the SQL as text rather than as parameters, so both are held to an
+# identifier shape a quoting mistake cannot escape.
+_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class QueryError(ValueError):
+    """A query that cannot be compiled against the projection schema."""
+
+
+@dataclasses.dataclass(frozen=True)
+class Compiled:
+    """A compiled query, and the compound names its parameters still need."""
+
+    sql: str
+    compounds: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class _Resolved:
+    """Where a path landed: the expression, whether it is a list, and its type."""
+
+    expression: str
+    repeated: bool
+    type: pa.DataType
+
+
+def _members(current: pa.Schema | pa.DataType) -> list[str]:
+    """Returns the field names available on a schema or struct type."""
+    if isinstance(current, pa.Schema):
+        return list(current.names)
+    if pa.types.is_struct(current):
+        return [field.name for field in current]
+    return []
+
+
+def _lookup(current: pa.Schema | pa.DataType, name: str, path: str) -> pa.Field:
+    """Returns the field ``name`` within ``current``, or raises a helpful QueryError."""
+    members = _members(current)
+    if name not in members:
+        if not members:
+            raise QueryError(f"{path}: {name!r} has no fields to descend into")
+        close = difflib.get_close_matches(name, members, n=3)
+        suggestion = f"; did you mean {', '.join(map(repr, close))}?" if close else ""
+        raise QueryError(f"{path}: no field named {name!r}{suggestion}")
+    if isinstance(current, pa.Schema):
+        return current.field(name)
+    return current.field(name)
+
+
+def resolve(
+    path: str, *, schema: pa.Schema = projection.SCHEMA, root: str | None = None
+) -> _Resolved:
+    """Resolves a dotted path against the projection schema.
+
+    Descending through a repeated level turns the expression into a list of the
+    elements beneath it, so the caller can tell a scalar it may compare from a level it
+    must quantify over.
+
+    Args:
+        path: Dotted column path, e.g. ``conditions.temperature.setpoint_kelvin``.
+        schema: Schema or struct type to resolve within.
+        root: Bound variable the path is relative to, inside a quantifier.
+
+    Returns:
+        The DuckDB expression, whether it evaluates to a list, and the type it reaches.
+
+    Raises:
+        QueryError: If the path is empty or names a field the schema does not hold.
+    """
+    if not path:
+        raise QueryError("empty path")
+    expression: str | None = None
+    repeated = False
+    current: Any = schema
+    for part in path.split("."):
+        field = _lookup(current, part, path)
+        if expression is None:
+            expression = part if root is None else f"{root}.{part}"
+        elif repeated:
+            expression = f"list_transform({expression}, x -> x.{part})"
+        else:
+            expression = f"{expression}.{part}"
+        inner = field.type
+        if pa.types.is_map(inner):
+            expression = (
+                f"flatten({expression})" if repeated else f"map_values({expression})"
+            )
+            repeated, current = True, inner.item_type
+        elif pa.types.is_list(inner):
+            if repeated:
+                expression = f"flatten({expression})"
+            repeated, current = True, inner.value_type
+        else:
+            current = inner
+    return _Resolved(expression or "", repeated, current)
+
+
+class Value(BaseModel):
+    """A comparison operand: a literal, or a compound to resolve and bind."""
+
+    literal: bool | int | float | str | None = None
+    compound: str | None = None
+
+    @model_validator(mode="after")
+    def _exactly_one(self) -> "Value":
+        if (self.literal is None) == (self.compound is None):
+            raise ValueError("a value is either a literal or a compound, not both")
+        if self.compound is not None and not _NAME.match(self.compound):
+            raise ValueError(f"compound name is not an identifier: {self.compound!r}")
+        return self
+
+
+class And(BaseModel):
+    """Every clause holds."""
+
+    op: Literal["and"]
+    clauses: list["Predicate"] = Field(min_length=1)
+
+
+class Or(BaseModel):
+    """At least one clause holds."""
+
+    op: Literal["or"]
+    clauses: list["Predicate"] = Field(min_length=1)
+
+
+class Not(BaseModel):
+    """The clause does not hold."""
+
+    op: Literal["not"]
+    clause: "Predicate"
+
+
+class Quantifier(BaseModel):
+    """Some, or every, element at a repeated level satisfies ``where``.
+
+    Paths inside ``where`` are relative to the element bound here, which is what lets a
+    single component be required to satisfy several conditions at once.
+    """
+
+    op: Literal["exists", "forall"]
+    path: str
+    where: "Predicate"
+
+
+class Comparison(BaseModel):
+    """A leaf compared against a literal or a resolved compound."""
+
+    op: Literal[
+        "eq", "ne", "lt", "le", "gt", "ge", "contains", "starts_with", "ends_with"
+    ]
+    path: str
+    value: Value
+
+
+class NullCheck(BaseModel):
+    """Whether the source recorded the leaf at all."""
+
+    op: Literal["is_null", "not_null"]
+    path: str
+
+
+Predicate = Annotated[
+    And | Or | Not | Quantifier | Comparison | NullCheck,
+    Field(discriminator="op"),
+]
+
+And.model_rebuild()
+Or.model_rebuild()
+Not.model_rebuild()
+Quantifier.model_rebuild()
+
+
+class Measure(BaseModel):
+    """One aggregate over the matching rows."""
+
+    fn: Literal["count", "count_distinct", "sum", "avg", "min", "max"]
+    path: str | None = None
+    name: str
+
+    @model_validator(mode="after")
+    def _check(self) -> "Measure":
+        if not _NAME.match(self.name):
+            raise ValueError(f"measure name is not an identifier: {self.name!r}")
+        if self.fn != "count" and self.path is None:
+            raise ValueError(f"{self.fn} needs a path")
+        return self
+
+
+class Aggregate(BaseModel):
+    """Group the matching rows and measure each group.
+
+    ``group_by`` paths must be scalar, so the number of groups is bounded by the values
+    a column holds rather than by an explosion over a repeated level.
+    """
+
+    group_by: list[str] = Field(default_factory=list)
+    measures: list[Measure] = Field(min_length=1)
+
+
+class Order(BaseModel):
+    """How to sort the result."""
+
+    key: str
+    descending: bool = False
+
+
+class Query(BaseModel):
+    """A whole query: which reactions, optionally grouped and measured."""
+
+    where: Predicate | None = None
+    aggregate: Aggregate | None = None
+    order_by: list[Order] = Field(default_factory=list)
+    limit: int | None = Field(default=None, gt=0)
+
+
+def _literal(value: Value, compounds: list[str]) -> str:
+    """Returns the SQL for a value, recording a compound that needs binding."""
+    if value.compound is not None:
+        if value.compound not in compounds:
+            compounds.append(value.compound)
+        return f"${value.compound}"
+    if isinstance(value.literal, str):
+        escaped = value.literal.replace("'", "''")
+        return f"'{escaped}'"
+    if isinstance(value.literal, bool):
+        return "TRUE" if value.literal else "FALSE"
+    return repr(value.literal)
+
+
+def _check_operand(node: Comparison, resolved: _Resolved) -> None:
+    """Raises if the operator or the value does not suit the leaf's type.
+
+    Args:
+        node: The comparison being compiled.
+        resolved: Where its path landed.
+
+    Raises:
+        QueryError: If the comparison cannot be meant.
+    """
+    leaf = resolved.type
+    if node.op in _TEXT and not pa.types.is_string(leaf):
+        raise QueryError(f"{node.path}: {node.op} needs a text column, not {leaf}")
+    if node.op in _ORDERED and not (
+        pa.types.is_integer(leaf) or pa.types.is_floating(leaf)
+    ):
+        raise QueryError(f"{node.path}: {node.op} needs a numeric column, not {leaf}")
+    if node.value.compound is not None and not pa.types.is_string(leaf):
+        raise QueryError(f"{node.path}: a compound compares against text, not {leaf}")
+    literal = node.value.literal
+    if literal is None:
+        return
+    if isinstance(literal, str) and not pa.types.is_string(leaf):
+        raise QueryError(f"{node.path}: holds {leaf}, compared against a string")
+    if isinstance(literal, bool) and not pa.types.is_boolean(leaf):
+        raise QueryError(f"{node.path}: holds {leaf}, compared against a boolean")
+    if (
+        isinstance(literal, int | float)
+        and not isinstance(literal, bool)
+        and not (pa.types.is_integer(leaf) or pa.types.is_floating(leaf))
+    ):
+        raise QueryError(f"{node.path}: holds {leaf}, compared against a number")
+
+
+def _leaf(node: Any, resolved: _Resolved, compounds: list[str]) -> str:
+    """Compiles a comparison or null check against an already-resolved scalar."""
+    if isinstance(node, NullCheck):
+        keyword = "NULL" if node.op == "is_null" else "NOT NULL"
+        return f"{resolved.expression} IS {keyword}"
+    _check_operand(node, resolved)
+    operand = _literal(node.value, compounds)
+    if node.op in _TEXT:
+        return f"{_TEXT[node.op]}({resolved.expression}, {operand})"
+    return f"{resolved.expression} {_COMPARISONS[node.op]} {operand}"
+
+
+def _quantifier(
+    node: "Quantifier", scope: str | None, schema: Any, compounds: list[str], depth: int
+) -> str:
+    """Compiles a quantifier to a filter over the elements at a repeated level.
+
+    The element is bound to a fresh variable, and the body compiles against *it* rather
+    than against the row, which is what lets one component be required to satisfy
+    several conditions at once.
+    """
+    resolved = resolve(node.path, schema=schema, root=scope)
+    if not resolved.repeated:
+        raise QueryError(
+            f"{node.path}: {node.op} needs a repeated level, and this path reaches "
+            f"{resolved.type}; compare it directly instead"
+        )
+    variable = f"e{depth}"
+    body = _predicate(node.where, variable, resolved.type, compounds, depth + 1)
+    if node.op == "exists":
+        return f"len(list_filter({resolved.expression}, {variable} -> {body})) > 0"
+    # No counterexample, which is vacuously true of an empty level.
+    return f"len(list_filter({resolved.expression}, {variable} -> NOT ({body}))) = 0"
+
+
+def _predicate(
+    node: Any, scope: str | None, schema: Any, compounds: list[str], depth: int
+) -> str:
+    """Compiles one predicate node to a boolean DuckDB expression."""
+    if isinstance(node, And | Or):
+        keyword = " AND " if isinstance(node, And) else " OR "
+        return (
+            "("
+            + keyword.join(
+                _predicate(clause, scope, schema, compounds, depth)
+                for clause in node.clauses
+            )
+            + ")"
+        )
+    if isinstance(node, Not):
+        return f"(NOT {_predicate(node.clause, scope, schema, compounds, depth)})"
+    if isinstance(node, Quantifier):
+        return _quantifier(node, scope, schema, compounds, depth)
+    resolved = resolve(node.path, schema=schema, root=scope)
+    if resolved.repeated:
+        raise QueryError(
+            f"{node.path}: crosses a repeated level, so whether it means any or every "
+            "element is unstated; wrap it in an exists or forall"
+        )
+    if isinstance(node, NullCheck):
+        return (
+            f"{resolved.expression} IS {'NULL' if node.op == 'is_null' else 'NOT NULL'}"
+        )
+    _check_operand(node, resolved)
+    operand = _literal(node.value, compounds)
+    if node.op in _TEXT:
+        return f"{_TEXT[node.op]}({resolved.expression}, {operand})"
+    return f"{resolved.expression} {_COMPARISONS[node.op]} {operand}"
+
+
+def _scalar(path: str, schema: pa.Schema, what: str) -> str:
+    """Returns the expression for a path that has to be scalar."""
+    resolved = resolve(path, schema=schema)
+    if resolved.repeated:
+        raise QueryError(f"{path}: {what} needs a scalar column, not a repeated level")
+    return resolved.expression
+
+
+def compile_query(
+    query: Query, *, schema: pa.Schema = projection.SCHEMA, table: str = TABLE
+) -> Compiled:
+    """Compiles a query to DuckDB SQL over the projection.
+
+    Args:
+        query: The query to compile.
+        schema: Schema to resolve paths against; the projection schema by default.
+        table: Relation name to read. Held to an identifier, because it reaches the SQL
+            as text: a caller passing ``"reactions, range(1000000000)"`` would otherwise
+            get a cross join the ``Query`` never asked for, and the single-relation cost
+            bound this grammar exists to provide would hold only by convention.
+
+    Returns:
+        The SQL, and the compound names whose resolved SMILES the caller binds.
+
+    Raises:
+        QueryError: If ``table`` is not an identifier, or if any path, operator, or
+            ordering key cannot be meant against the schema.
+    """
+    if not _NAME.match(table):
+        raise QueryError(f"table is not an identifier: {table!r}")
+    compounds: list[str] = []
+    if query.aggregate:
+        groups = [
+            _scalar(path, schema, "group_by") for path in query.aggregate.group_by
+        ]
+        selected = list(groups)
+        for measure in query.aggregate.measures:
+            if measure.path is None:
+                argument = "*"
+            else:
+                argument = _scalar(measure.path, schema, measure.fn)
+                if measure.fn == "count_distinct":
+                    argument = f"DISTINCT {argument}"
+            selected.append(f"{_AGGREGATES[measure.fn]}({argument}) AS {measure.name}")
+        names = {measure.name for measure in query.aggregate.measures}
+        orderable = names | set(query.aggregate.group_by)
+    else:
+        selected = ["reaction_id"]
+        orderable = None
+    # S608: assembling SQL is this function's purpose. Every fragment in `selected` is
+    # either an expression resolved against the schema or a measure name already held to
+    # an identifier shape, `table` is this module's constant, and every model-supplied
+    # value reached the string as a bound parameter or a quoted literal.
+    sql = f"SELECT {', '.join(selected)} FROM {table}"  # noqa: S608
+    if query.where is not None:
+        sql += f" WHERE {_predicate(query.where, None, schema, compounds, 0)}"
+    if query.aggregate and groups:
+        sql += " GROUP BY " + ", ".join(str(index + 1) for index in range(len(groups)))
+    if query.order_by:
+        keys = []
+        for order in query.order_by:
+            if orderable is None:
+                key = _scalar(order.key, schema, "order_by")
+            elif order.key in orderable:
+                key = (
+                    order.key if order.key in names else _scalar(order.key, schema, "")
+                )
+            else:
+                raise QueryError(
+                    f"{order.key}: an aggregated query orders by a measure name or a "
+                    f"group_by path, and this is neither"
+                )
+            keys.append(f"{key} DESC" if order.descending else key)
+        sql += " ORDER BY " + ", ".join(keys)
+    if query.limit is not None:
+        sql += f" LIMIT {query.limit}"
+    return Compiled(sql, tuple(compounds))

--- a/ord_schema/agent/query_test.py
+++ b/ord_schema/agent/query_test.py
@@ -1,0 +1,447 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.agent.query."""
+
+import duckdb
+import pytest
+from pydantic import ValidationError
+
+from ord_schema import projection
+from ord_schema.agent import query, sql
+
+
+def _compile(payload):
+    return query.compile_query(query.Query.model_validate(payload))
+
+
+def _run(compiled, parameters=None):
+    """Executes a compiled query against an empty projection, proving it is runnable."""
+    connection = duckdb.connect()
+    connection.register(query.TABLE, projection.SCHEMA.empty_table())
+    try:
+        return connection.execute(compiled.sql, parameters or {}).fetchall()
+    finally:
+        connection.close()
+
+
+# Path resolution
+
+
+def test_a_scalar_path_reaches_a_leaf():
+    resolved = query.resolve("conditions.temperature.setpoint_kelvin")
+    assert resolved.expression == "conditions.temperature.setpoint_kelvin"
+    assert not resolved.repeated
+
+
+def test_a_map_becomes_a_list_of_its_values():
+    resolved = query.resolve("inputs.components")
+    assert resolved.expression == (
+        "flatten(list_transform(map_values(inputs), x -> x.components))"
+    )
+    assert resolved.repeated
+
+
+def test_a_path_through_two_repeated_levels_flattens_once_each():
+    resolved = query.resolve("outcomes.products.measurements")
+    assert resolved.repeated
+    assert resolved.expression.count("flatten") == 2
+
+
+def test_an_unknown_field_suggests_a_near_one():
+    with pytest.raises(query.QueryError, match="did you mean 'temperature'"):
+        query.resolve("conditions.temprature.setpoint_kelvin")
+
+
+def test_an_unknown_field_with_no_near_match_still_names_the_path():
+    with pytest.raises(query.QueryError, match="no field named 'zzz'"):
+        query.resolve("conditions.zzz")
+
+
+def test_descending_into_a_leaf_is_refused():
+    with pytest.raises(query.QueryError, match="no fields to descend into"):
+        query.resolve("reaction_id.nope")
+
+
+# Compilation
+
+
+def test_a_comparison_compiles_to_a_scalar_test():
+    compiled = _compile(
+        {
+            "where": {
+                "op": "gt",
+                "path": "conditions.temperature.setpoint_kelvin",
+                "value": {"literal": 300.0},
+            }
+        }
+    )
+    assert compiled.sql == (
+        "SELECT reaction_id FROM reactions "
+        "WHERE conditions.temperature.setpoint_kelvin > 300.0"
+    )
+    assert compiled.compounds == ()
+
+
+def test_exists_compiles_to_a_list_lambda_never_to_unnest():
+    # The whole reason the model does not write SQL: the fast idiom is the only one the
+    # compiler can emit, so the 27-200x cliff is unreachable rather than discouraged.
+    compiled = _compile(
+        {
+            "where": {
+                "op": "exists",
+                "path": "inputs.components",
+                "where": {"op": "eq", "path": "smiles", "value": {"literal": "CCO"}},
+            }
+        }
+    )
+    assert "list_filter" in compiled.sql
+    assert "UNNEST" not in compiled.sql.upper()
+    sql.validate(compiled.sql)
+
+
+def test_forall_is_the_negation_of_a_counterexample():
+    compiled = _compile(
+        {
+            "where": {
+                "op": "forall",
+                "path": "outcomes.products",
+                "where": {"op": "not_null", "path": "smiles"},
+            }
+        }
+    )
+    assert "NOT (" in compiled.sql
+    assert compiled.sql.endswith(")) = 0")
+
+
+def test_a_nested_quantifier_binds_its_own_element():
+    # The bug this pins: an inner path resolved against the row instead of the bound
+    # element silently reads the reaction's own column and answers the wrong question.
+    compiled = _compile(
+        {
+            "where": {
+                "op": "exists",
+                "path": "inputs.components",
+                "where": {
+                    "op": "exists",
+                    "path": "identifiers",
+                    "where": {
+                        "op": "eq",
+                        "path": "value",
+                        "value": {"literal": "THF"},
+                    },
+                },
+            }
+        }
+    )
+    assert "e0.identifiers" in compiled.sql
+    assert "e1.value" in compiled.sql
+
+
+def test_co_membership_and_mere_co_occurrence_compile_differently():
+    both = _compile(
+        {
+            "where": {
+                "op": "exists",
+                "path": "inputs.components",
+                "where": {
+                    "op": "and",
+                    "clauses": [
+                        {"op": "eq", "path": "smiles", "value": {"literal": "CCO"}},
+                        {
+                            "op": "eq",
+                            "path": "reaction_role",
+                            "value": {"literal": "SOLVENT"},
+                        },
+                    ],
+                },
+            }
+        }
+    )
+    either = _compile(
+        {
+            "where": {
+                "op": "and",
+                "clauses": [
+                    {
+                        "op": "exists",
+                        "path": "inputs.components",
+                        "where": {
+                            "op": "eq",
+                            "path": "smiles",
+                            "value": {"literal": "CCO"},
+                        },
+                    },
+                    {
+                        "op": "exists",
+                        "path": "inputs.components",
+                        "where": {
+                            "op": "eq",
+                            "path": "reaction_role",
+                            "value": {"literal": "SOLVENT"},
+                        },
+                    },
+                ],
+            }
+        }
+    )
+    assert both.sql != either.sql
+    assert both.sql.count("list_filter") == 1
+    assert either.sql.count("list_filter") == 2
+
+
+def test_compounds_are_bound_not_spelled():
+    compiled = _compile(
+        {
+            "where": {
+                "op": "exists",
+                "path": "inputs.components",
+                "where": {"op": "eq", "path": "smiles", "value": {"compound": "thf"}},
+            }
+        }
+    )
+    assert "$thf" in compiled.sql
+    assert compiled.compounds == ("thf",)
+    assert _run(compiled, {"thf": "C1CCOC1"}) == []
+
+
+def test_a_string_literal_carrying_a_quote_cannot_close_it():
+    compiled = _compile(
+        {
+            "where": {
+                "op": "eq",
+                "path": "reaction_id",
+                "value": {"literal": "'; DROP TABLE reactions; --"},
+            }
+        }
+    )
+    assert _run(compiled) == []
+
+
+# Aggregation
+
+
+def test_an_aggregate_groups_and_measures():
+    compiled = _compile(
+        {
+            "aggregate": {
+                "group_by": ["conditions.stirring.type"],
+                "measures": [
+                    {
+                        "fn": "avg",
+                        "path": "conditions.temperature.setpoint_kelvin",
+                        "name": "mean_k",
+                    },
+                    {"fn": "count", "name": "n"},
+                ],
+            },
+            "order_by": [{"key": "mean_k", "descending": True}],
+            "limit": 5,
+        }
+    )
+    assert compiled.sql == (
+        "SELECT conditions.stirring.type, "
+        "avg(conditions.temperature.setpoint_kelvin) AS mean_k, count(*) AS n "
+        "FROM reactions GROUP BY 1 ORDER BY mean_k DESC LIMIT 5"
+    )
+    assert _run(compiled) == []
+
+
+def test_count_distinct_counts_distinctly():
+    compiled = _compile(
+        {
+            "aggregate": {
+                "measures": [
+                    {"fn": "count_distinct", "path": "provenance.doi", "name": "dois"}
+                ]
+            }
+        }
+    )
+    assert "count(DISTINCT provenance.doi)" in compiled.sql
+
+
+# Refusals
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        # The refusal that has no SQL equivalent: UNNEST would silently mean "any".
+        (
+            {
+                "where": {
+                    "op": "eq",
+                    "path": "inputs.components.smiles",
+                    "value": {"literal": "CCO"},
+                }
+            },
+            "crosses a repeated level",
+        ),
+        (
+            {
+                "where": {
+                    "op": "exists",
+                    "path": "reaction_id",
+                    "where": {"op": "not_null", "path": "reaction_id"},
+                }
+            },
+            "needs a repeated level",
+        ),
+        (
+            {
+                "where": {
+                    "op": "gt",
+                    "path": "conditions.temperature.setpoint_kelvin",
+                    "value": {"literal": "hot"},
+                }
+            },
+            "compared against a string",
+        ),
+        (
+            {
+                "where": {
+                    "op": "contains",
+                    "path": "conditions.temperature.setpoint_kelvin",
+                    "value": {"literal": "3"},
+                }
+            },
+            "needs a text column",
+        ),
+        (
+            {"where": {"op": "gt", "path": "reaction_id", "value": {"literal": 1}}},
+            "needs a numeric column",
+        ),
+        # A compound resolves to a SMILES, so it can only compare against text.
+        (
+            {
+                "where": {
+                    "op": "eq",
+                    "path": "conditions.temperature.setpoint_kelvin",
+                    "value": {"compound": "thf"},
+                }
+            },
+            "compares against text",
+        ),
+        (
+            {
+                "aggregate": {
+                    "group_by": ["inputs.components.smiles"],
+                    "measures": [{"fn": "count", "name": "n"}],
+                }
+            },
+            "needs a scalar column",
+        ),
+        (
+            {
+                "aggregate": {"measures": [{"fn": "count", "name": "n"}]},
+                "order_by": [{"key": "nope"}],
+            },
+            "measure name or a group_by path",
+        ),
+    ],
+)
+def test_refused(payload, match):
+    with pytest.raises(query.QueryError, match=match):
+        _compile(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # A measure name reaches the SQL as text, so it is held to an identifier shape.
+        {"aggregate": {"measures": [{"fn": "count", "name": "n; DROP TABLE x"}]}},
+        {
+            "where": {
+                "op": "eq",
+                "path": "reaction_id",
+                "value": {"compound": "x'; DROP TABLE y; --"},
+            }
+        },
+        # Neither a literal nor a compound, or both at once.
+        {"where": {"op": "eq", "path": "reaction_id", "value": {}}},
+        {
+            "where": {
+                "op": "eq",
+                "path": "reaction_id",
+                "value": {"literal": "a", "compound": "b"},
+            }
+        },
+        {"limit": 0},
+        {"aggregate": {"measures": [{"fn": "sum", "name": "n"}]}},
+        {"where": {"op": "and", "clauses": []}},
+    ],
+)
+def test_rejected_before_compilation(payload):
+    with pytest.raises(ValidationError):
+        query.Query.model_validate(payload)
+
+
+# The whole point
+
+
+def test_no_expressible_query_needs_a_join_or_recursion():
+    # The cost bound is structural: the grammar has one relation and no way to name
+    # another, no recursion, and no set-returning function. This asserts the surface
+    # rather than any one query -- a node type that broke it would fail here.
+    fields = set(query.Query.model_fields)
+    assert fields == {"where", "aggregate", "order_by", "limit"}
+    operators = set()
+    for member in (
+        query.And,
+        query.Or,
+        query.Not,
+        query.Quantifier,
+        query.Comparison,
+        query.NullCheck,
+    ):
+        operators.update(member.model_fields["op"].annotation.__args__)
+    assert operators == {
+        "and",
+        "or",
+        "not",
+        "exists",
+        "forall",
+        "eq",
+        "ne",
+        "lt",
+        "le",
+        "gt",
+        "ge",
+        "contains",
+        "starts_with",
+        "ends_with",
+        "is_null",
+        "not_null",
+    }
+
+
+@pytest.mark.parametrize(
+    "table",
+    [
+        # The cost bound is the point of the grammar, so the one string a caller can
+        # put into the FROM clause must not be able to add a relation to it.
+        "reactions, range(1000000000)",
+        "reactions AS a, reactions AS b",
+        "read_parquet('/etc/hosts')",
+    ],
+)
+def test_a_table_that_is_not_an_identifier_is_refused(table):
+    with pytest.raises(query.QueryError, match="not an identifier"):
+        query.compile_query(query.Query(), table=table)
+
+
+def test_a_plain_relation_name_is_still_allowed():
+    assert query.compile_query(query.Query(), table="projections").sql.endswith(
+        "FROM projections"
+    )

--- a/ord_schema/agent/sql.py
+++ b/ord_schema/agent/sql.py
@@ -1,0 +1,187 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Checking the SQL a model wrote before anything runs it.
+
+Validation needs no corpus. ``projection.SCHEMA`` is generated from the proto
+descriptors, so an empty Arrow table carrying it has the real 442-leaf shape, and
+planning a query against that resolves every column reference and type without reading a
+byte of data. The prompt in :mod:`ord_schema.agent.schema` renders the same schema
+object, so the columns a model is told about and the columns its query is checked
+against come from one call.
+
+Two classes of defect are caught, and they are different in kind:
+
+* **Not a query.** Anything but a single ``SELECT`` is refused, which is a whitelist
+  rather than a search for known-bad text. The connection also has no filesystem access,
+  so ``read_parquet`` and ``COPY`` fail to plan -- but that is a property of *this*
+  connection, not a certificate about the SQL: a reader that binds its path lazily, such
+  as ``sniff_csv``, plans cleanly here and is refused only when something executes it.
+* **Not answerable.** A column that does not exist, a type that will not compare, a
+  placeholder the model referenced but did not declare. These are ordinary binder
+  errors, surfaced early enough to retry the translation instead of failing a user.
+
+Placeholders are bound, never interpolated. A compound name reaches the query as a
+parameter value, so it cannot carry SQL with it, and the same values used here are the
+ones the query runs with.
+
+.. warning::
+   **Nothing here bounds what a query costs.** ``UNNEST`` in a ``FROM`` clause is
+   refused, because it materializes the exploded intermediate -- measured at 27-200x the
+   cost of the equivalent list lambdas, and over the full corpus the difference between
+   0.9 seconds and no result in four minutes -- and because it is the spelling every SQL
+   tutorial teaches, so a model reaches for it by default.
+
+   That is one entry in a blacklist, not a guard. A self-join over 2.4M reactions, a
+   cross join against ``range``, a recursive CTE counting to a billion, and a
+   predicate-free ``SELECT *`` all plan cleanly here, and none of them is reachable by
+   enumerating spellings: accepting SQL means accepting that the set of expensive
+   programs cannot be listed. A caller running validated SQL against a real corpus needs
+   its own bound -- a statement timeout, a row cap, a memory limit -- and must not read
+   this module as having provided one.
+"""
+
+import json
+from collections.abc import Iterator
+from typing import Any
+
+import duckdb
+import pyarrow as pa
+
+from ord_schema import projection
+
+# The name the model is told to query. The only relation in scope, so no other table is
+# reachable -- which is not the same as no join being expressible, since a query can
+# still join this one to itself.
+TABLE = "reactions"
+
+# DuckDB compiles UNNEST in a FROM clause to a table in-out function; list lambdas
+# compile to an ordinary projection over the child arrays. The operator name is
+# therefore the signal, and it survives the query being spelled in ways a text search
+# would miss.
+_EXPLODING_OPERATOR = "INOUT_FUNCTION"
+
+
+def _operators(node: Any) -> Iterator[str]:
+    """Yields the operator name of every node in a DuckDB JSON plan.
+
+    Only the node's own name is read, and only ``children`` is descended into, so a
+    string literal that happens to spell an operator name cannot be mistaken for one: a
+    query filtering on ``'INOUT_FUNCTION'`` carries that text in ``extra_info``, which
+    is never visited. Both spellings of the key are accepted because DuckDB has used
+    each.
+
+    Args:
+        node: A plan node, or the whole plan.
+
+    Yields:
+        Each operator name, outermost first.
+    """
+    if isinstance(node, list):
+        for item in node:
+            yield from _operators(item)
+        return
+    if not isinstance(node, dict):
+        return
+    name = node.get("name") or node.get("operator_type")
+    if isinstance(name, str):
+        yield name
+    yield from _operators(node.get("children", []))
+
+
+class InvalidQueryError(ValueError):
+    """The generated SQL is not a query this surface will run."""
+
+
+def _connect(schema: pa.Schema) -> duckdb.DuckDBPyConnection:
+    """Returns a connection holding an empty ``TABLE`` and no access to anything else.
+
+    External access is disabled after the table is registered, which leaves the
+    in-memory relation queryable while ``read_parquet``, ``COPY``, and ``ATTACH`` can
+    reach no path. The setting cannot be turned back on, so a query cannot lift it.
+
+    Args:
+        schema: Schema the registered table carries.
+
+    Returns:
+        A connection scoped to a single empty relation.
+    """
+    connection = duckdb.connect()
+    connection.register(TABLE, schema.empty_table())
+    connection.execute("SET enable_external_access=false")
+    return connection
+
+
+def validate(
+    sql: str,
+    *,
+    parameters: dict[str, str] | None = None,
+    schema: pa.Schema = projection.SCHEMA,
+) -> None:
+    """Checks that ``sql`` is a single read-only query this surface will run.
+
+    Says nothing about what the query costs; see the module warning.
+
+    Args:
+        sql: The generated SQL, querying ``TABLE``.
+        parameters: Values for the query's named placeholders, exactly as they will be
+            bound at execution. Planning needs them, so a query referencing a
+            placeholder the caller did not supply fails here rather than at execution.
+            Binding different values later invalidates the result, since constant
+            folding can prune a branch at plan time; nothing detects that, so validating
+            once and re-binding is the caller's mistake to avoid.
+        schema: Schema to plan against; the projection schema by default.
+
+    Raises:
+        InvalidQueryError: If the SQL does not parse, is more than one statement, is not
+            a ``SELECT``, references something the schema does not hold, or plans to an
+            exploded intermediate.
+    """
+    try:
+        statements = duckdb.extract_statements(sql)
+    except duckdb.ParserException as error:
+        raise InvalidQueryError(f"query does not parse: {error}") from error
+    if len(statements) != 1:
+        raise InvalidQueryError(
+            f"expected a single statement, got {len(statements)}; "
+            "a query answers one question"
+        )
+    if statements[0].type != duckdb.StatementType.SELECT:
+        raise InvalidQueryError(
+            f"expected a SELECT, got {statements[0].type.name}; this surface reads"
+        )
+    connection = _connect(schema)
+    try:
+        plan = connection.execute(
+            f"EXPLAIN (FORMAT json) {sql}", parameters or {}
+        ).fetchone()
+    except duckdb.Error as error:
+        raise InvalidQueryError(f"query cannot be planned: {error}") from error
+    finally:
+        connection.close()
+    # JSON rather than the default rendering, which draws the plan into a fixed-width
+    # canvas and silently drops whole subtrees once a query has more parallel pipelines
+    # than fit. A UNNEST padded with enough UNION ALL branches disappeared from it.
+    try:
+        operators = set(_operators(json.loads(plan[1]) if plan else None))
+    except (TypeError, IndexError, ValueError) as error:
+        # Fail closed. This check is the only affordability signal the module has, so a
+        # plan it cannot read is a query it cannot vouch for.
+        raise InvalidQueryError(f"query produced no readable plan: {error}") from error
+    if _EXPLODING_OPERATOR in operators:
+        raise InvalidQueryError(
+            "query explodes the nested columns with UNNEST in a FROM clause, which "
+            "materializes one row per element; rewrite it with list_filter / "
+            "list_transform / flatten lambdas, which read the same values in place"
+        )

--- a/ord_schema/agent/sql_test.py
+++ b/ord_schema/agent/sql_test.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.agent.sql."""
+
+import pytest
+
+from ord_schema.agent import sql
+
+_LAMBDA_QUERY = (
+    "SELECT reaction_id FROM reactions WHERE len(list_filter(flatten(list_transform("
+    "map_values(inputs), i -> i.components)), c -> c.smiles = $thf)) > 0"
+)
+_UNNEST_QUERY = (
+    "SELECT DISTINCT reaction_id FROM reactions, UNNEST(map_values(inputs)) t(i), "
+    "UNNEST(i.components) u(c) WHERE c.smiles = $thf"
+)
+
+
+@pytest.mark.parametrize(
+    ("query", "parameters"),
+    [
+        ("SELECT reaction_id FROM reactions", None),
+        (
+            "SELECT reaction_id FROM reactions "
+            "WHERE conditions.temperature.setpoint_kelvin > 300",
+            None,
+        ),
+        (
+            "SELECT provenance.record_created.person.organization, count(*) "
+            "FROM reactions GROUP BY 1",
+            None,
+        ),
+        (_LAMBDA_QUERY, {"thf": "C1CCOC1"}),
+        # UNNEST in the select list projects the elements; it is the FROM clause form
+        # that materializes the exploded intermediate.
+        ("SELECT unnest(map_keys(inputs)) FROM reactions", None),
+    ],
+)
+def test_valid(query, parameters):
+    sql.validate(query, parameters=parameters)
+
+
+@pytest.mark.parametrize(
+    ("query", "parameters", "match"),
+    [
+        ("SELECT FROM WHERE", None, "does not parse"),
+        (
+            "SELECT 1 FROM reactions; SELECT 2 FROM reactions",
+            None,
+            "single statement",
+        ),
+        ("DROP TABLE reactions", None, "expected a SELECT"),
+        ("SELECT nope FROM reactions", None, "cannot be planned"),
+        # A placeholder the model referenced but did not declare: caught before the
+        # query reaches data, so the translation can be retried.
+        (
+            "SELECT reaction_id FROM reactions WHERE smiles = $missing",
+            None,
+            "cannot be planned",
+        ),
+        (_UNNEST_QUERY, {"thf": "C1CCOC1"}, "UNNEST in a FROM clause"),
+    ],
+)
+def test_invalid(query, parameters, match):
+    with pytest.raises(sql.InvalidQueryError, match=match):
+        sql.validate(query, parameters=parameters)
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT * FROM read_parquet('/etc/hosts')",
+        "SELECT * FROM read_csv('/etc/hosts')",
+    ],
+)
+def test_no_file_access(query):
+    with pytest.raises(sql.InvalidQueryError, match="cannot be planned"):
+        sql.validate(query)
+
+
+def test_placeholders_are_bound_not_interpolated():
+    # A value that would end the string literal and append a statement if it were
+    # interpolated. Bound, it is just a string that matches nothing.
+    sql.validate(
+        "SELECT reaction_id FROM reactions WHERE smiles = $name",
+        parameters={"name": "'; DROP TABLE reactions; --"},
+    )
+
+
+def test_validation_needs_no_data():
+    # The whole point: the schema is generated, so an empty table has the real shape
+    # and planning resolves every column without a corpus.
+    sql.validate(
+        "SELECT reaction_id FROM reactions "
+        "WHERE list_contains(list_transform(coalesce(outcomes, []), "
+        "o -> o.reaction_time_seconds), 3600.0)"
+    )
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "SELECT a.reaction_id FROM reactions a, reactions b WHERE a.smiles = b.smiles",
+        "SELECT reaction_id FROM reactions, range(1000000000)",
+        "WITH RECURSIVE t(n) AS ("
+        "  SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 1000000000"
+        ") SELECT count(*) FROM t",
+        "SELECT * FROM reactions",
+    ],
+)
+def test_cost_is_not_bounded(query):
+    # Pinning the documented limit rather than a behavior worth having: refusing UNNEST
+    # is one entry in a blacklist, and the set of expensive programs expressible in SQL
+    # cannot be listed. A caller needs its own timeout or row cap; if a later change
+    # does start bounding cost, this test should fail and be rewritten, not deleted.
+    sql.validate(query)
+
+
+@pytest.mark.parametrize("padding", [0, 11, 30])
+def test_unnest_is_refused_however_wide_the_plan(padding):
+    # The default EXPLAIN draws the plan into a fixed-width canvas and drops whole
+    # subtrees once a query has more parallel pipelines than fit -- no ellipsis, no
+    # error. Eleven UNION ALL branches were enough to make the UNNEST vanish from it
+    # and the query pass, so the check reads the JSON plan instead.
+    filler = "SELECT reaction_id FROM reactions WHERE reaction_id = 'nomatch'"
+    branches = [filler] * padding + [_UNNEST_QUERY]
+    with pytest.raises(sql.InvalidQueryError, match="UNNEST in a FROM clause"):
+        sql.validate(" UNION ALL ".join(branches), parameters={"thf": "C1CCOC1"})
+
+
+def test_an_operator_name_in_a_literal_is_not_an_operator():
+    # The plan carries filter expressions alongside operator names, so a substring
+    # search over the JSON would refuse this.
+    sql.validate("SELECT reaction_id FROM reactions WHERE smiles = 'INOUT_FUNCTION'")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,14 @@ dependencies = [
 Homepage = "https://github.com/Open-Reaction-Database/ord-schema"
 
 [project.optional-dependencies]
+# Optional: the ord_schema.agent subpackage holds the schema descriptions, query
+# validation, and (later) prompts and tool surfaces an agent uses to query ORD. DuckDB
+# is the dialect the generated SQL is written in and the planner that checks it; parsing
+# or validating a dataset needs neither.
+agent = [
+    "duckdb>=1.1",
+    "pydantic>=2",
+]
 docs = [
     "Pygments>=2.13.0",
     "Sphinx>=5.3.0",
@@ -91,7 +99,7 @@ tests = [
     "treon>=0.1.3",
     # The suite exercises the optional-feature modules, so collecting it needs
     # their extras. Self-reference rather than duplicate the dependencies.
-    "ord-schema[huggingface,orm]",
+    "ord-schema[agent,huggingface,orm]",
 ]
 
 [tool.setuptools.packages.find]

--- a/uv.lock
+++ b/uv.lock
@@ -27,6 +27,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -629,6 +638,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "duckdb"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/19/e57151753576373c6696a12022648546cca6038e8833fda2908ee2342d9b/duckdb-1.5.5.tar.gz", hash = "sha256:72f33ee57ca7595b23957671a2cc7f7fe2be0ecc2d68f63abedcfcaa3a5c1238", size = 18066741, upload-time = "2026-07-22T10:55:17.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/c2/b62ec24d57bb8df4e24b0b58f7f8facb32f5fdb9f1895aed9e9fcdded168/duckdb-1.5.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1b543841b0ae18a9c982345cfa3987e9c065d3a4b0f067daa473d92d1e65f528", size = 32708371, upload-time = "2026-07-22T10:53:41.642Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ce/769171ba45f0b73632dc3bc3108d891e81dd6c6bbfba630a34a75b4dcc0f/duckdb-1.5.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a925d06c2a4c3b64553d6cc1aced5028d376d4479bed689a7d47e9b1dccd80a", size = 17343979, upload-time = "2026-07-22T10:53:44.951Z" },
+    { url = "https://files.pythonhosted.org/packages/46/59/a8e3384ee916e00d5dcf985194c1511d61978540778a1e96fa47f9fb3e0d/duckdb-1.5.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0c42757cb34722144bd4dfb94b6f336339e7b2468f6813fa7fa9a319ba07bab4", size = 15493704, upload-time = "2026-07-22T10:53:47.912Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1d/9840179c2607b90523a2884a129c4d4e6dbdc1178ba62a976c1043beba88/duckdb-1.5.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e72f9e1a4f90a5c8483ad4d540e495bf0834ba61c360b52499a573d7ed62a3f", size = 19366574, upload-time = "2026-07-22T10:53:51.876Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/55/f9641a4eebcc2f4df631287d6c3b9ed2eea3b92644f93acbad825e3972b6/duckdb-1.5.5-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9b6f86ed85d4ef5e0211eaebf75d057bd8bb520bba438a95dd0f4e42234bbfe", size = 21477952, upload-time = "2026-07-22T10:53:55.575Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/3a/07c3556e37a5c97b95917b029c8fdde4a25fbd76a660bacdac195cf20dcb/duckdb-1.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:9f4287f97ccf0c1f3d471e7115be2b067cbf99627e2d34bffd462dd64703cddc", size = 13156986, upload-time = "2026-07-22T10:53:58.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ff/07b48eef2078ca033847e9caa46cc7633b714c5f91ad1ce091c8ca89d792/duckdb-1.5.5-cp311-cp311-win_arm64.whl", hash = "sha256:179633a3fc6296c75d57c69c1e239fa9e5cdcb670fd1dbff88a02663f932905c", size = 14001317, upload-time = "2026-07-22T10:54:01.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/40/2e05d324400fdaa5656c9f48d6298da421cb034d85e509fa0e6e325cf04b/duckdb-1.5.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d4dd65f8941a604b947e0b9b4b4f7165988e29a23ec0b69b4038520956d9933e", size = 32753858, upload-time = "2026-07-22T10:54:05.514Z" },
+    { url = "https://files.pythonhosted.org/packages/79/15/5ceb58ffb5bb8a62b3fd7abb39c41467cdf94850ece02e6d88664dfc75ce/duckdb-1.5.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33db46679b071f108d57139493dee2d37e1f5efcf5c5c039c2969eed11a6c8a7", size = 17368293, upload-time = "2026-07-22T10:54:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/5c/bf02da0b354fe83cca4f95a4fbf762181af466f7d551ab2a093f7698882a/duckdb-1.5.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f0b88535a5d86fdd63dba6ea02ab68c003dfb9e4892b11256ef24c4da208baae", size = 15509131, upload-time = "2026-07-22T10:54:12.228Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a9/5f1f09da421d8e930e0b063d11c1b3f90363f40ede74438cd188afdd13a2/duckdb-1.5.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f316eae2323d9a851883fdf2dee91c1f9efe251ab33e14a2272f82a913422ed6", size = 19391959, upload-time = "2026-07-22T10:54:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/98/6549769f158126fa64fd6c1ac2eb59a18282146c939867a3eb31b7c1db07/duckdb-1.5.5-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a6d2d11859d82a936ebdcb30ce3d8a1cbb3e990bff05c12abb9b54c44fa7bd1", size = 21510909, upload-time = "2026-07-22T10:54:19.681Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b7/5753b41d3124838f868f9f523362812d9fc45409e9e4dd70dcbb0a25826e/duckdb-1.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:ddfbdb096c11d51ee22492397d342c90a82e62c5d09961477895934d0a25372f", size = 13168544, upload-time = "2026-07-22T10:54:22.789Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/28/44b679c7d46245f8398feae7edac959d1b83d4eb143e25b3fce0630b78bd/duckdb-1.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:2725d2b9ace3a4e75d72fc5a239f6a44b502c580edadb8fb2676db772c5f9282", size = 13988684, upload-time = "2026-07-22T10:54:26.003Z" },
+    { url = "https://files.pythonhosted.org/packages/47/37/4a38116e7700720fd152c666292214fd3abdf916496991296d8d1f66efbf/duckdb-1.5.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd98829b67788609017e65c761bd42a5dd0f9129441bed8bda4d6881ccf819f0", size = 32754294, upload-time = "2026-07-22T10:54:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/7d392f1ba1eee0eaf4ab4c8c7a604bfe3536cd63f979cf5c98798664f807/duckdb-1.5.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:feead93c56679b79592d437c62975d39cb67adedffa7592c763baf8160ac7366", size = 17368211, upload-time = "2026-07-22T10:54:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a5/0a6f4fa60562faa615e55e15bd1953a2f2b17a8edd8105e5cda215e43457/duckdb-1.5.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:49c963d9469373d7aba8d750d9ea565ab823e94166efed953f184dd9b169b98c", size = 15509136, upload-time = "2026-07-22T10:54:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/023c89f51978545b9fab318581bba0c457a58e7530d2d933e54ae7d8647c/duckdb-1.5.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a736217825461732b5442d05a220f3da2e23a0dae114efbf08c9bf171b53098a", size = 19392147, upload-time = "2026-07-22T10:54:39.551Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c5/41bef391fb8b23dbc133c9f2ba016e7a7a8124513d2cc1b430f1897d87e4/duckdb-1.5.5-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:078e6a60dd8eedde5832f45422ca5c4a6b8c837aeabd8a56ca0b7d933f588053", size = 21511060, upload-time = "2026-07-22T10:54:42.788Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9f/c44dfc1f924ac29b3252dc1b91393c01d009dbfe9f8ed33f10b986151bd1/duckdb-1.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:6826504277dba513c0c5d71d828456c94d729c9d2482f94b2e289f90a9167e28", size = 13168028, upload-time = "2026-07-22T10:54:46.127Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/591384b2cd59abddd6f5dc175e60374f9abae6064429f0c4402854c10f44/duckdb-1.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:baa9c5702002fabb559ded2a39008f9f421fcbc7237d388b8213eff1e08858de", size = 13989955, upload-time = "2026-07-22T10:54:49.262Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/56/12c65bfa2d2605b81981b264788891bcf11ec72227889554cead5d8d13b9/duckdb-1.5.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8e6413dd40facb7b8ab21bd844450cd8f549b29e138635be9cf090ef4d2049e2", size = 32761946, upload-time = "2026-07-22T10:54:53.412Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/46/682ce155f17e0d2822d4f13ee3db9ca4b5b7c2da61b841b2629035e1f4bc/duckdb-1.5.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:64078acfd16541132ac6e191eb81b2845554444a0305cc1aa581ba107e514aa8", size = 17375069, upload-time = "2026-07-22T10:54:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ce/a24bcbd3289c8f305a430759c5fc12242740b4af3e17f7593f3a34e333d2/duckdb-1.5.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c11775cc99a447618d5f1840126db17f2652f3eae05529df4f81f40e2df7151", size = 15519791, upload-time = "2026-07-22T10:55:00.681Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/76/3a01afbc615c1d418c0de58a6b68ac5ce2a8563232c0464bfbc2ce552398/duckdb-1.5.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77bbc1e6ba12e1e06f9020117bdf848627ecfdf36f907550e62e008e6109dece", size = 19398251, upload-time = "2026-07-22T10:55:04.168Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/43/3a5e81d1728f4d234c79bfe385808ee7c04834f7c37a4b5c257459c25614/duckdb-1.5.5-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fbf0f2d48b43c6c304d00463b463c27ead6c4b01c3c1816b750f728decf71afe", size = 21513851, upload-time = "2026-07-22T10:55:07.864Z" },
+    { url = "https://files.pythonhosted.org/packages/91/41/fc7c829172c60ca22485251eab285f4f1a0d87b486a024c726f21471d86e/duckdb-1.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:9dc826c4b50e64f6c4e4d07a3a9cb075ef70ba3899dc43ec5493dc3d7b04b353", size = 13691858, upload-time = "2026-07-22T10:55:11.181Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2c/95d9216b79e9273689d7ebce125a54503ed0c9bd7da931f0265888e99779/duckdb-1.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:63e48d4b74b15aeacd688976432a7225163df8c226eddeb8536bba2d4d4ff433", size = 14470180, upload-time = "2026-07-22T10:55:14.445Z" },
 ]
 
 [[package]]
@@ -2124,6 +2169,10 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+agent = [
+    { name = "duckdb" },
+    { name = "pydantic" },
+]
 docs = [
     { name = "ipython", version = "9.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "ipython", version = "9.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -2150,9 +2199,11 @@ orm = [
 ]
 tests = [
     { name = "coverage" },
+    { name = "duckdb" },
     { name = "huggingface-hub" },
     { name = "inflection" },
     { name = "psycopg", extra = ["binary", "pool"] },
+    { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
@@ -2167,6 +2218,7 @@ tests = [
 [package.metadata]
 requires-dist = [
     { name = "coverage", marker = "extra == 'tests'", specifier = ">=5.2.1" },
+    { name = "duckdb", marker = "extra == 'agent'", specifier = ">=1.1" },
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.20" },
     { name = "inflection", marker = "extra == 'orm'", specifier = ">=0.5.1" },
     { name = "ipython", marker = "extra == 'docs'", specifier = ">=8.4.0" },
@@ -2174,11 +2226,12 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'examples'", specifier = ">=3.3.4" },
     { name = "numpy", specifier = ">=1.26.4" },
     { name = "openpyxl", specifier = ">=3.0.5" },
-    { name = "ord-schema", extras = ["huggingface", "orm"], marker = "extra == 'tests'" },
+    { name = "ord-schema", extras = ["agent", "huggingface", "orm"], marker = "extra == 'tests'" },
     { name = "pandas", specifier = ">=1.0.4" },
     { name = "protobuf", specifier = ">=4.22.3,<6" },
     { name = "psycopg", extras = ["binary", "pool"], marker = "extra == 'orm'", specifier = ">=3" },
     { name = "pyarrow", specifier = ">=14" },
+    { name = "pydantic", marker = "extra == 'agent'", specifier = ">=2" },
     { name = "pygments", marker = "extra == 'docs'", specifier = ">=2.13.0" },
     { name = "pytest", marker = "extra == 'tests'", specifier = ">=7.1.1" },
     { name = "pytest-cov", marker = "extra == 'tests'", specifier = ">=3.0.0" },
@@ -2199,7 +2252,7 @@ requires-dist = [
     { name = "uuid6", marker = "extra == 'orm'", specifier = ">=2023" },
     { name = "wget", marker = "extra == 'examples'", specifier = ">=3.2" },
 ]
-provides-extras = ["docs", "examples", "huggingface", "orm", "tests"]
+provides-extras = ["agent", "docs", "examples", "huggingface", "orm", "tests"]
 
 [[package]]
 name = "overrides"
@@ -2641,6 +2694,123 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
 ]
 
 [[package]]
@@ -3793,6 +3963,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The model emits a structured `Query`, and the library compiles it to DuckDB SQL. Not for safety alone — bound parameters already gave that — but for **cost**: SQL's expensive programs cannot be enumerated, so every guard on generated SQL is a blacklist someone keeps adding to. This grammar has one relation, no join, no recursion, and no set-returning function, so the worst program expressible in it is one pass over the corpus plus a sort. Expensive queries are not discouraged; they are unwritable.

It still reaches all 442 leaves, because a column is a *parameter* rather than part of the grammar — the difference between this and the per-predicate enumeration it replaces.

**Stacked on #949**, which supplies the schema description this queries against; review that first. Design record in [ord-logbook#25](https://github.com/open-reaction-database/ord-logbook/pull/25).

## Changes

- `agent/query.py` — the grammar and its compiler. Paths resolve against `projection.SCHEMA` before any SQL exists, so an unknown field is a compile error with a near-match suggestion, and an operator that cannot suit its leaf's type is refused rather than run.
- `agent/sql.py` — a backstop on the compiler's own output, not the guard it started as.
- `agent/README.md`, and the `agent` extra carrying `duckdb` and `pydantic`.

## Testing

`uv run pytest` — 913 passed, 69 in the agent package.

Verified against the projection of `ord_dataset-488402f6` (40,000 reactions): compiled queries agree with hand-written SQL on every case tried — co-membership, `forall`, nested quantifiers — at the same speed, and their output passes `sql.validate`.

Two refusals are the point and are pinned: a path crossing a repeated level without a quantifier, where `UNNEST` would silently mean "any" *and* multiply the row count; and repeated levels compiling to list lambdas rather than `UNNEST` in a `FROM` clause, so the 27–200× cliff is unreachable rather than policed.

Fixed under review: `sql.validate` read DuckDB's *rendered* plan, which draws into a fixed-width canvas and silently drops subtrees — eleven `UNION ALL` branches made the exact query the tests assert is refused pass instead. It reads `EXPLAIN (FORMAT json)` now, walking operator names structurally, and refuses a plan it cannot read. And `compile_query` inserted its `table` argument verbatim, so a caller could pass `reactions, range(1000000000)` and get a cross join the `Query` never asked for.

## Notes

`sql.validate` still does not bound cost, and says so — that is a property of accepting SQL, and the reason the model no longer writes it. A caller running arbitrary SQL needs its own statement timeout or row cap.

Execution still needs a sandbox, unchanged: `enable_external_access=false` cannot be combined with a lazy Parquet view, so the real corpus needs `allowed_directories` or a subprocess. An IR removes the reasons to fear the query, not the reasons to contain the process.

Ibis was measured as a possible backend — same SQL shape, same speed — but its expressions are built from Python lambdas, which a model cannot emit without evaluating model-supplied Python. Worth revisiting if a second dialect is ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR introduces a structured query grammar and DuckDB SQL compiler so model-generated queries are constrained to one relation, while strengthening SQL-plan validation and documenting the execution boundary.
- Adds schema-aware predicates, quantifiers, aggregation, ordering, and query compilation.
- Restricts relation overrides to plain identifiers, closing the previously reported grammar bypass.
- Reads DuckDB plans as structured JSON and fails closed when a plan cannot be interpreted.
- Adds agent dependencies, documentation, and comprehensive query and validation tests.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/agent/query.py | Adds the schema-aware query IR and compiler, including the identifier restriction that fixes the previously reported table-expression bypass. |
| ord_schema/agent/query_test.py | Exercises path resolution, quantifier semantics, aggregation, injection-resistant values, grammar boundaries, and table-name refusal. |
| ord_schema/agent/sql.py | Implements read-only SQL planning against an empty projection and structurally inspects DuckDB JSON plans while accurately documenting that arbitrary SQL cost is not bounded. |
| ord_schema/agent/sql_test.py | Covers statement restrictions, disabled file access, parameter binding, exploding-plan rejection, and fail-closed plan parsing. |
| pyproject.toml | Adds the optional agent dependency group and includes it in the test environment. |
| uv.lock | Resolves the newly added DuckDB and Pydantic dependencies; advisory-matched Keras entries are unchanged and unrelated to the agent dependency path. |
| ord_schema/agent/README.md | Documents the structured-query design, supported grammar, compilation workflow, affordability boundary, and remaining execution-sandbox responsibility. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Model[Model emits structured Query] --> Validate[Validate paths and operators against projection schema]
    Validate --> Compile[Compile constrained DuckDB SQL]
    Compile --> Plan[Validate structured JSON plan]
    Plan --> Execute[Caller binds parameters and executes against reactions]
```
</details>

<sub>Reviews (9): Last reviewed commit: ["Compile a query the model emits instead ..."](https://github.com/open-reaction-database/ord-schema/commit/c73c838f9d472cc97efb00807e4161436ed4c372) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51379074)</sub>

<!-- /greptile_comment -->