### PR TITLE
Add a structures artifact, and stamp its ids into the projection

### DIFF
--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -66,6 +66,10 @@ is a compile error rather than a wrong answer:
 
 - A comparison path must end at a scalar and must not cross a repeated level.
 - An `exists`/`forall` path must end *at* a repeated level.
+- A path naming an artifact-internal column (`structure_id`, the join key into the
+  structures artifact) is refused, and internal columns are withheld from the rendered
+  schema and from "did you mean" suggestions: their values are not stable across
+  builds.
 - Operators must suit the leaf type — `contains` is text-only, ordering is numeric-only.
 - `group_by` paths must be scalar, so the number of groups is bounded by the values a column
   holds rather than by an explosion over a repeated level.

--- a/ord_schema/agent/query.py
+++ b/ord_schema/agent/query.py
@@ -116,9 +116,12 @@ def _lookup(current: pa.Schema | pa.DataType, name: str, path: str) -> pa.Field:
         close = difflib.get_close_matches(name, members, n=3)
         suggestion = f"; did you mean {', '.join(map(repr, close))}?" if close else ""
         raise QueryError(f"{path}: no field named {name!r}{suggestion}")
-    if isinstance(current, pa.Schema):
-        return current.field(name)
-    return current.field(name)
+    field = current.field(name)
+    if projection.is_internal(field):
+        # Artifact-internal machinery (structure_id): its values are not stable across
+        # builds, so a comparison against one is a wrong answer waiting to move.
+        raise QueryError(f"{path}: {name!r} is internal to the artifacts")
+    return field
 
 
 def resolve(

--- a/ord_schema/agent/query.py
+++ b/ord_schema/agent/query.py
@@ -113,7 +113,15 @@ def _lookup(current: pa.Schema | pa.DataType, name: str, path: str) -> pa.Field:
     if name not in members:
         if not members:
             raise QueryError(f"{path}: {name!r} has no fields to descend into")
-        close = difflib.get_close_matches(name, members, n=3)
+        # Internal fields are excluded from the suggestions, not just refused: a
+        # near-miss like 'structure' must not teach the model the one name the schema
+        # description withholds.
+        candidates = [
+            member
+            for member in members
+            if not projection.is_internal(current.field(member))
+        ]
+        close = difflib.get_close_matches(name, candidates, n=3)
         suggestion = f"; did you mean {', '.join(map(repr, close))}?" if close else ""
         raise QueryError(f"{path}: no field named {name!r}{suggestion}")
     field = current.field(name)

--- a/ord_schema/agent/query_test.py
+++ b/ord_schema/agent/query_test.py
@@ -445,3 +445,10 @@ def test_a_plain_relation_name_is_still_allowed():
     assert query.compile_query(query.Query(), table="projections").sql.endswith(
         "FROM projections"
     )
+
+
+def test_an_internal_column_is_refused():
+    # structure_id is real in the schema but internal to the artifacts: its values are
+    # not stable across builds, so a comparison against one is refused at resolution.
+    with pytest.raises(query.QueryError, match="internal"):
+        query.resolve("inputs.components.structure_id")

--- a/ord_schema/agent/query_test.py
+++ b/ord_schema/agent/query_test.py
@@ -452,3 +452,11 @@ def test_an_internal_column_is_refused():
     # not stable across builds, so a comparison against one is refused at resolution.
     with pytest.raises(query.QueryError, match="internal"):
         query.resolve("inputs.components.structure_id")
+
+
+def test_suggestions_do_not_name_internal_columns():
+    # A near-miss like 'structure' is exactly what a model gropes for when asked a
+    # structure question; the suggestion must not teach it the withheld name.
+    with pytest.raises(query.QueryError, match="no field named") as excinfo:
+        query.resolve("inputs.components.structure")
+    assert "structure_id" not in str(excinfo.value)

--- a/ord_schema/agent/schema.py
+++ b/ord_schema/agent/schema.py
@@ -86,6 +86,10 @@ def _render(field: pa.Field, depth: int, lines: list[str]) -> None:
         depth: Indentation depth.
         lines: Accumulator to append to.
     """
+    if projection.is_internal(field):
+        # Artifact-internal machinery (structure_id): not a fact about the reaction,
+        # and not stable across builds. A model told about it would compare against it.
+        return
     indent = _INDENT * depth
     name, dtype = field.name, field.type
     if pa.types.is_struct(dtype):

--- a/ord_schema/agent/schema_test.py
+++ b/ord_schema/agent/schema_test.py
@@ -126,8 +126,14 @@ def test_projection_schema_renders():
 
 
 def _fields(schema_or_type):
-    """Yields every field reachable from a schema or nested type, once each."""
+    """Yields every renderable field reachable from a schema or nested type.
+
+    Internal fields (structure_id) are skipped to match describe(), which hides them:
+    they join artifacts together rather than stating a fact a model may query.
+    """
     for field in schema_or_type:
+        if projection.is_internal(field):
+            continue
         yield field
         data_type = field.type
         if pa.types.is_list(data_type):
@@ -174,3 +180,9 @@ def test_only_a_field_carrying_members_is_annotated():
         )
     )
     assert rendered == "kind: VARCHAR  (A | B)\nfree: VARCHAR"
+
+
+def test_internal_columns_are_hidden():
+    # structure_id joins the projection to its structures artifact; its values are not
+    # stable across builds, so a model must not learn the name to compare against.
+    assert "structure_id" not in schema.describe()

--- a/ord_schema/artifacts.py
+++ b/ord_schema/artifacts.py
@@ -45,12 +45,18 @@ already uses for source datasets:
   every artifact names the dataset it reflects however many derivations away it sits,
   and one comparison answers "is this current for that dataset?"
 * ``ord.ord_schema_version`` -- what derived it.
+* ``ord.rdkit_version`` -- the RDKit that derived it. Every artifact leans on RDKit --
+  canonical SMILES in the projection and the view, fingerprints in the structures
+  artifact -- and RDKit releases have changed both canonicalization and pattern
+  fingerprints, either of which silently breaks an artifact whose consumers run the new
+  RDKit against files built by the old. Optional to *read* so that files stamped before
+  the key existed still load; absent reads as stale, which rebuilds them.
 * ``ord.source_dataset_id`` -- the source's ID, written only when the source records
   one, and so the only key not required to read stamps back.
 
-``is_current`` requires the artifact name, the source content, the library version, and
-the artifact version to all match, since any of the four changing can change a value or
-mean the file answers a different question.
+``is_current`` requires the artifact name, the source content, the library version, the
+artifact version, and the RDKit version to all match, since any of the five changing
+can change a value or mean the file answers a different question.
 """
 
 import dataclasses
@@ -62,6 +68,7 @@ from typing import Protocol
 
 import pyarrow as pa
 import pyarrow.parquet as pq
+from rdkit import rdBase
 
 from ord_schema import parquet
 from ord_schema.logging import get_logger
@@ -74,6 +81,7 @@ ARTIFACT_VERSION = "1"
 
 _META_ARTIFACT = "ord.artifact"
 _META_ARTIFACT_VERSION = "ord.artifact_version"
+_META_RDKIT_VERSION = "ord.rdkit_version"
 _META_SOURCE_DATASET_ID = "ord.source_dataset_id"
 _META_SOURCE_MD5 = "ord.source_md5"
 _META_ORD_SCHEMA_VERSION = "ord.ord_schema_version"
@@ -88,13 +96,18 @@ _REQUIRED = (
 
 @dataclasses.dataclass(frozen=True)
 class Stamps:
-    """Footer stamps recording what an artifact was derived from, and by what."""
+    """Footer stamps recording what an artifact was derived from, and by what.
+
+    ``rdkit_version`` is None only when read from a file stamped before the key
+    existed; such a file reads as stale.
+    """
 
     artifact: str
     source_dataset_id: str | None
     source_md5: str
     ord_schema_version: str
     artifact_version: str
+    rdkit_version: str | None = None
 
 
 class ArtifactWriter(Protocol):
@@ -139,6 +152,7 @@ def current_stamps(
         source_md5=source_md5,
         ord_schema_version=metadata.version("ord-schema"),
         artifact_version=ARTIFACT_VERSION,
+        rdkit_version=rdBase.rdkitVersion,
     )
 
 
@@ -152,6 +166,8 @@ def to_metadata(value: Stamps) -> dict[str, str]:
     }
     if value.source_dataset_id is not None:
         result[_META_SOURCE_DATASET_ID] = value.source_dataset_id
+    if value.rdkit_version is not None:
+        result[_META_RDKIT_VERSION] = value.rdkit_version
     return result
 
 
@@ -180,6 +196,7 @@ def load_stamps(path: str | os.PathLike[str]) -> Stamps:
             )
         values[key] = value.decode()
     source_dataset_id = raw.get(_META_SOURCE_DATASET_ID.encode())
