### PR TITLE
Describe the projection to a model, and record its enum members

### DIFF
--- a/ord_schema/agent/__init__.py
+++ b/ord_schema/agent/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Machinery for reaching ORD from an agent.
+
+Everything an agent needs to turn an intent into a query lives here: the schema a model
+is told about, the checks its query has to pass, name resolution, and -- as they arrive
+-- prompts, tool, and MCP surfaces.
+
+It sits in ``ord-schema`` rather than in a serving repository because these pieces
+describe the *data*, not a deployment. A description that tells a model which columns
+exist has to be versioned alongside the code that generates them, or it silently drifts
+from a schema it cannot see; :mod:`ord_schema.agent.schema` and
+:mod:`ord_schema.agent.sql` both read ``projection.SCHEMA`` for exactly that reason. For
+the same reason nothing here does HTTP, holds a database connection, or owns a cache; a
+server supplies those and maps library exceptions onto its own protocol.
+
+Requires the ``agent`` extra (``pip install ord-schema[agent]``).
+"""

--- a/ord_schema/agent/projection_schema.txt
+++ b/ord_schema/agent/projection_schema.txt
@@ -1,0 +1,537 @@
+smiles: VARCHAR
+identifiers: LIST<STRUCT>
+  type: VARCHAR  (UNSPECIFIED | CUSTOM | REACTION_SMILES | REACTION_CXSMILES | RDFILE | RINCHI | REACTION_TYPE)
+  details: VARCHAR
+  value: VARCHAR
+  is_mapped: BOOLEAN
+inputs: MAP<VARCHAR, STRUCT>
+  components: LIST<STRUCT>
+    smiles: VARCHAR
+    identifiers: LIST<STRUCT>
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | SMILES | INCHI | MOLBLOCK | IUPAC_NAME | NAME | CAS_NUMBER | PUBCHEM_CID | CHEMSPIDER_ID | CXSMILES | INCHI_KEY | XYZ | UNIPROT_ID | PDB_ID | AMINO_ACID_SEQUENCE | HELM | MDL)
+      details: VARCHAR
+      value: VARCHAR
+    amount: STRUCT
+      mass_grams: DOUBLE
+      mass_precision_grams: DOUBLE
+      moles_moles: DOUBLE
+      moles_precision_moles: DOUBLE
+      volume_liters: DOUBLE
+      volume_precision_liters: DOUBLE
+      unmeasured: STRUCT
+        type: VARCHAR  (UNSPECIFIED | CUSTOM | SATURATED | CATALYTIC | TITRATED)
+        details: VARCHAR
+      volume_includes_solutes: BOOLEAN
+    reaction_role: VARCHAR  (UNSPECIFIED | REACTANT | REAGENT | SOLVENT | CATALYST | WORKUP | INTERNAL_STANDARD | AUTHENTIC_STANDARD | PRODUCT | BYPRODUCT | SIDE_PRODUCT)
+    is_limiting: BOOLEAN
+    preparations: LIST<STRUCT>
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | NONE | REPURIFIED | SPARGED | DRIED | SYNTHESIZED)
+      details: VARCHAR
+      reaction_id: VARCHAR
+    source: STRUCT
+      vendor: VARCHAR
+      catalog_id: VARCHAR
+      lot: VARCHAR
+    features: MAP<VARCHAR, STRUCT>
+      float_value: FLOAT
+      integer_value: INTEGER
+      bytes_value: BLOB
+      string_value: VARCHAR
+      url: VARCHAR
+      description: VARCHAR
+      format: VARCHAR
+    analyses: MAP<VARCHAR, STRUCT>
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | LC | GC | IR | NMR_1H | NMR_13C | NMR_OTHER | MP | UV | TLC | MS | HRMS | MSMS | WEIGHT | LCMS | GCMS | ELSD | CD | SFC | EPR | XRD | RAMAN | ED | OPTICAL_ROTATION | CAD)
+      details: VARCHAR
+      chmo_id: INTEGER
+      is_of_isolated_species: BOOLEAN
+      data: MAP<VARCHAR, STRUCT>
+        float_value: FLOAT
+        integer_value: INTEGER
+        bytes_value: BLOB
+        string_value: VARCHAR
+        url: VARCHAR
+        description: VARCHAR
+        format: VARCHAR
+      instrument_manufacturer: VARCHAR
+      instrument_last_calibrated: STRUCT
+        value: VARCHAR
+    texture: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
+      details: VARCHAR
+  crude_components: LIST<STRUCT>
+    reaction_id: VARCHAR
+    includes_workup: BOOLEAN
+    has_derived_amount: BOOLEAN
+    amount: STRUCT
+      mass_grams: DOUBLE
+      mass_precision_grams: DOUBLE
+      moles_moles: DOUBLE
+      moles_precision_moles: DOUBLE
+      volume_liters: DOUBLE
+      volume_precision_liters: DOUBLE
+      unmeasured: STRUCT
+        type: VARCHAR  (UNSPECIFIED | CUSTOM | SATURATED | CATALYTIC | TITRATED)
+        details: VARCHAR
+      volume_includes_solutes: BOOLEAN
+    texture: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
+      details: VARCHAR
+  addition_order: INTEGER
+  addition_time_seconds: DOUBLE
+  addition_time_precision_seconds: DOUBLE
+  addition_speed: STRUCT
+    type: VARCHAR  (UNSPECIFIED | ALL_AT_ONCE | FAST | SLOW | DROPWISE | CONTINUOUS | PORTIONWISE)
+    details: VARCHAR
+  addition_duration_seconds: DOUBLE
+  addition_duration_precision_seconds: DOUBLE
+  flow_rate_milliliters_per_minute: DOUBLE
+  flow_rate_precision_milliliters_per_minute: DOUBLE
+  addition_device: STRUCT
+    type: VARCHAR  (UNSPECIFIED | CUSTOM | NONE | SYRINGE | CANNULA | ADDITION_FUNNEL | PIPETTE | POSITIVE_DISPLACEMENT_PIPETTE | PISTON_PUMP | SYRINGE_PUMP | PERISTALTIC_PUMP)
+    details: VARCHAR
+  addition_temperature_kelvin: DOUBLE
+  addition_temperature_precision_kelvin: DOUBLE
+  texture: STRUCT
+    type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
+    details: VARCHAR
+setup: STRUCT
+  vessel: STRUCT
+    type: VARCHAR  (UNSPECIFIED | CUSTOM | ROUND_BOTTOM_FLASK | VIAL | WELL_PLATE | MICROWAVE_VIAL | TUBE | CONTINUOUS_STIRRED_TANK_REACTOR | PACKED_BED_REACTOR | NMR_TUBE | PRESSURE_FLASK | PRESSURE_REACTOR | ELECTROCHEMICAL_CELL)
+    details: VARCHAR
+    material: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | GLASS | POLYPROPYLENE | PLASTIC | METAL | QUARTZ)
+      details: VARCHAR
+    preparations: LIST<STRUCT>
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | NONE | OVEN_DRIED | FLAME_DRIED | EVACUATED_BACKFILLED | PURGED)
+      details: VARCHAR
+    attachments: LIST<STRUCT>
+      type: VARCHAR  (UNSPECIFIED | NONE | CUSTOM | SEPTUM | CAP | MAT | REFLUX_CONDENSER | VENT_NEEDLE | DEAN_STARK | VACUUM_TUBE | ADDITION_FUNNEL | DRYING_TUBE | ALUMINUM_FOIL | THERMOCOUPLE | BALLOON | GAS_ADAPTER | PRESSURE_REGULATOR | RELEASE_VALVE)
+      details: VARCHAR
+    volume_liters: DOUBLE
+    volume_precision_liters: DOUBLE
+    vessel_id: VARCHAR
+    position: VARCHAR
+    row: VARCHAR
+    col: VARCHAR
+  is_automated: BOOLEAN
+  automation_platform: VARCHAR
+  automation_code: MAP<VARCHAR, STRUCT>
+    float_value: FLOAT
+    integer_value: INTEGER
+    bytes_value: BLOB
+    string_value: VARCHAR
+    url: VARCHAR
+    description: VARCHAR
+    format: VARCHAR
+  environment: STRUCT
+    type: VARCHAR  (UNSPECIFIED | CUSTOM | FUME_HOOD | BENCH_TOP | GLOVE_BOX | GLOVE_BAG)
+    details: VARCHAR
+conditions: STRUCT
+  temperature: STRUCT
+    control: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | AMBIENT | OIL_BATH | WATER_BATH | SAND_BATH | ICE_BATH | DRY_ALUMINUM_PLATE | MICROWAVE | DRY_ICE_BATH | AIR_FAN | LIQUID_NITROGEN)
+      details: VARCHAR
+    setpoint_kelvin: DOUBLE
+    setpoint_precision_kelvin: DOUBLE
+    measurements: LIST<STRUCT>
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | THERMOCOUPLE_INTERNAL | THERMOCOUPLE_EXTERNAL | INFRARED)
+      details: VARCHAR
+      time_seconds: DOUBLE
+      time_precision_seconds: DOUBLE
+      temperature_kelvin: DOUBLE
+      temperature_precision_kelvin: DOUBLE
+  pressure: STRUCT
+    control: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | AMBIENT | SLIGHT_POSITIVE | SEALED | PRESSURIZED)
+      details: VARCHAR
+    setpoint_kilopascals: DOUBLE
+    setpoint_precision_kilopascals: DOUBLE
+    atmosphere: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | AIR | NITROGEN | ARGON | OXYGEN | HYDROGEN | CARBON_MONOXIDE | CARBON_DIOXIDE | METHANE | AMMONIA | OZONE | ETHYLENE | ACETYLENE)
+      details: VARCHAR
+    measurements: LIST<STRUCT>
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | PRESSURE_TRANSDUCER)
+      details: VARCHAR
+      time_seconds: DOUBLE
+      time_precision_seconds: DOUBLE
+      pressure_kilopascals: DOUBLE
+      pressure_precision_kilopascals: DOUBLE
+  stirring: STRUCT
+    type: VARCHAR  (UNSPECIFIED | CUSTOM | NONE | STIR_BAR | OVERHEAD_MIXER | AGITATION | BALL_MILLING | SONICATION)
+    details: VARCHAR
+    rate: STRUCT
+      type: VARCHAR  (UNSPECIFIED | HIGH | MEDIUM | LOW)
+      details: VARCHAR
+      rpm: INTEGER
+  illumination: STRUCT
+    type: VARCHAR  (UNSPECIFIED | CUSTOM | AMBIENT | DARK | LED | HALOGEN_LAMP | DEUTERIUM_LAMP | SOLAR_SIMULATOR | BROAD_SPECTRUM)
+    details: VARCHAR
+    peak_wavelength_nanometers: DOUBLE
+    peak_wavelength_precision_nanometers: DOUBLE
+    color: VARCHAR
+    distance_to_vessel_centimeters: DOUBLE
+    distance_to_vessel_precision_centimeters: DOUBLE
+  electrochemistry: STRUCT
+    type: VARCHAR  (UNSPECIFIED | CUSTOM | CONSTANT_CURRENT | CONSTANT_VOLTAGE)
+    details: VARCHAR
+    current_amperes: DOUBLE
+    current_precision_amperes: DOUBLE
+    voltage_volts: DOUBLE
+    voltage_precision_volts: DOUBLE
+    anode_material: VARCHAR
+    cathode_material: VARCHAR
+    electrode_separation_centimeters: DOUBLE
+    electrode_separation_precision_centimeters: DOUBLE
+    measurements: LIST<STRUCT>
+      time_seconds: DOUBLE
+      time_precision_seconds: DOUBLE
+      current_amperes: DOUBLE
+      current_precision_amperes: DOUBLE
+      voltage_volts: DOUBLE
+      voltage_precision_volts: DOUBLE
+    cell: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | DIVIDED_CELL | UNDIVIDED_CELL)
+      details: VARCHAR
+  flow: STRUCT
+    type: VARCHAR  (UNSPECIFIED | CUSTOM | PLUG_FLOW_REACTOR | CONTINUOUS_STIRRED_TANK_REACTOR | PACKED_BED_REACTOR)
+    details: VARCHAR
+    pump_type: VARCHAR
+    tubing: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | STEEL | COPPER | PFA | FEP | TEFLONAF | PTFE | GLASS | QUARTZ | SILICON | PDMS)
+      details: VARCHAR
+      diameter_centimeters: DOUBLE
+      diameter_precision_centimeters: DOUBLE
+  reflux: BOOLEAN
+  ph: FLOAT
+  conditions_are_dynamic: BOOLEAN
+  details: VARCHAR
+notes: STRUCT
+  is_heterogeneous: BOOLEAN
+  forms_precipitate: BOOLEAN
+  is_exothermic: BOOLEAN
+  offgasses: BOOLEAN
+  is_sensitive_to_moisture: BOOLEAN
+  is_sensitive_to_oxygen: BOOLEAN
+  is_sensitive_to_light: BOOLEAN
+  safety_notes: VARCHAR
+  procedure_details: VARCHAR
+observations: LIST<STRUCT>
+  time_seconds: DOUBLE
+  time_precision_seconds: DOUBLE
+  comment: VARCHAR
+  image: STRUCT
+    float_value: FLOAT
+    integer_value: INTEGER
+    bytes_value: BLOB
+    string_value: VARCHAR
+    url: VARCHAR
+    description: VARCHAR
+    format: VARCHAR
+workups: LIST<STRUCT>
+  type: VARCHAR  (UNSPECIFIED | CUSTOM | ADDITION | ALIQUOT | TEMPERATURE | CONCENTRATION | EXTRACTION | FILTRATION | WASH | DRY_IN_VACUUM | DRY_WITH_MATERIAL | FLASH_CHROMATOGRAPHY | OTHER_CHROMATOGRAPHY | SCAVENGING | WAIT | STIRRING | PH_ADJUST | DISSOLUTION | DISTILLATION)
+  details: VARCHAR
+  duration_seconds: DOUBLE
+  duration_precision_seconds: DOUBLE
+  input: STRUCT
+    components: LIST<STRUCT>
+      smiles: VARCHAR
+      identifiers: LIST<STRUCT>
+        type: VARCHAR  (UNSPECIFIED | CUSTOM | SMILES | INCHI | MOLBLOCK | IUPAC_NAME | NAME | CAS_NUMBER | PUBCHEM_CID | CHEMSPIDER_ID | CXSMILES | INCHI_KEY | XYZ | UNIPROT_ID | PDB_ID | AMINO_ACID_SEQUENCE | HELM | MDL)
+        details: VARCHAR
+        value: VARCHAR
+      amount: STRUCT
+        mass_grams: DOUBLE
+        mass_precision_grams: DOUBLE
+        moles_moles: DOUBLE
+        moles_precision_moles: DOUBLE
+        volume_liters: DOUBLE
+        volume_precision_liters: DOUBLE
+        unmeasured: STRUCT
+          type: VARCHAR  (UNSPECIFIED | CUSTOM | SATURATED | CATALYTIC | TITRATED)
+          details: VARCHAR
+        volume_includes_solutes: BOOLEAN
+      reaction_role: VARCHAR  (UNSPECIFIED | REACTANT | REAGENT | SOLVENT | CATALYST | WORKUP | INTERNAL_STANDARD | AUTHENTIC_STANDARD | PRODUCT | BYPRODUCT | SIDE_PRODUCT)
+      is_limiting: BOOLEAN
+      preparations: LIST<STRUCT>
+        type: VARCHAR  (UNSPECIFIED | CUSTOM | NONE | REPURIFIED | SPARGED | DRIED | SYNTHESIZED)
+        details: VARCHAR
+        reaction_id: VARCHAR
+      source: STRUCT
+        vendor: VARCHAR
+        catalog_id: VARCHAR
+        lot: VARCHAR
+      features: MAP<VARCHAR, STRUCT>
+        float_value: FLOAT
+        integer_value: INTEGER
+        bytes_value: BLOB
+        string_value: VARCHAR
+        url: VARCHAR
+        description: VARCHAR
+        format: VARCHAR
+      analyses: MAP<VARCHAR, STRUCT>
+        type: VARCHAR  (UNSPECIFIED | CUSTOM | LC | GC | IR | NMR_1H | NMR_13C | NMR_OTHER | MP | UV | TLC | MS | HRMS | MSMS | WEIGHT | LCMS | GCMS | ELSD | CD | SFC | EPR | XRD | RAMAN | ED | OPTICAL_ROTATION | CAD)
+        details: VARCHAR
+        chmo_id: INTEGER
+        is_of_isolated_species: BOOLEAN
+        data: MAP<VARCHAR, STRUCT>
+          float_value: FLOAT
+          integer_value: INTEGER
+          bytes_value: BLOB
+          string_value: VARCHAR
+          url: VARCHAR
+          description: VARCHAR
+          format: VARCHAR
+        instrument_manufacturer: VARCHAR
+        instrument_last_calibrated: STRUCT
+          value: VARCHAR
+      texture: STRUCT
+        type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
+        details: VARCHAR
+    crude_components: LIST<STRUCT>
+      reaction_id: VARCHAR
+      includes_workup: BOOLEAN
+      has_derived_amount: BOOLEAN
+      amount: STRUCT
+        mass_grams: DOUBLE
+        mass_precision_grams: DOUBLE
+        moles_moles: DOUBLE
+        moles_precision_moles: DOUBLE
+        volume_liters: DOUBLE
+        volume_precision_liters: DOUBLE
+        unmeasured: STRUCT
+          type: VARCHAR  (UNSPECIFIED | CUSTOM | SATURATED | CATALYTIC | TITRATED)
+          details: VARCHAR
+        volume_includes_solutes: BOOLEAN
+      texture: STRUCT
+        type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
+        details: VARCHAR
+    addition_order: INTEGER
+    addition_time_seconds: DOUBLE
+    addition_time_precision_seconds: DOUBLE
+    addition_speed: STRUCT
+      type: VARCHAR  (UNSPECIFIED | ALL_AT_ONCE | FAST | SLOW | DROPWISE | CONTINUOUS | PORTIONWISE)
+      details: VARCHAR
+    addition_duration_seconds: DOUBLE
+    addition_duration_precision_seconds: DOUBLE
+    flow_rate_milliliters_per_minute: DOUBLE
+    flow_rate_precision_milliliters_per_minute: DOUBLE
+    addition_device: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | NONE | SYRINGE | CANNULA | ADDITION_FUNNEL | PIPETTE | POSITIVE_DISPLACEMENT_PIPETTE | PISTON_PUMP | SYRINGE_PUMP | PERISTALTIC_PUMP)
+      details: VARCHAR
+    addition_temperature_kelvin: DOUBLE
+    addition_temperature_precision_kelvin: DOUBLE
+    texture: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
+      details: VARCHAR
+  amount: STRUCT
+    mass_grams: DOUBLE
+    mass_precision_grams: DOUBLE
+    moles_moles: DOUBLE
+    moles_precision_moles: DOUBLE
+    volume_liters: DOUBLE
+    volume_precision_liters: DOUBLE
+    unmeasured: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | SATURATED | CATALYTIC | TITRATED)
+      details: VARCHAR
+    volume_includes_solutes: BOOLEAN
+  temperature: STRUCT
+    control: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | AMBIENT | OIL_BATH | WATER_BATH | SAND_BATH | ICE_BATH | DRY_ALUMINUM_PLATE | MICROWAVE | DRY_ICE_BATH | AIR_FAN | LIQUID_NITROGEN)
+      details: VARCHAR
+    setpoint_kelvin: DOUBLE
+    setpoint_precision_kelvin: DOUBLE
+    measurements: LIST<STRUCT>
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | THERMOCOUPLE_INTERNAL | THERMOCOUPLE_EXTERNAL | INFRARED)
+      details: VARCHAR
+      time_seconds: DOUBLE
+      time_precision_seconds: DOUBLE
+      temperature_kelvin: DOUBLE
+      temperature_precision_kelvin: DOUBLE
+  keep_phase: VARCHAR
+  stirring: STRUCT
+    type: VARCHAR  (UNSPECIFIED | CUSTOM | NONE | STIR_BAR | OVERHEAD_MIXER | AGITATION | BALL_MILLING | SONICATION)
+    details: VARCHAR
+    rate: STRUCT
+      type: VARCHAR  (UNSPECIFIED | HIGH | MEDIUM | LOW)
+      details: VARCHAR
+      rpm: INTEGER
+  target_ph: FLOAT
+  is_automated: BOOLEAN
+outcomes: LIST<STRUCT>
+  reaction_time_seconds: DOUBLE
+  reaction_time_precision_seconds: DOUBLE
+  conversion: STRUCT
+    value: FLOAT
+    precision: FLOAT
+  products: LIST<STRUCT>
+    smiles: VARCHAR
+    identifiers: LIST<STRUCT>
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | SMILES | INCHI | MOLBLOCK | IUPAC_NAME | NAME | CAS_NUMBER | PUBCHEM_CID | CHEMSPIDER_ID | CXSMILES | INCHI_KEY | XYZ | UNIPROT_ID | PDB_ID | AMINO_ACID_SEQUENCE | HELM | MDL)
+      details: VARCHAR
+      value: VARCHAR
+    is_desired_product: BOOLEAN
+    measurements: LIST<STRUCT>
+      analysis_key: VARCHAR
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | IDENTITY | YIELD | SELECTIVITY | PURITY | AREA | COUNTS | INTENSITY | AMOUNT)
+      details: VARCHAR
+      uses_internal_standard: BOOLEAN
+      is_normalized: BOOLEAN
+      uses_authentic_standard: BOOLEAN
+      authentic_standard: STRUCT
+        smiles: VARCHAR
+        identifiers: LIST<STRUCT>
+          type: VARCHAR  (UNSPECIFIED | CUSTOM | SMILES | INCHI | MOLBLOCK | IUPAC_NAME | NAME | CAS_NUMBER | PUBCHEM_CID | CHEMSPIDER_ID | CXSMILES | INCHI_KEY | XYZ | UNIPROT_ID | PDB_ID | AMINO_ACID_SEQUENCE | HELM | MDL)
+          details: VARCHAR
+          value: VARCHAR
+        amount: STRUCT
+          mass_grams: DOUBLE
+          mass_precision_grams: DOUBLE
+          moles_moles: DOUBLE
+          moles_precision_moles: DOUBLE
+          volume_liters: DOUBLE
+          volume_precision_liters: DOUBLE
+          unmeasured: STRUCT
+            type: VARCHAR  (UNSPECIFIED | CUSTOM | SATURATED | CATALYTIC | TITRATED)
+            details: VARCHAR
+          volume_includes_solutes: BOOLEAN
+        reaction_role: VARCHAR  (UNSPECIFIED | REACTANT | REAGENT | SOLVENT | CATALYST | WORKUP | INTERNAL_STANDARD | AUTHENTIC_STANDARD | PRODUCT | BYPRODUCT | SIDE_PRODUCT)
+        is_limiting: BOOLEAN
+        preparations: LIST<STRUCT>
+          type: VARCHAR  (UNSPECIFIED | CUSTOM | NONE | REPURIFIED | SPARGED | DRIED | SYNTHESIZED)
+          details: VARCHAR
+          reaction_id: VARCHAR
+        source: STRUCT
+          vendor: VARCHAR
+          catalog_id: VARCHAR
+          lot: VARCHAR
+        features: MAP<VARCHAR, STRUCT>
+          float_value: FLOAT
+          integer_value: INTEGER
+          bytes_value: BLOB
+          string_value: VARCHAR
+          url: VARCHAR
+          description: VARCHAR
+          format: VARCHAR
+        analyses: MAP<VARCHAR, STRUCT>
+          type: VARCHAR  (UNSPECIFIED | CUSTOM | LC | GC | IR | NMR_1H | NMR_13C | NMR_OTHER | MP | UV | TLC | MS | HRMS | MSMS | WEIGHT | LCMS | GCMS | ELSD | CD | SFC | EPR | XRD | RAMAN | ED | OPTICAL_ROTATION | CAD)
+          details: VARCHAR
+          chmo_id: INTEGER
+          is_of_isolated_species: BOOLEAN
+          data: MAP<VARCHAR, STRUCT>
+            float_value: FLOAT
+            integer_value: INTEGER
+            bytes_value: BLOB
+            string_value: VARCHAR
+            url: VARCHAR
+            description: VARCHAR
+            format: VARCHAR
+          instrument_manufacturer: VARCHAR
+          instrument_last_calibrated: STRUCT
+            value: VARCHAR
+        texture: STRUCT
+          type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
+          details: VARCHAR
+      percentage: STRUCT
+        value: FLOAT
+        precision: FLOAT
+      float_value: STRUCT
+        value: FLOAT
+        precision: FLOAT
+      string_value: VARCHAR
+      amount: STRUCT
+        mass_grams: DOUBLE
+        mass_precision_grams: DOUBLE
+        moles_moles: DOUBLE
+        moles_precision_moles: DOUBLE
+        volume_liters: DOUBLE
+        volume_precision_liters: DOUBLE
+        unmeasured: STRUCT
+          type: VARCHAR  (UNSPECIFIED | CUSTOM | SATURATED | CATALYTIC | TITRATED)
+          details: VARCHAR
+        volume_includes_solutes: BOOLEAN
+      retention_time_seconds: DOUBLE
+      retention_time_precision_seconds: DOUBLE
+      mass_spec_details: STRUCT
+        type: VARCHAR  (UNSPECIFIED | CUSTOM | TIC | TIC_POSITIVE | TIC_NEGATIVE | EIC)
+        details: VARCHAR
+        tic_minimum_mz: FLOAT
+        tic_maximum_mz: FLOAT
+        eic_masses: LIST<FLOAT>
+      selectivity: STRUCT
+        type: VARCHAR  (UNSPECIFIED | CUSTOM | EE | ER | DR | EZ | ZE)
+        details: VARCHAR
+      wavelength_nanometers: DOUBLE
+      wavelength_precision_nanometers: DOUBLE
+    isolated_color: VARCHAR
+    texture: STRUCT
+      type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
+      details: VARCHAR
+    features: MAP<VARCHAR, STRUCT>
+      float_value: FLOAT
+      integer_value: INTEGER
+      bytes_value: BLOB
+      string_value: VARCHAR
+      url: VARCHAR
+      description: VARCHAR
+      format: VARCHAR
+    reaction_role: VARCHAR  (UNSPECIFIED | REACTANT | REAGENT | SOLVENT | CATALYST | WORKUP | INTERNAL_STANDARD | AUTHENTIC_STANDARD | PRODUCT | BYPRODUCT | SIDE_PRODUCT)
+  analyses: MAP<VARCHAR, STRUCT>
+    type: VARCHAR  (UNSPECIFIED | CUSTOM | LC | GC | IR | NMR_1H | NMR_13C | NMR_OTHER | MP | UV | TLC | MS | HRMS | MSMS | WEIGHT | LCMS | GCMS | ELSD | CD | SFC | EPR | XRD | RAMAN | ED | OPTICAL_ROTATION | CAD)
+    details: VARCHAR
+    chmo_id: INTEGER
+    is_of_isolated_species: BOOLEAN
+    data: MAP<VARCHAR, STRUCT>
+      float_value: FLOAT
+      integer_value: INTEGER
+      bytes_value: BLOB
+      string_value: VARCHAR
+      url: VARCHAR
+      description: VARCHAR
+      format: VARCHAR
+    instrument_manufacturer: VARCHAR
+    instrument_last_calibrated: STRUCT
+      value: VARCHAR
+provenance: STRUCT
+  experimenter: STRUCT
+    username: VARCHAR
+    name: VARCHAR
+    orcid: VARCHAR
+    organization: VARCHAR
+    email: VARCHAR
+  city: VARCHAR
+  experiment_start: STRUCT
+    value: VARCHAR
+  doi: VARCHAR
+  patent: VARCHAR
+  publication_url: VARCHAR
+  record_created: STRUCT
+    time: STRUCT
+      value: VARCHAR
+    person: STRUCT
+      username: VARCHAR
+      name: VARCHAR
+      orcid: VARCHAR
+      organization: VARCHAR
+      email: VARCHAR
+    details: VARCHAR
+  record_modified: LIST<STRUCT>
+    time: STRUCT
+      value: VARCHAR
+    person: STRUCT
+      username: VARCHAR
+      name: VARCHAR
+      orcid: VARCHAR
+      organization: VARCHAR
+      email: VARCHAR
+    details: VARCHAR
+  reaction_metadata: MAP<VARCHAR, STRUCT>
+    float_value: FLOAT
+    integer_value: INTEGER
+    bytes_value: BLOB
+    string_value: VARCHAR
+    url: VARCHAR
+    description: VARCHAR
+    format: VARCHAR
+  is_mined: BOOLEAN
+reaction_id: VARCHAR

--- a/ord_schema/agent/schema.py
+++ b/ord_schema/agent/schema.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The projection schema, rendered for a model that has to write SQL against it.
+
+A model cannot query columns it has not been told about, so the whole schema goes in the
+prompt. It is small enough to: 442 leaves render as 537 lines and roughly 5,400 tokens,
+which is why translation can stay a single forced tool call instead of a retrieval loop
+over column metadata.
+
+An enum projects as its value *name*, so each enum column carries its members beside
+it. Without them a model has the column and no way to learn the spelling it must compare
+against, which is a guess it will sometimes get wrong silently. They are read from the
+field's own metadata, so this stays a rendering of the schema and nothing else.
+
+The rendering is generated from ``projection.SCHEMA`` rather than written by hand,
+because that schema is itself generated from the proto descriptors -- a field added
+upstream becomes a column with nobody deciding it should, and a hand-written description
+would silently fall behind it. ``ord_schema.agent.sql`` validates against the same
+schema object, so the columns a model is told about and the columns its query is checked
+against cannot disagree.
+
+Types are named in DuckDB's vocabulary rather than Arrow's, since DuckDB is the dialect
+the model writes. Units are already in the column names -- ``setpoint_kelvin``,
+``mass_grams`` -- so the tree carries them without a word of prose, and nothing has to
+explain that temperatures are kelvin.
+"""
+
+import pyarrow as pa
+
+from ord_schema import projection
+
+# Arrow leaf types the projection can hold, in DuckDB's names. Deliberately not a
+# fallback to ``str(dtype)``: a type the projection gains later should surface here as a
+# KeyError rather than reach a prompt as an Arrow spelling no DuckDB query can use.
+_SCALARS: dict[pa.DataType, str] = {
+    pa.string(): "VARCHAR",
+    pa.binary(): "BLOB",
+    pa.bool_(): "BOOLEAN",
+    pa.float32(): "FLOAT",
+    pa.float64(): "DOUBLE",
+    pa.int32(): "INTEGER",
+    pa.int64(): "BIGINT",
+    pa.uint32(): "UINTEGER",
+    pa.uint64(): "UBIGINT",
+}
+
+_INDENT = "  "
+
+
+def _scalar_name(dtype: pa.DataType) -> str:
+    """Returns the DuckDB name for a leaf type.
+
+    Args:
+        dtype: Arrow type of a leaf column.
+
+    Returns:
+        The DuckDB type name.
+
+    Raises:
+        KeyError: If the projection holds a leaf type this module does not name.
+    """
+    return _SCALARS[dtype]
+
+
+def _render(field: pa.Field, depth: int, lines: list[str]) -> None:
+    """Appends the lines describing one field, and recurses into its children.
+
+    A container is named by its header (``LIST<STRUCT>``) with its children indented
+    beneath, so the query that reaches a leaf can be read off the indentation. An enum
+    leaf is followed by the values it may hold, read from the field's own metadata.
+
+    Args:
+        field: Field to describe.
+        depth: Indentation depth.
+        lines: Accumulator to append to.
+    """
+    indent = _INDENT * depth
+    name, dtype = field.name, field.type
+    if pa.types.is_struct(dtype):
+        lines.append(f"{indent}{name}: STRUCT")
+        for child in dtype:
+            _render(child, depth + 1, lines)
+    elif pa.types.is_list(dtype):
+        value = dtype.value_type
+        if pa.types.is_struct(value):
+            lines.append(f"{indent}{name}: LIST<STRUCT>")
+            for child in value:
+                _render(child, depth + 1, lines)
+        else:
+            lines.append(f"{indent}{name}: LIST<{_scalar_name(value)}>")
+    elif pa.types.is_map(dtype):
+        key = _scalar_name(dtype.key_type)
+        value = dtype.item_type
+        if pa.types.is_struct(value):
+            lines.append(f"{indent}{name}: MAP<{key}, STRUCT>")
+            for child in value:
+                _render(child, depth + 1, lines)
+        else:
+            lines.append(f"{indent}{name}: MAP<{key}, {_scalar_name(value)}>")
+    else:
+        members = projection.enum_members(field)
+        values = f"  ({' | '.join(members)})" if members else ""
+        lines.append(f"{indent}{name}: {_scalar_name(dtype)}{values}")
+
+
+def describe(schema: pa.Schema = projection.SCHEMA) -> str:
+    """Returns ``schema`` as an indented type tree.
+
+    Args:
+        schema: Schema to render; the projection schema by default.
+
+    Returns:
+        One line per field, two spaces of indentation per level of nesting, with
+        container fields naming their shape and their children indented beneath, and
+        each enum column followed by the values it may hold. The indentation gives the
+        path to a leaf, not the syntax for reaching it: a child of a ``LIST`` or ``MAP``
+        needs a list function rather than a dot.
+
+    Raises:
+        KeyError: If the schema holds a leaf type this module does not name.
+    """
+    lines: list[str] = []
+    for field in schema:
+        _render(field, 0, lines)
+    return "\n".join(lines)

