### PR TITLE
Refuse a commit on main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,15 @@
 # limitations under the License.
 
 repos:
+  # Every change goes through a branch and a pull request, so a commit landing on main
+  # is a mistake rather than a shortcut. Listed first so it fails before the slower
+  # hooks spend time on a commit that should not exist.
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: no-commit-to-branch
+        args: [--branch, main]
+
   - repo: https://github.com/google/addlicense
     rev: v1.2.0
     hooks:


### PR DESCRIPTION
Every change here goes through a branch and a PR — every commit on `main` is a squash-merged PR — but nothing enforced it, and I landed a docs commit (`7cda212`) directly on `main` by not noticing which branch I was on.

Adds `no-commit-to-branch` from `pre-commit-hooks`, listed first so it fails before the slower hooks spend time on a commit that should not exist.

## Testing

Verified in a scratch clone with `pre-commit install`:

```
on main:     don't commit to branch ... Failed   -> nothing landed, HEAD unchanged
on a branch: don't commit to branch ... Passed   -> commit succeeded
```

My first attempt at that test was wrong and worth mentioning: a fresh `git clone` has no hooks, so the commit sailed through and looked like the guard had failed. It had simply never been installed.

## Notes

This guards the *working copy*, not the branch. `pre-commit` hooks live in `.git/hooks`, which a clone does not carry, so it only fires where someone has run `pre-commit install` — the same caveat every other hook in this config already has. A GitHub branch protection rule on `main` is what would make it unconditional, and is worth adding independently if direct pushes are a concern rather than just direct commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an early pre-commit guard that rejects commits made directly on `main`.
- Pins `pre-commit/pre-commit-hooks` at v6.0.0.
- Configures `no-commit-to-branch` for `main` before the repository’s slower hooks.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The configured hook and arguments match pre-commit-hooks v6.0.0 and implement the documented local guard without affecting CI or unrelated branches.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .pre-commit-config.yaml | Correctly configures the standard `no-commit-to-branch` hook to reject local commits on `main`; no actionable defects found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Refuse a commit on main"](https://github.com/open-reaction-database/ord-schema/commit/d577ed7c5cd4e501b0cee7b6725306650b0f4be0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51454579)</sub>

<!-- /greptile_comment -->