### PR TITLE
Add substructure and similarity predicates, and the executor that binds them

### DIFF
--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -78,24 +78,31 @@ is a compile error rather than a wrong answer:
   holds rather than by an explosion over a repeated level.
 - A `{"compound": ...}` value is resolved through [`ord_schema.resolvers`](../resolvers.py) and
   **bound as a parameter**, so the model names compounds and never spells structures.
-- A `substructure`/`similarity` path must name a compound's `smiles` (inside a
-  quantifier, like any element predicate), and a SMARTS with an explicit hydrogen is
-  refused outright: measured, `[H]OC` fails the fingerprint screen against methanol
-  while the equivalent H-count form `[OX2H]C` both matches and screens — explicit
-  hydrogens are the one case where the screen silently misses true hits.
+- A `substructure`/`similarity` path must name a compound's `smiles`, inside a
+  quantifier like any other element predicate.
+- A SMARTS naming a hydrogen the corpus stores implicitly is rewritten, with a warning,
+  rather than run as written: stored molecules come from SMILES, so `[H]OC` matches no
+  methanol and would return empty without saying why. `MergeQueryHs` folds it to
+  `[O&!H0]C`, which matches. Hydrogens that cannot be folded — isotopic (`[2H]`), or
+  with no heavy atom to fold into (`[H][H]`) — are left exactly as written, because
+  those are real graph atoms in a stored molecule and the query already works;
+  28,297 ORD reactions have an `[H][H]` component.
 
 ## Structure search
 
 A structure predicate compiles to a bitmap test, not to chemistry. The chemistry runs
 in [`execute.Corpus`](execute.py) against the [structures artifact](../structures.py):
-a fingerprint **screen** — complete but not exact — over every distinct structure in
-the corpus, then exact subgraph **verification** from the serialized molecules for
+a fingerprint **screen** — complete but not exact — over every structure row in the
+corpus (deduplicated per dataset, so a molecule in two datasets is screened twice),
+then exact subgraph **verification** from the serialized molecules for
 substructure (similarity needs no verification; Tanimoto is defined on the Morgan
 fingerprint, so the screen is the answer). The verified match set re-enters the query
-as a `BITSTRING` parameter indexed by the projection's internal `structure_id`, which
-is what preserves element binding: `exists(components, substructure(pyridine) and
-role = SOLVENT)` means one component that is both, and the measured alternative —
-intersecting reaction-id sets — over-returns by 94% on exactly that query.
+as a `BITSTRING` parameter indexed by the corpus-wide id (`structure_id` plus the
+file's offset), which is what preserves element binding: `exists(components,
+substructure(pyridine) and role = SOLVENT)` means one component that is both. The
+alternative — intersecting reaction-id sets — over-returns by 94% on exactly that
+query; see [ord-logbook#28](https://github.com/open-reaction-database/ord-logbook/pull/28),
+finding 4.
 
 ```python
 from ord_schema.agent import execute, query
