### PR TITLE
Match substructures on RDKit threads instead of worker processes

### DIFF
--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -91,12 +91,15 @@ is a compile error rather than a wrong answer:
 ## Structure search
 
 A structure predicate compiles to a bitmap test, not to chemistry. The chemistry runs
-in [`execute.Corpus`](execute.py) against the [structures artifact](../structures.py):
-a fingerprint **screen** — complete but not exact — over every structure row in the
-corpus (deduplicated per dataset, so a molecule in two datasets is screened twice),
-then exact subgraph **verification** from the serialized molecules for
-substructure (similarity needs no verification; Tanimoto is defined on the Morgan
-fingerprint, so the screen is the answer). The verified match set re-enters the query
+in [`execute.Corpus`](execute.py) against the [structures artifact](../structures.py).
+Substructure runs through an RDKit `SubstructLibrary` built over the corpus: a
+fingerprint **screen** — complete but not exact — over every structure row
+(deduplicated per dataset, so a molecule in two datasets is screened twice), then exact
+subgraph **verification** of the survivors. It runs on RDKit's own threads with the GIL
+released, so one `Corpus` serves concurrent requests without forking; the library is
+built on the first substructure query and costs about 8s and 2 GB for the full corpus.
+Similarity needs no verification — Tanimoto is defined on the Morgan fingerprint, so
+the screen is the answer — and stays in SQL. The verified match set re-enters the query
 as a `BITSTRING` parameter indexed by the corpus-wide id (`structure_id` plus the
 file's offset), which is what preserves element binding: `exists(components,
 substructure(pyridine) and role = SOLVENT)` means one component that is both. The
@@ -107,7 +110,7 @@ finding 4.
 ```python
 from ord_schema.agent import execute, query
 