--- a/ord_schema/agent/schema_test.py
+++ b/ord_schema/agent/schema_test.py
@@ -1,0 +1,176 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.agent.schema."""
+
+from importlib import resources
+
+import pyarrow as pa
+import pytest
+
+from ord_schema import projection
+from ord_schema.agent import schema
+
+
+def test_scalars():
+    rendered = schema.describe(
+        pa.schema([pa.field("reaction_id", pa.string()), pa.field("n", pa.int64())])
+    )
+    assert rendered == "reaction_id: VARCHAR\nn: BIGINT"
+
+
+def test_struct_children_are_indented():
+    rendered = schema.describe(
+        pa.schema(
+            [
+                pa.field(
+                    "provenance",
+                    pa.struct([pa.field("doi", pa.string())]),
+                )
+            ]
+        )
+    )
+    assert rendered == "provenance: STRUCT\n  doi: VARCHAR"
+
+
+def test_list_of_scalars_names_its_element_type():
+    rendered = schema.describe(pa.schema([pa.field("names", pa.list_(pa.string()))]))
+    assert rendered == "names: LIST<VARCHAR>"
+
+
+def test_list_of_structs_expands():
+    rendered = schema.describe(
+        pa.schema(
+            [
+                pa.field(
+                    "identifiers",
+                    pa.list_(pa.struct([pa.field("value", pa.string())])),
+                )
+            ]
+        )
+    )
+    assert rendered == "identifiers: LIST<STRUCT>\n  value: VARCHAR"
+
+
+def test_map_names_its_key_type_and_expands_its_value():
+    rendered = schema.describe(
+        pa.schema(
+            [
+                pa.field(
+                    "inputs",
+                    pa.map_(pa.string(), pa.struct([pa.field("n", pa.int32())])),
+                )
+            ]
+        )
+    )
+    assert rendered == "inputs: MAP<VARCHAR, STRUCT>\n  n: INTEGER"
+
+
+def test_nesting_compounds():
+    rendered = schema.describe(
+        pa.schema(
+            [
+                pa.field(
+                    "inputs",
+                    pa.map_(
+                        pa.string(),
+                        pa.struct(
+                            [
+                                pa.field(
+                                    "components",
+                                    pa.list_(
+                                        pa.struct([pa.field("smiles", pa.string())])
+                                    ),
+                                )
+                            ]
+                        ),
+                    ),
+                )
+            ]
+        )
+    )
+    assert rendered == (
+        "inputs: MAP<VARCHAR, STRUCT>\n  components: LIST<STRUCT>\n    smiles: VARCHAR"
+    )
+
+
+def test_unnamed_leaf_type_raises():
+    # A leaf the projection cannot currently hold, so the description would silently
+    # hand a model an Arrow spelling no DuckDB query can use.
+    with pytest.raises(KeyError):
+        schema.describe(pa.schema([pa.field("when", pa.timestamp("s"))]))
+
+
+def test_projection_schema_renders():
+    rendered = schema.describe()
+    lines = rendered.splitlines()
+    assert len(lines) == sum(1 for _ in _fields(projection.SCHEMA))
+    # Unit-carrying names are what let the prompt say nothing about units, and the
+    # indentation is the path: conditions -> temperature/pressure -> setpoint.
+    assert "conditions: STRUCT" in lines
+    assert "    setpoint_kelvin: DOUBLE" in lines
+    # The collapsed structural identifier is a top-level column, not nested.
+    assert "smiles: VARCHAR" in lines
+    assert "reaction_id: VARCHAR" in lines
+
+
+def _fields(schema_or_type):
+    """Yields every field reachable from a schema or nested type, once each."""
+    for field in schema_or_type:
+        yield field
+        data_type = field.type
+        if pa.types.is_list(data_type):
+            data_type = data_type.value_type
+        elif pa.types.is_map(data_type):
+            data_type = data_type.item_type
+        if pa.types.is_struct(data_type):
+            yield from _fields(data_type)
+
+
+def test_the_snapshot_matches_what_describe_renders():
+    # The rendered schema is what a model is told it may query, so a proto field added
+    # upstream silently rewrites the prompt. Checking a snapshot in puts that change in
+    # the diff, where it can be read, rather than leaving it to be discovered from a
+    # model's behavior. The snapshot is a review artifact, never a source: describe()
+    # generates what actually ships, and this test is what keeps the two honest.
+    path = resources.files("ord_schema.agent") / "projection_schema.txt"
+    assert path.read_text(encoding="utf-8") == schema.describe() + "\n", (
+        "the projection schema changed; regenerate the snapshot with\n"
+        "  python -c 'from ord_schema.agent import schema; "
+        'open("ord_schema/agent/projection_schema.txt", "w").write(schema.describe() '
+        "+ chr(10))'"
+    )
+
+
+def test_enum_columns_carry_their_members():
+    lines = schema.describe().splitlines()
+    role = next(line for line in lines if line.strip().startswith("reaction_role:"))
+    assert "REACTANT" in role
+    assert "SOLVENT" in role
+    # A plain string column is not decorated, so the parentheses mean something.
+    assert next(line for line in lines if line.startswith("reaction_id:")).endswith(
+        "VARCHAR"
+    )
+
+
+def test_only_a_field_carrying_members_is_annotated():
+    rendered = schema.describe(
+        pa.schema(
+            [
+                pa.field("kind", pa.string(), metadata={b"ord.enum": b"A,B"}),
+                pa.field("free", pa.string()),
+            ]
+        )
+    )
+    assert rendered == "kind: VARCHAR  (A | B)\nfree: VARCHAR"

--- a/ord_schema/projection.py
+++ b/ord_schema/projection.py
@@ -155,6 +155,14 @@ _ARROW_SCALARS: dict[int, pa.DataType] = {
 
 _RESOLVER = units.RESOLVER
 
+# Field metadata naming the values an enum column may hold. An enum projects as its
+# value *name*, and Arrow has no type that records the choices -- a dictionary column
+# carries only the values a batch happened to contain, and DuckDB reads it back as
+# VARCHAR regardless. Metadata does survive, nested to any depth, which makes the
+# published Parquet self-describing: a consumer learns the spellings from the footer
+# rather than from this library.
+_META_ENUM = "ord.enum"
+
 
 def _validate_canonical_units() -> None:
     """Checks ``_CANONICAL_UNITS`` against the resolver and the reachable messages.