@@ -124,8 +131,10 @@ table = corpus.search(
 ```
 
 `Corpus` refuses artifacts that do not pair: every projection must have a structures
-artifact derived from the same source dataset, because the ids joining them are
-meaningful only as a pair. Structure ids are dataset-local; the executor's relation
+artifact derived from the same source dataset, and long enough to hold every
+`structure_id` the projection carries, because the ids joining them are meaningful only
+as a pair. Pairing is by source dataset rather than by filename, so the two trees need
+not share a layout. Structure ids are dataset-local; the executor's relation
 carries a per-file offset column (`structure_offset`), which is why compiled SQL with a
 structure predicate runs only there — validate it against `query.executable_schema()`
 rather than the bare projection schema.

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -47,6 +47,9 @@ Predicate  = { op: "and" | "or", clauses: [Predicate] }
            | { op: "eq"|"ne"|"lt"|"le"|"gt"|"ge", path: Path, value: Value }
            | { op: "contains"|"starts_with"|"ends_with", path: Path, value: Value }
            | { op: "is_null" | "not_null", path: Path }
+           | { op: "substructure", path: Path, smarts?: string, compound?: <name> }
+           | { op: "similarity", path: Path, smiles?: string, compound?: <name>,
+               threshold: float }
 
 Value      = { literal: <scalar> } | { compound: <name> }
 
@@ -75,6 +78,57 @@ is a compile error rather than a wrong answer:
   holds rather than by an explosion over a repeated level.
 - A `{"compound": ...}` value is resolved through [`ord_schema.resolvers`](../resolvers.py) and
   **bound as a parameter**, so the model names compounds and never spells structures.
+- A `substructure`/`similarity` path must name a compound's `smiles` (inside a
+  quantifier, like any element predicate), and a SMARTS with an explicit hydrogen is
+  refused outright: measured, `[H]OC` fails the fingerprint screen against methanol
+  while the equivalent H-count form `[OX2H]C` both matches and screens — explicit
+  hydrogens are the one case where the screen silently misses true hits.
+
+## Structure search
+
+A structure predicate compiles to a bitmap test, not to chemistry. The chemistry runs
+in [`execute.Corpus`](execute.py) against the [structures artifact](../structures.py):
+a fingerprint **screen** — complete but not exact — over every distinct structure in
+the corpus, then exact subgraph **verification** from the serialized molecules for
+substructure (similarity needs no verification; Tanimoto is defined on the Morgan
+fingerprint, so the screen is the answer). The verified match set re-enters the query
+as a `BITSTRING` parameter indexed by the projection's internal `structure_id`, which
+is what preserves element binding: `exists(components, substructure(pyridine) and
+role = SOLVENT)` means one component that is both, and the measured alternative —
+intersecting reaction-id sets — over-returns by 94% on exactly that query.
+
+```python
+from ord_schema.agent import execute, query
+
+corpus = execute.Corpus("projections/*/*.parquet", "structures/*/*.parquet", n_jobs=8)
+table = corpus.search(
+    query.Query.model_validate(
+        {
+            "where": {
+                "op": "exists",
+                "path": "inputs.components",
+                "where": {
+                    "op": "and",
+                    "clauses": [
+                        {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"},
+                        {"op": "eq", "path": "reaction_role",
+                         "value": {"literal": "SOLVENT"}},
+                    ],
+                },
+            },
+            "limit": 100,
+        }
+    ),
+    timeout_seconds=60,
+)
+```
+
+`Corpus` refuses artifacts that do not pair: every projection must have a structures
+artifact derived from the same source dataset, because the ids joining them are
+meaningful only as a pair. Structure ids are dataset-local; the executor's relation
+carries a per-file offset column (`structure_offset`), which is why compiled SQL with a
+structure predicate runs only there — validate it against `query.executable_schema()`
+rather than the bare projection schema.
 
 ## Usage
 

--- a/ord_schema/agent/__init__.py
+++ b/ord_schema/agent/__init__.py
@@ -23,8 +23,10 @@ describe the *data*, not a deployment. A description that tells a model which co
 exist has to be versioned alongside the code that generates them, or it silently drifts
 from a schema it cannot see; :mod:`ord_schema.agent.schema` and
 :mod:`ord_schema.agent.sql` both read ``projection.SCHEMA`` for exactly that reason. For
-the same reason nothing here does HTTP, holds a database connection, or owns a cache; a
-server supplies those and maps library exceptions onto its own protocol.
+the same reason nothing here does HTTP or owns a cache; a server supplies those and
+maps library exceptions onto its own protocol. The one connection held is DuckDB's
+embedded one, opened by :mod:`ord_schema.agent.execute` over local artifact files --
+part of reading the data, not of serving it.
 
 Requires the ``agent`` extra (``pip install ord-schema[agent]``).
 """

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -114,10 +114,10 @@ def _verify_chunk(
 ) -> list[int]:
     """Returns the ids whose serialized molecule contains the query as a subgraph.
 
-    A module-level function so joblib can ship it to worker processes, and it returns
-    ids rather than flags so a worker sends back only what matched instead of a verdict
-    per candidate. The query travels as a string and is parsed once per chunk, which is
-    cheaper than shipping a molecule.
+    A module-level function so joblib can ship it to worker processes. Returning the
+    matching ids keeps a worker's reply proportional to the answer rather than to the
+    batch it was handed. The query travels as a string and is parsed once per chunk,
+    which is cheaper than shipping a molecule.
 
     Args:
         pattern: The query, as SMARTS or SMILES.

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -1,0 +1,402 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Running a compiled query against a corpus of projections and structures artifacts.
+
+The compiler (:mod:`ord_schema.agent.query`) leaves two kinds of work undone on
+purpose, and this module is where both happen:
+
+* **Names become structures.** Compound names bind as resolved SMILES, through
+  :mod:`ord_schema.resolvers` by default or any injected resolver.
+* **Structure predicates become bitmaps.** Each compiles to a bitmap test on the
+  element's ``structure_id``; the chemistry -- a fingerprint screen over the structures
+  artifact, then exact subgraph verification from the serialized molecules -- runs
+  here, and the verified match set binds as a ``BITSTRING`` parameter. Similarity has
+  no verification step: Tanimoto is defined on the Morgan fingerprint, so the screen is
+  the whole answer.
+
+Structure ids are dataset-local, so a corpus-wide bitmap needs an offset per file.
+``Corpus`` pairs every projection with its structures artifact, refuses a pair whose
+stamps disagree about the source dataset -- the two files are two statements of one
+derivation, and a mismatched pair would join ids to the wrong molecules silently --
+and publishes a ``reactions`` relation carrying each row's offset in the column the
+compiled SQL expects.
+
+The grammar bounds what a query can cost (one pass and a sort), so the remaining
+runaway risk is corpus size times a slow filter; ``search`` takes a wall-clock timeout
+that interrupts the query rather than trusting it.
+"""
+
+import glob
+import math
+import pathlib
+import threading
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any, Self
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+from joblib import Parallel, delayed
+from rdkit import Chem, DataStructs
+
+from ord_schema import artifacts, projection, resolvers, structures
+from ord_schema.agent import query
+from ord_schema.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Structures verified per joblib task. Large enough that pickling blobs is amortized,
+# small enough that a dozen workers stay busy on a typical survivor set.
+_VERIFY_CHUNK = 4096
+
+
+class PairingError(ValueError):
+    """The projections and structures artifacts do not form a consistent corpus."""
+
+
+def _resolve_with_resolvers(name: str) -> str:
+    """Resolves a compound name to SMILES through ord_schema.resolvers."""
+    smiles, _ = resolvers.resolve_name("name", name)
+    return smiles
+
+
+def _sql_strings(values: Iterable[str]) -> str:
+    """Returns ``values`` as a SQL list literal, single quotes escaped."""
+    quoted = ", ".join("'" + value.replace("'", "''") + "'" for value in values)
+    return f"[{quoted}]"
+
+
+def _verify_chunk(
+    pattern: str, from_smarts: bool, blobs: Sequence[bytes]
+) -> list[bool]:
+    """Returns whether each serialized molecule contains the query as a subgraph.
+
+    A module-level function so joblib can ship it to worker processes; the query is
+    rebuilt from its string per chunk because a mol does not cross the boundary.
+
+    Args:
+        pattern: The query, as SMARTS or SMILES.
+        from_smarts: Whether ``pattern`` is SMARTS.
+        blobs: Serialized molecules (``mol_binary`` column values).
+
+    Returns:
+        One flag per blob.
+    """
+    parsed = Chem.MolFromSmarts(pattern) if from_smarts else Chem.MolFromSmiles(pattern)
+    return [
+        Chem.Mol(bytes(blob)).HasSubstructMatch(parsed)  # ty: ignore[no-matching-overload]
+        for blob in blobs
+    ]
+
+
+def _pattern_blob(molecule: Chem.Mol) -> tuple[bytes, int]:
+    """Returns the packed pattern fingerprint and its popcount."""
+    fingerprint = Chem.PatternFingerprint(molecule, fpSize=structures.PATTERN_FP_SIZE)
+    return DataStructs.BitVectToBinaryText(fingerprint), fingerprint.GetNumOnBits()
+
+
+class Corpus:
+    """A searchable pairing of projections with their structures artifacts.
+
+    Opens one DuckDB connection over both artifact sets and publishes the relation a
+    compiled query runs against. Use as a context manager, or call ``close``.
+    """
+
+    def __init__(
+        self,
+        projection_pattern: str,
+        structures_pattern: str,
+        *,
+        resolver: Callable[[str], str] | None = None,
+        n_jobs: int = 1,
+        require_current: bool = True,
+    ) -> None:
+        """Pairs the artifacts, checks their stamps, and prepares the relations.
+
+        Args:
+            projection_pattern: Glob matching the projection files.
+            structures_pattern: Glob matching the structures artifacts.
+            resolver: Maps a compound name to SMILES. Defaults to
+                ``ord_schema.resolvers``, which calls external services; inject
+                something local for tests or offline use.
+            n_jobs: Worker processes for substructure verification. 1 verifies inline.
+            require_current: Refuse artifacts not written by the current library,
+                artifact, and RDKit versions. The screen's completeness guarantee
+                assumes the query and the artifact fingerprint identically, so turning
+                this off is only for reading a corpus known to match anyway.
+
+        Raises:
+            PairingError: If either pattern matches nothing, a file on one side has no
+                partner on the other, a pair's stamps disagree about the source
+                dataset, or -- with ``require_current`` -- any artifact is stale.
+        """
+        self._resolver = resolver if resolver is not None else _resolve_with_resolvers
+        self._n_jobs = n_jobs
+        pairs = self._pair(projection_pattern, structures_pattern, require_current)
+        self._connection = duckdb.connect()
+        self._total = self._prepare(pairs)
+
+    @staticmethod
+    def _pair(
+        projection_pattern: str, structures_pattern: str, require_current: bool
+    ) -> list[tuple[str, str]]:
+        """Returns (projection, structures) path pairs, verified by their stamps."""
+        projections = {
+            pathlib.Path(path).name: path
+            for path in glob.glob(projection_pattern, recursive=True)
+        }
+        structure_files = {
+            pathlib.Path(path).name: path
+            for path in glob.glob(structures_pattern, recursive=True)
+        }
+        if not projections:
+            raise PairingError(f"no projections matched: {projection_pattern}")
+        unpaired = sorted(projections.keys() ^ structure_files.keys())
+        if unpaired:
+            raise PairingError(
+                f"projections and structures artifacts do not pair up; only one side "
+                f"has {unpaired}"
+            )
+        pairs = []
+        for name in sorted(projections):
+            projected, structured = projections[name], structure_files[name]
+            left = artifacts.load_stamps(projected)
+            right = artifacts.load_stamps(structured)
+            for stamps, path, artifact in (
+                (left, projected, projection.ARTIFACT),
+                (right, structured, structures.ARTIFACT),
+            ):
+                if stamps.artifact != artifact:
+                    raise PairingError(
+                        f"{path} is a {stamps.artifact}, not a {artifact}"
+                    )
+                if require_current and not artifacts.stamps_are_current(
+                    stamps, artifact
+                ):
+                    raise PairingError(f"{path} is stale; derive it again first")
+            if left.source_md5 != right.source_md5:
+                raise PairingError(
+                    f"{projected} and {structured} were derived from different "
+                    "sources; their structure ids do not agree"
+                )
+            pairs.append((projected, structured))
+        return pairs
+
+    def _prepare(self, pairs: list[tuple[str, str]]) -> int:
+        """Publishes the relations and returns the corpus-wide structure count."""
+        offsets = []
+        total = 0
+        for projected, structured in pairs:
+            with pq.ParquetFile(structured) as artifact:
+                count = artifact.metadata.num_rows
+            offsets.append((projected, structured, total))
+            total += count
+        self._connection.register(
+            "structure_offsets",
+            pa.table(
+                {
+                    "projection_filename": [offset[0] for offset in offsets],
+                    "structures_filename": [offset[1] for offset in offsets],
+                    query.STRUCTURE_OFFSET: pa.array(
+                        [offset[2] for offset in offsets], type=pa.int64()
+                    ),
+                }
+            ),
+        )
+        # Inlined rather than bound because DuckDB refuses parameters in DDL. The
+        # paths came from this process's own glob, and the quoting still escapes them.
+        projection_files = _sql_strings(pair[0] for pair in pairs)
+        structure_files = _sql_strings(pair[1] for pair in pairs)
+        # S608: the fragments are this module's constants and this process's own
+        # glob results, quoted with their single quotes escaped.
+        self._connection.execute(
+            f"""
+            CREATE VIEW {query.TABLE} AS
+            SELECT p.* EXCLUDE (filename), o.{query.STRUCTURE_OFFSET}
+            FROM read_parquet({projection_files}, filename=true) p
+            JOIN structure_offsets o ON p.filename = o.projection_filename
+            """  # noqa: S608
+        )
+        self._connection.execute(
+            f"""
+            CREATE VIEW corpus_structures AS
+            SELECT s.* EXCLUDE (filename),
+                   (s.structure_id + o.{query.STRUCTURE_OFFSET})::BIGINT AS global_id
+            FROM read_parquet({structure_files}, filename=true) s
+            JOIN structure_offsets o ON s.filename = o.structures_filename
+            """  # noqa: S608
+        )
+        return total
+
+    def __enter__(self) -> Self:
+        """Returns the corpus itself; closing on exit is the whole protocol."""
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        """Closes the connection."""
+        self.close()
+
+    def close(self) -> None:
+        """Closes the connection."""
+        self._connection.close()
+
+    def _query_molecule(self, parameter: query.StructureParameter) -> Chem.Mol:
+        """Returns the query molecule for a structure predicate.
+
+        Args:
+            parameter: The predicate to build a molecule for.
+
+        Returns:
+            A pattern from SMARTS for a substructure predicate stated as one; a
+            molecule from SMILES otherwise (including every resolved compound).
+
+        Raises:
+            ValueError: If a resolved compound's SMILES does not parse -- the
+                resolver's contract is RDKit-readable SMILES, so this is a resolver
+                bug, not a query error.
+        """
+        if parameter.pattern is not None and parameter.op == "substructure":
+            return Chem.MolFromSmarts(parameter.pattern)  # Validated at model time.
+        if parameter.pattern is not None:
+            smiles = parameter.pattern
+        else:
+            assert parameter.compound is not None  # One of the two is always set.
+            smiles = self._resolver(parameter.compound)
+        molecule = Chem.MolFromSmiles(smiles)
+        if molecule is None:
+            raise ValueError(
+                f"resolver returned unreadable SMILES {smiles!r} "
+                f"for {parameter.compound!r}"
+            )
+        return molecule
+
+    def _substructure_ids(self, parameter: query.StructureParameter) -> list[int]:
+        """Screens and verifies a substructure predicate; returns global ids."""
+        molecule = self._query_molecule(parameter)
+        blob, popcount = _pattern_blob(molecule)
+        survivors = self._connection.execute(
+            """
+            SELECT global_id, mol_binary FROM corpus_structures
+            WHERE pattern_fp IS NOT NULL
+              AND bit_count(CAST(pattern_fp AS BITSTRING) & CAST($q AS BITSTRING)) = $n
+            """,
+            {"q": blob, "n": popcount},
+        ).fetchall()
+        if not survivors:
+            return []
+        pattern = parameter.pattern if parameter.op == "substructure" else None
+        from_smarts = pattern is not None
+        if not from_smarts:
+            pattern = Chem.MolToSmiles(molecule)
+        chunks = [
+            survivors[start : start + _VERIFY_CHUNK]
+            for start in range(0, len(survivors), _VERIFY_CHUNK)
+        ]
+        verified = Parallel(n_jobs=self._n_jobs)(
+            delayed(_verify_chunk)(pattern, from_smarts, [row[1] for row in chunk])
+            for chunk in chunks
+        )
+        return [
+            row[0]
+            for chunk, flags in zip(chunks, verified, strict=True)
+            for row, match in zip(chunk, flags, strict=True)
+            if match
+        ]
+
+    def _similarity_ids(self, parameter: query.StructureParameter) -> list[int]:
+        """Screens a similarity predicate; the fingerprint is the whole answer."""
+        molecule = self._query_molecule(parameter)
+        fingerprint = structures.morgan_fingerprint(molecule)
+        blob = DataStructs.BitVectToBinaryText(fingerprint)
+        popcount = fingerprint.GetNumOnBits()
+        threshold = parameter.threshold
+        assert threshold is not None  # A similarity predicate always carries one.
+        # Tanimoto >= t bounds the candidate popcount to [t * q, q / t], which the
+        # artifact's morgan_popcount column answers without touching the fingerprints.
+        rows = self._connection.execute(
+            """
+            SELECT global_id FROM corpus_structures
+            WHERE morgan_fp IS NOT NULL
+              AND morgan_popcount BETWEEN $lo AND $hi
+              AND bit_count(CAST(morgan_fp AS BITSTRING)
+                            & CAST($q AS BITSTRING))::DOUBLE
+                  / ($n + morgan_popcount
+                     - bit_count(CAST(morgan_fp AS BITSTRING) & CAST($q AS BITSTRING)))
+                  >= $t
+            """,
+            {
+                "q": blob,
+                "n": popcount,
+                "lo": math.ceil(threshold * popcount),
+                "hi": math.floor(popcount / threshold),
+                "t": threshold,
+            },
+        ).fetchall()
+        return [row[0] for row in rows]
+
+    def _bitmap(self, matched: Sequence[int]) -> str:
+        """Returns the match set as a bitmap over the corpus-wide id space."""
+        bits = bytearray(b"0" * max(self._total, 1))
+        for global_id in matched:
+            bits[global_id] = ord("1")
+        return bits.decode()
+
+    def search(
+        self, request: query.Query, *, timeout_seconds: float | None = None
+    ) -> pa.Table:
+        """Compiles and runs a query, returning the result as an Arrow table.
+
+        Args:
+            request: The query to run.
+            timeout_seconds: Wall-clock bound on the final query (structure screening
+                and verification are bounded by the corpus, not by the query, and are
+                not counted). None runs unbounded.
+
+        Returns:
+            The selected columns: ``reaction_id`` for a plain query, the group and
+            measure columns for an aggregated one.
+
+        Raises:
+            query.QueryError: If the query does not compile.
+            ValueError: If a compound name cannot be resolved.
+            TimeoutError: If the query exceeds ``timeout_seconds``.
+        """
+        compiled = query.compile_query(request)
+        parameters: dict[str, Any] = {}
+        for name in compiled.compounds:
+            parameters[name] = self._resolver(name)
+        for parameter in compiled.structures:
+            if parameter.op == "substructure":
+                matched = self._substructure_ids(parameter)
+            else:
+                matched = self._similarity_ids(parameter)
+            logger.info(
+                "%s %r matched %d of %d structures",
+                parameter.op,
+                parameter.pattern or parameter.compound,
+                len(matched),
+                self._total,
+            )
+            parameters[parameter.name] = self._bitmap(matched)
+        if timeout_seconds is None:
+            return self._connection.execute(compiled.sql, parameters).to_arrow_table()
+        timer = threading.Timer(timeout_seconds, self._connection.interrupt)
+        timer.start()
+        try:
+            return self._connection.execute(compiled.sql, parameters).to_arrow_table()
+        except duckdb.InterruptException as error:
+            raise TimeoutError(f"query exceeded {timeout_seconds} seconds") from error
+        finally:
+            timer.cancel()

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -33,16 +33,17 @@ derivation, and a mismatched pair would join ids to the wrong molecules silently
 and publishes a ``reactions`` relation carrying each row's offset in the column the
 compiled SQL expects.
 
-The grammar bounds what a query can cost (one pass and a sort), so the remaining
-runaway risk is corpus size times a slow filter; ``search`` takes a wall-clock timeout
-that interrupts the query rather than trusting it.
+The grammar bounds what a query can cost (one pass and a sort), and ``search``
+takes a wall-clock timeout that interrupts the final query. Name resolution, screening,
+and verification run before the timer starts: each is bounded by the corpus rather than
+by the query, so a slow one is slow for every caller and shows up in the logs rather
+than in a timeout.
 """
 
 import glob
 import math
-import pathlib
 import threading
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from typing import Any, Self
 
 import duckdb
@@ -78,26 +79,60 @@ def _sql_strings(values: Iterable[str]) -> str:
     return f"[{quoted}]"
 
 
-def _verify_chunk(
-    pattern: str, from_smarts: bool, blobs: Sequence[bytes]
-) -> list[bool]:
-    """Returns whether each serialized molecule contains the query as a subgraph.
+def _max_structure_id(path: str) -> int | None:
+    """Returns the largest ``structure_id`` a projection carries.
 
-    A module-level function so joblib can ship it to worker processes; the query is
-    rebuilt from its string per chunk because a mol does not cross the boundary.
+    Read from Parquet footer statistics, so it decodes no column data however large the
+    projection is.
+
+    Args:
+        path: Path to a projection.
+
+    Returns:
+        The maximum across every ``structure_id`` column, or None when the projection
+        holds no compound with a structure.
+    """
+    with pq.ParquetFile(path) as projected:
+        metadata = projected.metadata
+        columns = [
+            index
+            for index in range(metadata.num_columns)
+            if metadata.schema.column(index).name == "structure_id"
+        ]
+        largest = None
+        for group in range(metadata.num_row_groups):
+            for index in columns:
+                statistics = metadata.row_group(group).column(index).statistics
+                if statistics is not None and statistics.has_min_max:
+                    value = statistics.max
+                    largest = value if largest is None else max(largest, value)
+    return largest
+
+
+def _verify_chunk(
+    pattern: str, from_smarts: bool, identifiers: Sequence[int], blobs: Sequence[bytes]
+) -> list[int]:
+    """Returns the ids whose serialized molecule contains the query as a subgraph.
+
+    A module-level function so joblib can ship it to worker processes, and it returns
+    ids rather than flags so a worker sends back only what matched instead of a verdict
+    per candidate. The query travels as a string and is parsed once per chunk, which is
+    cheaper than shipping a molecule.
 
     Args:
         pattern: The query, as SMARTS or SMILES.
         from_smarts: Whether ``pattern`` is SMARTS.
+        identifiers: Corpus-wide structure ids, positionally matching ``blobs``.
         blobs: Serialized molecules (``mol_binary`` column values).
 
     Returns:
-        One flag per blob.
+        The subset of ``identifiers`` that verified.
     """
     parsed = Chem.MolFromSmarts(pattern) if from_smarts else Chem.MolFromSmiles(pattern)
     return [
-        Chem.Mol(bytes(blob)).HasSubstructMatch(parsed)  # ty: ignore[no-matching-overload]
-        for blob in blobs
+        identifier
+        for identifier, blob in zip(identifiers, blobs, strict=True)
+        if Chem.Mol(bytes(blob)).HasSubstructMatch(parsed)  # ty: ignore[no-matching-overload]
     ]
 
 
@@ -146,61 +181,94 @@ class Corpus:
         self._n_jobs = n_jobs
         pairs = self._pair(projection_pattern, structures_pattern, require_current)
         self._connection = duckdb.connect()
-        self._total = self._prepare(pairs)
+        try:
+            self._total, self._searchable = self._prepare(pairs)
+        except Exception:
+            # Nothing else holds the connection yet, and the caller has no object to
+            # close one from if __init__ does not return.
+            self._connection.close()
+            raise
+
+    @staticmethod
+    def _index(pattern: str, artifact: str, require_current: bool) -> dict[str, str]:
+        """Returns the artifacts matching ``pattern``, keyed by source dataset.
+
+        Keyed by the source hash rather than the filename because that is what an
+        artifact *is*: two files pair when they restate the same dataset, whatever
+        they are called or wherever they sit. Keying on the basename would let two
+        files in different directories collapse onto one another silently.
+
+        Args:
+            pattern: Glob matching the artifact files.
+            artifact: Artifact name every match must hold.
+            require_current: Refuse artifacts not written by the current versions.
+
+        Returns:
+            A mapping from source dataset hash to path.
+
+        Raises:
+            PairingError: If a match holds another artifact, is stale under
+                ``require_current``, or restates a dataset another match already did.
+        """
+        index: dict[str, str] = {}
+        for path in sorted(glob.glob(pattern, recursive=True)):
+            stamps = artifacts.load_stamps(path)
+            if stamps.artifact != artifact:
+                raise PairingError(f"{path} is a {stamps.artifact}, not a {artifact}")
+            if require_current and not artifacts.stamps_are_current(stamps, artifact):
+                raise PairingError(f"{path} is stale; derive it again first")
+            if stamps.source_md5 in index:
+                raise PairingError(
+                    f"{path} and {index[stamps.source_md5]} are both {artifact} "
+                    "artifacts of the same source dataset; which one answers a query "
+                    "would be arbitrary"
+                )
+            index[stamps.source_md5] = path
+        return index
 
     @staticmethod
     def _pair(
         projection_pattern: str, structures_pattern: str, require_current: bool
     ) -> list[tuple[str, str]]:
         """Returns (projection, structures) path pairs, verified by their stamps."""
-        projections = {
-            pathlib.Path(path).name: path
-            for path in glob.glob(projection_pattern, recursive=True)
-        }
-        structure_files = {
-            pathlib.Path(path).name: path
-            for path in glob.glob(structures_pattern, recursive=True)
-        }
+        projections = Corpus._index(
+            projection_pattern, projection.ARTIFACT, require_current
+        )
+        structure_files = Corpus._index(
+            structures_pattern, structures.ARTIFACT, require_current
+        )
         if not projections:
             raise PairingError(f"no projections matched: {projection_pattern}")
-        unpaired = sorted(projections.keys() ^ structure_files.keys())
+        unpaired = projections.keys() ^ structure_files.keys()
         if unpaired:
+            orphans = sorted((projections | structure_files)[key] for key in unpaired)
             raise PairingError(
-                f"projections and structures artifacts do not pair up; only one side "
-                f"has {unpaired}"
+                "projections and structures artifacts do not pair up; these have no "
+                f"counterpart derived from the same source dataset: {orphans}"
             )
-        pairs = []
-        for name in sorted(projections):
-            projected, structured = projections[name], structure_files[name]
-            left = artifacts.load_stamps(projected)
-            right = artifacts.load_stamps(structured)
-            for stamps, path, artifact in (
-                (left, projected, projection.ARTIFACT),
-                (right, structured, structures.ARTIFACT),
-            ):
-                if stamps.artifact != artifact:
-                    raise PairingError(
-                        f"{path} is a {stamps.artifact}, not a {artifact}"
-                    )
-                if require_current and not artifacts.stamps_are_current(
-                    stamps, artifact
-                ):
-                    raise PairingError(f"{path} is stale; derive it again first")
-            if left.source_md5 != right.source_md5:
-                raise PairingError(
-                    f"{projected} and {structured} were derived from different "
-                    "sources; their structure ids do not agree"
-                )
-            pairs.append((projected, structured))
-        return pairs
+        return [(projections[key], structure_files[key]) for key in sorted(projections)]
 
-    def _prepare(self, pairs: list[tuple[str, str]]) -> int:
-        """Publishes the relations and returns the corpus-wide structure count."""
+    def _prepare(self, pairs: list[tuple[str, str]]) -> tuple[int, int]:
+        """Publishes the relations, and returns the total and searchable row counts."""
         offsets = []
         total = 0
         for projected, structured in pairs:
             with pq.ParquetFile(structured) as artifact:
                 count = artifact.metadata.num_rows
+            # The ids the projection carries have to land inside the partner's rows.
+            # Stamps cannot see this: an artifact rederived from a rewritten
+            # projection keeps the same source hash, so a short one pairs cleanly and
+            # then aliases its neighbor's molecules -- in range for get_bit, wrong
+            # about the chemistry, and silent. Read from footer statistics, so it
+            # costs no column data.
+            largest = _max_structure_id(projected)
+            if largest is not None and largest >= count:
+                raise PairingError(
+                    f"{projected} carries structure_id {largest} but {structured} "
+                    f"holds only {count} structures, so its ids would join to another "
+                    "dataset's molecules; derive the structures artifact from this "
+                    "projection again"
+                )
             offsets.append((projected, structured, total))
             total += count
         self._connection.register(
@@ -238,7 +306,22 @@ class Corpus:
             JOIN structure_offsets o ON s.filename = o.structures_filename
             """  # noqa: S608
         )
-        return total
+        # Both views join on a path that Python read and DuckDB re-resolved. Anything
+        # that makes the two disagree -- a glob metacharacter in a directory name is
+        # the reachable one, since read_parquet globs each element it is handed --
+        # drops rows from the join rather than failing, leaving a corpus that answers
+        # every query with silence. Counting once here catches it whatever the cause.
+        counts = self._connection.execute(
+            "SELECT count(*), count(pattern_fp) FROM corpus_structures"
+        ).fetchone()
+        assert counts is not None  # An aggregate over any relation returns one row.
+        joined, searchable = counts
+        if joined != total:
+            raise PairingError(
+                f"the structures artifacts hold {total} rows but only {joined} joined "
+                "to their offsets; a path did not survive read_parquet"
+            )
+        return total, searchable
 
     def __enter__(self) -> Self:
         """Returns the corpus itself; closing on exit is the whole protocol."""
@@ -252,11 +335,14 @@ class Corpus:
         """Closes the connection."""
         self._connection.close()
 
-    def _query_molecule(self, parameter: query.StructureParameter) -> Chem.Mol:
+    def _query_molecule(
+        self, parameter: query.StructureParameter, resolve: Callable[[str], str]
+    ) -> Chem.Mol:
         """Returns the query molecule for a structure predicate.
 
         Args:
             parameter: The predicate to build a molecule for.
+            resolve: Maps a compound name to SMILES.
 
         Returns:
             A pattern from SMARTS for a substructure predicate stated as one; a
@@ -273,7 +359,7 @@ class Corpus:
             smiles = parameter.pattern
         else:
             assert parameter.compound is not None  # One of the two is always set.
-            smiles = self._resolver(parameter.compound)
+            smiles = resolve(parameter.compound)
         molecule = Chem.MolFromSmiles(smiles)
         if molecule is None:
             raise ValueError(
@@ -282,42 +368,55 @@ class Corpus:
             )
         return molecule
 
-    def _substructure_ids(self, parameter: query.StructureParameter) -> list[int]:
-        """Screens and verifies a substructure predicate; returns global ids."""
-        molecule = self._query_molecule(parameter)
-        blob, popcount = _pattern_blob(molecule)
-        survivors = self._connection.execute(
+    def _survivors(self, blob: bytes, popcount: int) -> Iterator[tuple[list, list]]:
+        """Yields (global ids, serialized molecules) for each batch the screen passes.
+
+        Streamed rather than fetched whole: a broad pattern survives the screen on most
+        of the corpus, and at ORD's scale the serialized molecules alone are hundreds of
+        megabytes. Batching lets each one be verified and released.
+
+        Args:
+            blob: The query's packed pattern fingerprint.
+            popcount: How many bits it sets.
+
+        Yields:
+            One (ids, molecules) pair per record batch.
+        """
+        reader = self._connection.execute(
             """
             SELECT global_id, mol_binary FROM corpus_structures
             WHERE pattern_fp IS NOT NULL
               AND bit_count(CAST(pattern_fp AS BITSTRING) & CAST($q AS BITSTRING)) = $n
             """,
             {"q": blob, "n": popcount},
-        ).fetchall()
-        if not survivors:
-            return []
-        pattern = parameter.pattern if parameter.op == "substructure" else None
-        from_smarts = pattern is not None
-        if not from_smarts:
-            pattern = Chem.MolToSmiles(molecule)
-        chunks = [
-            survivors[start : start + _VERIFY_CHUNK]
-            for start in range(0, len(survivors), _VERIFY_CHUNK)
-        ]
-        verified = Parallel(n_jobs=self._n_jobs)(
-            delayed(_verify_chunk)(pattern, from_smarts, [row[1] for row in chunk])
-            for chunk in chunks
-        )
-        return [
-            row[0]
-            for chunk, flags in zip(chunks, verified, strict=True)
-            for row, match in zip(chunk, flags, strict=True)
-            if match
-        ]
+        ).to_arrow_reader(_VERIFY_CHUNK)
+        for batch in reader:
+            yield (
+                batch.column("global_id").to_pylist(),
+                batch.column("mol_binary").to_pylist(),
+            )
 
-    def _similarity_ids(self, parameter: query.StructureParameter) -> list[int]:
+    def _substructure_ids(
+        self, parameter: query.StructureParameter, resolve: Callable[[str], str]
+    ) -> list[int]:
+        """Screens and verifies a substructure predicate; returns global ids."""
+        molecule = self._query_molecule(parameter, resolve)
+        blob, popcount = _pattern_blob(molecule)
+        if parameter.op == "substructure" and parameter.pattern is not None:
+            pattern, from_smarts = parameter.pattern, True
+        else:
+            pattern, from_smarts = Chem.MolToSmiles(molecule), False
+        verified = Parallel(n_jobs=self._n_jobs, return_as="generator")(
+            delayed(_verify_chunk)(pattern, from_smarts, identifiers, blobs)
+            for identifiers, blobs in self._survivors(blob, popcount)
+        )
+        return [identifier for chunk in verified for identifier in chunk]
+
+    def _similarity_ids(
+        self, parameter: query.StructureParameter, resolve: Callable[[str], str]
+    ) -> list[int]:
         """Screens a similarity predicate; the fingerprint is the whole answer."""
-        molecule = self._query_molecule(parameter)
+        molecule = self._query_molecule(parameter, resolve)
         fingerprint = structures.morgan_fingerprint(molecule)
         blob = DataStructs.BitVectToBinaryText(fingerprint)
         popcount = fingerprint.GetNumOnBits()
@@ -360,9 +459,9 @@ class Corpus:
 
         Args:
             request: The query to run.
-            timeout_seconds: Wall-clock bound on the final query (structure screening
-                and verification are bounded by the corpus, not by the query, and are
-                not counted). None runs unbounded.
+            timeout_seconds: Wall-clock bound on the final query. Name resolution,
+                screening, and verification run before the timer starts and are not
+                counted. None runs unbounded.
 
         Returns:
             The selected columns: ``reaction_id`` for a plain query, the group and
@@ -374,29 +473,76 @@ class Corpus:
             TimeoutError: If the query exceeds ``timeout_seconds``.
         """
         compiled = query.compile_query(request)
-        parameters: dict[str, Any] = {}
-        for name in compiled.compounds:
-            parameters[name] = self._resolver(name)
+        # Cached across the whole search: a compound named in both a value and a
+        # structure predicate is one external lookup, not two.
+        resolved: dict[str, str] = {}
+
+        def resolve(name: str) -> str:
+            if name not in resolved:
+                resolved[name] = self._resolver(name)
+            return resolved[name]
+
+        parameters: dict[str, Any] = {
+            name: resolve(name) for name in compiled.compounds
+        }
         for parameter in compiled.structures:
             if parameter.op == "substructure":
-                matched = self._substructure_ids(parameter)
+                matched = self._substructure_ids(parameter, resolve)
             else:
-                matched = self._similarity_ids(parameter)
+                matched = self._similarity_ids(parameter, resolve)
+            unsearchable = self._total - self._searchable
             logger.info(
-                "%s %r matched %d of %d structures",
+                "%s %r matched %d of %d structures (%d unsearchable)",
                 parameter.op,
-                parameter.pattern or parameter.compound,
+                parameter.pattern
+                if parameter.pattern is not None
+                else parameter.compound,
                 len(matched),
-                self._total,
+                self._searchable,
+                unsearchable,
             )
             parameters[parameter.name] = self._bitmap(matched)
         if timeout_seconds is None:
             return self._connection.execute(compiled.sql, parameters).to_arrow_table()
-        timer = threading.Timer(timeout_seconds, self._connection.interrupt)
+        return self._run_with_timeout(compiled.sql, parameters, timeout_seconds)
+
+    def _run_with_timeout(
+        self, sql: str, parameters: dict[str, Any], timeout_seconds: float
+    ) -> pa.Table:
+        """Runs ``sql``, interrupting it if it outlasts ``timeout_seconds``.
+
+        ``Timer.cancel`` only sets a flag, so a timer that has already passed its own
+        check fires anyway. The lock makes the interrupt and the teardown exclusive: it
+        either lands while this query owns the connection, or not at all. Without it a
+        late interrupt reaches whatever query runs next and reports that one as having
+        timed out.
+
+        Args:
+            sql: The compiled query.
+            parameters: Values to bind.
+            timeout_seconds: Wall-clock bound.
+
+        Returns:
+            The result as an Arrow table.
+
+        Raises:
+            TimeoutError: If the query is interrupted by the timer.
+        """
+        lock = threading.Lock()
+        running = True
+
+        def interrupt() -> None:
+            with lock:
+                if running:
+                    self._connection.interrupt()
+
+        timer = threading.Timer(timeout_seconds, interrupt)
         timer.start()
         try:
-            return self._connection.execute(compiled.sql, parameters).to_arrow_table()
+            return self._connection.execute(sql, parameters).to_arrow_table()
         except duckdb.InterruptException as error:
             raise TimeoutError(f"query exceeded {timeout_seconds} seconds") from error
         finally:
             timer.cancel()
+            with lock:
+                running = False

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -14,9 +14,11 @@
 
 """Tests for ord_schema.agent.execute."""
 
+import contextlib
 import pathlib
 from collections.abc import Iterator
 
+import pyarrow.parquet as pq
 import pytest
 
 from ord_schema import parquet, projection, structures
@@ -105,27 +107,27 @@ def _search(corpus, where) -> set[str]:
     return set(table.column("reaction_id").to_pylist())
 
 
-def test_substructure_binds_to_the_element(corpus):
-    # Both aa reactions contain pyridine; only aa01 has it as the solvent. The
-    # co-membership is the point: a reaction-granularity intersection would return
-    # both.
-    matched = _search(
-        corpus,
-        _exists(
-            {
-                "op": "and",
-                "clauses": [
-                    {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"},
-                    {
-                        "op": "eq",
-                        "path": "reaction_role",
-                        "value": {"literal": "SOLVENT"},
-                    },
-                ],
-            }
-        ),
+def _role_and_structure(smarts, role):
+    return _exists(
+        {
+            "op": "and",
+            "clauses": [
+                {"op": "substructure", "path": "smiles", "smarts": smarts},
+                {"op": "eq", "path": "reaction_role", "value": {"literal": role}},
+            ],
+        }
     )
-    assert matched == {"ord-aa01"}
+
+
+def test_substructure_binds_to_the_element(corpus):
+    # aa01 holds benzene as a REACTANT and pyridine as its SOLVENT. Bound, that is one
+    # component required to be both, which nothing satisfies. The unbound reading --
+    # "contains benzene" intersected with "contains a solvent" -- would return aa01, so
+    # this is the assertion that fails if element binding is ever lost.
+    assert _search(corpus, _role_and_structure("c1ccccc1", "SOLVENT")) == set()
+    # The same query against the component that really is the solvent does match, so
+    # the empty set above is binding at work rather than a predicate that never fires.
+    assert _search(corpus, _role_and_structure("c1ccncc1", "SOLVENT")) == {"ord-aa01"}
 
 
 def test_substructure_reaches_the_offset_dataset(corpus):
@@ -230,7 +232,7 @@ def test_verification_prunes_screen_false_positives(corpus, monkeypatch):
 
 
 def test_unpaired_artifacts_are_refused(corpus_dir, tmp_path):
-    with pytest.raises(execute.PairingError, match="only one side"):
+    with pytest.raises(execute.PairingError, match="no counterpart"):
         execute.Corpus(
             str(corpus_dir / "projections" / "*.parquet"),
             str(corpus_dir / "structures" / "ord_dataset-aa.parquet"),
@@ -259,7 +261,7 @@ def test_a_mismatched_pair_is_refused(corpus_dir, tmp_path):
         source = corpus_dir / "projections" / f"ord_dataset-{shard}.parquet"
         (projections / source.name).write_bytes(source.read_bytes())
     projection.write_projection(changed, projections / "ord_dataset-bb.parquet")
-    with pytest.raises(execute.PairingError, match="different sources"):
+    with pytest.raises(execute.PairingError, match="no counterpart"):
         execute.Corpus(
             str(projections / "*.parquet"),
             str(corpus_dir / "structures" / "*.parquet"),
@@ -272,3 +274,243 @@ def test_nothing_matched_is_refused(tmp_path):
             str(tmp_path / "absent" / "*.parquet"),
             str(tmp_path / "absent" / "*.parquet"),
         )
+
+
+def _copy_corpus(corpus_dir, tmp_path) -> pathlib.Path:
+    """Copies the built corpus so a test can damage one artifact in isolation."""
+    for name in ("projections", "structures"):
+        (tmp_path / name).mkdir()
+        for source in (corpus_dir / name).glob("*.parquet"):
+            (tmp_path / name / source.name).write_bytes(source.read_bytes())
+    return tmp_path
+
+
+def test_offsets_place_each_dataset_in_its_own_slice(corpus):
+    # Toluene is the product of every reaction and lives in BOTH datasets, at local id
+    # 2 in aa and 1 in bb. Reaching all three reactions therefore requires each id to
+    # be offset by its own file's base: swapping the two offsets, or shifting both,
+    # produces a different answer.
+    matched = corpus.search(
+        query.Query.model_validate(
+            {
+                "where": {
+                    "op": "exists",
+                    "path": "outcomes.products",
+                    "where": {
+                        "op": "substructure",
+                        "path": "smiles",
+                        "smarts": "Cc1ccccc1",
+                    },
+                }
+            }
+        )
+    )
+    assert set(matched.column("reaction_id").to_pylist()) == {
+        "ord-aa01",
+        "ord-aa02",
+        "ord-bb01",
+    }
+
+
+def test_a_structures_artifact_short_of_its_projection_is_refused(corpus_dir, tmp_path):
+    # The dangerous desynchronization: an artifact rederived from a rewritten
+    # projection keeps the same source hash, so the stamps still agree. A short one
+    # would pair cleanly and then alias the next dataset's molecules -- in range for
+    # get_bit, wrong about the chemistry, and silent.
+    root = _copy_corpus(corpus_dir, tmp_path)
+    target = root / "structures" / "ord_dataset-aa.parquet"
+    with pq.ParquetFile(target) as artifact:
+        table = artifact.read()
+        schema = artifact.schema_arrow
+    pq.write_table(table.slice(0, table.num_rows - 1).cast(schema), target)
+    with pytest.raises(execute.PairingError, match="would join to another dataset"):
+        execute.Corpus(
+            str(root / "projections" / "*.parquet"),
+            str(root / "structures" / "*.parquet"),
+        )
+
+
+def test_two_artifacts_of_one_dataset_are_refused(corpus_dir, tmp_path):
+    # Which of them answers a query would be arbitrary, so neither may.
+    root = _copy_corpus(corpus_dir, tmp_path)
+    source = root / "projections" / "ord_dataset-aa.parquet"
+    (root / "projections" / "copy.parquet").write_bytes(source.read_bytes())
+    with pytest.raises(execute.PairingError, match="same source dataset"):
+        execute.Corpus(
+            str(root / "projections" / "*.parquet"),
+            str(root / "structures" / "*.parquet"),
+        )
+
+
+def test_artifacts_pair_across_differing_directory_layouts(corpus_dir, tmp_path):
+    # Pairing is by source dataset, not by filename, so a corpus whose two trees are
+    # laid out differently -- or whose files share a basename across directories --
+    # still pairs. Keying on the basename would drop a dataset here without a word.
+    root = _copy_corpus(corpus_dir, tmp_path)
+    for shard, name in (
+        ("one", "ord_dataset-aa.parquet"),
+        ("two", "ord_dataset-bb.parquet"),
+    ):
+        (root / "sharded" / shard).mkdir(parents=True)
+        (root / "sharded" / shard / "data.parquet").write_bytes(
+            (root / "projections" / name).read_bytes()
+        )
+    with execute.Corpus(
+        str(root / "sharded" / "*" / "*.parquet"),
+        str(root / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        matched = value.search(
+            query.Query.model_validate(
+                {
+                    "where": _exists(
+                        {"op": "substructure", "path": "smiles", "smarts": "[OX2H]"}
+                    )
+                }
+            )
+        )
+    assert matched.column("reaction_id").to_pylist() == ["ord-bb01"]
+
+
+def test_a_stale_artifact_is_refused(corpus_dir, tmp_path):
+    root = _copy_corpus(corpus_dir, tmp_path)
+    target = root / "structures" / "ord_dataset-aa.parquet"
+    with pq.ParquetFile(target) as artifact:
+        table = artifact.read()
+        schema = artifact.schema_arrow
+    metadata = dict(schema.metadata)
+    metadata[b"ord.rdkit_version"] = b"0000.00.0"
+    pq.write_table(table.cast(schema.with_metadata(metadata)), target)
+    with pytest.raises(execute.PairingError, match="stale"):
+        execute.Corpus(
+            str(root / "projections" / "*.parquet"),
+            str(root / "structures" / "*.parquet"),
+        )
+    # The same corpus opens when the caller takes responsibility for the mismatch.
+    with execute.Corpus(
+        str(root / "projections" / "*.parquet"),
+        str(root / "structures" / "*.parquet"),
+        require_current=False,
+        resolver={}.__getitem__,
+    ) as value:
+        assert value.search(query.Query.model_validate({})).num_rows == 3
+
+
+def test_similarity_bounds_the_match_set_at_the_threshold(corpus):
+    # Tanimoto against pyridine in this fixture: benzene 0.3333, toluene 0.1765,
+    # ethanol 0.0. Exact sets on either side of benzene pin the popcount band and the
+    # comparison in both directions -- a band that dropped smaller candidates, or a
+    # strict >, would change one of these.
+    def at(threshold):
+        return _search(
+            corpus,
+            _exists(
+                {
+                    "op": "similarity",
+                    "path": "smiles",
+                    "smiles": "c1ccncc1",
+                    "threshold": threshold,
+                }
+            ),
+        )
+
+    assert at(0.3) == {"ord-aa01", "ord-aa02"}  # Reaches benzene, in aa01.
+    assert at(0.34) == {"ord-aa01", "ord-aa02"}  # Benzene excluded; pyridine remains.
+    assert at(1.0) == {"ord-aa01", "ord-aa02"}  # Identity: >= must not become >.
+
+
+def test_similarity_at_one_is_an_exact_structure_query(corpus):
+    # threshold 1.0 is legal and is the exact-structure query; a strict comparison
+    # would return nothing for it.
+    matched = _search(
+        corpus,
+        _exists(
+            {
+                "op": "similarity",
+                "path": "smiles",
+                "smiles": "OCC",
+                "threshold": 1.0,
+            }
+        ),
+    )
+    assert matched == {"ord-bb01"}
+
+
+def test_an_explicit_hydrogen_smarts_runs_after_the_rewrite(corpus):
+    # The rewritten pattern has to survive the screen and the verification, not just
+    # RDKit: [H]OC matches no stored molecule, [O&!H0]C matches ethanol's hydroxyl.
+    with pytest.warns(UserWarning, match="rewritten"):
+        request = query.Query.model_validate(
+            {
+                "where": _exists(
+                    {"op": "substructure", "path": "smiles", "smarts": "[H]OC"}
+                )
+            }
+        )
+    matched = set(corpus.search(request).column("reaction_id").to_pylist())
+    assert matched == {"ord-bb01"}
+
+
+def test_forall_and_not_compose_with_a_structure_predicate(corpus):
+    pyridine = {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"}
+    # aa02's only input is pyridine, so it is the one reaction where every component
+    # satisfies the predicate.
+    every = corpus.search(
+        query.Query.model_validate(
+            {"where": {"op": "forall", "path": "inputs.components", "where": pyridine}}
+        )
+    )
+    assert "ord-aa02" in set(every.column("reaction_id").to_pylist())
+    negated = _search(corpus, _exists({"op": "not", "clause": pyridine}))
+    assert negated == {"ord-aa01", "ord-bb01"}
+
+
+def test_verification_runs_in_worker_processes(corpus_dir):
+    # Blobs and ids have to survive pickling to the workers and back.
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        n_jobs=2,
+        resolver={}.__getitem__,
+    ) as value:
+        matched = value.search(
+            query.Query.model_validate(
+                {
+                    "where": _exists(
+                        {"op": "substructure", "path": "smiles", "smarts": "[OX2H]"}
+                    )
+                }
+            )
+        )
+    assert matched.column("reaction_id").to_pylist() == ["ord-bb01"]
+
+
+def test_a_timeout_does_not_outlive_its_own_search(corpus):
+    # Timer.cancel only sets a flag, so a timer past its own check fires anyway. If
+    # that interrupt could outlive the search that armed it, the NEXT query would fail
+    # and be reported as having timed out.
+    request = query.Query.model_validate(
+        {"where": _exists({"op": "eq", "path": "smiles", "value": {"literal": "CCO"}})}
+    )
+    # A timeout this short may or may not fire; either outcome is fine for the query
+    # that armed it. What must never happen is the interrupt landing on a later query.
+    for _ in range(20):
+        with contextlib.suppress(TimeoutError):
+            corpus.search(request, timeout_seconds=0.001)
+        assert _search(
+            corpus, _exists({"op": "eq", "path": "smiles", "value": {"literal": "CCO"}})
+        ) == {"ord-bb01"}
+
+
+def test_a_generous_timeout_returns_the_answer(corpus):
+    matched = corpus.search(
+        query.Query.model_validate(
+            {
+                "where": _exists(
+                    {"op": "substructure", "path": "smiles", "smarts": "[OX2H]"}
+                )
+            }
+        ),
+        timeout_seconds=60,
+    )
+    assert matched.column("reaction_id").to_pylist() == ["ord-bb01"]

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -1,0 +1,274 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.agent.execute."""
+
+import pathlib
+from collections.abc import Iterator
+
+import pytest
+
+from ord_schema import parquet, projection, structures
+from ord_schema.agent import execute, query
+from ord_schema.proto import dataset_pb2, reaction_pb2
+
+_ROLE = reaction_pb2.ReactionRole
+
+
+def _component(reaction_input, smiles, role):
+    component = reaction_input.components.add(reaction_role=role)
+    component.identifiers.add(type="SMILES", value=smiles)
+
+
+def _reaction(reaction_id, *, components, product="Cc1ccccc1"):
+    """A reaction with the given (smiles, role) input components."""
+    reaction = reaction_pb2.Reaction(reaction_id=reaction_id)
+    for smiles, role in components:
+        _component(reaction.inputs["in"], smiles, role)
+    outcome = reaction.outcomes.add()
+    outcome.products.add().identifiers.add(type="SMILES", value=product)
+    return reaction
+
+
+# Two datasets, so that the second's structure ids only join correctly through a
+# nonzero offset. Basenames sort "aa" before "bb".
+_REACTIONS = {
+    "aa": [
+        # Pyridine as the solvent; benzene as the reactant.
+        _reaction(
+            "ord-aa01",
+            components=[("c1ccncc1", _ROLE.SOLVENT), ("c1ccccc1", _ROLE.REACTANT)],
+        ),
+        # Pyridine as a reactant: contains pyridine, but not as a solvent.
+        _reaction("ord-aa02", components=[("c1ccncc1", _ROLE.REACTANT)]),
+    ],
+    "bb": [
+        # Ethanol: the only structure with a hydroxyl, and it lives in the second
+        # dataset, so finding it proves the offset arithmetic.
+        _reaction("ord-bb01", components=[("CCO", _ROLE.REACTANT)]),
+    ],
+}
+
+
+@pytest.fixture(scope="module")
+def corpus_dir(tmp_path_factory) -> pathlib.Path:
+    """Builds sources, projections, and structures artifacts for both datasets."""
+    root = tmp_path_factory.mktemp("corpus")
+    for shard, reactions in _REACTIONS.items():
+        source = root / "data" / f"ord_dataset-{shard}.parquet"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        parquet.save_dataset(
+            dataset_pb2.Dataset(
+                dataset_id=f"ord_dataset-{shard}",
+                name="test",
+                description="test",
+                reactions=reactions,
+            ),
+            str(source),
+        )
+        projected = root / "projections" / source.name
+        projected.parent.mkdir(parents=True, exist_ok=True)
+        projection.write_projection(source, projected)
+        structured = root / "structures" / source.name
+        structured.parent.mkdir(parents=True, exist_ok=True)
+        structures.write_structures(projected, structured)
+    return root
+
+
+@pytest.fixture(scope="module")
+def corpus(corpus_dir) -> Iterator[execute.Corpus]:
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={"pyridine": "c1ccncc1", "ethanol": "CCO"}.__getitem__,
+    ) as value:
+        yield value
+
+
+def _exists(where):
+    return {"op": "exists", "path": "inputs.components", "where": where}
+
+
+def _search(corpus, where) -> set[str]:
+    table = corpus.search(query.Query.model_validate({"where": where}))
+    return set(table.column("reaction_id").to_pylist())
+
+
+def test_substructure_binds_to_the_element(corpus):
+    # Both aa reactions contain pyridine; only aa01 has it as the solvent. The
+    # co-membership is the point: a reaction-granularity intersection would return
+    # both.
+    matched = _search(
+        corpus,
+        _exists(
+            {
+                "op": "and",
+                "clauses": [
+                    {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"},
+                    {
+                        "op": "eq",
+                        "path": "reaction_role",
+                        "value": {"literal": "SOLVENT"},
+                    },
+                ],
+            }
+        ),
+    )
+    assert matched == {"ord-aa01"}
+
+
+def test_substructure_reaches_the_offset_dataset(corpus):
+    # The hydroxyl is only in bb, whose ids are only correct through its offset.
+    matched = _search(
+        corpus,
+        _exists({"op": "substructure", "path": "smiles", "smarts": "[OX2H]"}),
+    )
+    assert matched == {"ord-bb01"}
+
+
+def test_substructure_without_matches_returns_no_rows(corpus):
+    matched = _search(
+        corpus,
+        _exists({"op": "substructure", "path": "smiles", "smarts": "[Pt]"}),
+    )
+    assert matched == set()
+
+
+def test_a_compound_name_resolves_to_a_substructure_query(corpus):
+    matched = _search(
+        corpus,
+        _exists({"op": "substructure", "path": "smiles", "compound": "pyridine"}),
+    )
+    assert matched == {"ord-aa01", "ord-aa02"}
+
+
+def test_similarity_finds_the_identical_structure(corpus):
+    matched = _search(
+        corpus,
+        _exists(
+            {
+                "op": "similarity",
+                "path": "smiles",
+                "smiles": "OCC",  # Ethanol, spelled differently than the corpus.
+                "threshold": 0.99,
+            }
+        ),
+    )
+    assert matched == {"ord-bb01"}
+
+
+def test_similarity_at_a_loose_threshold_stays_bounded_by_chemistry(corpus):
+    # Pyridine and benzene are similar molecules but not Tanimoto-identical; a loose
+    # threshold reaches them both, and ethanol never.
+    matched = _search(
+        corpus,
+        _exists(
+            {
+                "op": "similarity",
+                "path": "smiles",
+                "smiles": "c1ccncc1",
+                "threshold": 0.3,
+            }
+        ),
+    )
+    assert "ord-bb01" not in matched
+    assert "ord-aa02" in matched
+
+
+def test_a_plain_query_still_runs(corpus):
+    matched = _search(
+        corpus,
+        _exists({"op": "eq", "path": "smiles", "value": {"literal": "CCO"}}),
+    )
+    assert matched == {"ord-bb01"}
+
+
+def test_an_aggregate_with_a_structure_predicate(corpus):
+    table = corpus.search(
+        query.Query.model_validate(
+            {
+                "where": _exists(
+                    {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"}
+                ),
+                "aggregate": {"measures": [{"fn": "count", "name": "n"}]},
+            }
+        )
+    )
+    assert table.column("n").to_pylist() == [2]
+
+
+def test_verification_prunes_screen_false_positives(corpus, monkeypatch):
+    # Force the screen to pass everything: verification alone must still produce the
+    # right answer, which is what makes the screen safe to loosen and never to skip.
+    matched_rows = corpus._connection.execute(
+        "SELECT count(*) FROM corpus_structures"
+    ).fetchone()[0]
+    assert matched_rows > 0
+    original = execute._pattern_blob
+
+    def _passes_everything(molecule):
+        blob, _ = original(molecule)
+        return b"\x00" * len(blob), 0
+
+    monkeypatch.setattr(execute, "_pattern_blob", _passes_everything)
+    matched = _search(
+        corpus,
+        _exists({"op": "substructure", "path": "smiles", "smarts": "[OX2H]"}),
+    )
+    assert matched == {"ord-bb01"}
+
+
+def test_unpaired_artifacts_are_refused(corpus_dir, tmp_path):
+    with pytest.raises(execute.PairingError, match="only one side"):
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "ord_dataset-aa.parquet"),
+        )
+
+
+def test_a_mismatched_pair_is_refused(corpus_dir, tmp_path):
+    # Rebuild bb's projection from a different source; its structures artifact now
+    # describes molecules the projection does not hold, so the pair must not open.
+    changed = tmp_path / "ord_dataset-bb.parquet"
+    parquet.save_dataset(
+        dataset_pb2.Dataset(
+            dataset_id="ord_dataset-bb",
+            name="test",
+            description="changed",
+            reactions=[
+                _reaction("ord-bb01", components=[("CCN", _ROLE.REACTANT)]),
+                _reaction("ord-bb02", components=[("CCO", _ROLE.REACTANT)]),
+            ],
+        ),
+        str(changed),
+    )
+    projections = tmp_path / "projections"
+    projections.mkdir()
+    for shard in ("aa", "bb"):
+        source = corpus_dir / "projections" / f"ord_dataset-{shard}.parquet"
+        (projections / source.name).write_bytes(source.read_bytes())
+    projection.write_projection(changed, projections / "ord_dataset-bb.parquet")
+    with pytest.raises(execute.PairingError, match="different sources"):
+        execute.Corpus(
+            str(projections / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+        )
+
+
+def test_nothing_matched_is_refused(tmp_path):
+    with pytest.raises(execute.PairingError, match="no projections"):
+        execute.Corpus(
+            str(tmp_path / "absent" / "*.parquet"),
+            str(tmp_path / "absent" / "*.parquet"),
+        )

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -240,8 +240,9 @@ def test_unpaired_artifacts_are_refused(corpus_dir, tmp_path):
 
 
 def test_a_mismatched_pair_is_refused(corpus_dir, tmp_path):
-    # Rebuild bb's projection from a different source; its structures artifact now
-    # describes molecules the projection does not hold, so the pair must not open.
+    # Rebuild bb's projection from a different source, leaving its structures
+    # artifact describing molecules the projection does not hold: the pair must not
+    # open, or ids would join to the wrong chemistry.
     changed = tmp_path / "ord_dataset-bb.parquet"
     parquet.save_dataset(
         dataset_pb2.Dataset(

--- a/ord_schema/agent/query.py
+++ b/ord_schema/agent/query.py
@@ -43,21 +43,57 @@ They are different nodes rather than a subtlety of join keys.
 Compounds are named, never spelled. A ``{"compound": "thf"}`` value compiles to a bound
 parameter, so the model never writes a structure and the caller resolves the name
 through :mod:`ord_schema.resolvers` before binding.
+
+Structure predicates -- ``substructure`` and ``similarity`` -- compile to a bitmap test
+rather than to chemistry. The chemistry runs *outside* the query, against the
+:mod:`ord_schema.structures` artifact (:mod:`ord_schema.agent.execute` is the driver),
+and the match set re-enters as a bitmap parameter indexed by the projection's
+``structure_id``: DuckDB permits no subquery inside a lambda expression, so the
+element a quantifier binds cannot semi-join a match table, but it can test one integer
+against a bitmap. The compiled SQL therefore references ``structure_offset``, a column
+only the executor's relation carries -- a raw projection cannot answer a structure
+query, which is the point: the ids are dataset-local and only the executor knows the
+offsets that make them one corpus-wide space.
 """
 
 import dataclasses
 import difflib
 import re
+import warnings
 from typing import Annotated, Any, Literal
 
 import pyarrow as pa
 from pydantic import BaseModel, Field, model_validator
+from rdkit import Chem
 
 from ord_schema import projection
 
 # The relation a compiled query reads. The only one in scope, so nothing else is
 # nameable and a join has nothing to join to.
 TABLE = "reactions"
+
+# The per-row column mapping a dataset-local structure_id into the corpus-wide id
+# space a bitmap parameter is indexed by. Supplied by the executor's relation; absent
+# from the projection itself, so it is unreachable through resolve().
+STRUCTURE_OFFSET = "structure_offset"
+
+
+def executable_schema(schema: pa.Schema | None = None) -> pa.Schema:
+    """Returns the schema of the relation a compiled query actually runs against.
+
+    The executor's relation is the projection plus ``STRUCTURE_OFFSET``, so validating
+    compiled SQL (:func:`ord_schema.agent.sql.validate`) needs this schema whenever the
+    query carries a structure predicate; the projection schema alone cannot bind it.
+
+    Args:
+        schema: Base schema; the projection schema by default.
+
+    Returns:
+        The base schema with the offset column appended.
+    """
+    base = schema if schema is not None else projection.SCHEMA
+    return base.append(pa.field(STRUCTURE_OFFSET, pa.int64()))
+
 
 _COMPARISONS = {"eq": "=", "ne": "<>", "lt": "<", "le": "<=", "gt": ">", "ge": ">="}
 _ORDERED = frozenset({"lt", "le", "gt", "ge"})
@@ -82,11 +118,34 @@ class QueryError(ValueError):
 
 
 @dataclasses.dataclass(frozen=True)
+class StructureParameter:
+    """A structure predicate the executor evaluates and binds as a bitmap.
+
+    Exactly one of ``pattern`` and ``compound`` is set. ``pattern`` is a SMARTS for a
+    substructure predicate and a SMILES for a similarity one, already validated;
+    ``compound`` is a name still to be resolved at execution.
+    """
+
+    name: str
+    op: str
+    pattern: str | None
+    compound: str | None
+    threshold: float | None
+
+
+@dataclasses.dataclass(frozen=True)
 class Compiled:
-    """A compiled query, and the compound names its parameters still need."""
+    """A compiled query, and the parameters its execution still needs.
+
+    ``compounds`` are names whose resolved SMILES the caller binds. ``structures`` are
+    predicates the caller evaluates against the structures artifact, each bound as a
+    bitmap over corpus-wide structure ids; a query carrying any also references the
+    ``STRUCTURE_OFFSET`` column, so it runs only against the executor's relation.
+    """
 
     sql: str
     compounds: tuple[str, ...]
+    structures: tuple[StructureParameter, ...] = ()
 
 
 @dataclasses.dataclass(frozen=True)
@@ -107,7 +166,9 @@ def _members(current: pa.Schema | pa.DataType) -> list[str]:
     return []
 
 
-def _lookup(current: pa.Schema | pa.DataType, name: str, path: str) -> pa.Field:
+def _lookup(
+    current: pa.Schema | pa.DataType, name: str, path: str, allow_internal: bool
+) -> pa.Field:
     """Returns the field ``name`` within ``current``, or raises a helpful QueryError."""
     members = _members(current)
     if name not in members:
@@ -125,7 +186,7 @@ def _lookup(current: pa.Schema | pa.DataType, name: str, path: str) -> pa.Field:
         suggestion = f"; did you mean {', '.join(map(repr, close))}?" if close else ""
         raise QueryError(f"{path}: no field named {name!r}{suggestion}")
     field = current.field(name)
-    if projection.is_internal(field):
+    if projection.is_internal(field) and not allow_internal:
         # Artifact-internal machinery (structure_id): its values are not stable across
         # builds, so a comparison against one is a wrong answer waiting to move.
         raise QueryError(f"{path}: {name!r} is internal to the artifacts")
@@ -133,7 +194,11 @@ def _lookup(current: pa.Schema | pa.DataType, name: str, path: str) -> pa.Field:
 
 
 def resolve(
-    path: str, *, schema: pa.Schema = projection.SCHEMA, root: str | None = None
+    path: str,
+    *,
+    schema: pa.Schema = projection.SCHEMA,
+    root: str | None = None,
+    allow_internal: bool = False,
 ) -> _Resolved:
     """Resolves a dotted path against the projection schema.
 
@@ -145,6 +210,8 @@ def resolve(
         path: Dotted column path, e.g. ``conditions.temperature.setpoint_kelvin``.
         schema: Schema or struct type to resolve within.
         root: Bound variable the path is relative to, inside a quantifier.
+        allow_internal: Permit internal columns. Library-internal: the compiler reaches
+            ``structure_id`` this way; a model-supplied path never sets it.
 
     Returns:
         The DuckDB expression, whether it evaluates to a list, and the type it reaches.
@@ -158,7 +225,7 @@ def resolve(
     repeated = False
     current: Any = schema
     for part in path.split("."):
-        field = _lookup(current, part, path)
+        field = _lookup(current, part, path, allow_internal)
         if expression is None:
             expression = part if root is None else f"{root}.{part}"
         elif repeated:
@@ -245,8 +312,85 @@ class NullCheck(BaseModel):
     path: str
 
 
+class Substructure(BaseModel):
+    """The element's structure contains the query as a subgraph.
+
+    ``path`` names a compound's ``smiles``. The query is a SMARTS pattern, or a
+    compound name resolved to a molecule at execution; exactly one is given.
+    """
+
+    op: Literal["substructure"]
+    path: str
+    smarts: str | None = None
+    compound: str | None = None
+
+    @model_validator(mode="after")
+    def _check(self) -> "Substructure":
+        if (self.smarts is None) == (self.compound is None):
+            raise ValueError("a substructure query is a smarts or a compound, not both")
+        if self.compound is not None and not _NAME.match(self.compound):
+            raise ValueError(f"compound name is not an identifier: {self.compound!r}")
+        if self.smarts is not None:
+            pattern = Chem.MolFromSmarts(self.smarts)
+            if pattern is None:
+                raise ValueError(f"SMARTS does not parse: {self.smarts!r}")
+            if any(atom.GetAtomicNum() == 1 for atom in pattern.GetAtoms()):
+                # Explicit hydrogens are the one case where the fingerprint screen
+                # produces false negatives -- measured: [H]OC screens out methanol
+                # while the merged query matches it -- so the pattern is rewritten
+                # with the hydrogens folded into their heavy atoms as H-count
+                # constraints, which both matches and screens. MergeQueryHs keeps an
+                # H it cannot fold -- isotopic ([2H]), or with no heavy neighbor --
+                # and those are refused: dropping the atom would change what the
+                # pattern means, and keeping it would silently miss true hits.
+                merged = Chem.MergeQueryHs(pattern)
+                if any(atom.GetAtomicNum() == 1 for atom in merged.GetAtoms()):
+                    raise ValueError(
+                        f"SMARTS with an explicit hydrogen is refused: {self.smarts!r} "
+                        "would silently miss true matches at the fingerprint screen, "
+                        "and its hydrogens cannot be folded into heavy-atom H counts "
+                        "(isotopic hydrogens and hydrogens with no heavy neighbor "
+                        "cannot be)."
+                    )
+                rewritten = Chem.MolToSmarts(merged)
+                warnings.warn(
+                    f"SMARTS {self.smarts!r} carries explicit hydrogens, which fail "
+                    f"the fingerprint screen; rewritten as {rewritten!r} with the "
+                    "hydrogens folded into heavy-atom H counts",
+                    stacklevel=2,
+                )
+                self.smarts = rewritten
+        return self
+
+
+class Similarity(BaseModel):
+    """The element's structure is Tanimoto-similar to the query molecule.
+
+    Similarity is defined on the Morgan fingerprints in the structures artifact, so
+    the screen is the whole answer and no verification step exists. ``path`` names a
+    compound's ``smiles``. The query is a SMILES, or a compound name resolved at
+    execution; exactly one is given.
+    """
+
+    op: Literal["similarity"]
+    path: str
+    smiles: str | None = None
+    compound: str | None = None
+    threshold: float = Field(gt=0, le=1)
+
+    @model_validator(mode="after")
+    def _check(self) -> "Similarity":
+        if (self.smiles is None) == (self.compound is None):
+            raise ValueError("a similarity query is a smiles or a compound, not both")
+        if self.compound is not None and not _NAME.match(self.compound):
+            raise ValueError(f"compound name is not an identifier: {self.compound!r}")
+        if self.smiles is not None and Chem.MolFromSmiles(self.smiles) is None:
+            raise ValueError(f"SMILES does not parse: {self.smiles!r}")
+        return self
+
+
 Predicate = Annotated[
-    And | Or | Not | Quantifier | Comparison | NullCheck,
+    And | Or | Not | Quantifier | Comparison | NullCheck | Substructure | Similarity,
     Field(discriminator="op"),
 ]
 
@@ -359,8 +503,82 @@ def _leaf(node: Any, resolved: _Resolved, compounds: list[str]) -> str:
     return f"{resolved.expression} {_COMPARISONS[node.op]} {operand}"
 
 
+def _structure_parameter(
+    node: "Substructure | Similarity", structures: list[StructureParameter]
+) -> str:
+    """Returns the parameter name for a structure predicate, reusing an equal one.
+
+    Deduplicated by content so the executor screens and verifies each distinct
+    predicate once, however many times the query states it.
+    """
+    pattern = node.smarts if isinstance(node, Substructure) else node.smiles
+    threshold = node.threshold if isinstance(node, Similarity) else None
+    for existing in structures:
+        if (existing.op, existing.pattern, existing.compound, existing.threshold) == (
+            node.op,
+            pattern,
+            node.compound,
+            threshold,
+        ):
+            return existing.name
+    parameter = StructureParameter(
+        name=f"structure_{len(structures)}",
+        op=node.op,
+        pattern=pattern,
+        compound=node.compound,
+        threshold=threshold,
+    )
+    structures.append(parameter)
+    return parameter.name
+
+
+def _structure(
+    node: "Substructure | Similarity",
+    scope: str | None,
+    schema: Any,
+    structures: list[StructureParameter],
+) -> str:
+    """Compiles a structure predicate to a bitmap test on the element's structure id.
+
+    The chemistry happens in the executor; what compiles here is only the re-entry of
+    its match set. The null guard keeps a compound with no recorded structure from
+    reading as a match under negation-free semantics: no structure, no match.
+    """
+    parts = node.path.split(".")
+    if parts[-1] != "smiles":
+        raise QueryError(
+            f"{node.path}: {node.op} applies to a compound ``smiles`` column"
+        )
+    resolved = resolve(node.path, schema=schema, root=scope)
+    if resolved.repeated:
+        raise QueryError(
+            f"{node.path}: crosses a repeated level, so whether it means any or every "
+            "element is unstated; wrap it in an exists or forall"
+        )
+    identifier_path = ".".join([*parts[:-1], "structure_id"])
+    try:
+        identifier = resolve(
+            identifier_path, schema=schema, root=scope, allow_internal=True
+        )
+    except QueryError as error:
+        raise QueryError(
+            f"{node.path}: {node.op} needs a compound smiles, and this smiles has no "
+            f"structure id beside it ({error})"
+        ) from error
+    parameter = _structure_parameter(node, structures)
+    return (
+        f"({identifier.expression} IS NOT NULL AND get_bit(CAST(${parameter} AS "
+        f"BITSTRING), ({identifier.expression} + {STRUCTURE_OFFSET})::INTEGER) = 1)"
+    )
+
+
 def _quantifier(
-    node: "Quantifier", scope: str | None, schema: Any, compounds: list[str], depth: int
+    node: "Quantifier",
+    scope: str | None,
+    schema: Any,
+    compounds: list[str],
+    structures: list[StructureParameter],
+    depth: int,
 ) -> str:
     """Compiles a quantifier to a filter over the elements at a repeated level.
 
@@ -375,7 +593,9 @@ def _quantifier(
             f"{resolved.type}; compare it directly instead"
         )
     variable = f"e{depth}"
-    body = _predicate(node.where, variable, resolved.type, compounds, depth + 1)
+    body = _predicate(
+        node.where, variable, resolved.type, compounds, structures, depth + 1
+    )
     if node.op == "exists":
         return f"len(list_filter({resolved.expression}, {variable} -> {body})) > 0"
     # No counterexample, which is vacuously true of an empty level.
@@ -383,7 +603,12 @@ def _quantifier(
 
 
 def _predicate(
-    node: Any, scope: str | None, schema: Any, compounds: list[str], depth: int
+    node: Any,
+    scope: str | None,
+    schema: Any,
+    compounds: list[str],
+    structures: list[StructureParameter],
+    depth: int,
 ) -> str:
     """Compiles one predicate node to a boolean DuckDB expression."""
     if isinstance(node, And | Or):
@@ -391,30 +616,25 @@ def _predicate(
         return (
             "("
             + keyword.join(
-                _predicate(clause, scope, schema, compounds, depth)
+                _predicate(clause, scope, schema, compounds, structures, depth)
                 for clause in node.clauses
             )
             + ")"
         )
     if isinstance(node, Not):
-        return f"(NOT {_predicate(node.clause, scope, schema, compounds, depth)})"
+        inner = _predicate(node.clause, scope, schema, compounds, structures, depth)
+        return f"(NOT {inner})"
     if isinstance(node, Quantifier):
-        return _quantifier(node, scope, schema, compounds, depth)
+        return _quantifier(node, scope, schema, compounds, structures, depth)
+    if isinstance(node, Substructure | Similarity):
+        return _structure(node, scope, schema, structures)
     resolved = resolve(node.path, schema=schema, root=scope)
     if resolved.repeated:
         raise QueryError(
             f"{node.path}: crosses a repeated level, so whether it means any or every "
             "element is unstated; wrap it in an exists or forall"
         )
-    if isinstance(node, NullCheck):
-        return (
-            f"{resolved.expression} IS {'NULL' if node.op == 'is_null' else 'NOT NULL'}"
-        )
-    _check_operand(node, resolved)
-    operand = _literal(node.value, compounds)
-    if node.op in _TEXT:
-        return f"{_TEXT[node.op]}({resolved.expression}, {operand})"
-    return f"{resolved.expression} {_COMPARISONS[node.op]} {operand}"
+    return _leaf(node, resolved, compounds)
 
 
 def _scalar(path: str, schema: pa.Schema, what: str) -> str:
@@ -448,6 +668,7 @@ def compile_query(
     if not _NAME.match(table):
         raise QueryError(f"table is not an identifier: {table!r}")
     compounds: list[str] = []
+    structures: list[StructureParameter] = []
     if query.aggregate:
         groups = [
             _scalar(path, schema, "group_by") for path in query.aggregate.group_by
@@ -472,7 +693,17 @@ def compile_query(
     # value reached the string as a bound parameter or a quoted literal.
     sql = f"SELECT {', '.join(selected)} FROM {table}"  # noqa: S608
     if query.where is not None:
-        sql += f" WHERE {_predicate(query.where, None, schema, compounds, 0)}"
+        sql += (
+            f" WHERE {_predicate(query.where, None, schema, compounds, structures, 0)}"
+        )
+    taken = {parameter.name for parameter in structures}
+    collisions = sorted(taken & set(compounds))
+    if collisions:
+        # Both reach the SQL as $-parameters, so a compound named like a structure
+        # parameter would receive the wrong binding silently.
+        raise QueryError(
+            f"compound names collide with structure parameters: {collisions}"
+        )
     if query.aggregate and groups:
         sql += " GROUP BY " + ", ".join(str(index + 1) for index in range(len(groups)))
     if query.order_by:
@@ -493,4 +724,4 @@ def compile_query(
         sql += " ORDER BY " + ", ".join(keys)
     if query.limit is not None:
         sql += f" LIMIT {query.limit}"
-    return Compiled(sql, tuple(compounds))
+    return Compiled(sql, tuple(compounds), tuple(structures))

--- a/ord_schema/agent/query.py
+++ b/ord_schema/agent/query.py
@@ -47,13 +47,14 @@ through :mod:`ord_schema.resolvers` before binding.
 Structure predicates -- ``substructure`` and ``similarity`` -- compile to a bitmap test
 rather than to chemistry. The chemistry runs *outside* the query, against the
 :mod:`ord_schema.structures` artifact (:mod:`ord_schema.agent.execute` is the driver),
-and the match set re-enters as a bitmap parameter indexed by the projection's
-``structure_id``: DuckDB permits no subquery inside a lambda expression, so the
-element a quantifier binds cannot semi-join a match table, but it can test one integer
-against a bitmap. The compiled SQL therefore references ``structure_offset``, a column
-only the executor's relation carries -- a raw projection cannot answer a structure
-query, which is the point: the ids are dataset-local and only the executor knows the
-offsets that make them one corpus-wide space.
+and the match set re-enters as a bitmap parameter indexed by the corpus-wide id --
+the projection's ``structure_id`` plus its file's offset: DuckDB permits no subquery
+inside a lambda expression, so the element a quantifier binds cannot semi-join a match
+table, but it can test one integer against a bitmap. The compiled SQL therefore
+references ``structure_offset``, a column only the executor's relation carries -- a raw
+projection cannot answer a structure query, which is the point: the ids are
+dataset-local and only the executor knows the offsets that make them one corpus-wide
+space.
 """
 
 import dataclasses
@@ -73,8 +74,9 @@ from ord_schema import projection
 TABLE = "reactions"
 
 # The per-row column mapping a dataset-local structure_id into the corpus-wide id
-# space a bitmap parameter is indexed by. Supplied by the executor's relation; absent
-# from the projection itself, so it is unreachable through resolve().
+# space a bitmap parameter is indexed by. Supplied by the executor's relation and
+# absent from the projection schema resolve() defaults to, so a model-supplied path
+# does not reach it.
 STRUCTURE_OFFSET = "structure_offset"
 
 
@@ -115,6 +117,11 @@ _NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 class QueryError(ValueError):
     """A query that cannot be compiled against the projection schema."""
+
+
+def _explicit_hydrogens(pattern: Chem.Mol) -> int:
+    """Returns how many of a query's atoms are hydrogens in their own right."""
+    return sum(1 for atom in pattern.GetAtoms() if atom.GetAtomicNum() == 1)
 
 
 @dataclasses.dataclass(frozen=True)
@@ -334,32 +341,34 @@ class Substructure(BaseModel):
             pattern = Chem.MolFromSmarts(self.smarts)
             if pattern is None:
                 raise ValueError(f"SMARTS does not parse: {self.smarts!r}")
-            if any(atom.GetAtomicNum() == 1 for atom in pattern.GetAtoms()):
-                # Explicit hydrogens are the one case where the fingerprint screen
-                # produces false negatives -- measured: [H]OC screens out methanol
-                # while the merged query matches it -- so the pattern is rewritten
-                # with the hydrogens folded into their heavy atoms as H-count
-                # constraints, which both matches and screens. MergeQueryHs keeps an
-                # H it cannot fold -- isotopic ([2H]), or with no heavy neighbor --
-                # and those are refused: dropping the atom would change what the
-                # pattern means, and keeping it would silently miss true hits.
-                merged = Chem.MergeQueryHs(pattern)
-                if any(atom.GetAtomicNum() == 1 for atom in merged.GetAtoms()):
-                    raise ValueError(
-                        f"SMARTS with an explicit hydrogen is refused: {self.smarts!r} "
-                        "would silently miss true matches at the fingerprint screen, "
-                        "and its hydrogens cannot be folded into heavy-atom H counts "
-                        "(isotopic hydrogens and hydrogens with no heavy neighbor "
-                        "cannot be)."
-                    )
+            if not pattern.GetNumAtoms():
+                # An empty SMARTS parses to a zero-atom query whose fingerprint has
+                # no bits, so the screen admits every structure and verification then
+                # rejects all of them: a guaranteed-empty answer at full corpus cost.
+                raise ValueError(f"SMARTS has no atoms: {self.smarts!r}")
+            merged = Chem.MergeQueryHs(pattern)
+            if _explicit_hydrogens(merged) < _explicit_hydrogens(pattern):
+                # A stored molecule is built from SMILES, so its hydrogens are
+                # implicit wherever they can be, and a query naming one as its own
+                # atom matches nothing -- [H]OC finds no methanol, and says nothing
+                # about why. Folding them into heavy-atom H counts asks the question
+                # the corpus can answer.
                 rewritten = Chem.MolToSmarts(merged)
                 warnings.warn(
-                    f"SMARTS {self.smarts!r} carries explicit hydrogens, which fail "
-                    f"the fingerprint screen; rewritten as {rewritten!r} with the "
-                    "hydrogens folded into heavy-atom H counts",
-                    stacklevel=2,
+                    f"SMARTS {self.smarts!r} names hydrogens that a stored molecule "
+                    f"holds implicitly, and would match nothing; rewritten as "
+                    f"{rewritten!r}, with those hydrogens folded into heavy-atom H "
+                    "counts",
+                    # No fixed stacklevel reaches the caller: pydantic-core invokes
+                    # this validator, so anything but the default points into pydantic.
+                    stacklevel=1,
                 )
                 self.smarts = rewritten
+            # Hydrogens that do not fold -- isotopic ([2H]), or with no heavy atom to
+            # fold into ([H][H]) -- are left exactly as written. They cannot be
+            # implicit in a stored molecule either, so they are real graph atoms that
+            # the query already matches and screens for; 28,297 ORD reactions have an
+            # [H][H] component, and rewriting or refusing those would lose them.
         return self
 
 
@@ -384,8 +393,14 @@ class Similarity(BaseModel):
             raise ValueError("a similarity query is a smiles or a compound, not both")
         if self.compound is not None and not _NAME.match(self.compound):
             raise ValueError(f"compound name is not an identifier: {self.compound!r}")
-        if self.smiles is not None and Chem.MolFromSmiles(self.smiles) is None:
-            raise ValueError(f"SMILES does not parse: {self.smiles!r}")
+        if self.smiles is not None:
+            molecule = Chem.MolFromSmiles(self.smiles)
+            if molecule is None:
+                raise ValueError(f"SMILES does not parse: {self.smiles!r}")
+            if not molecule.GetNumAtoms():
+                # Its fingerprint has no bits, so Tanimoto against it is 0 for every
+                # structure: a guaranteed-empty answer that still scans the corpus.
+                raise ValueError(f"SMILES has no atoms: {self.smiles!r}")
         return self
 
 
@@ -659,11 +674,13 @@ def compile_query(
             bound this grammar exists to provide would hold only by convention.
 
     Returns:
-        The SQL, and the compound names whose resolved SMILES the caller binds.
+        The SQL, the compound names whose resolved SMILES the caller binds, and the
+        structure predicates the caller evaluates and binds as bitmaps.
 
     Raises:
-        QueryError: If ``table`` is not an identifier, or if any path, operator, or
-            ordering key cannot be meant against the schema.
+        QueryError: If ``table`` is not an identifier, if any path, operator, or
+            ordering key cannot be meant against the schema, or if a compound name
+            collides with a generated structure parameter.
     """
     if not _NAME.match(table):
         raise QueryError(f"table is not an identifier: {table!r}")

--- a/ord_schema/agent/query_test.py
+++ b/ord_schema/agent/query_test.py
@@ -17,6 +17,7 @@
 import duckdb
 import pytest
 from pydantic import ValidationError
+from rdkit import Chem
 
 from ord_schema import projection
 from ord_schema.agent import query, sql
@@ -460,3 +461,188 @@ def test_suggestions_do_not_name_internal_columns():
     with pytest.raises(query.QueryError, match="no field named") as excinfo:
         query.resolve("inputs.components.structure")
     assert "structure_id" not in str(excinfo.value)
+
+
+# Structure predicates
+
+
+def _substructure(smarts="c1ccncc1", path="smiles"):
+    return {"op": "substructure", "path": path, "smarts": smarts}
+
+
+def test_substructure_compiles_to_a_bitmap_test():
+    compiled = query.compile_query(
+        query.Query.model_validate(
+            {
+                "where": {
+                    "op": "exists",
+                    "path": "inputs.components",
+                    "where": _substructure(),
+                }
+            }
+        )
+    )
+    assert "get_bit(CAST($structure_0 AS BITSTRING)" in compiled.sql
+    assert "e0.structure_id IS NOT NULL" in compiled.sql
+    assert f"+ {query.STRUCTURE_OFFSET})::INTEGER" in compiled.sql
+    (parameter,) = compiled.structures
+    assert parameter.op == "substructure"
+    assert parameter.pattern == "c1ccncc1"
+    assert parameter.compound is None
+
+
+def test_equal_structure_predicates_share_one_parameter():
+    # The executor screens and verifies each distinct predicate once, however many
+    # times the query states it.
+    compiled = query.compile_query(
+        query.Query.model_validate(
+            {
+                "where": {
+                    "op": "or",
+                    "clauses": [
+                        {
+                            "op": "exists",
+                            "path": "inputs.components",
+                            "where": _substructure(),
+                        },
+                        {
+                            "op": "exists",
+                            "path": "outcomes.products",
+                            "where": _substructure(),
+                        },
+                    ],
+                }
+            }
+        )
+    )
+    assert len(compiled.structures) == 1
+    assert compiled.sql.count("$structure_0") == 2
+
+
+def test_similarity_compiles_with_its_threshold():
+    compiled = query.compile_query(
+        query.Query.model_validate(
+            {
+                "where": {
+                    "op": "exists",
+                    "path": "inputs.components",
+                    "where": {
+                        "op": "similarity",
+                        "path": "smiles",
+                        "smiles": "CCO",
+                        "threshold": 0.7,
+                    },
+                }
+            }
+        )
+    )
+    (parameter,) = compiled.structures
+    assert parameter.op == "similarity"
+    assert parameter.pattern == "CCO"
+    assert parameter.threshold == 0.7
+
+
+def test_a_smarts_with_an_explicit_hydrogen_is_merged_with_a_warning():
+    # Measured: [H]OC fails the fingerprint screen against methanol even though the
+    # merged query matches it, so the hydrogens are folded into heavy-atom H counts
+    # rather than silently missing true hits.
+    with pytest.warns(UserWarning, match="rewritten"):
+        model = query.Substructure.model_validate(
+            {"op": "substructure", "path": "smiles", "smarts": "[H]OC"}
+        )
+    merged = Chem.MolFromSmarts(model.smarts)
+    assert merged is not None
+    assert not any(atom.GetAtomicNum() == 1 for atom in merged.GetAtoms())
+    assert Chem.MolFromSmiles("CO").HasSubstructMatch(merged)
+
+
+def test_an_unmergeable_explicit_hydrogen_is_refused():
+    # A hydrogen with no heavy neighbor has nothing to fold into, and folding an
+    # isotopic hydrogen into a count would drop the isotope constraint silently.
+    for smarts in ("[H][H]", "[2H]OC"):
+        with pytest.raises(ValueError, match="explicit hydrogen"):
+            query.Substructure.model_validate(
+                {"op": "substructure", "path": "smiles", "smarts": smarts}
+            )
+
+
+def test_an_h_count_smarts_is_accepted():
+    query.Substructure.model_validate(
+        {"op": "substructure", "path": "smiles", "smarts": "[OX2H]C"}
+    )
+
+
+def test_an_unparseable_smarts_is_refused():
+    with pytest.raises(ValueError, match="does not parse"):
+        query.Substructure.model_validate(
+            {"op": "substructure", "path": "smiles", "smarts": "not-smarts"}
+        )
+
+
+def test_a_substructure_on_a_non_smiles_column_is_refused():
+    with pytest.raises(query.QueryError, match="smiles"):
+        query.compile_query(
+            query.Query.model_validate(
+                {
+                    "where": {
+                        "op": "exists",
+                        "path": "inputs.components",
+                        "where": _substructure(path="reaction_role"),
+                    }
+                }
+            )
+        )
+
+
+def test_a_substructure_on_the_reaction_smiles_is_refused():
+    # The reaction-level smiles is a reaction, not a molecule; it has no structure id
+    # and reaction substructure search is a different operation.
+    with pytest.raises(query.QueryError, match="no structure id"):
+        query.compile_query(
+            query.Query.model_validate({"where": _substructure(path="smiles")})
+        )
+
+
+def test_an_unquantified_substructure_is_refused():
+    with pytest.raises(query.QueryError, match="exists or forall"):
+        query.compile_query(
+            query.Query.model_validate(
+                {"where": _substructure(path="inputs.components.smiles")}
+            )
+        )
+
+
+def test_a_similarity_threshold_is_required_and_bounded():
+    with pytest.raises(ValueError, match="threshold"):
+        query.Similarity.model_validate(
+            {"op": "similarity", "path": "smiles", "smiles": "CCO"}
+        )
+    with pytest.raises(ValueError, match="less than or equal to 1"):
+        query.Similarity.model_validate(
+            {"op": "similarity", "path": "smiles", "smiles": "CCO", "threshold": 1.5}
+        )
+
+
+def test_a_compound_named_like_a_structure_parameter_is_refused():
+    with pytest.raises(query.QueryError, match="collide"):
+        query.compile_query(
+            query.Query.model_validate(
+                {
+                    "where": {
+                        "op": "exists",
+                        "path": "inputs.components",
+                        "where": {
+                            "op": "and",
+                            "clauses": [
+                                _substructure(),
+                                {
+                                    "op": "eq",
+                                    "path": "smiles",
+                                    "value": {"compound": "structure_0"},
+                                },
+                            ],
+                        },
+                    }
+                }
+            )
+        )

--- a/ord_schema/agent/query_test.py
+++ b/ord_schema/agent/query_test.py
@@ -14,6 +14,8 @@
 
 """Tests for ord_schema.agent.query."""
 
+import warnings
+
 import duckdb
 import pytest
 from pydantic import ValidationError
@@ -556,14 +558,35 @@ def test_a_smarts_with_an_explicit_hydrogen_is_merged_with_a_warning():
     assert Chem.MolFromSmiles("CO").HasSubstructMatch(merged)
 
 
-def test_an_unmergeable_explicit_hydrogen_is_refused():
-    # A hydrogen with no heavy neighbor has nothing to fold into, and folding an
-    # isotopic hydrogen into a count would drop the isotope constraint silently.
-    for smarts in ("[H][H]", "[2H]OC"):
-        with pytest.raises(ValueError, match="explicit hydrogen"):
-            query.Substructure.model_validate(
-                {"op": "substructure", "path": "smiles", "smarts": smarts}
-            )
+@pytest.mark.parametrize("smarts", ["[H][H]", "[2H]OC", "[2H]"])
+def test_an_unfoldable_explicit_hydrogen_passes_through(smarts):
+    # These hydrogens cannot be implicit in a stored molecule either -- an isotope and
+    # H2 have no heavy atom to hide in -- so they are real graph atoms the query
+    # already matches. 28,297 ORD reactions have an [H][H] component, so rewriting or
+    # refusing them would lose exactly the queries that work.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        model = query.Substructure.model_validate(
+            {"op": "substructure", "path": "smiles", "smarts": smarts}
+        )
+    assert model.smarts == smarts
+
+
+@pytest.mark.parametrize("smarts", ["", "[]"])
+def test_a_smarts_with_no_atoms_is_refused(smarts):
+    # An empty query fingerprints to no bits, so the screen admits the whole corpus
+    # and verification then rejects all of it: an empty answer at full cost.
+    with pytest.raises(ValueError, match=r"no atoms|does not parse"):
+        query.Substructure.model_validate(
+            {"op": "substructure", "path": "smiles", "smarts": smarts}
+        )
+
+
+def test_a_similarity_smiles_with_no_atoms_is_refused():
+    with pytest.raises(ValueError, match="no atoms"):
+        query.Similarity.model_validate(
+            {"op": "similarity", "path": "smiles", "smiles": "", "threshold": 0.5}
+        )
 
 
 def test_an_h_count_smarts_is_accepted():

--- a/ord_schema/agent/sql_test.py
+++ b/ord_schema/agent/sql_test.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from ord_schema.agent import sql
+from ord_schema.agent import query, sql
 
 _LAMBDA_QUERY = (
     "SELECT reaction_id FROM reactions WHERE len(list_filter(flatten(list_transform("
@@ -144,3 +144,27 @@ def test_an_operator_name_in_a_literal_is_not_an_operator():
     # The plan carries filter expressions alongside operator names, so a substring
     # search over the JSON would refuse this.
     sql.validate("SELECT reaction_id FROM reactions WHERE smiles = 'INOUT_FUNCTION'")
+
+
+def test_a_structure_query_validates_against_the_executable_schema():
+    # A compiled structure predicate references the executor's offset column, which
+    # the bare projection schema cannot bind.
+    compiled = query.compile_query(
+        query.Query.model_validate(
+            {
+                "where": {
+                    "op": "exists",
+                    "path": "inputs.components",
+                    "where": {
+                        "op": "substructure",
+                        "path": "smiles",
+                        "smarts": "c1ccncc1",
+                    },
+                }
+            }
+        )
+    )
+    parameters = {compiled.structures[0].name: "0"}
+    with pytest.raises(sql.InvalidQueryError, match="structure_offset"):
+        sql.validate(compiled.sql, parameters=parameters)
+    sql.validate(compiled.sql, parameters=parameters, schema=query.executable_schema())

--- a/ord_schema/structures.py
+++ b/ord_schema/structures.py
@@ -78,6 +78,16 @@ _MORGAN = rdFingerprintGenerator.GetMorganGenerator(
     radius=MORGAN_RADIUS, fpSize=MORGAN_FP_SIZE
 )
 
+
+def morgan_fingerprint(molecule: Chem.Mol) -> DataStructs.ExplicitBitVect:
+    """Returns the Morgan fingerprint with the parameters this artifact stores.
+
+    The query side of a similarity search must fingerprint identically to the artifact
+    or the comparison is meaningless, so this is the one place the parameters live.
+    """
+    return _MORGAN.GetFingerprint(molecule)
+
+
 # Named so a published file says how its fingerprints were made; the reader recovers
 # the parameters from the footer rather than from this library's history.
 _META_FINGERPRINT = "ord.fingerprint"

--- a/ord_schema/structures.py
+++ b/ord_schema/structures.py
@@ -38,10 +38,12 @@ check cannot see that the pairing changed.
 
 The screen's completeness is an invariant, not a hope: if query ``Q`` is a subgraph of
 target ``T``, every bit of ``Q``'s pattern fingerprint is set in ``T``'s, so
-``bit_count(fp & q) = popcount(q)`` never rejects a true match. That guarantee fails
-for SMARTS with explicit hydrogens -- measured: ``[H]OC`` screens *out* methanol while
-the ``MergeQueryHs``-transformed query matches it -- which is why a query layer must
-refuse them rather than merge them. Similarity needs no verification at all: Tanimoto
+``bit_count(fp & q) = popcount(q)`` never rejects a true match -- measured across 221
+query/target pairs, including explicit-hydrogen queries, with no exception. What a
+query layer still has to handle is that these molecules are built from SMILES and so
+hold their hydrogens implicitly: a SMARTS naming one as its own atom matches nothing,
+which :mod:`ord_schema.agent.query` rewrites rather than runs. Similarity needs no
+verification at all: Tanimoto
 is defined on the Morgan fingerprint, so the screen *is* the answer, and
 ``morgan_popcount`` bounds it (``popcount(B)`` must lie within ``[t * popcount(A),
 popcount(A) / t]`` for Tanimoto ``>= t``).
@@ -261,7 +263,7 @@ def _row(structure_id: int, smiles: str) -> dict[str, Any]:
     mol = Chem.MolFromSmiles(smiles)
     if mol is None:
         return row
-    morgan = _MORGAN.GetFingerprint(mol)
+    morgan = morgan_fingerprint(mol)
     row["pattern_fp"] = DataStructs.BitVectToBinaryText(
         Chem.PatternFingerprint(mol, fpSize=PATTERN_FP_SIZE)
     )


### PR DESCRIPTION
## Summary

The second slice of structure search (design: [ord-logbook#28](https://github.com/open-reaction-database/ord-logbook/pull/28); build side: #956). The IR gains `substructure` and `similarity` predicates that compile to a bitmap test on the element's corpus-wide structure id — legal inside the list lambda where DuckDB permits no subquery, which is what preserves element binding. The chemistry runs in the new `agent.execute.Corpus`: screen over the structures artifact, exact verification from the serialized molecules, Tanimoto directly on Morgan fingerprints for similarity.

## Changes

- `agent/query.py`: `Substructure`/`Similarity` predicate models; compilation to `get_bit($bitmap, structure_id + structure_offset)`; content-deduplicated `StructureParameter`s; `executable_schema()`; zero-atom patterns refused; explicit-hydrogen handling (below).
- `agent/execute.py` (new): `Corpus` pairs projections with structures artifacts **by source dataset**, refuses a partner too short to hold the projection's ids, verifies the join survived, screens/verifies/binds, and runs with an interruptible timeout that cannot outlive its own call.
- `agent/README.md`, `structures.py`: grammar, a Structure search section, and the corrected explicit-hydrogen policy.

## Testing

994 pass. Coverage added for every finding below, plus the gaps mutation testing exposed: element binding now uses the discriminating case, offsets are pinned by a molecule present in both datasets, and the similarity band, threshold inclusivity, worker processes, `forall`/`not`, and staleness paths are covered.

## Notes

### A claim I had wrong

I asserted repeatedly that explicit-hydrogen SMARTS break the fingerprint screen's completeness. **That was wrong.** The measurement behind it compared the screen of the *unmerged* pattern against the match of the *merged* one. Measured properly, `[H]OC` against methanol gives `match=False, screen=False` — they agree — and across 221 query/target pairs the screen rejected zero true matches. Corrected in [ord-logbook#29](https://github.com/open-reaction-database/ord-logbook/pull/29).

The real hazard is different: stored molecules hold hydrogens implicitly, so an explicit-H pattern matches nothing and returns empty without saying why. Merging fixes that. But hydrogens the merge *cannot* fold are exactly the ones a stored molecule cannot hold implicitly either — they are real graph atoms and the query already works — so they now pass through untouched. Refusing them had made `[H][H]` unsearchable, and **28,297 ORD reactions have an `[H][H]` component**; hydrogenation is one of the most common reaction classes in the corpus.

### Review findings fixed

- **A short structures artifact silently returned wrong chemistry.** Two reviewers independently demonstrated it: an artifact rederived from a rewritten projection keeps the same source hash, so the stamps cannot see the changed pairing; a short one pairs cleanly and then aliases the next dataset's molecules, reporting toluene as containing a hydroxyl. `_prepare` now reads the projection's largest `structure_id` from footer statistics and refuses a partner too short for it.
- **The timeout could kill the next query.** `Timer.cancel` only sets a flag, so a timer past its own check fires regardless; reproduced end to end as a query that succeeded followed by a false `TimeoutError` on the next one. The interrupt and the teardown now hold a lock.
- **Pairing keyed on basename** could silently drop a dataset (Greptile P1) — now keyed on source dataset, which also lets the two trees differ in layout.
- **A glob metacharacter in a directory name** silently emptied the join; a join-count check now catches that and any other cause.
- **Verification materialized every survivor** — hundreds of megabytes at ORD scale for a broad pattern. It now streams record batches.
- Smaller: zero-atom patterns refused, compound resolution cached per search, connection closed if `__init__` fails, unsearchable rows excluded from the match-log denominator, and the prose the comment reviewer disproved (the pickling rationale, the timeout's scope, stale docs in `structures.py` and the README).

Corpus-scale numbers will follow as a comment once the local rebuild finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds substructure and similarity predicates plus a corpus executor that pairs projection and structure artifacts, performs fingerprint screening and exact verification, and binds matches into compiled queries.
- Adds structure-search predicate validation, compilation, and parameter deduplication.
- Adds source-dataset artifact pairing, corpus-wide structure offsets, streaming verification, and interruptible execution.
- Updates structure-search documentation and explicit-hydrogen handling.
- Adds coverage for pairing, offsets, element binding, similarity thresholds, hydrogen rewriting, stale artifacts, and timeout behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains in the previously reviewed pairing or explicit-hydrogen fixes.

The current implementation pairs artifacts by consistently propagated source identity, rejects ambiguity and incomplete joins, and aligns the documented explicit-hydrogen policy with query validation; no blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/agent/execute.py | Adds artifact pairing, structure screening and verification, bitmap binding, corpus execution, and timeout handling; the fixes related to the prior pairing thread appear complete. |
| ord_schema/agent/query.py | Adds validated structure predicates and compilation to offset bitmap tests, including explicit-hydrogen rewriting. |
| ord_schema/agent/execute_test.py | Exercises artifact pairing, offsets, search semantics, stale and malformed artifacts, worker execution, and timeout cleanup. |
| ord_schema/agent/README.md | Documents the structure-search pipeline and updates the explicit-hydrogen policy consistently with the implemented validator. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Q[Validated Query] --> C[Compile predicates]
    P[Projection artifacts] --> Pair[Pair by source dataset]
    S[Structure artifacts] --> Pair
    Pair --> Offset[Assign corpus-wide offsets]
    C --> Screen[Fingerprint screening]
    S --> Screen
    Screen --> Verify[Exact substructure verification]
    Verify --> Bitmap[Bind match bitmap]
    Offset --> SQL[Execute DuckDB query]
    Bitmap --> SQL
    SQL --> Result[Arrow result]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Distill two comments that compared again..."](https://github.com/open-reaction-database/ord-schema/commit/a8d3bf69208682053758ae314f3487d4fe80df1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51523041)</sub>

<!-- /greptile_comment -->