+    rdkit_version = raw.get(_META_RDKIT_VERSION.encode())
     return Stamps(
         artifact=values[_META_ARTIFACT],
         source_dataset_id=(
@@ -188,15 +205,16 @@ def load_stamps(path: str | os.PathLike[str]) -> Stamps:
         source_md5=values[_META_SOURCE_MD5],
         ord_schema_version=values[_META_ORD_SCHEMA_VERSION],
         artifact_version=values[_META_ARTIFACT_VERSION],
+        rdkit_version=rdkit_version.decode() if rdkit_version is not None else None,
     )
 
 
 def is_current(path: str | os.PathLike[str], artifact: str, source_md5: str) -> bool:
     """Returns whether ``path`` holds ``artifact`` derived from ``source_md5`` by us.
 
-    All of the source content, the library version, and the artifact version must match;
-    any of them changing can change a value. A missing, unreadable, or wrong-artifact
-    file is not current.
+    All of the source content, the library version, the artifact version, and the RDKit
+    version must match; any of them changing can change a value. A missing, unreadable,
+    or wrong-artifact file is not current.
     """
     try:
         value = load_stamps(path)
@@ -219,13 +237,14 @@ def stamps_are_current(value: Stamps, artifact: str) -> bool:
         artifact: Artifact name the file is expected to hold.
 
     Returns:
-        Whether the artifact name, the library version, and the artifact version all
-        match.
+        Whether the artifact name, the library version, the artifact version, and the
+        RDKit version all match. A file with no RDKit stamp is not current.
     """
     return (
         value.artifact == artifact
         and value.ord_schema_version == metadata.version("ord-schema")
         and value.artifact_version == ARTIFACT_VERSION
+        and value.rdkit_version == rdBase.rdkitVersion
     )
 
 
@@ -450,7 +469,9 @@ def derive_tree(
             parent_stamps[match] = stamps
         else:
             ignored += 1
-    logger.info("Found %d %ss", len(sources), parent_artifact or "dataset")
+    logger.info(
+        "Found %d matching %s files", len(sources), parent_artifact or "dataset"
+    )
     # Every destination against every source, not against its own: an output_dir nested
     # in the source tree maps one dataset onto a *different* one, which a per-source
     # check passes, destroying a source the run had not reached yet.

--- a/ord_schema/artifacts.py
+++ b/ord_schema/artifacts.py
@@ -487,7 +487,7 @@ def derive_tree(
         logger.info("Wrote %d rows to %s", rows, destination)
         written += 1
     logger.info(
-        "Derived %d %ss (%d already current, %d ignored)",
+        "Derived %d %s artifacts (%d already current, %d ignored)",
         written,
         artifact,
         skipped,

--- a/ord_schema/artifacts_test.py
+++ b/ord_schema/artifacts_test.py
@@ -14,12 +14,14 @@
 
 """Tests for ord_schema.artifacts."""
 
+import dataclasses
 import pathlib
 from importlib import metadata
 
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from rdkit import rdBase
 
 from ord_schema import artifacts, parquet
 from ord_schema.proto import dataset_pb2, reaction_pb2
@@ -43,6 +45,7 @@ def _valid_metadata(**overrides):
         "ord.artifact_version": artifacts.ARTIFACT_VERSION,
         "ord.source_md5": "0" * 32,
         "ord.ord_schema_version": "9.9.9",
+        "ord.rdkit_version": rdBase.rdkitVersion,
         "ord.source_dataset_id": "ord_dataset-1",
     }
     metadata.update(overrides)
@@ -452,3 +455,29 @@ def test_derive_tree_still_rewrites_its_own_artifacts(tmp_path):
         parent_artifact="projection",
     )
     assert (written, skipped, ignored) == (1, 0, 0)
+
+
+def test_stamps_record_the_rdkit_version():
+    value = artifacts.current_stamps("view", "ord_dataset-1", "abc")
+    assert value.rdkit_version == rdBase.rdkitVersion
+    assert artifacts.stamps_are_current(value, "view")
+
+
+def test_an_artifact_from_a_different_rdkit_reads_stale():
+    # Fingerprints and canonical SMILES are both functions of RDKit, so an upgrade
+    # must mark artifacts stale or the screen's completeness rests on cross-version
+    # fingerprint compatibility nothing enforces.
+    value = dataclasses.replace(
+        artifacts.current_stamps("view", "ord_dataset-1", "abc"),
+        rdkit_version="0000.00.0",
+    )
+    assert not artifacts.stamps_are_current(value, "view")
+
+
+def test_an_artifact_with_no_rdkit_stamp_reads_stale():
+    # Files stamped before the key existed still load, and read stale: rebuilding is
+    # the safe answer for an artifact whose RDKit nobody recorded.
+    value = dataclasses.replace(
+        artifacts.current_stamps("view", "ord_dataset-1", "abc"), rdkit_version=None
+    )
+    assert not artifacts.stamps_are_current(value, "view")

--- a/ord_schema/projection.py
+++ b/ord_schema/projection.py
@@ -149,9 +149,9 @@ _STRUCTURAL_TYPES: dict[str, frozenset[int]] = {
     "Reaction": _STRUCTURAL_REACTION_TYPES,
 }
 
-# Messages whose collapsed ``smiles`` is a molecule, and so gets a ``structure_id``.
-# Reaction is structural but its smiles is a reaction; reaction-level structure search
-# is a different operation and no id is assigned there.
+# Messages whose collapsed ``smiles`` is a molecule, and that therefore carry a
+# ``structure_id``. Reaction is structural but its smiles is a reaction;
+# reaction-level structure search is a different operation and no id is assigned there.
 _STRUCTURE_ID_TYPES = frozenset({"Compound", "ProductCompound"})
 
 _ARROW_SCALARS: dict[int, pa.DataType] = {

--- a/ord_schema/projection.py
+++ b/ord_schema/projection.py
@@ -154,6 +154,14 @@ _STRUCTURAL_TYPES: dict[str, frozenset[int]] = {
 # reaction-level structure search is a different operation and no id is assigned there.
 _STRUCTURE_ID_TYPES = frozenset({"Compound", "ProductCompound"})
 
+# An id rides beside the collapsed smiles and cannot exist without it: the schema
+# would gain a structure_id with no sibling smiles, and message_row would KeyError.
+if not set(_STRUCTURAL_TYPES) >= _STRUCTURE_ID_TYPES:
+    raise ValueError(
+        "_STRUCTURE_ID_TYPES must be a subset of _STRUCTURAL_TYPES; "
+        f"{sorted(_STRUCTURE_ID_TYPES - set(_STRUCTURAL_TYPES))} has no smiles"
+    )
+
 _ARROW_SCALARS: dict[int, pa.DataType] = {
     FieldDescriptor.TYPE_DOUBLE: pa.float64(),
     FieldDescriptor.TYPE_FLOAT: pa.float32(),
@@ -619,8 +627,9 @@ def write_projection(
     schema = SCHEMA.with_metadata(artifacts.to_metadata(stamps))
     rows = 0
     unreadable = 0
-    # One id space per dataset, in first-seen order: deterministic for a given source,
-    # and shared with the structures artifact derived from this file.
+    # One id space per dataset, in first-seen order, shared with the structures
+    # artifact derived from this file. The order follows protobuf map iteration, which
+    # is unspecified, so ids are a fact about this file rather than about the dataset.
     structure_ids: dict[str, int] = {}
     with (
         atomic_io.atomic_path(output) as temp_path,

--- a/ord_schema/projection.py
+++ b/ord_schema/projection.py
@@ -57,6 +57,17 @@ Every other identifier is kept, as a list. ``NAME`` alone covers compounds that 
 structural identifier reaches, and a compound may carry several of them, so pivoting
 identifiers into named scalar fields would silently drop data.
 
+One derived column rides beside the compound-level ``smiles``: a ``structure_id``
+numbering the dataset's distinct structures in first-seen order, the join key into the
+dataset's ``structures`` artifact (:mod:`ord_schema.structures`), where the
+fingerprints live. It exists because a structure predicate is evaluated *outside* the
+query -- screened and verified against the structures artifact -- and its match set has
+to re-enter the query at element granularity: DuckDB does not allow a subquery inside a
+lambda expression, so the components a quantifier binds cannot semi-join against a match
+table, but they can test one integer against a bitmap parameter. The ids are meaningful
+only alongside the projection that assigned them, so the column is marked internal and
+stays out of what a model is told it may query.
+
 Anything else -- the original units, the identifier types that were collapsed -- remains
 in the source ``reaction`` column, which stays authoritative for byte-exact
 round-tripping. The projection promises that every field is *readable*, not that it is
@@ -86,7 +97,7 @@ reproducible from the projection alone.
 """
 
 import os
-from collections.abc import Iterator
+from collections.abc import Iterator, MutableMapping
 from typing import Any, cast, get_args
 
 import pyarrow as pa
@@ -138,6 +149,11 @@ _STRUCTURAL_TYPES: dict[str, frozenset[int]] = {
     "Reaction": _STRUCTURAL_REACTION_TYPES,
 }
 
+# Messages whose collapsed ``smiles`` is a molecule, and so gets a ``structure_id``.
+# Reaction is structural but its smiles is a reaction; reaction-level structure search
+# is a different operation and no id is assigned there.
+_STRUCTURE_ID_TYPES = frozenset({"Compound", "ProductCompound"})
+
 _ARROW_SCALARS: dict[int, pa.DataType] = {
     FieldDescriptor.TYPE_DOUBLE: pa.float64(),
     FieldDescriptor.TYPE_FLOAT: pa.float32(),
@@ -162,6 +178,13 @@ _RESOLVER = units.RESOLVER
 # published Parquet self-describing: a consumer learns the spellings from the footer
 # rather than from this library.
 _META_ENUM = "ord.enum"
+
+# Field metadata marking a column as artifact-internal: machinery the library uses to
+# join artifacts together, not a fact about the reaction. Internal columns stay out of
+# the schema description a model queries against, and a query naming one is refused --
+# their values are not stable across builds, so nothing outside this library should
+# depend on them.
+_META_INTERNAL = "ord.internal"
 
 
 def _validate_canonical_units() -> None:
@@ -273,6 +296,20 @@ def enum_members(field: pa.Field) -> tuple[str, ...] | None:
     return tuple(raw.decode().split(",")) if raw else None
 
 
+def is_internal(field: pa.Field) -> bool:
+    """Returns whether ``field`` is artifact-internal machinery rather than data.
+
+    Args:
+        field: A field of ``SCHEMA``, or of a struct within it.
+
+    Returns:
+        True for columns like ``structure_id`` whose values join artifacts together and
+        are not stable across builds. They are hidden from the schema description a
+        model sees, and a query naming one is refused.
+    """
+    return bool((field.metadata or {}).get(_META_INTERNAL.encode()))
+
+
 def _field_type(field: FieldDescriptor, stack: frozenset[str]) -> pa.DataType:
     if _canonical_unit(field) is not None:
         # No field _struct_fields handles reaches here: it expands a united field into a
@@ -307,6 +344,14 @@ def _struct_fields(descriptor: Descriptor, stack: frozenset[str]) -> list[pa.Fie
     fields = []
     if descriptor.name in _STRUCTURAL_TYPES:
         fields.append(pa.field("smiles", pa.string()))
+    if descriptor.name in _STRUCTURE_ID_TYPES:
+        fields.append(
+            pa.field(
+                "structure_id",
+                pa.uint32(),
+                metadata={_META_INTERNAL: "joins the dataset's structures artifact"},
+            )
+        )
     for field in descriptor.fields:
         if _canonical_unit(field) is None:
             fields.append(
@@ -391,7 +436,9 @@ def _enum_name(field: FieldDescriptor, number: int) -> str:
     return field.enum_type.values_by_number[number].name
 
 
-def message_row(message: Message) -> dict[str, Any]:
+def message_row(
+    message: Message, structure_ids: MutableMapping[str, int] | None = None
+) -> dict[str, Any]:
     """Projects ``message`` to a dict matching its struct type in ``SCHEMA``.
 
     Unset fields are None rather than the proto default, so a consumer can tell "the
@@ -399,6 +446,10 @@ def message_row(message: Message) -> dict[str, Any]:
 
     Args:
         message: Any message reachable from Reaction.
+        structure_ids: Mapping from SMILES to ``structure_id``, extended in first-seen
+            order as compounds are projected. None -- the default, for a message
+            projected outside a dataset -- leaves every ``structure_id`` null, since an
+            id is meaningful only against the artifact that shares the mapping.
 
     Returns:
         A dict keyed by projected column name.
@@ -413,6 +464,13 @@ def message_row(message: Message) -> dict[str, Any]:
         row["smiles"] = smiles
         if smiles is not None:
             collapsed = _STRUCTURAL_TYPES[descriptor.name]
+    if descriptor.name in _STRUCTURE_ID_TYPES:
+        if row["smiles"] is not None and structure_ids is not None:
+            row["structure_id"] = structure_ids.setdefault(
+                row["smiles"], len(structure_ids)
+            )
+        else:
+            row["structure_id"] = None
     for field in descriptor.fields:
         name = column_name(field)
         canonical = _canonical_unit(field)
@@ -428,7 +486,9 @@ def message_row(message: Message) -> dict[str, Any]:
             value_field = message_type.fields_by_name["value"]
             items = getattr(message, field.name).items()
             if value_field.message_type is not None:
-                row[name] = [(key, message_row(value)) for key, value in items] or None
+                row[name] = [
+                    (key, message_row(value, structure_ids)) for key, value in items
+                ] or None
             else:
                 row[name] = list(items) or None
             continue
@@ -437,7 +497,9 @@ def message_row(message: Message) -> dict[str, Any]:
             if field.name == "identifiers":
                 values = _kept_identifiers(values, collapsed)
             if message_type is not None:
-                row[name] = [message_row(value) for value in values] or None
+                row[name] = [
+                    message_row(value, structure_ids) for value in values
+                ] or None
             elif field.type == FieldDescriptor.TYPE_ENUM:
                 row[name] = [_enum_name(field, value) for value in values] or None
             else:
@@ -445,7 +507,7 @@ def message_row(message: Message) -> dict[str, Any]:
             continue
         if message_type is not None:
             row[name] = (
-                message_row(getattr(message, field.name))
+                message_row(getattr(message, field.name), structure_ids)
                 if message.HasField(field.name)
                 else None
             )
@@ -466,7 +528,9 @@ def message_row(message: Message) -> dict[str, Any]:
 
 
 def reaction_row(
-    reaction: reaction_pb2.Reaction, reaction_id: str | None
+    reaction: reaction_pb2.Reaction,
+    reaction_id: str | None,
+    structure_ids: MutableMapping[str, int] | None = None,
 ) -> dict[str, Any]:
     """Projects one row of a source dataset to a dict matching ``SCHEMA``.
 
@@ -483,6 +547,9 @@ def reaction_row(
             where the column is null. Required rather than defaulted, so a null cannot
             arrive looking like a caller who read no column and skip the check. Project
             a Reaction from anywhere else with ``message_row``.
+        structure_ids: Mapping from SMILES to ``structure_id``, shared across a
+            dataset's rows and extended in first-seen order. None leaves every
+            ``structure_id`` null.
 
     Returns:
         A dict keyed by projected column name.
@@ -501,7 +568,7 @@ def reaction_row(
             f"reaction_id column {reaction_id!r} disagrees with the reaction's own "
             f"{reaction.reaction_id!r}"
         )
-    return message_row(reaction)
+    return message_row(reaction, structure_ids)
 
 
 def is_current(path: str | os.PathLike[str], source_md5: str) -> bool:
@@ -552,6 +619,9 @@ def write_projection(
     schema = SCHEMA.with_metadata(artifacts.to_metadata(stamps))
     rows = 0
     unreadable = 0
+    # One id space per dataset, in first-seen order: deterministic for a given source,
+    # and shared with the structures artifact derived from this file.
+    structure_ids: dict[str, int] = {}
     with (
         atomic_io.atomic_path(output) as temp_path,
         pq.ParquetWriter(temp_path, schema, compression=compression) as writer,
@@ -560,7 +630,7 @@ def write_projection(
             batch = []
             for reaction_id, reaction in view.iter_reactions(row_group=row_group):
                 try:
-                    row = reaction_row(reaction, reaction_id)
+                    row = reaction_row(reaction, reaction_id, structure_ids)
                 except ValueError as error:
                     raise ValueError(f"{view.path}: {error}") from error
                 unreadable += _unreadable_structures(row)

--- a/ord_schema/projection_test.py
+++ b/ord_schema/projection_test.py
@@ -598,3 +598,30 @@ def test_write_projection_stamps_one_id_space_per_dataset(tmp_path):
         (product,) = row["outcomes"][0]["products"]
         assert component["structure_id"] == 0
         assert product["structure_id"] == 1
+
+
+def test_structure_ids_span_source_row_groups(tmp_path):
+    # The id mapping is created once per dataset, not once per row group: rebuilding
+    # it inside the loop would restart the ids and corrupt every join in a dataset
+    # bigger than one group, while every small test still passed.
+    source = _source(
+        tmp_path, [_reaction(f"ord-{i:04d}") for i in range(3)], row_group_size=1
+    )
+    output = tmp_path / "projection.parquet"
+    projection.write_projection(source, output)
+    with pq.ParquetFile(output) as projected:
+        assert projected.num_row_groups == 3
+        for row_group in range(projected.num_row_groups):
+            table = projected.read_row_group(
+                row_group,
+                columns=[
+                    "inputs.key_value.key",
+                    "inputs.key_value.value.components.list.element.structure_id",
+                    "outcomes.list.element.products.list.element.structure_id",
+                ],
+            )
+            for row in table.to_pylist():
+                (component,) = row["inputs"][0][1]["components"]
+                (product,) = row["outcomes"][0]["products"]
+                assert component["structure_id"] == 0
+                assert product["structure_id"] == 1

--- a/ord_schema/projection_test.py
+++ b/ord_schema/projection_test.py
@@ -513,3 +513,88 @@ def test_a_repeated_united_field_is_refused():
     descriptor = SimpleNamespace(name="Fake", full_name="ord.Fake", fields=[field])
     with pytest.raises(ValueError, match="repeated united message"):
         projection._struct_fields(cast(Descriptor, descriptor), frozenset())
+
+
+def test_schema_adds_a_structure_id_beside_the_compound_smiles():
+    components = (
+        projection.SCHEMA.field("inputs").type.item_type.field("components").type
+    )
+    field = components.value_type.field("structure_id")
+    assert field.type == pa.uint32()
+    assert projection.is_internal(field)
+    # The reaction-level smiles is a reaction, not a molecule; no id is assigned there.
+    assert "structure_id" not in projection.SCHEMA.names
+    assert not projection.is_internal(projection.SCHEMA.field("smiles"))
+
+
+def test_message_row_without_a_mapping_leaves_structure_id_null():
+    row = projection.message_row(_reaction())
+    (component,) = row["inputs"][0][1]["components"]
+    assert component["smiles"] == "Cc1ccccc1"
+    assert component["structure_id"] is None
+
+
+def test_structure_ids_are_assigned_in_first_seen_order():
+    structure_ids: dict[str, int] = {}
+    row = projection.message_row(_reaction(), structure_ids)
+    (component,) = row["inputs"][0][1]["components"]
+    (product,) = row["outcomes"][0]["products"]
+    assert component["structure_id"] == 0
+    assert product["structure_id"] == 1
+    assert structure_ids == {"Cc1ccccc1": 0, "Cc1ccccc1O": 1}
+
+
+def test_the_same_structure_shares_one_id_across_reactions():
+    structure_ids: dict[str, int] = {}
+    first = projection.message_row(_reaction("ord-0001"), structure_ids)
+    second = projection.message_row(_reaction("ord-0002"), structure_ids)
+    for row in (first, second):
+        (component,) = row["inputs"][0][1]["components"]
+        assert component["structure_id"] == 0
+    assert len(structure_ids) == 2
+
+
+def test_a_compound_without_a_smiles_gets_no_structure_id():
+    reaction = _reaction()
+    component = reaction.inputs["unnamed"].components.add()
+    component.identifiers.add(type="NAME", value="mystery compound")
+    structure_ids: dict[str, int] = {}
+    row = projection.message_row(reaction, structure_ids)
+    (unnamed,) = dict(row["inputs"])["unnamed"]["components"]
+    assert unnamed["smiles"] is None
+    assert unnamed["structure_id"] is None
+    assert "mystery compound" not in structure_ids
+
+
+def test_structure_ids_reach_compounds_beyond_inputs_and_products():
+    # message_row assigns by descriptor name, so a compound in a workup input or an
+    # authentic standard shares the id space; the structures artifact reads them all.
+    reaction = _reaction()
+    workup = reaction.workups.add()
+    workup.input.components.add().identifiers.add(type="SMILES", value="Cc1ccccc1")
+    structure_ids: dict[str, int] = {}
+    row = projection.message_row(reaction, structure_ids)
+    (workup_component,) = row["workups"][0]["input"]["components"]
+    assert workup_component["structure_id"] == 0  # Same molecule as the toluene input.
+    assert len(structure_ids) == 2
+
+
+def test_write_projection_stamps_one_id_space_per_dataset(tmp_path):
+    source = _source(tmp_path, [_reaction(f"ord-{i:04d}") for i in range(3)])
+    output = tmp_path / "projection.parquet"
+    projection.write_projection(source, output)
+    with pq.ParquetFile(output) as projected:
+        table = projected.read_row_group(
+            0,
+            columns=[
+                "inputs.key_value.key",
+                "inputs.key_value.value.components.list.element.structure_id",
+                "outcomes.list.element.products.list.element.structure_id",
+            ],
+        )
+    assert table.num_rows == 3
+    for row in table.to_pylist():
+        (component,) = row["inputs"][0][1]["components"]
+        (product,) = row["outcomes"][0]["products"]
+        assert component["structure_id"] == 0
+        assert product["structure_id"] == 1

--- a/ord_schema/scripts/derive_structures.py
+++ b/ord_schema/scripts/derive_structures.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Derives structure-search artifacts from projections.
+
+Each projection yields one structures artifact: one row per distinct structure, with
+the fingerprints a query engine screens against and the serialized molecule
+verification reads; see ``ord_schema.structures`` for the columns and why. Outputs
+mirror the inputs' directory layout beneath ``--output_dir``::
+
+    derive_structures.py --input_pattern='projections/*/*.parquet' \
+        --output_dir=structures
+
+    projections/aa/ord_dataset-<id>.parquet -> structures/aa/ord_dataset-<id>.parquet
+
+Artifacts whose footer already records the current source content, library version, and
+artifact version are skipped, so re-running is cheap; --force rewrites them anyway.
+
+A match that is not a projection -- a source dataset, or a structures artifact from an
+earlier run -- is ignored rather than derived from, so --output_dir may sit inside a
+recursive pattern's reach. These are errors: an --output_dir that would write over any
+input, a match that cannot be read as Parquet at all, and a run that derives nothing.
+"""
+
+import argparse
+
+from ord_schema import artifacts, projection, structures
+from ord_schema.logging import silence_rdkit_logs
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parses command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--input_pattern", required=True, help="Input pattern for Parquet projections"
+    )
+    parser.add_argument(
+        "--output_dir", required=True, help="Directory to write artifacts beneath"
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Rewrite artifacts that are already current",
+    )
+    return parser.parse_args(argv)
+
+
+def main(args: argparse.Namespace) -> None:
+    """Derives a structures artifact for every projection matching the input pattern.
+
+    Args:
+        args: Parsed command-line arguments.
+
+    Raises:
+        ValueError: If the pattern matched no projections, which usually means it was
+            aimed at the source tree, or at an output tree, rather than at the
+            projections. Silence there would let a pipeline step downstream proceed as
+            though the artifacts had been built.
+    """
+    silence_rdkit_logs()
+    written, skipped, ignored = artifacts.derive_tree(
+        args.input_pattern,
+        args.output_dir,
+        artifact=structures.ARTIFACT,
+        write=structures.write_structures,
+        force=args.force,
+        parent_artifact=projection.ARTIFACT,
+    )
+    if not written and not skipped:
+        raise ValueError(
+            f"no structures derived: none of the {ignored} matches for "
+            f"{args.input_pattern!r} are projections"
+        )
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/ord_schema/scripts/derive_structures.py
+++ b/ord_schema/scripts/derive_structures.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Derives structure-search artifacts from projections.
+r"""Derives structure-search artifacts from projections.
 
 Each projection yields one structures artifact: one row per distinct structure, with
 the fingerprints a query engine screens against and the serialized molecule
@@ -30,7 +30,8 @@ artifact version are skipped, so re-running is cheap; --force rewrites them anyw
 A match that is not a projection -- a source dataset, or a structures artifact from an
 earlier run -- is ignored rather than derived from, so --output_dir may sit inside a
 recursive pattern's reach. These are errors: an --output_dir that would write over any
-input, a match that cannot be read as Parquet at all, and a run that derives nothing.
+input, a match that cannot be read as Parquet at all, and a run that finds no
+projections at all.
 """
 
 import argparse

--- a/ord_schema/scripts/derive_structures_test.py
+++ b/ord_schema/scripts/derive_structures_test.py
@@ -27,11 +27,15 @@ from ord_schema import artifacts, parquet, structures
 from ord_schema.proto import dataset_pb2, reaction_pb2
 from ord_schema.scripts import derive_projection, derive_structures
 
+# Distinct molecules per shard, so a test can tell one dataset's artifact -- and its
+# id space -- from another's.
+_SHARD_SMILES = {"aa": "c1ccccc1", "bb": "CCO"}
 
-def _dataset(dataset_id: str):
+
+def _dataset(dataset_id: str, smiles: str):
     reaction = reaction_pb2.Reaction(reaction_id="ord-0001")
     component = reaction.inputs["a"].components.add()
-    component.identifiers.add(type="SMILES", value="c1ccccc1")
+    component.identifiers.add(type="SMILES", value=smiles)
     return dataset_pb2.Dataset(
         dataset_id=dataset_id, name="test", description="desc", reactions=[reaction]
     )
@@ -43,7 +47,7 @@ def _corpus(root: pathlib.Path, shards=("aa", "bb")) -> None:
         directory = root / "data" / shard
         directory.mkdir(parents=True, exist_ok=True)
         parquet.save_dataset(
-            _dataset(f"ord_dataset-{shard}"),
+            _dataset(f"ord_dataset-{shard}", _SHARD_SMILES[shard]),
             str(directory / f"ord_dataset-{shard}.parquet"),
         )
 
@@ -81,7 +85,10 @@ def test_main_writes_one_artifact_per_dataset(tmp_path):
         assert artifact.exists()
         table = pq.read_table(artifact)
         assert table.schema.names == structures.SCHEMA.names
-        assert table.column("smiles").to_pylist() == ["c1ccccc1"]
+        # Each dataset gets its own artifact and its own id space: each shard's
+        # molecule sits at id 0 of its own file, not offset by the other's.
+        assert table.column("smiles").to_pylist() == [_SHARD_SMILES[shard]]
+        assert table.column("structure_id").to_pylist() == [0]
 
 
 def test_main_stamps_artifacts_with_their_source(tmp_path):

--- a/ord_schema/scripts/derive_structures_test.py
+++ b/ord_schema/scripts/derive_structures_test.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.scripts.derive_structures.
+
+Artifact behavior is covered in ord_schema.structures_test; these cover the CLI: path
+mapping, which matches count as sources, the skip-if-current shortcut, and --force.
+"""
+
+import pathlib
+
+import pyarrow.parquet as pq
+import pytest
+
+from ord_schema import artifacts, parquet, structures
+from ord_schema.proto import dataset_pb2, reaction_pb2
+from ord_schema.scripts import derive_projection, derive_structures
+
+
+def _dataset(dataset_id: str):
+    reaction = reaction_pb2.Reaction(reaction_id="ord-0001")
+    component = reaction.inputs["a"].components.add()
+    component.identifiers.add(type="SMILES", value="c1ccccc1")
+    return dataset_pb2.Dataset(
+        dataset_id=dataset_id, name="test", description="desc", reactions=[reaction]
+    )
+
+
+def _corpus(root: pathlib.Path, shards=("aa", "bb")) -> None:
+    """Writes data/<shard>/ord_dataset-<shard>.parquet under root."""
+    for shard in shards:
+        directory = root / "data" / shard
+        directory.mkdir(parents=True, exist_ok=True)
+        parquet.save_dataset(
+            _dataset(f"ord_dataset-{shard}"),
+            str(directory / f"ord_dataset-{shard}.parquet"),
+        )
+
+
+def _project(root: pathlib.Path) -> None:
+    """Projects the corpus, which is what structures are derived from."""
+    derive_projection.main(
+        derive_projection.parse_args(
+            [
+                f"--input_pattern={root / 'data' / '*' / '*.parquet'}",
+                f"--output_dir={root / 'projections'}",
+            ]
+        )
+    )
+
+
+def _run(root: pathlib.Path, *extra: str) -> None:
+    derive_structures.main(
+        derive_structures.parse_args(
+            [
+                f"--input_pattern={root / 'projections' / '*' / '*.parquet'}",
+                f"--output_dir={root / 'structures'}",
+                *extra,
+            ]
+        )
+    )
+
+
+def test_main_writes_one_artifact_per_dataset(tmp_path):
+    _corpus(tmp_path)
+    _project(tmp_path)
+    _run(tmp_path)
+    for shard in ("aa", "bb"):
+        artifact = tmp_path / "structures" / shard / f"ord_dataset-{shard}.parquet"
+        assert artifact.exists()
+        table = pq.read_table(artifact)
+        assert table.schema.names == structures.SCHEMA.names
+        assert table.column("smiles").to_pylist() == ["c1ccccc1"]
+
+
+def test_main_stamps_artifacts_with_their_source(tmp_path):
+    _corpus(tmp_path, shards=("aa",))
+    _project(tmp_path)
+    _run(tmp_path)
+    source = tmp_path / "data" / "aa" / "ord_dataset-aa.parquet"
+    stamps = artifacts.load_stamps(
+        tmp_path / "structures" / "aa" / "ord_dataset-aa.parquet"
+    )
+    assert stamps.artifact == structures.ARTIFACT
+    assert stamps.source_dataset_id == "ord_dataset-aa"
+    assert stamps.source_md5 == parquet.DatasetView(source).md5()
+
+
+# write_structures publishes by renaming a fresh temp file into place, so the inode
+# changes if and only if the artifact was rewritten. That is exact, unlike mtimes.
+def test_main_skips_artifacts_that_are_current(tmp_path):
+    _corpus(tmp_path, shards=("aa",))
+    _project(tmp_path)
+    _run(tmp_path)
+    artifact = tmp_path / "structures" / "aa" / "ord_dataset-aa.parquet"
+    before = artifact.stat().st_ino
+    _run(tmp_path)
+    assert artifact.stat().st_ino == before
+
+
+def test_force_rewrites_a_current_artifact(tmp_path):
+    _corpus(tmp_path, shards=("aa",))
+    _project(tmp_path)
+    _run(tmp_path)
+    artifact = tmp_path / "structures" / "aa" / "ord_dataset-aa.parquet"
+    before = artifact.stat().st_ino
+    _run(tmp_path, "--force")
+    assert artifact.stat().st_ino != before
+
+
+def test_main_ignores_source_datasets(tmp_path):
+    # The structures artifact featurizes a projection, so a pattern aimed at the
+    # sources has nothing to read -- rather than silently deriving one the slow way.
+    _corpus(tmp_path, shards=("aa",))
+    _project(tmp_path)
+    with pytest.raises(ValueError, match="are projections"):
+        derive_structures.main(
+            derive_structures.parse_args(
+                [
+                    f"--input_pattern={tmp_path}/data/*/*.parquet",
+                    f"--output_dir={tmp_path}/structures",
+                ]
+            )
+        )
+
+
+def test_main_raises_when_nothing_matches(tmp_path):
+    with pytest.raises(ValueError, match="no datasets matched"):
+        derive_structures.main(
+            derive_structures.parse_args(
+                [
+                    f"--input_pattern={tmp_path / 'absent' / '*.parquet'}",
+                    f"--output_dir={tmp_path / 'structures'}",
+                ]
+            )
+        )

--- a/ord_schema/structures.py
+++ b/ord_schema/structures.py
@@ -1,0 +1,313 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A structure-search artifact: one row per distinct structure in a projection.
+
+Structure search runs in two steps that this artifact serves in turn. A **screen**
+tests the query's fingerprint bits against every row -- a bitwise scan a query engine
+runs in milliseconds, with no chemistry library in sight -- and is complete but not
+exact: it never misses a true match, and passes false ones. **Verification** then runs
+real subgraph isomorphism over the survivors, from the serialized molecule carried
+here, which skips re-parsing SMILES and runs about five times faster for it. Neither
+step needs an index; the reason a structure search elsewhere needs one is the cost of
+scanning rows one at a time, and a columnar scan of every distinct structure in the
+corpus is cheap.
+
+The artifact is deduplicated, which is what makes both steps affordable: the corpus
+holds roughly fifteen component occurrences per distinct structure, so screening and
+verification run against the distinct set and their results fan back out through the
+projection. The join is ``structure_id`` -- assigned by ``write_projection`` in
+first-seen order, carried on every compound there and numbered ``0..n-1`` here, so a
+match set travels back into a query as a bitmap indexed by id. The two files are two
+statements of one derivation and are meaningful only together; ids are not stable
+across builds and nothing outside the artifacts should record them.
+
+The screen's completeness is an invariant, not a hope: if query ``Q`` is a subgraph of
+target ``T``, every bit of ``Q``'s pattern fingerprint is set in ``T``'s, so
+``bit_count(fp & q) = popcount(q)`` never rejects a true match. That guarantee fails
+for SMARTS with explicit hydrogens -- measured: ``[H]OC`` screens *out* methanol while
+the ``MergeQueryHs``-transformed query matches it -- which is why a query layer must
+refuse them rather than merge them. Similarity needs no verification at all: Tanimoto
+is defined on the Morgan fingerprint, so the screen *is* the answer, and
+``morgan_popcount`` bounds it (``popcount(B)`` must lie within ``[t * popcount(A),
+popcount(A) / t]`` for Tanimoto ``>= t``).
+
+A structure whose SMILES RDKit cannot parse keeps its row -- the id space must stay
+dense -- with every derived column null. It can never match a structure query, and the
+count of such rows is logged per dataset.
+"""
+
+import os
+from collections.abc import Iterator
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from rdkit import Chem, DataStructs
+from rdkit.Chem import rdFingerprintGenerator
+
+from ord_schema import artifacts, atomic_io, projection
+from ord_schema.logging import get_logger
+
+logger = get_logger(__name__)
+
+ARTIFACT = "structures"
+
+# Fingerprint parameters. Screen precision plateaus by 2048 bits -- the residual false
+# positives are the gap between feature containment and subgraph isomorphism, which no
+# width closes -- so wider fingerprints buy storage, not selectivity.
+PATTERN_FP_SIZE = 2048
+MORGAN_FP_SIZE = 2048
+MORGAN_RADIUS = 2
+
+_MORGAN = rdFingerprintGenerator.GetMorganGenerator(
+    radius=MORGAN_RADIUS, fpSize=MORGAN_FP_SIZE
+)
+
+# Named so a published file says how its fingerprints were made; the reader recovers
+# the parameters from the footer rather than from this library's history.
+_META_FINGERPRINT = "ord.fingerprint"
+
+SCHEMA = pa.schema(
+    [
+        # The join key: every compound in the sibling projection carries one, and rows
+        # here are numbered 0..n-1 in the same first-seen order.
+        pa.field("structure_id", pa.uint32(), nullable=False),
+        pa.field("smiles", pa.string(), nullable=False),
+        pa.field(
+            "pattern_fp",
+            pa.binary(),
+            metadata={_META_FINGERPRINT: f"rdkit-pattern;fpSize={PATTERN_FP_SIZE}"},
+        ),
+        pa.field(
+            "morgan_fp",
+            pa.binary(),
+            metadata={
+                _META_FINGERPRINT: (
+                    f"morgan;radius={MORGAN_RADIUS};fpSize={MORGAN_FP_SIZE}"
+                )
+            },
+        ),
+        pa.field("morgan_popcount", pa.uint32()),
+        # Chem.Mol(mol_binary) reconstructs the molecule without re-parsing SMILES,
+        # which is what verification spends most of its time on otherwise.
+        pa.field("mol_binary", pa.binary()),
+    ]
+)
+
+
+def _structure_columns(schema: pa.Schema = projection.SCHEMA) -> list[str]:
+    """Returns the projection's (smiles, structure_id) leaves as Parquet column paths.
+
+    Walked from the schema rather than listed by hand, so a compound field added
+    upstream is read from wherever it lands -- components, products, workup inputs,
+    authentic standards -- without anyone updating a list here.
+
+    Args:
+        schema: The projection schema.
+
+    Returns:
+        Parquet physical column paths, in schema order.
+    """
+    paths: list[str] = []
+
+    def walk(dtype: pa.DataType, prefix: str) -> None:
+        if pa.types.is_struct(dtype):
+            if "structure_id" in [field.name for field in dtype]:
+                paths.append(f"{prefix}.smiles")
+                paths.append(f"{prefix}.structure_id")
+            for child in dtype:
+                walk(child.type, f"{prefix}.{child.name}")
+        elif pa.types.is_list(dtype):
+            walk(dtype.value_type, f"{prefix}.list.element")
+        elif pa.types.is_map(dtype):
+            walk(dtype.item_type, f"{prefix}.key_value.value")
+
+    for field in schema:
+        walk(field.type, field.name)
+    return paths
+
+
+def _pairs(value: Any) -> Iterator[tuple[str | None, int | None]]:
+    """Yields every (smiles, structure_id) pair within a pruned projection row.
+
+    Args:
+        value: A projection row read through ``_structure_columns``, or any value
+            within one: structs arrive as dicts, lists as lists, and maps as lists of
+            ``(key, value)`` tuples.
+
+    Yields:
+        One pair per compound struct, however deeply nested.
+    """
+    if isinstance(value, dict):
+        if "structure_id" in value:
+            yield value.get("smiles"), value["structure_id"]
+        for child in value.values():
+            yield from _pairs(child)
+    elif isinstance(value, (list, tuple)):
+        for child in value:
+            yield from _pairs(child)
+
+
+def _collect(source: str | os.PathLike[str]) -> list[str]:
+    """Reads the (smiles, structure_id) mapping back out of a projection.
+
+    Args:
+        source: Path to the projection.
+
+    Returns:
+        The distinct SMILES, indexed by ``structure_id``.
+
+    Raises:
+        ValueError: If the pairs do not state a single dense mapping -- an id bound to
+            two SMILES, a compound with one half of the pair, or a gap in the id space.
+            Each means ``source`` was not written by ``write_projection``, and an
+            artifact derived from it would join wrongly rather than fail.
+    """
+    smiles_by_id: dict[int, str] = {}
+    columns = _structure_columns()
+    with pq.ParquetFile(source) as projected:
+        for row_group in range(projected.num_row_groups):
+            table = projected.read_row_group(row_group, columns=columns)
+            for row in table.to_pylist():
+                for smiles, structure_id in _pairs(row):
+                    if smiles is None and structure_id is None:
+                        continue  # A compound whose structure the source never stated.
+                    if smiles is None or structure_id is None:
+                        raise ValueError(
+                            f"{source}: compound with smiles={smiles!r} but "
+                            f"structure_id={structure_id!r}; the projection assigns "
+                            "both or neither"
+                        )
+                    known = smiles_by_id.setdefault(structure_id, smiles)
+                    if known != smiles:
+                        raise ValueError(
+                            f"{source}: structure_id {structure_id} is both "
+                            f"{known!r} and {smiles!r}"
+                        )
+    if set(smiles_by_id) != set(range(len(smiles_by_id))):
+        missing = sorted(set(range(len(smiles_by_id))) - set(smiles_by_id))[:5]
+        raise ValueError(
+            f"{source}: structure ids are not dense; first missing {missing}"
+        )
+    return [smiles_by_id[structure_id] for structure_id in range(len(smiles_by_id))]
+
+
+def _row(structure_id: int, smiles: str) -> dict[str, Any]:
+    """Featurizes one structure into a row matching ``SCHEMA``.
+
+    Args:
+        structure_id: The row's id, equal to its position in the artifact.
+        smiles: The structure, as the projection derived it.
+
+    Returns:
+        A dict keyed by column name; every derived column is None when RDKit cannot
+        parse ``smiles``.
+    """
+    row: dict[str, Any] = {
+        "structure_id": structure_id,
+        "smiles": smiles,
+        "pattern_fp": None,
+        "morgan_fp": None,
+        "morgan_popcount": None,
+        "mol_binary": None,
+    }
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return row
+    morgan = _MORGAN.GetFingerprint(mol)
+    row["pattern_fp"] = DataStructs.BitVectToBinaryText(
+        Chem.PatternFingerprint(mol, fpSize=PATTERN_FP_SIZE)
+    )
+    row["morgan_fp"] = DataStructs.BitVectToBinaryText(morgan)
+    row["morgan_popcount"] = morgan.GetNumOnBits()
+    row["mol_binary"] = mol.ToBinary()
+    return row
+
+
+def is_current(path: str | os.PathLike[str], source_md5: str) -> bool:
+    """Returns whether ``path`` is a structures artifact of ``source_md5`` by us.
+
+    Delegates to ``artifacts.is_current``, which requires the artifact name, the source
+    content, the library version, and the artifact version to all match. A missing or
+    unreadable file is not current.
+    """
+    return artifacts.is_current(path, ARTIFACT, source_md5)
+
+
+def write_structures(
+    source: str | os.PathLike[str],
+    output: str | os.PathLike[str],
+    *,
+    source_md5: str | None = None,
+    source_dataset_id: str | None = None,
+    compression: str = "zstd",
+    row_group_size: int = 10_000,
+) -> int:
+    """Derives a structures artifact from a projection and writes it.
+
+    Only the smiles and structure_id leaves are decoded, one projection row group at a
+    time. The output is published atomically, so a failure partway leaves any existing
+    artifact untouched.
+
+    Args:
+        source: Path to the projection whose structures to featurize.
+        output: Path to write the artifact to.
+        source_md5: Hash of the *source dataset* to stamp, if the caller already read
+            one. Taken from the projection's own stamps when omitted, so the artifact
+            names the dataset it reflects rather than the file it read.
+        source_dataset_id: Source dataset ID to stamp, if the caller already read one.
+            Taken from the projection's stamps when omitted.
+        compression: Parquet compression codec.
+        row_group_size: Rows per output row group.
+
+    Returns:
+        Number of rows written: the number of distinct structures in the projection.
+
+    Raises:
+        ValueError: If ``source`` is not a projection, or does not state a single dense
+            (smiles, structure_id) mapping.
+    """
+    parent = artifacts.load_stamps(source)
+    if parent.artifact != projection.ARTIFACT:
+        raise ValueError(
+            f"{source} is a {parent.artifact}, not a {projection.ARTIFACT}; the "
+            "structures artifact featurizes a projection"
+        )
+    if source_md5 is None:
+        source_md5 = parent.source_md5
+    if source_dataset_id is None:
+        source_dataset_id = parent.source_dataset_id
+    stamps = artifacts.current_stamps(ARTIFACT, source_dataset_id, source_md5)
+    schema = SCHEMA.with_metadata(artifacts.to_metadata(stamps))
+    all_smiles = _collect(source)
+    unparseable = 0
+    with (
+        atomic_io.atomic_path(output) as temp_path,
+        pq.ParquetWriter(temp_path, schema, compression=compression) as writer,
+    ):
+        for start in range(0, len(all_smiles), row_group_size) or [0]:
+            batch = [
+                _row(structure_id, smiles)
+                for structure_id, smiles in enumerate(
+                    all_smiles[start : start + row_group_size], start=start
+                )
+            ]
+            unparseable += sum(row["mol_binary"] is None for row in batch)
+            writer.write_table(pa.Table.from_pylist(batch, schema=schema))
+    if unparseable:
+        # Per dataset rather than per row: a count is diffable between runs, so a
+        # regression in structure parsing shows up instead of hiding in the nulls.
+        logger.info("%s: %d structures do not parse", source, unparseable)
+    return len(all_smiles)

--- a/ord_schema/structures.py
+++ b/ord_schema/structures.py
@@ -170,12 +170,14 @@ def _collect(source: str | os.PathLike[str]) -> list[str]:
         The distinct SMILES, indexed by ``structure_id``.
 
     Raises:
-        ValueError: If the pairs do not state a single dense mapping -- an id bound to
-            two SMILES, a compound with one half of the pair, or a gap in the id space.
-            Each means ``source`` was not written by ``write_projection``, and an
-            artifact derived from it would join wrongly rather than fail.
+        ValueError: If the pairs do not state a single dense one-to-one mapping -- an
+            id bound to two SMILES, one SMILES under two ids, a compound with one half
+            of the pair, or a gap in the id space. Each means ``source`` was not
+            written by ``write_projection``, and an artifact derived from it would
+            join wrongly rather than fail.
     """
     smiles_by_id: dict[int, str] = {}
+    id_by_smiles: dict[str, int] = {}
     columns = _structure_columns()
     with pq.ParquetFile(source) as projected:
         for row_group in range(projected.num_row_groups):
@@ -195,6 +197,13 @@ def _collect(source: str | os.PathLike[str]) -> list[str]:
                         raise ValueError(
                             f"{source}: structure_id {structure_id} is both "
                             f"{known!r} and {smiles!r}"
+                        )
+                    known_id = id_by_smiles.setdefault(smiles, structure_id)
+                    if known_id != structure_id:
+                        raise ValueError(
+                            f"{source}: {smiles!r} is both structure_id {known_id} "
+                            f"and {structure_id}; the artifact would hold one "
+                            "structure twice"
                         )
     if set(smiles_by_id) != set(range(len(smiles_by_id))):
         missing = sorted(set(range(len(smiles_by_id))) - set(smiles_by_id))[:5]
@@ -297,6 +306,8 @@ def write_structures(
         atomic_io.atomic_path(output) as temp_path,
         pq.ParquetWriter(temp_path, schema, compression=compression) as writer,
     ):
+        # ``or [0]``: a projection with no structures still writes one empty table, so
+        # the file exists and carries the schema and stamps a reader checks.
         for start in range(0, len(all_smiles), row_group_size) or [0]:
             batch = [
                 _row(structure_id, smiles)

--- a/ord_schema/structures.py
+++ b/ord_schema/structures.py
@@ -28,10 +28,13 @@ The artifact is deduplicated, which is what makes both steps affordable: the cor
 holds roughly fifteen component occurrences per distinct structure, so screening and
 verification run against the distinct set and their results fan back out through the
 projection. The join is ``structure_id`` -- assigned by ``write_projection`` in
-first-seen order, carried on every compound there and numbered ``0..n-1`` here, so a
-match set travels back into a query as a bitmap indexed by id. The two files are two
-statements of one derivation and are meaningful only together; ids are not stable
-across builds and nothing outside the artifacts should record them.
+first-seen order, carried on every compound there that records a structure and numbered
+``0..n-1`` here, so a match set travels back into a query as a bitmap indexed by id.
+The two files are two statements of one derivation and are meaningful only together:
+ids are not stable across builds, nothing outside the artifacts should record them, and
+a projection rewritten in place needs its structures artifact rederived with it -- the
+currency stamps name the source dataset rather than the projection file, so the skip
+check cannot see that the pairing changed.
 
 The screen's completeness is an invariant, not a hope: if query ``Q`` is a subgraph of
 target ``T``, every bit of ``Q``'s pattern fingerprint is set in ``T``'s, so
@@ -81,8 +84,8 @@ _META_FINGERPRINT = "ord.fingerprint"
 
 SCHEMA = pa.schema(
     [
-        # The join key: every compound in the sibling projection carries one, and rows
-        # here are numbered 0..n-1 in the same first-seen order.
+        # The join key: every compound in the sibling projection with a ``smiles``
+        # carries one, and rows here are numbered 0..n-1 in the same first-seen order.
         pa.field("structure_id", pa.uint32(), nullable=False),
         pa.field("smiles", pa.string(), nullable=False),
         pa.field(
@@ -170,16 +173,29 @@ def _collect(source: str | os.PathLike[str]) -> list[str]:
         The distinct SMILES, indexed by ``structure_id``.
 
     Raises:
-        ValueError: If the pairs do not state a single dense one-to-one mapping -- an
-            id bound to two SMILES, one SMILES under two ids, a compound with one half
-            of the pair, or a gap in the id space. Each means ``source`` was not
-            written by ``write_projection``, and an artifact derived from it would
-            join wrongly rather than fail.
+        ValueError: If ``source``'s schema does not hold the structure columns this
+            library's projection defines, or if the pairs do not state a single dense
+            one-to-one mapping -- an id bound to two SMILES, one SMILES under two ids,
+            a compound with one half of the pair, or a gap in the id space. Each means
+            ``source`` was not written by this library's ``write_projection``, and an
+            artifact derived from it would join wrongly rather than fail.
     """
     smiles_by_id: dict[int, str] = {}
     id_by_smiles: dict[str, int] = {}
     columns = _structure_columns()
     with pq.ParquetFile(source) as projected:
+        # Checked against the file's own schema because read_row_group silently drops
+        # requested columns the file does not have: an old-schema projection would
+        # otherwise state no pairs at all and derive an empty artifact that stamps
+        # itself current.
+        available = _structure_columns(projected.schema_arrow)
+        if available != columns:
+            raise ValueError(
+                f"{source}: structure columns disagree with this library's projection "
+                f"schema (missing {sorted(set(columns) - set(available))}, unexpected "
+                f"{sorted(set(available) - set(columns))}); derive the projection "
+                "again first"
+            )
         for row_group in range(projected.num_row_groups):
             table = projected.read_row_group(row_group, columns=columns)
             for row in table.to_pylist():
@@ -294,6 +310,13 @@ def write_structures(
             f"{source} is a {parent.artifact}, not a {projection.ARTIFACT}; the "
             "structures artifact featurizes a projection"
         )
+    # derive_tree refuses stale parents, but this writer is public and its output
+    # inherits the dataset hash: an artifact derived from a stale projection would
+    # claim a provenance it does not have and nothing would ever mark it stale again.
+    if not artifacts.stamps_are_current(parent, projection.ARTIFACT):
+        raise ValueError(
+            f"{source} is a stale {projection.ARTIFACT}; derive it again first"
+        )
     if source_md5 is None:
         source_md5 = parent.source_md5
     if source_dataset_id is None:
@@ -306,9 +329,9 @@ def write_structures(
         atomic_io.atomic_path(output) as temp_path,
         pq.ParquetWriter(temp_path, schema, compression=compression) as writer,
     ):
-        # ``or [0]``: a projection with no structures still writes one empty table, so
-        # the file exists and carries the schema and stamps a reader checks.
-        for start in range(0, len(all_smiles), row_group_size) or [0]:
+        # A projection with no structures leaves the loop empty; the writer's close
+        # still produces a valid zero-row file carrying the schema and stamps.
+        for start in range(0, len(all_smiles), row_group_size):
             batch = [
                 _row(structure_id, smiles)
                 for structure_id, smiles in enumerate(
@@ -318,7 +341,8 @@ def write_structures(
             unparseable += sum(row["mol_binary"] is None for row in batch)
             writer.write_table(pa.Table.from_pylist(batch, schema=schema))
     if unparseable:
-        # Per dataset rather than per row: a count is diffable between runs, so a
-        # regression in structure parsing shows up instead of hiding in the nulls.
-        logger.info("%s: %d structures do not parse", source, unparseable)
+        # A warning because any nonzero count is anomalous: the projection's SMILES
+        # are RDKit-canonical, so a re-parse failure means version skew or an RDKit
+        # bug. Per dataset rather than per row so the count is diffable between runs.
+        logger.warning("%s: %d structures do not parse", source, unparseable)
     return len(all_smiles)

--- a/ord_schema/structures_test.py
+++ b/ord_schema/structures_test.py
@@ -51,7 +51,8 @@ def _project(tmp_path, reactions=None) -> pathlib.Path:
 
 def test_structure_columns_cover_every_compound_location():
     columns = structures._structure_columns()
-    # Compounds sit in four places; a hand-written list missed two of them once.
+    # Compounds sit in four places; the two beyond inputs and products are easy to
+    # overlook, which is why the columns are walked from the schema rather than listed.
     for prefix in (
         "inputs.key_value.value.components",
         "workups.list.element.input.components",
@@ -205,6 +206,19 @@ def test_conflicting_ids_are_refused(tmp_path):
     row_a["reaction_id"], row_b["reaction_id"] = "ord-0001", "ord-0002"
     path = _corrupt_projection(tmp_path, [row_a, row_b])
     with pytest.raises(ValueError, match="is both"):
+        structures.write_structures(path, tmp_path / "structures.parquet")
+
+
+def test_one_smiles_under_two_ids_is_refused(tmp_path):
+    # The reverse defect of conflicting ids: the mapping must be one-to-one in both
+    # directions, or the artifact holds duplicate rows and an inflated distinct count.
+    ids_a = {"c1ccccc1": 0, "Cc1ccccc1": 1}
+    ids_b = {"c1ccccc1": 2, "Cc1ccccc1": 1}
+    row_a = projection.message_row(_reaction("ord-0001"), ids_a)
+    row_b = projection.message_row(_reaction("ord-0002"), ids_b)
+    row_a["reaction_id"], row_b["reaction_id"] = "ord-0001", "ord-0002"
+    path = _corrupt_projection(tmp_path, [row_a, row_b])
+    with pytest.raises(ValueError, match="one structure twice"):
         structures.write_structures(path, tmp_path / "structures.parquet")
 
 

--- a/ord_schema/structures_test.py
+++ b/ord_schema/structures_test.py
@@ -82,6 +82,30 @@ def test_shared_structures_are_deduplicated(tmp_path):
     source = _project(tmp_path, reactions)
     output = tmp_path / "structures.parquet"
     assert structures.write_structures(source, output) == 2
+    table = pq.read_table(output)
+    assert table.column("structure_id").to_pylist() == [0, 1]
+    assert table.column("smiles").to_pylist() == ["c1ccccc1", "Cc1ccccc1"]
+
+
+def test_row_groups_keep_ids_aligned(tmp_path):
+    # Position in the file is the id, so each output row group must continue the
+    # sequence and each row's derived columns must be its own molecule's --
+    # misalignment here is silent join corruption, not an error.
+    reaction = _reaction()
+    component = reaction.inputs["b"].components.add()
+    component.identifiers.add(type="SMILES", value="CCO")
+    source = _project(tmp_path, [reaction])
+    output = tmp_path / "structures.parquet"
+    assert structures.write_structures(source, output, row_group_size=1) == 3
+    with pq.ParquetFile(output) as artifact:
+        assert artifact.num_row_groups == 3
+    table = pq.read_table(output)
+    assert table.column("structure_id").to_pylist() == [0, 1, 2]
+    for row in table.to_pylist():
+        mol = Chem.Mol(row["mol_binary"])
+        assert Chem.MolToSmiles(mol) == Chem.CanonSmiles(row["smiles"]), row["smiles"]
+        fingerprint = DataStructs.CreateFromBinaryText(row["morgan_fp"])
+        assert row["morgan_popcount"] == fingerprint.GetNumOnBits()
 
 
 def test_the_screen_is_complete_and_verification_is_exact(tmp_path):
@@ -104,6 +128,21 @@ def test_the_screen_is_complete_and_verification_is_exact(tmp_path):
     mol = Chem.Mol(target["mol_binary"])
     assert mol.HasSubstructMatch(query)
     assert Chem.MolToSmiles(mol) == Chem.CanonSmiles("Cc1ccccc1")
+    # Containment is directional: benzene's row must not pass a toluene query, or the
+    # screen is comparing something other than the fingerprints.
+    benzene_fp = DataStructs.CreateFromBinaryText(
+        next(row for row in rows if row["smiles"] == "c1ccccc1")["pattern_fp"]
+    )
+    assert (target_fp & benzene_fp).GetNumOnBits() < target_fp.GetNumOnBits()
+    # A query with a generic atom exercises RDKit's query-fingerprint generalization,
+    # the part of PatternFingerprint most likely to shift under an upgrade.
+    generic = Chem.MolFromSmarts("*c1ccccc1")
+    generic_fp = DataStructs.CreateFromBinaryText(
+        DataStructs.BitVectToBinaryText(
+            Chem.PatternFingerprint(generic, fpSize=structures.PATTERN_FP_SIZE)
+        )
+    )
+    assert (generic_fp & target_fp).GetNumOnBits() == generic_fp.GetNumOnBits()
 
 
 def test_morgan_popcount_counts_the_morgan_fingerprint(tmp_path):
@@ -139,6 +178,8 @@ def test_structures_from_workups_and_standards_are_included(tmp_path):
 
 
 def test_a_dataset_with_no_structures_writes_an_empty_artifact(tmp_path):
+    # The empty file is the point: it carries the schema and stamps, so the derive
+    # driver can tell "done, nothing to featurize" from "never derived".
     reaction = reaction_pb2.Reaction(reaction_id="ord-0001")
     component = reaction.inputs["a"].components.add()
     component.identifiers.add(type="NAME", value="mystery")
@@ -149,6 +190,9 @@ def test_a_dataset_with_no_structures_writes_an_empty_artifact(tmp_path):
     table = pq.read_table(output)
     assert table.num_rows == 0
     assert table.schema.names == structures.SCHEMA.names
+    stamps = artifacts.load_stamps(output)
+    assert stamps.artifact == structures.ARTIFACT
+    assert structures.is_current(output, stamps.source_md5)
 
 
 def test_stamps_name_the_source_dataset_not_the_projection(tmp_path):
@@ -227,4 +271,67 @@ def test_a_gap_in_the_id_space_is_refused(tmp_path):
     row["reaction_id"] = "ord-0001"
     path = _corrupt_projection(tmp_path, [row])
     with pytest.raises(ValueError, match="not dense"):
+        structures.write_structures(path, tmp_path / "structures.parquet")
+
+
+def test_an_unparseable_structure_survives_the_write_path(tmp_path):
+    # Cannot arise from a same-version projection -- its SMILES are RDKit-canonical --
+    # so it is staged through _corrupt_projection: the row must keep its position (the
+    # id space stays dense) rather than being cleaned out of the batch.
+    ids: dict[str, int] = {}
+    row = projection.message_row(_reaction(), ids)
+    (component,) = dict(row["inputs"])["a"]["components"]
+    component["smiles"] = "not-a-smiles"  # Keeps the id benzene was assigned.
+    row["reaction_id"] = "ord-0001"
+    path = _corrupt_projection(tmp_path, [row])
+    output = tmp_path / "structures.parquet"
+    assert structures.write_structures(path, output) == 2
+    rows = pq.read_table(output).to_pylist()
+    bad = next(r for r in rows if r["smiles"] == "not-a-smiles")
+    assert bad["structure_id"] == ids["c1ccccc1"]
+    for column in ("pattern_fp", "morgan_fp", "morgan_popcount", "mol_binary"):
+        assert bad[column] is None, column
+    good = next(r for r in rows if r["smiles"] != "not-a-smiles")
+    assert good["mol_binary"] is not None
+
+
+def test_a_projection_missing_the_id_columns_is_refused(tmp_path):
+    # read_row_group silently drops requested columns a file does not have, so an
+    # old-schema projection would otherwise state no pairs at all and derive an empty
+    # artifact that stamps itself current.
+    stamps = artifacts.current_stamps(projection.ARTIFACT, "ord_dataset-1", "0" * 32)
+    component = pa.struct([pa.field("smiles", pa.string())])
+    reaction_input = pa.struct([pa.field("components", pa.list_(component))])
+    schema = pa.schema(
+        [
+            pa.field("reaction_id", pa.string()),
+            pa.field("inputs", pa.map_(pa.string(), reaction_input)),
+        ]
+    ).with_metadata(artifacts.to_metadata(stamps))
+    path = tmp_path / "projection.parquet"
+    pq.write_table(
+        pa.Table.from_pylist(
+            [{"reaction_id": "ord-0001", "inputs": []}], schema=schema
+        ),
+        path,
+    )
+    with pytest.raises(ValueError, match="derive the projection again"):
+        structures.write_structures(path, tmp_path / "structures.parquet")
+
+
+def test_a_stale_projection_is_refused(tmp_path):
+    # The output inherits the dataset hash, so an artifact derived from a stale
+    # projection would claim a provenance it does not have and never read stale again.
+    stamps = artifacts.Stamps(
+        artifact=projection.ARTIFACT,
+        source_dataset_id="ord_dataset-1",
+        source_md5="0" * 32,
+        ord_schema_version="0.0.0",
+        artifact_version=artifacts.ARTIFACT_VERSION,
+        rdkit_version="0000.00.0",
+    )
+    schema = projection.SCHEMA.with_metadata(artifacts.to_metadata(stamps))
+    path = tmp_path / "projection.parquet"
+    pq.write_table(pa.Table.from_pylist([], schema=schema), path)
+    with pytest.raises(ValueError, match="stale"):
         structures.write_structures(path, tmp_path / "structures.parquet")

--- a/ord_schema/structures_test.py
+++ b/ord_schema/structures_test.py
@@ -1,0 +1,216 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.structures."""
+
+import pathlib
+from importlib import metadata
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from rdkit import Chem, DataStructs
+
+from ord_schema import artifacts, parquet, projection, structures
+from ord_schema.proto import reaction_pb2
+
+
+def _reaction(
+    reaction_id: str = "ord-0001", *, input_smiles: str = "c1ccccc1"
+) -> reaction_pb2.Reaction:
+    reaction = reaction_pb2.Reaction(reaction_id=reaction_id)
+    component = reaction.inputs["a"].components.add()
+    component.identifiers.add(type="SMILES", value=input_smiles)
+    outcome = reaction.outcomes.add()
+    outcome.products.add().identifiers.add(type="SMILES", value="Cc1ccccc1")
+    return reaction
+
+
+def _project(tmp_path, reactions=None) -> pathlib.Path:
+    """Writes a source dataset and its projection, which is what structures reads."""
+    source = tmp_path / "source.parquet"
+    with parquet.DatasetWriter(
+        source, name="test", description="test", dataset_id="ord_dataset-1"
+    ) as writer:
+        writer.write_all(reactions or [_reaction()])
+    path = tmp_path / "projection.parquet"
+    projection.write_projection(source, path)
+    return path
+
+
+def test_structure_columns_cover_every_compound_location():
+    columns = structures._structure_columns()
+    # Compounds sit in four places; a hand-written list missed two of them once.
+    for prefix in (
+        "inputs.key_value.value.components",
+        "workups.list.element.input.components",
+        "outcomes.list.element.products",
+        "outcomes.list.element.products.list.element.measurements.list.element"
+        ".authentic_standard",
+    ):
+        assert f"{prefix}.list.element.smiles" in columns or (
+            f"{prefix}.smiles" in columns
+        ), prefix
+
+
+def test_write_structures_round_trips(tmp_path):
+    source = _project(tmp_path)
+    output = tmp_path / "structures.parquet"
+    assert structures.write_structures(source, output) == 2
+    table = pq.read_table(output)
+    assert table.schema.names == structures.SCHEMA.names
+    assert table.column("structure_id").to_pylist() == [0, 1]
+    assert table.column("smiles").to_pylist() == ["c1ccccc1", "Cc1ccccc1"]
+
+
+def test_shared_structures_are_deduplicated(tmp_path):
+    # Benzene appears in every reaction; the artifact holds it once, under the id the
+    # projection stamped everywhere it occurs.
+    reactions = [_reaction(f"ord-{i:04d}") for i in range(5)]
+    source = _project(tmp_path, reactions)
+    output = tmp_path / "structures.parquet"
+    assert structures.write_structures(source, output) == 2
+
+
+def test_the_screen_is_complete_and_verification_is_exact(tmp_path):
+    # Toluene contains benzene: every query bit must be set in the target fingerprint
+    # (the screen never rejects a true match), and the serialized molecule must verify
+    # identically to one re-parsed from SMILES.
+    source = _project(tmp_path)
+    output = tmp_path / "structures.parquet"
+    structures.write_structures(source, output)
+    rows = pq.read_table(output).to_pylist()
+    target = next(row for row in rows if row["smiles"] == "Cc1ccccc1")
+    query = Chem.MolFromSmarts("c1ccccc1")
+    query_fp = DataStructs.CreateFromBinaryText(
+        DataStructs.BitVectToBinaryText(
+            Chem.PatternFingerprint(query, fpSize=structures.PATTERN_FP_SIZE)
+        )
+    )
+    target_fp = DataStructs.CreateFromBinaryText(target["pattern_fp"])
+    assert (query_fp & target_fp).GetNumOnBits() == query_fp.GetNumOnBits()
+    mol = Chem.Mol(target["mol_binary"])
+    assert mol.HasSubstructMatch(query)
+    assert Chem.MolToSmiles(mol) == Chem.CanonSmiles("Cc1ccccc1")
+
+
+def test_morgan_popcount_counts_the_morgan_fingerprint(tmp_path):
+    source = _project(tmp_path)
+    output = tmp_path / "structures.parquet"
+    structures.write_structures(source, output)
+    for row in pq.read_table(output).to_pylist():
+        fingerprint = DataStructs.CreateFromBinaryText(row["morgan_fp"])
+        assert row["morgan_popcount"] == fingerprint.GetNumOnBits()
+        assert row["morgan_popcount"] > 0
+
+
+def test_an_unparseable_structure_keeps_its_row_with_null_columns():
+    row = structures._row(7, "not-a-smiles")
+    assert row["structure_id"] == 7
+    assert row["smiles"] == "not-a-smiles"
+    for column in ("pattern_fp", "morgan_fp", "morgan_popcount", "mol_binary"):
+        assert row[column] is None, column
+
+
+def test_structures_from_workups_and_standards_are_included(tmp_path):
+    reaction = _reaction()
+    workup = reaction.workups.add()
+    workup.input.components.add().identifiers.add(type="SMILES", value="CCO")
+    measurement = reaction.outcomes[0].products[0].measurements.add()
+    measurement.authentic_standard.identifiers.add(type="SMILES", value="CCN")
+    source = _project(tmp_path, [reaction])
+    output = tmp_path / "structures.parquet"
+    assert structures.write_structures(source, output) == 4
+    smiles = pq.read_table(output).column("smiles").to_pylist()
+    assert "CCO" in smiles
+    assert "CCN" in smiles
+
+
+def test_a_dataset_with_no_structures_writes_an_empty_artifact(tmp_path):
+    reaction = reaction_pb2.Reaction(reaction_id="ord-0001")
+    component = reaction.inputs["a"].components.add()
+    component.identifiers.add(type="NAME", value="mystery")
+    reaction.outcomes.add()
+    source = _project(tmp_path, [reaction])
+    output = tmp_path / "structures.parquet"
+    assert structures.write_structures(source, output) == 0
+    table = pq.read_table(output)
+    assert table.num_rows == 0
+    assert table.schema.names == structures.SCHEMA.names
+
+
+def test_stamps_name_the_source_dataset_not_the_projection(tmp_path):
+    source_path = tmp_path / "source.parquet"
+    with parquet.DatasetWriter(
+        source_path, name="test", description="test", dataset_id="ord_dataset-1"
+    ) as writer:
+        writer.write_all([_reaction()])
+    projected = tmp_path / "projection.parquet"
+    projection.write_projection(source_path, projected)
+    output = tmp_path / "structures.parquet"
+    structures.write_structures(projected, output)
+    stamps = artifacts.load_stamps(output)
+    assert stamps.artifact == structures.ARTIFACT
+    assert stamps.source_md5 == parquet.DatasetView(source_path).md5()
+    assert stamps.source_dataset_id == "ord_dataset-1"
+    assert stamps.ord_schema_version == metadata.version("ord-schema")
+    assert structures.is_current(output, stamps.source_md5)
+
+
+def test_a_source_dataset_is_refused(tmp_path):
+    source = tmp_path / "source.parquet"
+    with parquet.DatasetWriter(
+        source, name="test", description="test", dataset_id="ord_dataset-1"
+    ) as writer:
+        writer.write_all([_reaction()])
+    with pytest.raises(ValueError, match="not a derived artifact"):
+        structures.write_structures(source, tmp_path / "structures.parquet")
+
+
+def _corrupt_projection(tmp_path, rows) -> pathlib.Path:
+    """Writes ``rows`` under a projection's schema and stamps, bypassing the writer."""
+    stamps = artifacts.current_stamps(projection.ARTIFACT, "ord_dataset-1", "0" * 32)
+    schema = projection.SCHEMA.with_metadata(artifacts.to_metadata(stamps))
+    path = tmp_path / "projection.parquet"
+    pq.write_table(pa.Table.from_pylist(rows, schema=schema), path)
+    return path
+
+
+def test_a_smiles_without_an_id_is_refused(tmp_path):
+    # message_row without a mapping leaves ids null; deriving from such a file would
+    # join wrongly rather than fail, so the mismatch is an error here.
+    row = projection.message_row(_reaction())
+    row["reaction_id"] = "ord-0001"
+    path = _corrupt_projection(tmp_path, [row])
+    with pytest.raises(ValueError, match="both or neither"):
+        structures.write_structures(path, tmp_path / "structures.parquet")
+
+
+def test_conflicting_ids_are_refused(tmp_path):
+    ids_a = {"c1ccccc1": 0, "Cc1ccccc1": 1}
+    ids_b = {"c1ccccc1": 1, "Cc1ccccc1": 0}
+    row_a = projection.message_row(_reaction("ord-0001"), ids_a)
+    row_b = projection.message_row(_reaction("ord-0002"), ids_b)
+    row_a["reaction_id"], row_b["reaction_id"] = "ord-0001", "ord-0002"
+    path = _corrupt_projection(tmp_path, [row_a, row_b])
+    with pytest.raises(ValueError, match="is both"):
+        structures.write_structures(path, tmp_path / "structures.parquet")
+
+
+def test_a_gap_in_the_id_space_is_refused(tmp_path):
+    row = projection.message_row(_reaction(), {"c1ccccc1": 3, "Cc1ccccc1": 4})
+    row["reaction_id"] = "ord-0001"
+    path = _corrupt_projection(tmp_path, [row])
+    with pytest.raises(ValueError, match="not dense"):
+        structures.write_structures(path, tmp_path / "structures.parquet")

--- a/ord_schema/views.py
+++ b/ord_schema/views.py
@@ -366,6 +366,13 @@ def write_view(
             f"{source} is a {parent.artifact}, not a {projection.ARTIFACT}; a view "
             "narrows a projection"
         )
+    # derive_tree refuses stale parents, but this writer is public and its output
+    # inherits the dataset hash: a view derived from a stale projection would claim a
+    # provenance it does not have and nothing would ever mark it stale again.
+    if not artifacts.stamps_are_current(parent, projection.ARTIFACT):
+        raise ValueError(
+            f"{source} is a stale {projection.ARTIFACT}; derive it again first"
+        )
     if source_md5 is None:
         source_md5 = parent.source_md5
     if source_dataset_id is None:

--- a/ord_schema/views_test.py
+++ b/ord_schema/views_test.py
@@ -18,6 +18,7 @@ import pathlib
 from importlib import metadata
 from typing import NamedTuple
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
@@ -612,3 +613,21 @@ def test_write_view_refuses_a_source_dataset_as_its_parent(tmp_path):
     _project(tmp_path)
     with pytest.raises(ValueError, match="not a derived artifact"):
         views.write_view(tmp_path / "ds.parquet", tmp_path / "out.parquet")
+
+
+def test_write_view_refuses_a_stale_projection(tmp_path):
+    # The output inherits the dataset hash, so a view derived from a stale projection
+    # would claim a provenance it does not have and never read stale again.
+    stamps = artifacts.Stamps(
+        artifact=projection.ARTIFACT,
+        source_dataset_id="ord_dataset-1",
+        source_md5="0" * 32,
+        ord_schema_version="0.0.0",
+        artifact_version=artifacts.ARTIFACT_VERSION,
+        rdkit_version="0000.00.0",
+    )
+    schema = projection.SCHEMA.with_metadata(artifacts.to_metadata(stamps))
+    path = tmp_path / "projection.parquet"
+    pq.write_table(pa.Table.from_pylist([], schema=schema), path)
+    with pytest.raises(ValueError, match="stale"):
+        views.write_view(path, tmp_path / "view.parquet")


### PR DESCRIPTION
## Summary

First implementation slice of structure search over the projection (design: [ord-logbook#28](https://github.com/open-reaction-database/ord-logbook/pull/28)). A new per-dataset `structures` artifact carries one row per distinct structure — pattern and Morgan fingerprints for screening, Morgan popcount for the Tanimoto bound, and the serialized molecule verification reads (4.9× faster than re-parsing SMILES). The projection gains one internal column beside each compound `smiles`: a `structure_id` in first-seen order, the join key that lets a verified match set re-enter a query as a bitmap tested inside a list lambda, where DuckDB permits no subquery.

## Changes

- `structures.py` + `derive_structures.py`: the artifact, derived from a projection like `views`; refuses a non-dense or conflicting id mapping.
- `projection.py`: `structure_id` on Compound/ProductCompound structs, assigned wherever compounds appear (components, workup inputs, authentic standards — found by walking the schema, not a hand list).
- `agent/schema.py` / `agent/query.py`: the column is marked internal in field metadata; `describe()` hides it from the model and `resolve()` refuses a path naming it, since ids are not stable across builds.
- `artifacts.py`: log line no longer pluralizes an already-plural artifact name ("structuress").

## Testing

- 28 new tests; full suite passes (941, ORM excluded as environmental).
- End to end on the largest real dataset (409,035 reactions → 564,815 distinct structures, 160 MB, 2 min single-core): screen 789 ms, verify 4.7 s on one core, bind 543 ms — and the bound result (106,458 reactions) agrees exactly with brute force over SMILES.
- The screen-completeness invariant is tested directly (query fp bits ⊆ target fp bits for a true match), as is verification from `mol_binary` against re-parsed SMILES.

## Notes

- `ARTIFACT_VERSION` is deliberately untouched: nothing has shipped, so local artifacts are rebuilt with `--force`.
- The IR's `substructure`/`similarity` predicate and the executor (screen → narrow → verify → bind) are the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR introduces per-dataset structure artifacts and stamps their IDs into projections for future structure-search queries.
- Adds pattern and Morgan fingerprints, popcounts, and serialized molecules for each distinct structure.
- Assigns dense projection-local structure IDs and validates a one-to-one mapping when deriving the artifact.
- Hides internal IDs from agent schema descriptions and query resolution.
- Adds RDKit-version artifact stamps and rejects stale parent projections.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/structures.py | Defines structure-artifact derivation and now enforces dense, bidirectional SMILES-to-ID consistency. |
| ord_schema/projection.py | Adds internal structure IDs to compound projections and shares one first-seen ID space across each dataset. |
| ord_schema/artifacts.py | Adds RDKit-version provenance so incompatible artifacts are recognized as stale. |
| ord_schema/agent/query.py | Prevents direct query resolution or suggestions of unstable artifact-internal fields. |
| ord_schema/views.py | Rejects stale projection parents before deriving views that inherit their provenance. |
| ord_schema/scripts/derive_structures.py | Adds the command-line workflow for deriving structure artifacts from projection trees. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    D[Source dataset] --> P[Projection writer]
    P -->|assign dense structure_id values| PF[Projection artifact]
    PF -->|validate one-to-one mapping| S[Structures derivation]
    S --> SF[Structures artifact]
    SF -->|screen and verify structures| M[Matched structure IDs]
    M -->|bind IDs back into projection query| PF
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Refuse a stale projection in write\_view ..."](https://github.com/open-reaction-database/ord-schema/commit/b5f3b10f67e8fc7418c8587f765da4fc9e5ee0e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51517181)</sub>

<!-- /greptile_comment -->