-corpus = execute.Corpus("projections/*/*.parquet", "structures/*/*.parquet", n_jobs=8)
+corpus = execute.Corpus("projections/*/*.parquet", "structures/*/*.parquet")
 table = corpus.search(
     query.Query.model_validate(
         {

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -100,10 +100,10 @@ released, so one `Corpus` serves concurrent requests without forking; the librar
 built on the first substructure query and costs about 8s and 2 GB for the full corpus.
 Similarity needs no verification — Tanimoto is defined on the Morgan fingerprint, so
 the screen is the answer — and stays in SQL. The verified match set re-enters the query
-as a `BITSTRING` parameter indexed by the corpus-wide id (`structure_id` plus the
+as a `BITSTRING` parameter indexed by the corpus-wide ID (`structure_id` plus the
 file's offset), which is what preserves element binding: `exists(components,
 substructure(pyridine) and role = SOLVENT)` means one component that is both. The
-alternative — intersecting reaction-id sets — over-returns by 94% on exactly that
+alternative — intersecting reaction-ID sets — over-returns by 94% on exactly that
 query; see [ord-logbook#28](https://github.com/open-reaction-database/ord-logbook/pull/28),
 finding 4.
 
@@ -135,9 +135,9 @@ table = corpus.search(
 
 `Corpus` refuses artifacts that do not pair: every projection must have a structures
 artifact derived from the same source dataset, and long enough to hold every
-`structure_id` the projection carries, because the ids joining them are meaningful only
+`structure_id` the projection carries, because the IDs joining them are meaningful only
 as a pair. Pairing is by source dataset rather than by filename, so the two trees need
-not share a layout. Structure ids are dataset-local; the executor's relation
+not share a layout. Structure IDs are dataset-local; the executor's relation
 carries a per-file offset column (`structure_offset`), which is why compiled SQL with a
 structure predicate runs only there — validate it against `query.executable_schema()`
 rather than the bare projection schema.

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -98,6 +98,11 @@ fingerprint **screen** — complete but not exact — over every structure row
 subgraph **verification** of the survivors. It runs on RDKit's own threads with the GIL
 released, so one `Corpus` serves concurrent requests without forking; the library is
 built on the first substructure query and costs about 8s and 2 GB for the full corpus.
+Each search takes its own DuckDB cursor, since a connection holds the pending result of
+its last `execute` and concurrent searches sharing one would read each other's rows.
+`threads` is per search rather than per corpus, so a server expecting several at once
+should set it to the core count divided by that concurrency instead of leaving it at
+`-1`.
 Similarity needs no verification — Tanimoto is defined on the Morgan fingerprint, so
 the screen is the answer — and stays in SQL. The verified match set re-enters the query
 as a `BITSTRING` parameter indexed by the corpus-wide ID (`structure_id` plus the

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -271,9 +271,9 @@ class Corpus:
                 ),
             }
         )
-        # Copied into the catalog rather than left as a registration: a registered
-        # object belongs to the connection that registered it, so the views below would
-        # fail to resolve on the per-search cursors with a catalog error.
+        # A registered object belongs to the connection that registered it, so a
+        # per-search cursor raises a catalog error on any view built over one. Copying
+        # it into the catalog puts the views below within reach of every cursor.
         self._connection.register("registered_offsets", registered)
         self._connection.execute(
             "CREATE TABLE structure_offsets AS SELECT * FROM registered_offsets"

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -20,11 +20,13 @@ purpose, and this module is where both happen:
 * **Names become structures.** Compound names bind as resolved SMILES, through
   :mod:`ord_schema.resolvers` by default or any injected resolver.
 * **Structure predicates become bitmaps.** Each compiles to a bitmap test on the
-  element's ``structure_id``; the chemistry -- a fingerprint screen over the structures
-  artifact, then exact subgraph verification from the serialized molecules -- runs
-  here, and the verified match set binds as a ``BITSTRING`` parameter. Similarity has
-  no verification step: Tanimoto is defined on the Morgan fingerprint, so the screen is
-  the whole answer.
+  element's ``structure_id``, and the chemistry runs here. Substructure goes through an
+  RDKit ``SubstructLibrary`` built over the corpus: it screens on the pattern
+  fingerprints the artifact already stores and matches the survivors exactly, across
+  its own threads with the GIL released, so a server can share one corpus between
+  concurrent requests without forking. Similarity stays in SQL and has no verification
+  step at all -- Tanimoto is defined on the Morgan fingerprint, so the screen is the
+  whole answer.
 
 Structure ids are dataset-local, so a corpus-wide bitmap needs an offset per file.
 ``Corpus`` pairs every projection with its structures artifact, refuses a pair whose
@@ -43,14 +45,15 @@ than in a timeout.
 import glob
 import math
 import threading
-from collections.abc import Callable, Iterable, Iterator, Sequence
+import time
+from collections.abc import Callable, Iterable, Sequence
 from typing import Any, Self
 
 import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
-from joblib import Parallel, delayed
 from rdkit import Chem, DataStructs
+from rdkit.Chem import rdSubstructLibrary
 
 from ord_schema import artifacts, projection, resolvers, structures
 from ord_schema.agent import query
@@ -58,9 +61,9 @@ from ord_schema.logging import get_logger
 
 logger = get_logger(__name__)
 
-# Structures verified per joblib task. Large enough that pickling blobs is amortized,
-# small enough that a dozen workers stay busy on a typical survivor set.
-_VERIFY_CHUNK = 4096
+# Structures read per batch while building the library. Bounds peak memory during the
+# build without making the per-batch Python overhead matter.
+_BUILD_BATCH = 50_000
 
 
 class PairingError(ValueError):
@@ -109,37 +112,11 @@ def _max_structure_id(path: str) -> int | None:
     return largest
 
 
-def _verify_chunk(
-    pattern: str, from_smarts: bool, identifiers: Sequence[int], blobs: Sequence[bytes]
-) -> list[int]:
-    """Returns the ids whose serialized molecule contains the query as a subgraph.
-
-    A module-level function so joblib can ship it to worker processes. Returning the
-    matching ids keeps a worker's reply proportional to the answer rather than to the
-    batch it was handed. The query travels as a string and is parsed once per chunk,
-    which is cheaper than shipping a molecule.
-
-    Args:
-        pattern: The query, as SMARTS or SMILES.
-        from_smarts: Whether ``pattern`` is SMARTS.
-        identifiers: Corpus-wide structure ids, positionally matching ``blobs``.
-        blobs: Serialized molecules (``mol_binary`` column values).
-
-    Returns:
-        The subset of ``identifiers`` that verified.
-    """
-    parsed = Chem.MolFromSmarts(pattern) if from_smarts else Chem.MolFromSmiles(pattern)
-    return [
-        identifier
-        for identifier, blob in zip(identifiers, blobs, strict=True)
-        if Chem.Mol(bytes(blob)).HasSubstructMatch(parsed)  # ty: ignore[no-matching-overload]
-    ]
-
-
-def _pattern_blob(molecule: Chem.Mol) -> tuple[bytes, int]:
-    """Returns the packed pattern fingerprint and its popcount."""
-    fingerprint = Chem.PatternFingerprint(molecule, fpSize=structures.PATTERN_FP_SIZE)
-    return DataStructs.BitVectToBinaryText(fingerprint), fingerprint.GetNumOnBits()
+# An id whose structure did not parse still occupies a slot, so a library index is a
+# corpus-wide structure id and needs no translation. An empty molecule fingerprints to
+# no bits, and a query with no atoms is refused, so it can never match.
+_UNPARSEABLE = Chem.Mol().ToBinary()
+_NO_BITS = DataStructs.ExplicitBitVect(structures.PATTERN_FP_SIZE)
 
 
 class Corpus:
@@ -155,7 +132,7 @@ class Corpus:
         structures_pattern: str,
         *,
         resolver: Callable[[str], str] | None = None,
-        n_jobs: int = 1,
+        threads: int = -1,
         require_current: bool = True,
     ) -> None:
         """Pairs the artifacts, checks their stamps, and prepares the relations.
@@ -166,7 +143,9 @@ class Corpus:
             resolver: Maps a compound name to SMILES. Defaults to
                 ``ord_schema.resolvers``, which calls external services; inject
                 something local for tests or offline use.
-            n_jobs: Worker processes for substructure verification. 1 verifies inline.
+            threads: Threads RDKit uses to match a substructure query; -1 means one
+                per core. These are real threads with the GIL released, so a server
+                may share one corpus across concurrent requests.
             require_current: Refuse artifacts not written by the current library,
                 artifact, and RDKit versions. The screen's completeness guarantee
                 assumes the query and the artifact fingerprint identically, so turning
@@ -178,7 +157,9 @@ class Corpus:
                 dataset, or -- with ``require_current`` -- any artifact is stale.
         """
         self._resolver = resolver if resolver is not None else _resolve_with_resolvers
-        self._n_jobs = n_jobs
+        self._threads = threads
+        # Built on first substructure query; see _library.
+        self._substruct_library: rdSubstructLibrary.SubstructLibrary | None = None
         pairs = self._pair(projection_pattern, structures_pattern, require_current)
         self._connection = duckdb.connect()
         try:
@@ -368,49 +349,70 @@ class Corpus:
             )
         return molecule
 
-    def _survivors(self, blob: bytes, popcount: int) -> Iterator[tuple[list, list]]:
-        """Yields (global ids, serialized molecules) for each batch the screen passes.
+    def _library(self) -> rdSubstructLibrary.SubstructLibrary:
+        """Returns the substructure library, building it on first use.
 
-        Streamed rather than fetched whole: a broad pattern survives the screen on most
-        of the corpus, and at ORD's scale the serialized molecules alone are hundreds of
-        megabytes. Batching lets each one be verified and released.
+        Built lazily because it costs seconds and gigabytes, and a corpus asked only
+        for similarity or scalar queries never needs it. Streamed in id order so a
+        library index *is* a corpus-wide structure id: a structure that did not parse
+        still occupies its slot, holding an empty molecule that nothing matches.
 
-        Args:
-            blob: The query's packed pattern fingerprint.
-            popcount: How many bits it sets.
-
-        Yields:
-            One (ids, molecules) pair per record batch.
+        Returns:
+            A library over every structure in the corpus, screened by the pattern
+            fingerprints the artifact already stores.
         """
-        reader = self._connection.execute(
-            """
-            SELECT global_id, mol_binary FROM corpus_structures
-            WHERE pattern_fp IS NOT NULL
-              AND bit_count(CAST(pattern_fp AS BITSTRING) & CAST($q AS BITSTRING)) = $n
-            """,
-            {"q": blob, "n": popcount},
-        ).to_arrow_reader(_VERIFY_CHUNK)
-        for batch in reader:
-            yield (
-                batch.column("global_id").to_pylist(),
-                batch.column("mol_binary").to_pylist(),
+        if self._substruct_library is None:
+            start = time.perf_counter()
+            molecules = rdSubstructLibrary.CachedMolHolder()
+            patterns = rdSubstructLibrary.PatternHolder(structures.PATTERN_FP_SIZE)
+            reader = self._connection.execute(
+                "SELECT mol_binary, pattern_fp FROM corpus_structures "
+                "ORDER BY global_id"
+            ).to_arrow_reader(_BUILD_BATCH)
+            for batch in reader:
+                blobs = batch.column("mol_binary").to_pylist()
+                fingerprints = batch.column("pattern_fp").to_pylist()
+                for blob, fingerprint in zip(blobs, fingerprints, strict=True):
+                    if blob is None:
+                        molecules.AddBinary(_UNPARSEABLE)
+                        patterns.AddFingerprint(_NO_BITS)
+                    else:
+                        molecules.AddBinary(blob)
+                        patterns.AddFingerprint(
+                            DataStructs.CreateFromBinaryText(fingerprint)
+                        )
+            library = rdSubstructLibrary.SubstructLibrary(molecules, patterns)
+            if len(library) != self._total:
+                raise PairingError(
+                    f"the library holds {len(library)} structures but the corpus has "
+                    f"{self._total}; its indices would not be structure ids"
+                )
+            logger.info(
+                "built a substructure library over %d structures in %.1fs",
+                len(library),
+                time.perf_counter() - start,
             )
+            self._substruct_library = library
+        return self._substruct_library
 
     def _substructure_ids(
         self, parameter: query.StructureParameter, resolve: Callable[[str], str]
     ) -> list[int]:
-        """Screens and verifies a substructure predicate; returns global ids."""
+        """Screens and verifies a substructure predicate; returns global ids.
+
+        RDKit screens and matches in one call, across its own threads with the GIL
+        released, so a server handling concurrent requests neither forks nor
+        serializes on this.
+        """
         molecule = self._query_molecule(parameter, resolve)
-        blob, popcount = _pattern_blob(molecule)
-        if parameter.op == "substructure" and parameter.pattern is not None:
-            pattern, from_smarts = parameter.pattern, True
-        else:
-            pattern, from_smarts = Chem.MolToSmiles(molecule), False
-        verified = Parallel(n_jobs=self._n_jobs, return_as="generator")(
-            delayed(_verify_chunk)(pattern, from_smarts, identifiers, blobs)
-            for identifiers, blobs in self._survivors(blob, popcount)
+        library = self._library()
+        # maxResults defaults to 1000, which would silently truncate: a broad pattern
+        # matches hundreds of thousands of structures in ORD.
+        return list(
+            library.GetMatches(
+                molecule, numThreads=self._threads, maxResults=len(library) or 1
+            )
         )
-        return [identifier for chunk in verified for identifier in chunk]
 
     def _similarity_ids(
         self, parameter: query.StructureParameter, resolve: Callable[[str], str]

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -28,10 +28,10 @@ purpose, and this module is where both happen:
   step at all -- Tanimoto is defined on the Morgan fingerprint, so the screen is the
   whole answer.
 
-Structure ids are dataset-local, so a corpus-wide bitmap needs an offset per file.
+Structure IDs are dataset-local, so a corpus-wide bitmap needs an offset per file.
 ``Corpus`` pairs every projection with its structures artifact, refuses a pair whose
 stamps disagree about the source dataset -- the two files are two statements of one
-derivation, and a mismatched pair would join ids to the wrong molecules silently --
+derivation, and a mismatched pair would join IDs to the wrong molecules silently --
 and publishes a ``reactions`` relation carrying each row's offset in the column the
 compiled SQL expects.
 
@@ -112,8 +112,8 @@ def _max_structure_id(path: str) -> int | None:
     return largest
 
 
-# An id whose structure did not parse still occupies a slot, so a library index is a
-# corpus-wide structure id and needs no translation. An empty molecule fingerprints to
+# An ID whose structure did not parse still occupies a slot, so a library index is a
+# corpus-wide structure ID and needs no translation. An empty molecule fingerprints to
 # no bits, and a query with no atoms is refused, so it can never match.
 _UNPARSEABLE = Chem.Mol().ToBinary()
 _NO_BITS = DataStructs.ExplicitBitVect(structures.PATTERN_FP_SIZE)
@@ -236,7 +236,7 @@ class Corpus:
         for projected, structured in pairs:
             with pq.ParquetFile(structured) as artifact:
                 count = artifact.metadata.num_rows
-            # The ids the projection carries have to land inside the partner's rows.
+            # The IDs the projection carries have to land inside the partner's rows.
             # Stamps cannot see this: an artifact rederived from a rewritten
             # projection keeps the same source hash, so a short one pairs cleanly and
             # then aliases its neighbor's molecules -- in range for get_bit, wrong
@@ -246,7 +246,7 @@ class Corpus:
             if largest is not None and largest >= count:
                 raise PairingError(
                     f"{projected} carries structure_id {largest} but {structured} "
-                    f"holds only {count} structures, so its ids would join to another "
+                    f"holds only {count} structures, so its IDs would join to another "
                     "dataset's molecules; derive the structures artifact from this "
                     "projection again"
                 )
@@ -353,8 +353,8 @@ class Corpus:
         """Returns the substructure library, building it on first use.
 
         Built lazily because it costs seconds and gigabytes, and a corpus asked only
-        for similarity or scalar queries never needs it. Streamed in id order so a
-        library index *is* a corpus-wide structure id: a structure that did not parse
+        for similarity or scalar queries never needs it. Streamed in ID order so a
+        library index *is* a corpus-wide structure ID: a structure that did not parse
         still occupies its slot, holding an empty molecule that nothing matches.
 
         Returns:
@@ -385,7 +385,7 @@ class Corpus:
             if len(library) != self._total:
                 raise PairingError(
                     f"the library holds {len(library)} structures but the corpus has "
-                    f"{self._total}; its indices would not be structure ids"
+                    f"{self._total}; its indices would not be structure IDs"
                 )
             logger.info(
                 "built a substructure library over %d structures in %.1fs",
@@ -398,7 +398,7 @@ class Corpus:
     def _substructure_ids(
         self, parameter: query.StructureParameter, resolve: Callable[[str], str]
     ) -> list[int]:
-        """Screens and verifies a substructure predicate; returns global ids.
+        """Screens and verifies a substructure predicate; returns global IDs.
 
         RDKit screens and matches in one call, across its own threads with the GIL
         released, so a server handling concurrent requests neither forks nor
@@ -448,7 +448,7 @@ class Corpus:
         return [row[0] for row in rows]
 
     def _bitmap(self, matched: Sequence[int]) -> str:
-        """Returns the match set as a bitmap over the corpus-wide id space."""
+        """Returns the match set as a bitmap over the corpus-wide ID space."""
         bits = bytearray(b"0" * max(self._total, 1))
         for global_id in matched:
             bits[global_id] = ord("1")

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -306,7 +306,10 @@ class Corpus:
         # that makes the two disagree -- a glob metacharacter in a directory name is
         # the reachable one, since read_parquet globs each element it is handed --
         # drops rows from the join rather than failing, leaving a corpus that answers
-        # every query with silence. Counting once here catches it whatever the cause.
+        # every query with silence. The structures side is counted against a total
+        # taken from the footers; the reactions side has no such total to check
+        # against, so a projection whose path failed the same way goes unnoticed here
+        # and shows up only as reactions nobody can find.
         counts = self._connection.execute(
             "SELECT count(*), count(pattern_fp) FROM corpus_structures"
         ).fetchone()
@@ -381,8 +384,9 @@ class Corpus:
             fingerprints the artifact already stores.
 
         Raises:
-            PairingError: If the built library does not hold one entry per structure,
-                which would stop its indices from being structure IDs.
+            PairingError: If the corpus IDs are not exactly ``0`` to ``total - 1``, so
+                that a library index would name a different structure, or if a
+                structure holds one of its derived columns without the other.
         """
         with self._library_lock:
             if self._substructure_library is not None:
@@ -391,15 +395,45 @@ class Corpus:
             molecules = rdSubstructLibrary.CachedMolHolder()
             patterns = rdSubstructLibrary.PatternHolder(structures.PATTERN_FP_SIZE)
             cursor = self._connection.cursor()
+            position = 0
             try:
                 reader = cursor.execute(
-                    "SELECT mol_binary, pattern_fp FROM corpus_structures "
+                    "SELECT global_id, mol_binary, pattern_fp FROM corpus_structures "
                     "ORDER BY global_id"
                 ).to_arrow_reader(_BUILD_BATCH)
                 for batch in reader:
+                    identifiers = batch.column("global_id").to_pylist()
                     blobs = batch.column("mol_binary").to_pylist()
                     fingerprints = batch.column("pattern_fp").to_pylist()
-                    for blob, fingerprint in zip(blobs, fingerprints, strict=True):
+                    for global_id, blob, fingerprint in zip(
+                        identifiers, blobs, fingerprints, strict=True
+                    ):
+                        # Sorting alone does not make an index an ID; it does that only
+                        # while the IDs are every integer from zero, each once. A
+                        # duplicate or a gap slides every later structure onto a
+                        # neighbor's index, which a row count cannot see.
+                        if global_id != position:
+                            raise PairingError(
+                                f"the corpus states structure ID {global_id} where "
+                                f"{position} was expected, so its IDs are not one "
+                                "unbroken run and a library index would name a "
+                                "different structure; derive the structures artifacts "
+                                "again"
+                            )
+                        # A structures artifact writes the derived columns together or
+                        # not at all. One without the other means the row came from
+                        # somewhere else, and taking either branch would be a guess:
+                        # dropping a live fingerprint makes the structure unmatchable
+                        # while it still counts as searchable, and a missing one
+                        # reaches RDKit as a type error naming no row.
+                        if (blob is None) != (fingerprint is None):
+                            raise PairingError(
+                                f"structure {global_id} has "
+                                f"{'no ' if blob is None else 'a '}molecule but "
+                                f"{'no ' if fingerprint is None else 'a '}fingerprint; "
+                                "a structures artifact writes both or neither, so this "
+                                "one was not written by this library"
+                            )
                         if blob is None:
                             molecules.AddBinary(_UNPARSEABLE)
                             patterns.AddFingerprint(_NO_BITS)
@@ -408,6 +442,7 @@ class Corpus:
                             patterns.AddFingerprint(
                                 DataStructs.CreateFromBinaryText(fingerprint)
                             )
+                        position += 1
             finally:
                 cursor.close()
             library = rdSubstructLibrary.SubstructLibrary(molecules, patterns)

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -35,11 +35,18 @@ derivation, and a mismatched pair would join IDs to the wrong molecules silently
 and publishes a ``reactions`` relation carrying each row's offset in the column the
 compiled SQL expects.
 
+A ``Corpus`` is safe to share between concurrent searches. A ``DuckDBPyConnection``
+holds the pending result of its last ``execute``, so two threads stepping on one read
+each other's rows rather than raising; each search therefore takes its own cursor. A
+cursor in turn sees only the catalog, not the objects ``register`` attaches to the
+connection that registered them, so every relation here is a catalog table or view.
+
 The grammar bounds what a query can cost (one pass and a sort), and ``search``
-takes a wall-clock timeout that interrupts the final query. Name resolution, screening,
-and verification run before the timer starts: each is bounded by the corpus rather than
-by the query, so a slow one is slow for every caller and shows up in the logs rather
-than in a timeout.
+takes a wall-clock timeout that interrupts the final query. Name resolution, the
+one-time library build, screening, and verification all run before the timer starts:
+each is bounded by the corpus rather than by the query, so a slow one is slow for every
+caller and shows up in the logs rather than in a timeout. The first substructure search
+therefore takes the build's several seconds on top of whatever timeout it was given.
 """
 
 import glob
@@ -144,8 +151,10 @@ class Corpus:
                 ``ord_schema.resolvers``, which calls external services; inject
                 something local for tests or offline use.
             threads: Threads RDKit uses to match a substructure query; -1 means one
-                per core. These are real threads with the GIL released, so a server
-                may share one corpus across concurrent requests.
+                per core. These are real threads with the GIL released, so concurrent
+                searches overlap instead of serializing. The count is per search, not
+                per corpus, so a server expecting several at once should divide the
+                core count by that concurrency rather than leaving this at -1.
             require_current: Refuse artifacts not written by the current library,
                 artifact, and RDKit versions. The screen's completeness guarantee
                 assumes the query and the artifact fingerprint identically, so turning
@@ -159,7 +168,8 @@ class Corpus:
         self._resolver = resolver if resolver is not None else _resolve_with_resolvers
         self._threads = threads
         # Built on first substructure query; see _library.
-        self._substruct_library: rdSubstructLibrary.SubstructLibrary | None = None
+        self._substructure_library: rdSubstructLibrary.SubstructLibrary | None = None
+        self._library_lock = threading.Lock()
         pairs = self._pair(projection_pattern, structures_pattern, require_current)
         self._connection = duckdb.connect()
         try:
@@ -252,18 +262,23 @@ class Corpus:
                 )
             offsets.append((projected, structured, total))
             total += count
-        self._connection.register(
-            "structure_offsets",
-            pa.table(
-                {
-                    "projection_filename": [offset[0] for offset in offsets],
-                    "structures_filename": [offset[1] for offset in offsets],
-                    query.STRUCTURE_OFFSET: pa.array(
-                        [offset[2] for offset in offsets], type=pa.int64()
-                    ),
-                }
-            ),
+        registered = pa.table(
+            {
+                "projection_filename": [offset[0] for offset in offsets],
+                "structures_filename": [offset[1] for offset in offsets],
+                query.STRUCTURE_OFFSET: pa.array(
+                    [offset[2] for offset in offsets], type=pa.int64()
+                ),
+            }
         )
+        # Copied into the catalog rather than left as a registration: a registered
+        # object belongs to the connection that registered it, so the views below would
+        # fail to resolve on the per-search cursors with a catalog error.
+        self._connection.register("registered_offsets", registered)
+        self._connection.execute(
+            "CREATE TABLE structure_offsets AS SELECT * FROM registered_offsets"
+        )
+        self._connection.unregister("registered_offsets")
         # Inlined rather than bound because DuckDB refuses parameters in DDL. The
         # paths came from this process's own glob, and the quoting still escapes them.
         projection_files = _sql_strings(pair[0] for pair in pairs)
@@ -357,30 +372,44 @@ class Corpus:
         library index *is* a corpus-wide structure ID: a structure that did not parse
         still occupies its slot, holding an empty molecule that nothing matches.
 
+        Concurrent first searches serialize on the build rather than each building a
+        copy, which at corpus scale is about 2 GB apiece. Whoever waits needs the
+        finished library anyway.
+
         Returns:
             A library over every structure in the corpus, screened by the pattern
             fingerprints the artifact already stores.
+
+        Raises:
+            PairingError: If the built library does not hold one entry per structure,
+                which would stop its indices from being structure IDs.
         """
-        if self._substruct_library is None:
+        with self._library_lock:
+            if self._substructure_library is not None:
+                return self._substructure_library
             start = time.perf_counter()
             molecules = rdSubstructLibrary.CachedMolHolder()
             patterns = rdSubstructLibrary.PatternHolder(structures.PATTERN_FP_SIZE)
-            reader = self._connection.execute(
-                "SELECT mol_binary, pattern_fp FROM corpus_structures "
-                "ORDER BY global_id"
-            ).to_arrow_reader(_BUILD_BATCH)
-            for batch in reader:
-                blobs = batch.column("mol_binary").to_pylist()
-                fingerprints = batch.column("pattern_fp").to_pylist()
-                for blob, fingerprint in zip(blobs, fingerprints, strict=True):
-                    if blob is None:
-                        molecules.AddBinary(_UNPARSEABLE)
-                        patterns.AddFingerprint(_NO_BITS)
-                    else:
-                        molecules.AddBinary(blob)
-                        patterns.AddFingerprint(
-                            DataStructs.CreateFromBinaryText(fingerprint)
-                        )
+            cursor = self._connection.cursor()
+            try:
+                reader = cursor.execute(
+                    "SELECT mol_binary, pattern_fp FROM corpus_structures "
+                    "ORDER BY global_id"
+                ).to_arrow_reader(_BUILD_BATCH)
+                for batch in reader:
+                    blobs = batch.column("mol_binary").to_pylist()
+                    fingerprints = batch.column("pattern_fp").to_pylist()
+                    for blob, fingerprint in zip(blobs, fingerprints, strict=True):
+                        if blob is None:
+                            molecules.AddBinary(_UNPARSEABLE)
+                            patterns.AddFingerprint(_NO_BITS)
+                        else:
+                            molecules.AddBinary(blob)
+                            patterns.AddFingerprint(
+                                DataStructs.CreateFromBinaryText(fingerprint)
+                            )
+            finally:
+                cursor.close()
             library = rdSubstructLibrary.SubstructLibrary(molecules, patterns)
             if len(library) != self._total:
                 raise PairingError(
@@ -392,8 +421,8 @@ class Corpus:
                 len(library),
                 time.perf_counter() - start,
             )
-            self._substruct_library = library
-        return self._substruct_library
+            self._substructure_library = library
+            return self._substructure_library
 
     def _substructure_ids(
         self, parameter: query.StructureParameter, resolve: Callable[[str], str]
@@ -401,8 +430,14 @@ class Corpus:
         """Screens and verifies a substructure predicate; returns global IDs.
 
         RDKit screens and matches in one call, across its own threads with the GIL
-        released, so a server handling concurrent requests neither forks nor
-        serializes on this.
+        released, so concurrent searches overlap here instead of serializing.
+
+        Args:
+            parameter: The predicate to match.
+            resolve: Maps a compound name to SMILES.
+
+        Returns:
+            The corpus-wide structure IDs whose molecules contain the query.
         """
         molecule = self._query_molecule(parameter, resolve)
         library = self._library()
@@ -415,7 +450,10 @@ class Corpus:
         )
 
     def _similarity_ids(
-        self, parameter: query.StructureParameter, resolve: Callable[[str], str]
+        self,
+        cursor: duckdb.DuckDBPyConnection,
+        parameter: query.StructureParameter,
+        resolve: Callable[[str], str],
     ) -> list[int]:
         """Screens a similarity predicate; the fingerprint is the whole answer."""
         molecule = self._query_molecule(parameter, resolve)
@@ -426,7 +464,7 @@ class Corpus:
         assert threshold is not None  # A similarity predicate always carries one.
         # Tanimoto >= t bounds the candidate popcount to [t * q, q / t], which the
         # artifact's morgan_popcount column answers without touching the fingerprints.
-        rows = self._connection.execute(
+        rows = cursor.execute(
             """
             SELECT global_id FROM corpus_structures
             WHERE morgan_fp IS NOT NULL
@@ -459,11 +497,16 @@ class Corpus:
     ) -> pa.Table:
         """Compiles and runs a query, returning the result as an Arrow table.
 
+        Runs on its own cursor, so concurrent searches sharing this corpus do not read
+        each other's results. They still serialize on the library build, and only on
+        that: the first substructure search builds it while the others wait.
+
         Args:
             request: The query to run.
-            timeout_seconds: Wall-clock bound on the final query. Name resolution,
-                screening, and verification run before the timer starts and are not
-                counted. None runs unbounded.
+            timeout_seconds: Wall-clock bound on the final query. Name resolution, the
+                library build, screening, and verification run before the timer starts
+                and are not counted, so a first substructure search can take seconds
+                longer than this allows. None runs unbounded.
 
         Returns:
             The selected columns: ``reaction_id`` for a plain query, the group and
@@ -472,6 +515,7 @@ class Corpus:
         Raises:
             query.QueryError: If the query does not compile.
             ValueError: If a compound name cannot be resolved.
+            PairingError: If the library does not come out one entry per structure.
             TimeoutError: If the query exceeds ``timeout_seconds``.
         """
         compiled = query.compile_query(request)
@@ -484,42 +528,52 @@ class Corpus:
                 resolved[name] = self._resolver(name)
             return resolved[name]
 
-        parameters: dict[str, Any] = {
-            name: resolve(name) for name in compiled.compounds
-        }
-        for parameter in compiled.structures:
-            if parameter.op == "substructure":
-                matched = self._substructure_ids(parameter, resolve)
-            else:
-                matched = self._similarity_ids(parameter, resolve)
-            unsearchable = self._total - self._searchable
-            logger.info(
-                "%s %r matched %d of %d structures (%d unsearchable)",
-                parameter.op,
-                parameter.pattern
-                if parameter.pattern is not None
-                else parameter.compound,
-                len(matched),
-                self._searchable,
-                unsearchable,
+        cursor = self._connection.cursor()
+        try:
+            parameters: dict[str, Any] = {
+                name: resolve(name) for name in compiled.compounds
+            }
+            for parameter in compiled.structures:
+                if parameter.op == "substructure":
+                    matched = self._substructure_ids(parameter, resolve)
+                else:
+                    matched = self._similarity_ids(cursor, parameter, resolve)
+                unsearchable = self._total - self._searchable
+                logger.info(
+                    "%s %r matched %d of %d structures (%d unsearchable)",
+                    parameter.op,
+                    parameter.pattern
+                    if parameter.pattern is not None
+                    else parameter.compound,
+                    len(matched),
+                    self._searchable,
+                    unsearchable,
+                )
+                parameters[parameter.name] = self._bitmap(matched)
+            if timeout_seconds is None:
+                return cursor.execute(compiled.sql, parameters).to_arrow_table()
+            return self._run_with_timeout(
+                cursor, compiled.sql, parameters, timeout_seconds
             )
-            parameters[parameter.name] = self._bitmap(matched)
-        if timeout_seconds is None:
-            return self._connection.execute(compiled.sql, parameters).to_arrow_table()
-        return self._run_with_timeout(compiled.sql, parameters, timeout_seconds)
+        finally:
+            cursor.close()
 
+    @staticmethod
     def _run_with_timeout(
-        self, sql: str, parameters: dict[str, Any], timeout_seconds: float
+        cursor: duckdb.DuckDBPyConnection,
+        sql: str,
+        parameters: dict[str, Any],
+        timeout_seconds: float,
     ) -> pa.Table:
         """Runs ``sql``, interrupting it if it outlasts ``timeout_seconds``.
 
         ``Timer.cancel`` only sets a flag, so a timer that has already passed its own
-        check fires anyway. The lock makes the interrupt and the teardown exclusive: it
-        either lands while this query owns the connection, or not at all. Without it a
-        late interrupt reaches whatever query runs next and reports that one as having
-        timed out.
+        check fires anyway. The lock makes the interrupt and the teardown exclusive, so
+        it either lands while this query is running or not at all -- and in particular
+        never after the caller closes the cursor.
 
         Args:
+            cursor: The cursor to run on, and the one an expired timer interrupts.
             sql: The compiled query.
             parameters: Values to bind.
             timeout_seconds: Wall-clock bound.
@@ -536,12 +590,12 @@ class Corpus:
         def interrupt() -> None:
             with lock:
                 if running:
-                    self._connection.interrupt()
+                    cursor.interrupt()
 
         timer = threading.Timer(timeout_seconds, interrupt)
         timer.start()
         try:
-            return self._connection.execute(sql, parameters).to_arrow_table()
+            return cursor.execute(sql, parameters).to_arrow_table()
         except duckdb.InterruptException as error:
             raise TimeoutError(f"query exceeded {timeout_seconds} seconds") from error
         finally:

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -16,8 +16,12 @@
 
 import contextlib
 import pathlib
+import threading
+import time
 from collections.abc import Iterator
 
+import duckdb
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 from rdkit import Chem
@@ -229,12 +233,48 @@ def test_the_screen_only_accelerates_the_answer(corpus):
         assert with_screen == without_screen, smarts
 
 
-def test_an_unparseable_structure_holds_its_slot(corpus):
-    # A structure that did not parse still occupies its ID, or every ID after it would
-    # shift and the bitmap would name different molecules. It matches nothing.
-    library = corpus._library()
-    assert len(library) == corpus._total
-    assert not library.GetMatches(Chem.MolFromSmarts("[#0]"), maxResults=len(library))
+def test_an_unparseable_structure_holds_its_slot(corpus_dir, tmp_path):
+    # A structure RDKit could not read still occupies its ID. Skipping it instead would
+    # shift every later ID down one, and the bitmap would then name molecules that are
+    # not the ones matched -- wrong chemistry, corpus-wide, and silent. The nulled row
+    # is aa's first structure, so every remaining structure in the corpus sits after it
+    # and answers correctly only if the empty slot is really there.
+    root = _copy_corpus(corpus_dir, tmp_path)
+    target = root / "structures" / "ord_dataset-aa.parquet"
+    with pq.ParquetFile(target) as artifact:
+        table = artifact.read()
+        schema = artifact.schema_arrow
+    assert table.column("smiles")[0].as_py() == "c1ccncc1", "expected pyridine first"
+    columns = {field.name: table.column(field.name) for field in schema}
+    for name in ("mol_binary", "pattern_fp"):
+        values = table.column(name).to_pylist()
+        values[0] = None
+        columns[name] = pa.array(values, type=schema.field(name).type)
+    pq.write_table(pa.table(columns, schema=schema), target)
+    with execute.Corpus(
+        str(root / "projections" / "*.parquet"),
+        str(root / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        assert len(value._library()) == value._total
+        # Benzene sits after the hole inside aa, ethanol after it over in bb. Both
+        # still name their own reactions, which holds only while the slot is held.
+        assert _search(
+            value,
+            _exists({"op": "substructure", "path": "smiles", "smarts": "c1ccccc1"}),
+        ) == {"ord-aa01"}
+        assert _search(
+            value, _exists({"op": "substructure", "path": "smiles", "smarts": "[OX2H]"})
+        ) == {"ord-bb01"}
+        # The unreadable structure matches nothing at all, rather than matching whatever
+        # molecule happens to land on its index.
+        assert (
+            _search(
+                value,
+                _exists({"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"}),
+            )
+            == set()
+        )
 
 
 def test_unpaired_artifacts_are_refused(corpus_dir, tmp_path):
@@ -493,10 +533,10 @@ def test_matching_runs_across_threads(corpus_dir):
     assert matched.column("reaction_id").to_pylist() == ["ord-bb01"]
 
 
-def test_a_timeout_does_not_outlive_its_own_search(corpus):
-    # Timer.cancel only sets a flag, so a timer past its own check fires anyway. If
-    # that interrupt could outlive the search that armed it, the NEXT query would fail
-    # and be reported as having timed out.
+def test_a_timeout_does_not_disturb_a_later_search(corpus):
+    # Timer.cancel only sets a flag, so a timer past its own check fires anyway. An
+    # interrupt outliving the search that armed it would fail a later query and report
+    # it as having timed out.
     request = query.Query.model_validate(
         {"where": _exists({"op": "eq", "path": "smiles", "value": {"literal": "CCO"}})}
     )
@@ -508,6 +548,69 @@ def test_a_timeout_does_not_outlive_its_own_search(corpus):
         assert _search(
             corpus, _exists({"op": "eq", "path": "smiles", "value": {"literal": "CCO"}})
         ) == {"ord-bb01"}
+
+
+def test_a_timeout_interrupts_a_query_that_outlasts_it():
+    # Nothing in the fixture corpus is slow enough to time out, so the interrupt itself
+    # is pinned here against a query that is. Were it ever to stop reaching the running
+    # statement, every timeout would quietly become no timeout at all.
+    connection = duckdb.connect()
+    try:
+        cursor = connection.cursor()
+        started = time.perf_counter()
+        with pytest.raises(TimeoutError, match=r"exceeded 0\.2 seconds"):
+            execute.Corpus._run_with_timeout(
+                cursor, "SELECT count(*) FROM range(100000000000)", {}, 0.2
+            )
+        # The bound is what ends it, rather than the query finishing on its own.
+        assert time.perf_counter() - started < 30
+    finally:
+        connection.close()
+
+
+def test_a_timeout_does_not_disturb_a_concurrent_search(corpus_dir):
+    # A search arming a timer must interrupt only itself. Interrupting anything wider
+    # would abort whatever else is in flight and report it, wrongly, as a timeout.
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        value._library()
+        timed = query.Query.model_validate(
+            {"where": _exists({"op": "substructure", "path": "smiles", "smarts": "*"})}
+        )
+        steady = query.Query.model_validate(
+            {
+                "where": _exists(
+                    {"op": "eq", "path": "smiles", "value": {"literal": "CCO"}}
+                )
+            }
+        )
+        failures: list[BaseException] = []
+        wrong: list[list[str]] = []
+        stop = threading.Event()
+
+        def timing_out():
+            try:
+                while not stop.is_set():
+                    with contextlib.suppress(TimeoutError):
+                        value.search(timed, timeout_seconds=0.001)
+            except BaseException as error:  # noqa: BLE001
+                failures.append(error)
+
+        armer = threading.Thread(target=timing_out)
+        armer.start()
+        try:
+            for _ in range(40):
+                matched = value.search(steady).column("reaction_id").to_pylist()
+                if matched != ["ord-bb01"]:
+                    wrong.append(matched)
+        finally:
+            stop.set()
+            armer.join(timeout=_WAIT)
+    assert failures == []
+    assert wrong == []
 
 
 def test_a_generous_timeout_returns_the_answer(corpus):
@@ -522,6 +625,199 @@ def test_a_generous_timeout_returns_the_answer(corpus):
         timeout_seconds=60,
     )
     assert matched.column("reaction_id").to_pylist() == ["ord-bb01"]
+
+
+# Long enough that a loaded machine does not trip it, short enough that a regression
+# reports as a failure instead of parking the suite forever. Nothing here waits on real
+# work: every barrier is released by threads that have already been started.
+_WAIT = 60
+
+
+class _CursorCounter:
+    """A connection that counts cursors and refuses to be queried directly.
+
+    Forwards everything else, so a search that takes a cursor works and one that runs
+    its own query on the shared connection fails.
+    """
+
+    def __init__(self, connection):
+        self.connection = connection
+        self.cursors = 0
+
+    def cursor(self):
+        self.cursors += 1
+        return self.connection.cursor()
+
+    def execute(self, *args, **kwargs):
+        raise AssertionError("the search queried the shared connection")
+
+    def __getattr__(self, name):
+        return getattr(self.connection, name)
+
+
+def test_a_search_runs_on_a_cursor_rather_than_the_shared_connection(corpus_dir):
+    # A DuckDBPyConnection carries the pending result of its last execute, so searches
+    # sharing one read each other's rows instead of raising. Counting cursors alone
+    # would pass an implementation that took one and then queried the connection
+    # anyway, so the connection is made unusable for queries: the search has to run on
+    # what cursor() handed it.
+    request = query.Query.model_validate(
+        {"where": _exists({"op": "eq", "path": "smiles", "value": {"literal": "CCO"}})}
+    )
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        value._connection = counter = _CursorCounter(value._connection)
+        assert value.search(request).num_rows == 1
+        assert counter.cursors == 1
+
+
+def test_concurrent_searches_return_their_own_answers(corpus_dir):
+    # Distinct queries with distinct answers, run at once against one corpus: each
+    # thread has to come back with the reactions its own query selected. Sharing one
+    # connection also makes searches raise "No open result set" as often as it makes
+    # them lie, so the exceptions are collected too -- a thread that dies takes its
+    # traceback to threading.excepthook, where an assertion on results alone sees
+    # nothing wrong.
+    # The similarity thread earns its place: that path runs its screen and then the
+    # compiled query as two statements on one cursor, so it is where reuse within a
+    # single search would show up.
+    expected = {
+        "hydroxyl": ["ord-bb01"],
+        "pyridine": ["ord-aa01", "ord-aa02"],
+        "benzene": ["ord-aa01"],
+        "like ethanol": ["ord-bb01"],
+    }
+    predicates = {
+        "hydroxyl": {"op": "substructure", "path": "smiles", "smarts": "[OX2H]"},
+        "pyridine": {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"},
+        "benzene": {"op": "substructure", "path": "smiles", "smarts": "c1ccccc1"},
+        "like ethanol": {
+            "op": "similarity",
+            "path": "smiles",
+            "smiles": "OCC",
+            "threshold": 0.99,
+        },
+    }
+    rounds = 20
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        value._library()  # Build once up front, so the threads race on searching.
+        # Built before any thread starts: validation that raised inside a thread would
+        # leave the others parked on a barrier nobody else reaches.
+        requests = {
+            label: query.Query.model_validate({"where": _exists(predicate)})
+            for label, predicate in predicates.items()
+        }
+        wrong: list[tuple[str, list[str]]] = []
+        failures: list[BaseException] = []
+        completed: list[str] = []
+        ready = threading.Barrier(len(expected))
+
+        def search(label):
+            try:
+                ready.wait(timeout=_WAIT)
+                for _ in range(rounds):
+                    matched = sorted(
+                        value.search(requests[label]).column("reaction_id").to_pylist()
+                    )
+                    if matched != expected[label]:
+                        wrong.append((label, matched))
+                completed.append(label)
+            except BaseException as error:  # noqa: BLE001
+                failures.append(error)
+
+        threads = [threading.Thread(target=search, args=(label,)) for label in expected]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=_WAIT)
+        alive = [thread for thread in threads if thread.is_alive()]
+    assert failures == []
+    assert alive == []
+    assert wrong == []
+    assert sorted(completed) == sorted(expected)
+
+
+def test_concurrent_first_searches_build_one_library(corpus_dir, monkeypatch):
+    # The library is about 2 GB at corpus scale. First searches arriving together must
+    # not each build their own copy, so the build is serialized and whoever waits takes
+    # the finished one.
+    threads_count = 4
+    builds = 0
+    counting = threading.Lock()
+    original = execute.rdSubstructLibrary.SubstructLibrary
+
+    def counted(*args, **kwargs):
+        nonlocal builds
+        with counting:
+            builds += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(execute.rdSubstructLibrary, "SubstructLibrary", counted)
+    ready = threading.Barrier(threads_count)
+
+    def resolver(name):
+        # Every thread is inside search and about to want the library; releasing them
+        # together is what makes the race reachable at all. This assumes each search
+        # resolves the name itself -- were that cache ever hoisted to the corpus, the
+        # threads that skipped it would leave this barrier one short, so it times out
+        # rather than parking the suite.
+        ready.wait(timeout=_WAIT)
+        return {"pyridine": "c1ccncc1"}[name]
+
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver=resolver,
+    ) as value:
+        request = query.Query.model_validate(
+            {
+                "where": _exists(
+                    {"op": "substructure", "path": "smiles", "compound": "pyridine"}
+                )
+            }
+        )
+        results: list[list[str]] = []
+        failures: list[BaseException] = []
+
+        def search():
+            try:
+                matched = value.search(request).column("reaction_id").to_pylist()
+                results.append(sorted(matched))
+            except BaseException as error:  # noqa: BLE001
+                failures.append(error)
+
+        threads = [threading.Thread(target=search) for _ in range(threads_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=_WAIT)
+        alive = [thread for thread in threads if thread.is_alive()]
+    assert failures == []
+    assert alive == []
+    assert builds == 1
+    assert results == [["ord-aa01", "ord-aa02"]] * threads_count
+
+
+def test_the_match_limit_has_to_be_passed_or_matches_are_dropped():
+    # GetMatches defaults to 1000 results and truncates in silence, which at corpus
+    # scale would turn a broad pattern into a wrong answer rather than a slow one. The
+    # fixture has five structures, so no test of it can reach the limit; the default is
+    # pinned here instead, against a library large enough to cross it.
+    benzene = Chem.MolFromSmiles("c1ccccc1")
+    holder = rdSubstructLibrary.CachedMolHolder()
+    for _ in range(1500):
+        holder.AddMol(benzene)
+    library = rdSubstructLibrary.SubstructLibrary(holder)
+    pattern = Chem.MolFromSmarts("c1ccccc1")
+    assert len(library.GetMatches(pattern)) == 1000
+    assert len(library.GetMatches(pattern, maxResults=len(library))) == 1500
 
 
 def test_the_artifact_fingerprint_is_the_one_the_library_screens_with():

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -377,6 +377,65 @@ def test_a_structures_artifact_short_of_its_projection_is_refused(corpus_dir, tm
         )
 
 
+def _rewrite_structures(root, shard, **columns):
+    """Replaces whole columns of one structures artifact, keeping its schema."""
+    target = root / "structures" / f"ord_dataset-{shard}.parquet"
+    with pq.ParquetFile(target) as artifact:
+        table = artifact.read()
+        schema = artifact.schema_arrow
+    replaced = {field.name: table.column(field.name) for field in schema}
+    for name, values in columns.items():
+        replaced[name] = pa.array(values, type=schema.field(name).type)
+    pq.write_table(pa.table(replaced, schema=schema), target)
+
+
+@pytest.mark.parametrize(
+    ("label", "identifiers"),
+    [("a duplicate", [0, 1, 1]), ("a gap", [0, 1, 3])],
+)
+def test_structure_ids_that_are_not_one_unbroken_run_are_refused(
+    corpus_dir, tmp_path, label, identifiers
+):
+    # A library index is a structure ID only while the IDs are every integer from zero,
+    # each exactly once. A duplicate or a gap slides later structures onto a neighbor's
+    # index, and the row count -- unchanged by either -- cannot see it.
+    root = _copy_corpus(corpus_dir, tmp_path)
+    _rewrite_structures(root, "aa", structure_id=identifiers)
+    with (
+        execute.Corpus(
+            str(root / "projections" / "*.parquet"),
+            str(root / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+        ) as value,
+        pytest.raises(execute.PairingError, match="not one unbroken run"),
+    ):
+        value._library()
+
+
+@pytest.mark.parametrize("missing", ["mol_binary", "pattern_fp"])
+def test_half_a_derived_structure_is_refused(corpus_dir, tmp_path, missing):
+    # The artifact writes a molecule and its fingerprint together or not at all, and
+    # the library relies on that. Left to itself, one without the other goes two
+    # different wrong ways: a missing molecule discards a live fingerprint, so the
+    # structure quietly matches nothing while still counting as searchable, and a
+    # missing fingerprint reaches RDKit as a type error naming no row at all.
+    root = _copy_corpus(corpus_dir, tmp_path)
+    target = root / "structures" / "ord_dataset-bb.parquet"
+    with pq.ParquetFile(target) as artifact:
+        values = artifact.read().column(missing).to_pylist()
+    values[0] = None
+    _rewrite_structures(root, "bb", **{missing: values})
+    with (
+        execute.Corpus(
+            str(root / "projections" / "*.parquet"),
+            str(root / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+        ) as value,
+        pytest.raises(execute.PairingError, match="writes both or neither"),
+    ):
+        value._library()
+
+
 def test_two_artifacts_of_one_dataset_are_refused(corpus_dir, tmp_path):
     # Which of them answers a query would be arbitrary, so neither may.
     root = _copy_corpus(corpus_dir, tmp_path)

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -45,7 +45,7 @@ def _reaction(reaction_id, *, components, product="Cc1ccccc1"):
     return reaction
 
 
-# Two datasets, so that the second's structure ids only join correctly through a
+# Two datasets, so that the second's structure IDs only join correctly through a
 # nonzero offset. Basenames sort "aa" before "bb".
 _REACTIONS = {
     "aa": [
@@ -133,7 +133,7 @@ def test_substructure_binds_to_the_element(corpus):
 
 
 def test_substructure_reaches_the_offset_dataset(corpus):
-    # The hydroxyl is only in bb, whose ids are only correct through its offset.
+    # The hydroxyl is only in bb, whose IDs are only correct through its offset.
     matched = _search(
         corpus,
         _exists({"op": "substructure", "path": "smiles", "smarts": "[OX2H]"}),
@@ -230,7 +230,7 @@ def test_the_screen_only_accelerates_the_answer(corpus):
 
 
 def test_an_unparseable_structure_holds_its_slot(corpus):
-    # A structure that did not parse still occupies its id, or every id after it would
+    # A structure that did not parse still occupies its ID, or every ID after it would
     # shift and the bitmap would name different molecules. It matches nothing.
     library = corpus._library()
     assert len(library) == corpus._total
@@ -248,7 +248,7 @@ def test_unpaired_artifacts_are_refused(corpus_dir, tmp_path):
 def test_a_mismatched_pair_is_refused(corpus_dir, tmp_path):
     # Rebuild bb's projection from a different source, leaving its structures
     # artifact describing molecules the projection does not hold: the pair must not
-    # open, or ids would join to the wrong chemistry.
+    # open, or IDs would join to the wrong chemistry.
     changed = tmp_path / "ord_dataset-bb.parquet"
     parquet.save_dataset(
         dataset_pb2.Dataset(
@@ -293,8 +293,8 @@ def _copy_corpus(corpus_dir, tmp_path) -> pathlib.Path:
 
 
 def test_offsets_place_each_dataset_in_its_own_slice(corpus):
-    # Toluene is the product of every reaction and lives in BOTH datasets, at local id
-    # 2 in aa and 1 in bb. Reaching all three reactions therefore requires each id to
+    # Toluene is the product of every reaction and lives in BOTH datasets, at local ID
+    # 2 in aa and 1 in bb. Reaching all three reactions therefore requires each ID to
     # be offset by its own file's base: swapping the two offsets, or shifting both,
     # produces a different answer.
     matched = corpus.search(

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -257,8 +257,8 @@ def test_an_unparseable_structure_holds_its_slot(corpus_dir, tmp_path):
         resolver={}.__getitem__,
     ) as value:
         assert len(value._library()) == value._total
-        # Benzene sits after the hole inside aa, ethanol after it over in bb. Both
-        # still name their own reactions, which holds only while the slot is held.
+        # Benzene sits after the hole in aa, ethanol after it in bb. Both still name
+        # their own reactions, which holds only while the empty slot is there.
         assert _search(
             value,
             _exists({"op": "substructure", "path": "smiles", "smarts": "c1ccccc1"}),
@@ -681,9 +681,9 @@ def test_concurrent_searches_return_their_own_answers(corpus_dir):
     # them lie, so the exceptions are collected too -- a thread that dies takes its
     # traceback to threading.excepthook, where an assertion on results alone sees
     # nothing wrong.
-    # The similarity thread earns its place: that path runs its screen and then the
-    # compiled query as two statements on one cursor, so it is where reuse within a
-    # single search would show up.
+    # The similarity thread covers the one path that runs two statements on a single
+    # cursor -- its screen, then the compiled query -- so reuse within one search shows
+    # up here and nowhere else.
     expected = {
         "hydroxyl": ["ord-bb01"],
         "pyridine": ["ord-aa01", "ord-aa02"],

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -20,6 +20,8 @@ from collections.abc import Iterator
 
 import pyarrow.parquet as pq
 import pytest
+from rdkit import Chem
+from rdkit.Chem import rdSubstructLibrary
 
 from ord_schema import parquet, projection, structures
 from ord_schema.agent import execute, query
@@ -210,25 +212,29 @@ def test_an_aggregate_with_a_structure_predicate(corpus):
     assert table.column("n").to_pylist() == [2]
 
 
-def test_verification_prunes_screen_false_positives(corpus, monkeypatch):
-    # Force the screen to pass everything: verification alone must still produce the
-    # right answer, which is what makes the screen safe to loosen and never to skip.
-    matched_rows = corpus._connection.execute(
-        "SELECT count(*) FROM corpus_structures"
-    ).fetchone()[0]
-    assert matched_rows > 0
-    original = execute._pattern_blob
-
-    def _passes_everything(molecule):
-        blob, _ = original(molecule)
-        return b"\x00" * len(blob), 0
-
-    monkeypatch.setattr(execute, "_pattern_blob", _passes_everything)
-    matched = _search(
-        corpus,
-        _exists({"op": "substructure", "path": "smiles", "smarts": "[OX2H]"}),
+def test_the_screen_only_accelerates_the_answer(corpus):
+    # The fingerprint screen is an accelerator, never part of the answer: a library
+    # built with no screen at all has to match exactly the same structures. That is
+    # the property which makes the screen safe to loosen and never safe to trust.
+    screened = corpus._library()
+    unscreened = rdSubstructLibrary.SubstructLibrary(
+        rdSubstructLibrary.CachedMolHolder()
     )
-    assert matched == {"ord-bb01"}
+    for index in range(len(screened)):
+        unscreened.AddMol(screened.GetMol(index))
+    for smarts in ("[OX2H]", "c1ccncc1", "c1ccccc1"):
+        pattern = Chem.MolFromSmarts(smarts)
+        with_screen = set(screened.GetMatches(pattern, maxResults=len(screened)))
+        without_screen = set(unscreened.GetMatches(pattern, maxResults=len(unscreened)))
+        assert with_screen == without_screen, smarts
+
+
+def test_an_unparseable_structure_holds_its_slot(corpus):
+    # A structure that did not parse still occupies its id, or every id after it would
+    # shift and the bitmap would name different molecules. It matches nothing.
+    library = corpus._library()
+    assert len(library) == corpus._total
+    assert not library.GetMatches(Chem.MolFromSmarts("[#0]"), maxResults=len(library))
 
 
 def test_unpaired_artifacts_are_refused(corpus_dir, tmp_path):
@@ -466,12 +472,13 @@ def test_forall_and_not_compose_with_a_structure_predicate(corpus):
     assert negated == {"ord-aa01", "ord-bb01"}
 
 
-def test_verification_runs_in_worker_processes(corpus_dir):
-    # Blobs and ids have to survive pickling to the workers and back.
+def test_matching_runs_across_threads(corpus_dir):
+    # RDKit matches across its own threads with the GIL released; the answer must not
+    # depend on how many it uses.
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
-        n_jobs=2,
+        threads=2,
         resolver={}.__getitem__,
     ) as value:
         matched = value.search(
@@ -515,3 +522,15 @@ def test_a_generous_timeout_returns_the_answer(corpus):
         timeout_seconds=60,
     )
     assert matched.column("reaction_id").to_pylist() == ["ord-bb01"]
+
+
+def test_the_artifact_fingerprint_is_the_one_the_library_screens_with():
+    # The library is fed the pattern_fp the artifact already stores rather than
+    # recomputing it. That is only sound while RDKit's own PatternHolder fingerprint
+    # is the same function -- if it ever diverges, the screen would start rejecting
+    # true matches, so the equality is pinned here rather than assumed.
+    molecule = Chem.MolFromSmiles("Cc1ccncc1O")
+    holder = rdSubstructLibrary.PatternHolder(structures.PATTERN_FP_SIZE)
+    holder.AddMol(molecule)
+    stored = Chem.PatternFingerprint(molecule, fpSize=structures.PATTERN_FP_SIZE)
+    assert list(holder.GetFingerprint(0).GetOnBits()) == list(stored.GetOnBits())

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -627,6 +627,52 @@ def test_a_timeout_interrupts_a_query_that_outlasts_it():
         connection.close()
 
 
+def test_an_interrupt_reaches_only_the_cursor_it_was_called_on():
+    # Timeouts are per search because interrupt() is per cursor. That is DuckDB's
+    # behavior rather than this module's, and the whole timeout design rests on it: were
+    # an interrupt ever to reach the connection's other cursors, one search timing out
+    # would abort every search in flight and report each as having timed out. Pinned
+    # here so the change is caught on a version bump instead of in production.
+    connection = duckdb.connect()
+    try:
+        victim, other = connection.cursor(), connection.cursor()
+        slow = "SELECT count(*) FROM range(30000000000)"
+        # The query has to be long enough that an interrupt lands mid-flight, or the
+        # assertions below would hold for a query that simply finished first.
+        timer = threading.Timer(0.2, victim.interrupt)
+        timer.start()
+        try:
+            with pytest.raises(duckdb.InterruptException):
+                victim.execute(slow).fetchall()
+        finally:
+            timer.cancel()
+        # Same query, same duration, interrupted through a sibling cursor instead.
+        outcome: list[str] = []
+
+        def run():
+            try:
+                other.execute(slow).fetchall()
+                outcome.append("completed")
+            except duckdb.InterruptException:
+                outcome.append("interrupted")
+
+        thread = threading.Thread(target=run)
+        thread.start()
+        time.sleep(0.2)  # Well inside the query, as the self-interrupt above showed.
+        victim.interrupt()
+        connection.interrupt()
+        time.sleep(0.3)  # Longer than the self-interrupt took to land.
+        # Neither reached it: the query is still running. Asserting that it is alive is
+        # the whole test, since interrupting it below would end it either way.
+        still_running = thread.is_alive()
+        other.interrupt()  # Ends the query, so the test does not run for minutes.
+        thread.join(timeout=_WAIT)
+    finally:
+        connection.close()
+    assert still_running, "a sibling cursor or the connection interrupted the query"
+    assert outcome == ["interrupted"]  # Its own cursor did stop it.
+
+
 def test_a_timeout_does_not_disturb_a_concurrent_search(corpus_dir):
     # A search arming a timer must interrupt only itself. Interrupting anything wider
     # would abort whatever else is in flight and report it, wrongly, as a timeout.

--- a/ord_schema/agent/query.py
+++ b/ord_schema/agent/query.py
@@ -47,12 +47,12 @@ through :mod:`ord_schema.resolvers` before binding.
 Structure predicates -- ``substructure`` and ``similarity`` -- compile to a bitmap test
 rather than to chemistry. The chemistry runs *outside* the query, against the
 :mod:`ord_schema.structures` artifact (:mod:`ord_schema.agent.execute` is the driver),
-and the match set re-enters as a bitmap parameter indexed by the corpus-wide id --
+and the match set re-enters as a bitmap parameter indexed by the corpus-wide ID --
 the projection's ``structure_id`` plus its file's offset: DuckDB permits no subquery
 inside a lambda expression, so the element a quantifier binds cannot semi-join a match
 table, but it can test one integer against a bitmap. The compiled SQL therefore
 references ``structure_offset``, a column only the executor's relation carries -- a raw
-projection cannot answer a structure query, which is the point: the ids are
+projection cannot answer a structure query, which is the point: the IDs are
 dataset-local and only the executor knows the offsets that make them one corpus-wide
 space.
 """
@@ -73,7 +73,7 @@ from ord_schema import projection
 # nameable and a join has nothing to join to.
 TABLE = "reactions"
 
-# The per-row column mapping a dataset-local structure_id into the corpus-wide id
+# The per-row column mapping a dataset-local structure_id into the corpus-wide ID
 # space a bitmap parameter is indexed by. Supplied by the executor's relation and
 # absent from the projection schema resolve() defaults to, so a model-supplied path
 # does not reach it.
@@ -146,7 +146,7 @@ class Compiled:
 
     ``compounds`` are names whose resolved SMILES the caller binds. ``structures`` are
     predicates the caller evaluates against the structures artifact, each bound as a
-    bitmap over corpus-wide structure ids; a query carrying any also references the
+    bitmap over corpus-wide structure IDs; a query carrying any also references the
     ``STRUCTURE_OFFSET`` column, so it runs only against the executor's relation.
     """
 
@@ -553,7 +553,7 @@ def _structure(
     schema: Any,
     structures: list[StructureParameter],
 ) -> str:
-    """Compiles a structure predicate to a bitmap test on the element's structure id.
+    """Compiles a structure predicate to a bitmap test on the element's structure ID.
 
     The chemistry happens in the executor; what compiles here is only the re-entry of
     its match set. The null guard keeps a compound with no recorded structure from
@@ -578,7 +578,7 @@ def _structure(
     except QueryError as error:
         raise QueryError(
             f"{node.path}: {node.op} needs a compound smiles, and this smiles has no "
-            f"structure id beside it ({error})"
+            f"structure ID beside it ({error})"
         ) from error
     parameter = _structure_parameter(node, structures)
     return (

--- a/ord_schema/agent/query_test.py
+++ b/ord_schema/agent/query_test.py
@@ -618,9 +618,9 @@ def test_a_substructure_on_a_non_smiles_column_is_refused():
 
 
 def test_a_substructure_on_the_reaction_smiles_is_refused():
-    # The reaction-level smiles is a reaction, not a molecule; it has no structure id
+    # The reaction-level smiles is a reaction, not a molecule; it has no structure ID
     # and reaction substructure search is a different operation.
-    with pytest.raises(query.QueryError, match="no structure id"):
+    with pytest.raises(query.QueryError, match="no structure ID"):
         query.compile_query(
             query.Query.model_validate({"where": _substructure(path="smiles")})
         )

--- a/ord_schema/projection.py
+++ b/ord_schema/projection.py
@@ -64,7 +64,7 @@ fingerprints live. It exists because a structure predicate is evaluated *outside
 query -- screened and verified against the structures artifact -- and its match set has
 to re-enter the query at element granularity: DuckDB does not allow a subquery inside a
 lambda expression, so the components a quantifier binds cannot semi-join against a match
-table, but they can test one integer against a bitmap parameter. The ids are meaningful
+table, but they can test one integer against a bitmap parameter. The IDs are meaningful
 only alongside the projection that assigned them, so the column is marked internal and
 stays out of what a model is told it may query.
 
@@ -151,10 +151,10 @@ _STRUCTURAL_TYPES: dict[str, frozenset[int]] = {
 
 # Messages whose collapsed ``smiles`` is a molecule, and that therefore carry a
 # ``structure_id``. Reaction is structural but its smiles is a reaction;
-# reaction-level structure search is a different operation and no id is assigned there.
+# reaction-level structure search is a different operation and no ID is assigned there.
 _STRUCTURE_ID_TYPES = frozenset({"Compound", "ProductCompound"})
 
-# An id rides beside the collapsed smiles and cannot exist without it: the schema
+# An ID rides beside the collapsed smiles and cannot exist without it: the schema
 # would gain a structure_id with no sibling smiles, and message_row would KeyError.
 if not set(_STRUCTURAL_TYPES) >= _STRUCTURE_ID_TYPES:
     raise ValueError(
@@ -457,7 +457,7 @@ def message_row(
         structure_ids: Mapping from SMILES to ``structure_id``, extended in first-seen
             order as compounds are projected. None -- the default, for a message
             projected outside a dataset -- leaves every ``structure_id`` null, since an
-            id is meaningful only against the artifact that shares the mapping.
+            ID is meaningful only against the artifact that shares the mapping.
 
     Returns:
         A dict keyed by projected column name.
@@ -627,9 +627,9 @@ def write_projection(
     schema = SCHEMA.with_metadata(artifacts.to_metadata(stamps))
     rows = 0
     unreadable = 0
-    # One id space per dataset, in first-seen order, shared with the structures
+    # One ID space per dataset, in first-seen order, shared with the structures
     # artifact derived from this file. The order follows protobuf map iteration, which
-    # is unspecified, so ids are a fact about this file rather than about the dataset.
+    # is unspecified, so IDs are a fact about this file rather than about the dataset.
     structure_ids: dict[str, int] = {}
     with (
         atomic_io.atomic_path(output) as temp_path,

--- a/ord_schema/projection_test.py
+++ b/ord_schema/projection_test.py
@@ -522,7 +522,7 @@ def test_schema_adds_a_structure_id_beside_the_compound_smiles():
     field = components.value_type.field("structure_id")
     assert field.type == pa.uint32()
     assert projection.is_internal(field)
-    # The reaction-level smiles is a reaction, not a molecule; no id is assigned there.
+    # The reaction-level smiles is a reaction, not a molecule; no ID is assigned there.
     assert "structure_id" not in projection.SCHEMA.names
     assert not projection.is_internal(projection.SCHEMA.field("smiles"))
 
@@ -568,7 +568,7 @@ def test_a_compound_without_a_smiles_gets_no_structure_id():
 
 def test_structure_ids_reach_compounds_beyond_inputs_and_products():
     # message_row assigns by descriptor name, so a compound in a workup input or an
-    # authentic standard shares the id space; the structures artifact reads them all.
+    # authentic standard shares the ID space; the structures artifact reads them all.
     reaction = _reaction()
     workup = reaction.workups.add()
     workup.input.components.add().identifiers.add(type="SMILES", value="Cc1ccccc1")
@@ -601,8 +601,8 @@ def test_write_projection_stamps_one_id_space_per_dataset(tmp_path):
 
 
 def test_structure_ids_span_source_row_groups(tmp_path):
-    # The id mapping is created once per dataset, not once per row group: rebuilding
-    # it inside the loop would restart the ids and corrupt every join in a dataset
+    # The ID mapping is created once per dataset, not once per row group: rebuilding
+    # it inside the loop would restart the IDs and corrupt every join in a dataset
     # bigger than one group, while every small test still passed.
     source = _source(
         tmp_path, [_reaction(f"ord-{i:04d}") for i in range(3)], row_group_size=1

--- a/ord_schema/structures.py
+++ b/ord_schema/structures.py
@@ -29,9 +29,9 @@ holds roughly fifteen component occurrences per distinct structure, so screening
 verification run against the distinct set and their results fan back out through the
 projection. The join is ``structure_id`` -- assigned by ``write_projection`` in
 first-seen order, carried on every compound there that records a structure and numbered
-``0..n-1`` here, so a match set travels back into a query as a bitmap indexed by id.
+``0..n-1`` here, so a match set travels back into a query as a bitmap indexed by ID.
 The two files are two statements of one derivation and are meaningful only together:
-ids are not stable across builds, nothing outside the artifacts should record them, and
+IDs are not stable across builds, nothing outside the artifacts should record them, and
 a projection rewritten in place needs its structures artifact rederived with it -- the
 currency stamps name the source dataset rather than the projection file, so the skip
 check cannot see that the pairing changed.
@@ -48,7 +48,7 @@ is defined on the Morgan fingerprint, so the screen *is* the answer, and
 ``morgan_popcount`` bounds it (``popcount(B)`` must lie within ``[t * popcount(A),
 popcount(A) / t]`` for Tanimoto ``>= t``).
 
-A structure whose SMILES RDKit cannot parse keeps its row -- the id space must stay
+A structure whose SMILES RDKit cannot parse keeps its row -- the ID space must stay
 dense -- with every derived column null. It can never match a structure query, and the
 count of such rows is logged per dataset.
 """
@@ -187,8 +187,8 @@ def _collect(source: str | os.PathLike[str]) -> list[str]:
     Raises:
         ValueError: If ``source``'s schema does not hold the structure columns this
             library's projection defines, or if the pairs do not state a single dense
-            one-to-one mapping -- an id bound to two SMILES, one SMILES under two ids,
-            a compound with one half of the pair, or a gap in the id space. Each means
+            one-to-one mapping -- an ID bound to two SMILES, one SMILES under two IDs,
+            a compound with one half of the pair, or a gap in the ID space. Each means
             ``source`` was not written by this library's ``write_projection``, and an
             artifact derived from it would join wrongly rather than fail.
     """
@@ -236,7 +236,7 @@ def _collect(source: str | os.PathLike[str]) -> list[str]:
     if set(smiles_by_id) != set(range(len(smiles_by_id))):
         missing = sorted(set(range(len(smiles_by_id))) - set(smiles_by_id))[:5]
         raise ValueError(
-            f"{source}: structure ids are not dense; first missing {missing}"
+            f"{source}: structure IDs are not dense; first missing {missing}"
         )
     return [smiles_by_id[structure_id] for structure_id in range(len(smiles_by_id))]
 
@@ -245,7 +245,7 @@ def _row(structure_id: int, smiles: str) -> dict[str, Any]:
     """Featurizes one structure into a row matching ``SCHEMA``.
 
     Args:
-        structure_id: The row's id, equal to its position in the artifact.
+        structure_id: The row's ID, equal to its position in the artifact.
         smiles: The structure, as the projection derived it.
 
     Returns:

--- a/ord_schema/structures_test.py
+++ b/ord_schema/structures_test.py
@@ -76,7 +76,7 @@ def test_write_structures_round_trips(tmp_path):
 
 
 def test_shared_structures_are_deduplicated(tmp_path):
-    # Benzene appears in every reaction; the artifact holds it once, under the id the
+    # Benzene appears in every reaction; the artifact holds it once, under the ID the
     # projection stamped everywhere it occurs.
     reactions = [_reaction(f"ord-{i:04d}") for i in range(5)]
     source = _project(tmp_path, reactions)
@@ -88,7 +88,7 @@ def test_shared_structures_are_deduplicated(tmp_path):
 
 
 def test_row_groups_keep_ids_aligned(tmp_path):
-    # Position in the file is the id, so each output row group must continue the
+    # Position in the file is the ID, so each output row group must continue the
     # sequence and each row's derived columns must be its own molecule's --
     # misalignment here is silent join corruption, not an error.
     reaction = _reaction()
@@ -233,7 +233,7 @@ def _corrupt_projection(tmp_path, rows) -> pathlib.Path:
 
 
 def test_a_smiles_without_an_id_is_refused(tmp_path):
-    # message_row without a mapping leaves ids null; deriving from such a file would
+    # message_row without a mapping leaves IDs null; deriving from such a file would
     # join wrongly rather than fail, so the mismatch is an error here.
     row = projection.message_row(_reaction())
     row["reaction_id"] = "ord-0001"
@@ -254,7 +254,7 @@ def test_conflicting_ids_are_refused(tmp_path):
 
 
 def test_one_smiles_under_two_ids_is_refused(tmp_path):
-    # The reverse defect of conflicting ids: the mapping must be one-to-one in both
+    # The reverse defect of conflicting IDs: the mapping must be one-to-one in both
     # directions, or the artifact holds duplicate rows and an inflated distinct count.
     ids_a = {"c1ccccc1": 0, "Cc1ccccc1": 1}
     ids_b = {"c1ccccc1": 2, "Cc1ccccc1": 1}
@@ -277,11 +277,11 @@ def test_a_gap_in_the_id_space_is_refused(tmp_path):
 def test_an_unparseable_structure_survives_the_write_path(tmp_path):
     # Cannot arise from a same-version projection -- its SMILES are RDKit-canonical --
     # so it is staged through _corrupt_projection: the row must keep its position (the
-    # id space stays dense) rather than being cleaned out of the batch.
+    # ID space stays dense) rather than being cleaned out of the batch.
     ids: dict[str, int] = {}
     row = projection.message_row(_reaction(), ids)
     (component,) = dict(row["inputs"])["a"]["components"]
-    component["smiles"] = "not-a-smiles"  # Keeps the id benzene was assigned.
+    component["smiles"] = "not-a-smiles"  # Keeps the ID benzene was assigned.
     row["reaction_id"] = "ord-0001"
     path = _corrupt_projection(tmp_path, [row])
     output = tmp_path / "structures.parquet"


### PR DESCRIPTION
## Summary

The executor forked a joblib pool per search — the wrong shape behind a web server: ten processes per request, pool spin-up each time, contention between concurrent requests. RDKit's `SubstructLibrary` does the same work on its own threads with the GIL released, so one `Corpus` now serves concurrent requests without forking.

It replaces both stages at once: `PatternHolder` screens on the pattern fingerprints the structures artifact already stores, and the library matches the survivors exactly.

## Measurements

Full corpus, 2,016,224 structures / 2,428,291 reactions.

| | before (10 processes) | after (threads) |
| --- | --- | --- |
| pyridine match | 2.57s warm + ~1s pool spawn | **1.35s** |
| pyridine, one thread | — | 18.54s |
| bound pyridine + role, steady state | 4.9s | **3.6s** |
| aggregate over pyridine | 5.3s | **3.8s** |
| unbound intersection | 5.9s | **4.5s** |
| concurrency | 10 forks per request | shared, C++ threads |

**GIL is released**: two concurrent searches in Python threads take 20.16s, not the 37.60s they would if serialized.

Match sets are unchanged — 431,627 structures for pyridine, identical to what the process pool returned.

Cost: the library is built on the first substructure query, about 8s and 2 GB for the whole corpus, which a server pays at startup rather than per request. Streaming the build in batches keeps peak RSS at 2.05 GB rather than the 3.24 GB a materialized fetch needed.

## Correctness

- **The stored fingerprint is the one the library wants.** `PatternHolder`'s own fingerprint is bit-for-bit identical to `Chem.PatternFingerprint(fpSize=2048)`, so reusing the artifact column is exact rather than approximate. That equality is now pinned by a test, since the soundness of reusing the column rests entirely on it and it would otherwise break silently under an RDKit change. (The RDKit version is stamped in the artifact, so such a change also marks artifacts stale — defense in depth.)
- **A library index is a corpus-wide structure id by construction.** A structure that did not parse still holds its slot with an empty molecule, which fingerprints to no bits and matches nothing; the library length is checked against the corpus total.
- **`maxResults` is passed explicitly** — it defaults to 1000, which would have truncated silently at ORD scale.
- The sabotaged-screen test is replaced by a stronger one: a library built with **no screen at all** must match exactly the same structures, which is the property that makes the screen safe to loosen and never safe to trust.

## Concurrency

Sharing one `Corpus` behind a web server is the point of this change, so the shared state got a second look. Two bugs, both silent, both only reachable under concurrency:

**Searches read each other's results.** A `DuckDBPyConnection` carries the pending result of its last `execute`, and `search` ran `execute(...)` then `.to_arrow_table()` as two steps. Two threads stepping on one connection interleave into that window. Measured on a 7-thread loop against a shared connection: **303 wrong answers out of 350**, each thread receiving another thread's result set, plus 6 `No open result set` exceptions. Every search now takes its own cursor. `register`ed objects belong to the connection that registered them and are invisible to a cursor, so the offsets relation moved into the catalog.

**Concurrent first searches each built a library.** The lazy build was an unsynchronized check followed by an 8s, 2 GB construction (this was Greptile's finding). It now builds under a lock; whoever waits takes the finished library.

Every guard was checked by reverting the code it covers and confirming the test fails:

| reverted | caught |
| --- | --- |
| per-search cursor | 20/20 concurrent answers, 5/5 cursor isolation |
| offsets left as a registration | 5/5 |
| library build lock | 10/10 |
| unparseable slot held | PairingError |

## Test corrections

`test_an_unparseable_structure_holds_its_slot` asserted nothing. The fixture contained no unparseable structure, so `len(library) == total` and "`[#0]` matches nothing" both held for *any* corpus — deleting the branch it was named for left it green. It now nulls a real row and checks that the structures after the hole still name their own reactions, which is the property that actually fails when a slot is dropped.

The timeout tests were re-aimed. Per-cursor interrupts make the old "outlives its own search" failure unreachable, and nothing asserted a timeout ever *fires* — a dead interrupt would have turned every timeout into no timeout at all, silently. Both are covered now, along with a timing-out search not disturbing a concurrent one.

Also closed from review: concurrent similarity is now exercised (it is the only path running two statements on one cursor), the `maxResults` truncation hazard is pinned against a library large enough to cross 1000, and every barrier and join carries a timeout so a regression fails instead of parking the suite.

A third pass (silent-failure hunt) found two more, both in the newly added build:

**A library index is a structure ID only while the IDs are one unbroken run.** The build streams `ORDER BY global_id` and appends positionally, guarded by a row count — which a duplicate or a gap leaves untouched while sliding every later structure onto a neighbor's index. It now reads `global_id` and checks it against the running position.

**The two derived columns disagreed about "unsearchable".** The build branched on `mol_binary`; `_searchable` counted `pattern_fp`. Verified both directions on a real corpus: a NULL molecule with a live fingerprint returns **empty silently** while the log reads `matched 0 of 5 structures (0 unsearchable)` — the denominator asserting it was searched — and the reverse raises a bare Boost `ArgumentError` naming no row, file, or ID. Both refused now.

**Stated plainly, because it is not fixed:** a structures artifact whose IDs are a *permutation* of the projection's is still dense, still the right length, and still passes every check here. I reproduced it — a pyridine query returns one reaction instead of two, and a benzene query returns the other's — and it is silent. The stamps cannot see it either, since both files restate the same source dataset. Worth knowing before anyone runs with `require_current=False` or a foreign artifact.

## Notes

- `n_jobs` becomes `threads` (default -1). Nothing consumes the old parameter yet — it shipped in #957 an hour ago. Note that `threads` is per search, not per corpus: a server expecting several concurrent requests should set it to core count divided by that concurrency rather than leaving it at -1.
- The remaining dominant cost is the final DuckDB pass over the projection (~3s of a 3.6s query). DuckDB is internally threaded and GIL-free, so it is web-server-safe, but it is the next target; an inverted index (structure id to reaction ids) would remove it for structure-only queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces process-based substructure verification with a lazily initialized, fingerprint-screened RDKit `SubstructLibrary` and makes shared `Corpus` searches concurrency-safe.
- Runs substructure matching on configurable RDKit threads and preserves corpus-wide structure-ID alignment.
- Gives each search its own DuckDB cursor and scopes timeout interrupts to that cursor.
- Adds artifact consistency checks and extensive matching, timeout, cursor-isolation, and concurrency coverage.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the previously reported concurrent initialization and timeout-isolation failures no longer remain.

Current code serializes lazy library construction under one lock, executes each search on a dedicated cursor, and synchronizes timer teardown so an interrupt cannot escape its owning search; targeted concurrent tests cover both previously reported failures.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/agent/execute.py | Replaces joblib verification with a locked RDKit library, validates positional structure invariants, and isolates each search and timeout on its own DuckDB cursor. |
| ord_schema/agent/execute_test.py | Adds focused coverage for concurrent initialization, cursor result isolation, interrupt isolation, timeout behavior, artifact corruption, and structure-ID alignment. |
| ord_schema/structures.py | Updates structure artifact behavior needed to supply the stored fingerprints and molecule data consumed by the new library. |
| ord_schema/projection.py | Maintains projection metadata and structure-ID behavior used when pairing projection and structure artifacts. |
| ord_schema/agent/query.py | Updates query-facing structure-search configuration and contracts to align with threaded execution. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Corpus
    participant Lock as Library Lock
    participant RDKit as SubstructLibrary
    participant Cursor as DuckDB Cursor
    Client->>Corpus: search(request)
    Corpus->>Cursor: create per-search cursor
    alt first substructure search
        Corpus->>Lock: acquire
        Corpus->>RDKit: build corpus-wide library
        Corpus->>Lock: release
    end
    Corpus->>RDKit: GetMatches(query, threads)
    RDKit-->>Corpus: structure IDs
    Corpus->>Cursor: execute compiled query with bitmap
    Cursor-->>Client: Arrow table
    Corpus->>Cursor: close
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Pin interrupt scoping, which the timeout..."](https://github.com/open-reaction-database/ord-schema/commit/43200bfc4e4f71f48eaeabf6c74faf834f04fdd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51678813)</sub>

<!-- /greptile_comment -->