@@ -245,15 +253,35 @@ def precision_column_name(field: FieldDescriptor) -> str:
     return f"{field.name}_precision_{canonical[1]}"
 
 
+def _enum_metadata(field: FieldDescriptor) -> dict[str, str] | None:
+    """Returns metadata recording an enum's members, or None for any other type."""
+    if field.type != FieldDescriptor.TYPE_ENUM:
+        return None
+    return {_META_ENUM: ",".join(value.name for value in field.enum_type.values)}
+
+
+def enum_members(field: pa.Field) -> tuple[str, ...] | None:
+    """Returns the values ``field`` may hold, or None if it is not an enum column.
+
+    Args:
+        field: A field of ``SCHEMA``, or of a struct within it.
+
+    Returns:
+        The member names in declaration order, or None.
+    """
+    raw = (field.metadata or {}).get(_META_ENUM.encode())
+    return tuple(raw.decode().split(",")) if raw else None
+
+
 def _field_type(field: FieldDescriptor, stack: frozenset[str]) -> pa.DataType:
     if _canonical_unit(field) is not None:
-        # Singular united fields never reach here: _struct_fields expands them into a
-        # value column and a precision column, which is a pair of leaves rather than
-        # one type. A repeated or map-valued one added upstream would, and that pair
-        # cannot represent it.
+        # No field _struct_fields handles reaches here: it expands a united field into a
+        # value column and a precision column, which is a pair of leaves rather than one
+        # type, and refuses a repeated one outright. Only a map whose values are united
+        # arrives, and that pair cannot represent one either.
         raise ValueError(
-            f"{field.full_name} is a repeated or map-valued united message; the "
-            "canonical value and precision columns represent only singular ones"
+            f"{field.full_name} is a map-valued united message; a value column and a "
+            "precision column represent only singular ones"
         )
     message_type = field.message_type
     if message_type is not None and message_type.GetOptions().map_entry:
@@ -280,11 +308,25 @@ def _struct_fields(descriptor: Descriptor, stack: frozenset[str]) -> list[pa.Fie
     if descriptor.name in _STRUCTURAL_TYPES:
         fields.append(pa.field("smiles", pa.string()))
     for field in descriptor.fields:
-        if _canonical_unit(field) is not None:
-            fields.append(pa.field(column_name(field), pa.float64()))
-            fields.append(pa.field(precision_column_name(field), pa.float64()))
-        else:
-            fields.append(pa.field(column_name(field), _field_type(field, stack)))
+        if _canonical_unit(field) is None:
+            fields.append(
+                pa.field(
+                    column_name(field),
+                    _field_type(field, stack),
+                    metadata=_enum_metadata(field),
+                )
+            )
+            continue
+        if field.label == FieldDescriptor.LABEL_REPEATED:
+            # Two scalar columns cannot carry a list of measurements, and expanding one
+            # anyway would publish a schema that quietly holds a single value per
+            # reaction where the source holds several.
+            raise ValueError(
+                f"{field.full_name} is a repeated united message; a value column and a "
+                "precision column represent only singular ones"
+            )
+        fields.append(pa.field(column_name(field), pa.float64()))
+        fields.append(pa.field(precision_column_name(field), pa.float64()))
     return fields
 
 

--- a/ord_schema/projection_test.py
+++ b/ord_schema/projection_test.py
@@ -15,12 +15,13 @@
 """Tests for ord_schema.projection."""
 
 import pathlib
+from types import SimpleNamespace
 from typing import cast
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
-from google.protobuf.descriptor import Descriptor
+from google.protobuf.descriptor import Descriptor, FieldDescriptor
 from rdkit import Chem
 
 from ord_schema import artifacts, parquet, projection
@@ -471,3 +472,44 @@ def test_precision_without_a_value_is_null():
     temperature = projection.message_row(reaction)["conditions"]["temperature"]
     assert temperature["setpoint_kelvin"] is None
     assert temperature["setpoint_precision_kelvin"] is None
+
+
+def test_enum_fields_carry_their_members_in_metadata():
+    # Arrow has no type that records an enum's choices: a dictionary column carries only
+    # the values a batch contained, and DuckDB reads it back as VARCHAR either way.
+    # Metadata does survive, nested to any depth, so the published file says what the
+    # spellings are without anyone holding this library.
+    components = (
+        projection.SCHEMA.field("inputs").type.item_type.field("components").type
+    )
+    members = projection.enum_members(components.value_type.field("reaction_role"))
+    assert members is not None
+    assert members[:2] == ("UNSPECIFIED", "REACTANT")
+    assert projection.enum_members(projection.SCHEMA.field("reaction_id")) is None
+
+
+def test_enum_metadata_survives_a_parquet_round_trip(tmp_path):
+    source = _source(tmp_path, [_reaction()])
+    output = tmp_path / "projection.parquet"
+    projection.write_projection(source, output)
+    schema = pq.read_schema(output)
+    components = schema.field("inputs").type.item_type.field("components").type
+    members = projection.enum_members(components.value_type.field("reaction_role"))
+    assert members is not None
+    assert members[:2] == ("UNSPECIFIED", "REACTANT")
+
+
+def test_a_repeated_united_field_is_refused():
+    # A tripwire for a schema change upstream, so it needs its own proof: a repeated
+    # united field takes the same branch as a singular one, and expanding it would
+    # publish two scalar columns holding one measurement per reaction where the source
+    # holds several. No such field exists today, hence the synthetic descriptor.
+    field = SimpleNamespace(
+        name="durations",
+        full_name="ord.Fake.durations",
+        message_type=SimpleNamespace(name="Time"),
+        label=FieldDescriptor.LABEL_REPEATED,
+    )
+    descriptor = SimpleNamespace(name="Fake", full_name="ord.Fake", fields=[field])
+    with pytest.raises(ValueError, match="repeated united message"):
+        projection._struct_fields(cast(Descriptor, descriptor), frozenset())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,8 @@ include = ["ord_schema*"]
 
 [tool.setuptools.package-data]
 "ord_schema.proto" = ["*.pyi"]
+# The projection schema snapshot, read back through importlib.resources by its test.
+"ord_schema.agent" = ["*.txt"]
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
## Summary

A model cannot query columns it has not been told about, so the whole projection schema goes in the prompt. It fits: 442 leaves render as 537 lines and roughly 5,400 tokens, which is what lets a translation stay a single call rather than a retrieval loop over column metadata.

The rendering is generated from `projection.SCHEMA`, which is itself generated from the proto descriptors — a field added upstream becomes a column with nobody deciding it should, and a hand-written description would fall behind it silently.

First of two; the query surface that consumes this follows in #948. This half needs no new dependencies.

## Changes

- `agent/schema.py` — `describe()` renders the schema as an indented type tree in DuckDB's type names, with `projection_schema.txt` checked in as a snapshot and a test that regenerates and compares.
- `projection.py` — enum columns carry their members in Arrow field metadata, and building the schema now refuses a repeated united field.
- `pyproject.toml` — packages the snapshot, which its test reads through `importlib.resources`.

## Testing

`uv run pytest` — 855 passed.

**Enums needed the schema to carry more than it did.** An enum projects as its value *name*, and Arrow has no type that records the choices: `Table.from_pylist` builds a dictionary column from *observed* values, so unused members never appear, and DuckDB reads it back as `VARCHAR` either way. Field metadata does survive — verified nested through `MAP → STRUCT → LIST → STRUCT`, through a Parquet round trip, with DuckDB queries unaffected. Without it a model has the column and no way to learn the spelling to compare against, which is a guess it gets wrong silently.

The snapshot test earns its place: I checked it fails both when the file drifts by one character and when a field is added upstream leaving it stale. It reads through `importlib.resources`, so without the packaging entry it would pass in an editable install and fail against a wheel — checked by building both and installing the wheel clean.

The repeated-united-field refusal is a tripwire for a schema change upstream, so it has its own test using a synthetic descriptor; verified by removing the guard and watching it fail.

## Notes

`agent/schema.py` imports only `pyarrow` and `projection` — confirmed it renders with `duckdb` and `pydantic` forced unavailable. The `agent` extra arrives with the query surface that needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a generated, model-oriented rendering of the projection schema and records protobuf enum members in Arrow field metadata.
- Introduces `ord_schema.agent.schema.describe()` and a packaged schema snapshot.
- Adds enum metadata to projected Arrow fields and verifies Parquet preservation.
- Rejects repeated united fields that cannot be represented by scalar value and precision columns.
- Adds focused rendering, snapshot, metadata, and schema-guard tests.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The schema renderer, enum metadata propagation, Parquet round trip, package resource declaration, and repeated-field guard are internally consistent and covered by focused tests.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/projection.py | Attaches enum-member metadata to generated Arrow fields and rejects repeated united fields that cannot be faithfully projected. |
| ord_schema/agent/schema.py | Renders the projection schema as an indented DuckDB-oriented type tree with enum choices. |
| ord_schema/agent/projection_schema.txt | Records the generated projection-schema rendering as a reviewable snapshot. |
| ord_schema/agent/schema_test.py | Covers scalar and nested rendering, enum annotations, unsupported types, and snapshot consistency. |
| ord_schema/projection_test.py | Verifies enum metadata generation and Parquet preservation plus repeated-united-field rejection. |
| pyproject.toml | Packages the projection schema snapshot with the new agent subpackage. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Proto[Protobuf descriptors] --> Projection[projection.SCHEMA]
  Projection --> Metadata[Arrow fields with enum metadata]
  Projection --> Describe[agent.schema.describe]
  Metadata --> Describe
  Describe --> Prompt[Indented DuckDB schema description]
  Describe --> Snapshot[projection_schema.txt snapshot]
  Metadata --> Parquet[Projection Parquet schema]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Describe the projection to a model, and ..."](https://github.com/open-reaction-database/ord-schema/commit/cedde40977d181506abb1be915a3da1664cab3b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51390446)</sub>

<!-- /greptile_comment -->