### PR TITLE
Answer structure queries from an occurrence index

### DIFF
--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -109,18 +109,21 @@ larger one. An **occurrence index** — one row per structure occurrence, carryi
 corpus-wide ID, the path, and the element's own `reaction_role` — makes that a filter
 over a narrow table rather than a scan of every reaction. Keeping the role beside the
 structure is what keeps a bound query a condition on one row. At corpus scale the index
-is 14.1M rows and about 130 MB, held in memory for the life of the `Corpus`, and answers
-pyridine among the inputs in 1.46s, pyridine as the solvent in 1.74s, and a boronic acid
-in 0.15s. What remains for common patterns is the RDKit screen and verify, which the
-index does not touch.
+is 14.1M rows and about 130 MB, resident for the life of the `Corpus`. A search for
+pyridine among the inputs returns in 1.46s **end to end**, pyridine as the solvent in
+1.74s, and a boronic acid in 0.15s — and for a common pattern nearly all of that is the
+RDKit screen and verify, which the index does not touch: pyridine's match alone is about
+1.4s of its 1.46s. What the index cut is the reaction lookup, from roughly 3.5s to 0.2s.
 
 The index answers only the shape it holds: a bare `exists` at an indexed path whose body
 asks for one structure and at most one role. A query reaching another element field, or
 needing a projection column to group or sort by — and every `forall`, negation, and
-disjunction — runs against the projection. Both paths screen and verify through the same
-compiler, and the log line says which one answered. The index is built on the first query
-that routes to it, four passes over the projections, so a server wanting the first real
-query to be fast should warm it rather than budget for it at open.
+disjunction — runs against the projection, so "reactions with yield > 50% where pyridine
+is the solvent" is answered there rather than here. Both paths screen and verify through
+the same compiler, and the log line says which one answered. The index is built on the
+first query that routes to it, one pass over the projections per indexed path, so a
+server that wants its first real query to be fast should issue a throwaway structure
+query at startup.
 
 A `limit` with no `order_by` is the one place the two paths visibly differ: neither
 relation orders what it was not asked to order, so each returns some rows of the same
@@ -128,12 +131,13 @@ match set and they do not agree on which.
 
 Similarity needs no verification — Tanimoto is defined on the Morgan fingerprint, so
 the screen is the answer — and stays in SQL. The verified match set re-enters the query
-as a `BITSTRING` parameter indexed by the corpus-wide ID (`structure_id` plus the
-file's offset), which is what preserves element binding: `exists(components,
+as a `BITSTRING` parameter indexed by the corpus-wide ID (`structure_id` plus the file's
+offset), which is how the projection path tests a single element: `exists(components,
 substructure(pyridine) and role = SOLVENT)` means one component that is both. The
 alternative — intersecting reaction-ID sets — over-returns by 94% on exactly that
 query; see [ord-logbook#28](https://github.com/open-reaction-database/ord-logbook/pull/28),
-finding 4.
+finding 4. Every corpus-scale figure on this page was measured against that logbook
+entry's snapshot of ORD.
 
 ```python
 from ord_schema.agent import execute, query

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -106,18 +106,26 @@ should set it to the core count divided by that concurrency instead of leaving i
 
 Finding which reactions hold a match is a separate cost from the chemistry, and the
 larger one. An **occurrence index** — one row per structure occurrence, carrying the
-corpus-wide ID, the path, and the element's own `reaction_role` — replaces that scan
-with a filter over a narrow table (14.1M rows, 130 MB against the projections' 1.65 GB).
-Keeping the role beside the structure is what preserves element binding. End to end at
-corpus scale: pyridine among the inputs 7.56s → 1.46s, pyridine as the solvent
-5.00s → 1.74s, a boronic acid 2.93s → 0.15s, with identical match sets. The remainder
-for common patterns is the RDKit screen and verify, which the index does not touch.
+corpus-wide ID, the path, and the element's own `reaction_role` — makes that a filter
+over a narrow table rather than a scan of every reaction. Keeping the role beside the
+structure is what keeps a bound query a condition on one row. At corpus scale the index
+is 14.1M rows and about 130 MB, held in memory for the life of the `Corpus`, and answers
+pyridine among the inputs in 1.46s, pyridine as the solvent in 1.74s, and a boronic acid
+in 0.15s. What remains for common patterns is the RDKit screen and verify, which the
+index does not touch.
 
-The index answers only the shape it holds: some element at an indexed path contains a
-structure, optionally with a given role. A query reaching another element field, or
-needing a projection column to group or sort by, runs against the projection unchanged.
-It is built on the first query that can use it — four passes over the projections, so
-budget for it alongside the library at startup.
+The index answers only the shape it holds: a bare `exists` at an indexed path whose body
+asks for one structure and at most one role. A query reaching another element field, or
+needing a projection column to group or sort by — and every `forall`, negation, and
+disjunction — runs against the projection. Both paths screen and verify through the same
+compiler, and the log line says which one answered. The index is built on the first query
+that routes to it, four passes over the projections, so a server wanting the first real
+query to be fast should warm it rather than budget for it at open.
+
+A `limit` with no `order_by` is the one place the two paths visibly differ: neither
+relation orders what it was not asked to order, so each returns some rows of the same
+match set and they do not agree on which.
+
 Similarity needs no verification — Tanimoto is defined on the Morgan fingerprint, so
 the screen is the answer — and stays in SQL. The verified match set re-enters the query
 as a `BITSTRING` parameter indexed by the corpus-wide ID (`structure_id` plus the

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -103,6 +103,21 @@ its last `execute` and concurrent searches sharing one would read each other's r
 `threads` is per search rather than per corpus, so a server expecting several at once
 should set it to the core count divided by that concurrency instead of leaving it at
 `-1`.
+
+Finding which reactions hold a match is a separate cost from the chemistry, and the
+larger one. An **occurrence index** — one row per structure occurrence, carrying the
+corpus-wide ID, the path, and the element's own `reaction_role` — replaces that scan
+with a filter over a narrow table (14.1M rows, 130 MB against the projections' 1.65 GB).
+Keeping the role beside the structure is what preserves element binding. End to end at
+corpus scale: pyridine among the inputs 7.56s → 1.46s, pyridine as the solvent
+5.00s → 1.74s, a boronic acid 2.93s → 0.15s, with identical match sets. The remainder
+for common patterns is the RDKit screen and verify, which the index does not touch.
+
+The index answers only the shape it holds: some element at an indexed path contains a
+structure, optionally with a given role. A query reaching another element field, or
+needing a projection column to group or sort by, runs against the projection unchanged.
+It is built on the first query that can use it — four passes over the projections, so
+budget for it alongside the library at startup.
 Similarity needs no verification — Tanimoto is defined on the Morgan fingerprint, so
 the screen is the answer — and stays in SQL. The verified match set re-enters the query
 as a `BITSTRING` parameter indexed by the corpus-wide ID (`structure_id` plus the

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -47,10 +47,13 @@ per structure occurrence, carrying the corpus-wide ID, the path it sat at, and t
 element's own ``reaction_role`` -- turns that scan into a filter over a narrow table.
 Keeping the role beside the structure is what preserves element binding: "pyridine as
 the solvent" stays a condition on a single row rather than an intersection of two
-reaction sets, which over-returns. A query the index cannot answer, because it reaches
-an element field the index does not carry or needs a projection column to group or sort
-by, runs against the projection; both paths screen and verify through the same compiler,
-so they differ only in how they reach the reactions.
+reaction sets, which over-returns. The index answers one query shape -- a bare
+``exists`` at an indexed path asking for one structure and at most one role -- and every
+other query runs against the projection: a second structure predicate, a scalar beside
+the quantifier, an aggregate, an ordering, a negation, a disjunction, a ``forall``. Both
+paths screen and verify through the same compiler, so they differ only in how they reach
+the reactions, and a ``limit`` with no ``order_by`` is the one place that shows: each
+path takes some rows of one match set, and they take different ones.
 
 The grammar bounds what a query can cost (one pass and a sort), and ``search``
 takes a wall-clock timeout that interrupts the final query. Name resolution, the
@@ -151,26 +154,47 @@ def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
     same elements the projection does by construction rather than by a list here
     agreeing with one there.
 
+    Every path the schema can carry a structure at has to come out covered, which is
+    what lets the build check what it indexed against what the corpus says it holds. A
+    path this walk dropped would make a whole corpus look like one that lost structures.
+
     Args:
         schema: The projection schema.
 
     Returns:
         Dotted query paths to the DuckDB expression yielding their elements, for every
-        repeated level whose elements carry both a structure and ``_INDEXED_FIELD``.
+        level whose elements carry a structure.
+
+    Raises:
+        ValueError: If a structure-bearing level carries no ``_INDEXED_FIELD`` or does
+            not resolve to a repeated expression, so the index cannot cover it; or if
+            the schema carries no structure at all. Raised at import, naming the path,
+            because the answer is to change this module rather than to retry.
     """
     paths: dict[str, str] = {}
 
     def walk(dtype: pa.DataType, prefix: str) -> None:
         if pa.types.is_struct(dtype):
             names = [field.name for field in dtype]
-            if "structure_id" in names and _INDEXED_FIELD in names:
+            if "structure_id" in names:
                 # The schema walk speaks Parquet; the grammar has no wrapper levels.
                 path = prefix.replace(".list.element", "").replace(
                     ".key_value.value", ""
                 )
-                resolved = query.resolve(path, allow_internal=True)
-                if resolved.repeated:
-                    paths[path] = resolved.expression
+                resolved = query.resolve(path, schema=schema, allow_internal=True)
+                if _INDEXED_FIELD not in names:
+                    raise ValueError(
+                        f"{path} carries a structure but no {_INDEXED_FIELD}, so the "
+                        "occurrence index cannot cover it and a structure sitting only "
+                        "there would look like one the index lost"
+                    )
+                if not resolved.repeated:
+                    raise ValueError(
+                        f"{path} carries a structure but resolves to one element "
+                        "rather than a repeated expression, which the build cannot "
+                        "unnest"
+                    )
+                paths[path] = resolved.expression
             for child in dtype:
                 walk(child.type, f"{prefix}.{child.name}")
         elif pa.types.is_list(dtype):
@@ -180,6 +204,11 @@ def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
 
     for field in schema:
         walk(field.type, field.name)
+    if not paths:
+        raise ValueError(
+            "the schema carries no structure at any path, so an occurrence index has "
+            "nothing to index and its build would assemble no SQL at all"
+        )
     return paths
 
 
@@ -191,9 +220,9 @@ class _IndexTerms:
     """What a predicate the occurrence index can answer asks of one row.
 
     Attributes:
-        role: The role the element must hold, or None if the query does not bind one.
-            Absence is not a wildcard the index applies -- it is a query that named no
-            role, so the condition is left off.
+        role: The role the element must hold, or None when the query leaves the role
+            unconstrained -- which is not the same as requiring no role, and compiles to
+            no condition rather than to one on NULL.
     """
 
     role: str | None
@@ -243,8 +272,11 @@ class Corpus:
         # Built on first substructure query; see _library.
         self._substructure_library: rdSubstructLibrary.SubstructLibrary | None = None
         self._library_lock = threading.Lock()
-        # Built on the first query that can use it; see _occurrences.
+        # Built on the first query that can use it; see _occurrences. A build that finds
+        # the corpus unindexable keeps its reason here, since the corpus cannot change
+        # while this object is open and rebuilding costs a pass per path to reach it.
         self._occurrences_built = False
+        self._refused: str | None = None
         self._occurrences_lock = threading.Lock()
         pairs = self._pair(projection_pattern, structures_pattern, require_current)
         self._connection = duckdb.connect()
@@ -543,9 +575,10 @@ class Corpus:
             where: The predicate inside a quantifier, relative to the element.
 
         Returns:
-            The terms, if every clause is a structure predicate on the element's own
-            structure or an equality on the indexed field, or None if any clause reaches
-            something the index does not carry.
+            The terms, if the predicate is exactly one structure predicate on the
+            element's own ``smiles`` and at most one equality on the indexed field, or
+            None if any clause reaches something an occurrence row does not carry, or if
+            the structure predicates number anything but one.
         """
         clauses = where.clauses if isinstance(where, query.And) else [where]
         structures_seen = 0
@@ -633,13 +666,10 @@ class Corpus:
             "SELECT DISTINCT reaction_id FROM occurrences "  # noqa: S608
             f"WHERE {' AND '.join(conditions)}{limit}"
         )
-        # Which relation answered is the one thing a result does not show, and the two
-        # are supposed to agree, so a disagreement is only ever debugged from here.
-        logger.info("the occurrence index answers %s", where.path)
         return dataclasses.replace(compiled, sql=sql)
 
     def _occurrences(self) -> None:
-        """Builds the occurrence index, once, if it is not already built.
+        """Builds the occurrence index, once.
 
         One row per structure occurrence, carrying the corpus-wide ID, the path it sat
         at, and the element's own ``reaction_role``. Keeping the role beside the
@@ -652,13 +682,16 @@ class Corpus:
         here and share the result.
 
         Raises:
-            PairingError: If a corpus holding structures indexes none of them. Every
-                path the projection can carry a structure at is indexed, so an empty
-                index means a traversal reached nothing -- and an empty index answers
-                every structure query with "no matches", which reads like an answer
-                rather than like a corpus that cannot be searched.
+            PairingError: If the index does not reach every structure the corpus holds.
+                An unreached structure is one whose reactions no routed query can find,
+                and the answer comes back empty rather than wrong -- which reads like an
+                answer rather than like a corpus that cannot be searched. The reason is
+                kept and re-raised, since a corpus does not change under an open
+                ``Corpus`` and rebuilding is several passes to reach the same refusal.
         """
         with self._occurrences_lock:
+            if self._refused is not None:
+                raise PairingError(self._refused)
             if self._occurrences_built:
                 return
             start = time.perf_counter()
@@ -684,26 +717,40 @@ class Corpus:
                 # forever. S608: the fragments are this module's own schema walk and
                 # the compiler's traversals, not anything a query supplies.
                 cursor.execute(f"CREATE OR REPLACE TABLE occurrences AS {selects}")
-                indexed = cursor.execute(
-                    "SELECT path, count(*) FROM occurrences GROUP BY path"
-                ).fetchall()
-                counts = dict(indexed)
-                total = sum(counts.values())
-                if self._total and not total:
-                    raise PairingError(
-                        f"the occurrence index came out empty over {self._total} "
-                        f"structures; none of {sorted(INDEXED_PATHS)} reached an "
-                        "element, so the projections are not the schema this walk was "
-                        "built from"
+                counts = dict(
+                    cursor.execute(
+                        "SELECT path, count(*) FROM occurrences GROUP BY path"
+                    ).fetchall()
+                )
+                reached = cursor.execute(
+                    "SELECT count(DISTINCT global_id) FROM occurrences"
+                ).fetchone()
+                assert reached is not None  # An aggregate returns one row.
+                # A structures artifact holds one row per distinct structure its
+                # projection uses, so every ID it states is one some element carries and
+                # the index has to find all of them. Counting them is what catches a
+                # single traversal reaching nothing, which a total over every path
+                # cannot: the other paths carry the total and the dead one answers its
+                # queries with silence.
+                if reached[0] != self._total:
+                    self._refused = (
+                        f"the occurrence index reached {reached[0]} of the corpus's "
+                        f"{self._total} structures over {sorted(INDEXED_PATHS)}; "
+                        "either the projections are not the schema this walk was built "
+                        "from, or their rows did not survive the filename join, so the "
+                        "reactions holding the rest cannot be found"
                     )
+                    raise PairingError(self._refused)
                 self._occurrences_built = True
             finally:
                 cursor.close()
-            # Per path, so one that reaches nothing is visible here rather than only in
-            # the answers it fails to contribute to.
+            # Per path, so how the occurrences are distributed is visible rather than
+            # only their total. A path holding none is normal -- most corpora have no
+            # authentic standards -- which is why the refusal above counts structures
+            # rather than paths.
             logger.info(
                 "indexed %d structure occurrences in %.1fs: %s",
-                total,
+                sum(counts.values()),
                 time.perf_counter() - start,
                 ", ".join(f"{path} {counts.get(path, 0)}" for path in INDEXED_PATHS),
             )
@@ -786,11 +833,13 @@ class Corpus:
         build, each of which the first search wanting it performs while the others wait.
 
         A query the occurrence index can answer runs against it instead of the
-        projection, which is the same answer reached without scanning every reaction.
-        The screening and verification are the compiler's either way, so the two paths
-        differ only in how they find the reactions holding a match. Which one answered
-        is logged, because it is the one thing about a search that the result does not
-        show.
+        projection, reaching the same reactions without scanning every one of them. The
+        screening and verification are the compiler's either way, so the two paths
+        differ only in how they find the reactions holding a match -- with one
+        exception: a ``limit`` with no ``order_by`` asks for some rows of the match set
+        rather than for particular ones, and the two take different rows of it. Which
+        relation answered is logged, because it is the one thing about a search that
+        the result does not show.
 
         Args:
             request: The query to run.
@@ -806,14 +855,20 @@ class Corpus:
         Raises:
             query.QueryError: If the query does not compile.
             ValueError: If a compound name cannot be resolved.
-            PairingError: If the corpus IDs do not come out one unbroken run, or a
-                corpus holding structures indexes none of them.
+            PairingError: If the corpus IDs do not come out one unbroken run, or the
+                occurrence index does not reach every structure the corpus holds.
             TimeoutError: If the query exceeds ``timeout_seconds``.
         """
         indexed = self._plan(request)
         compiled = indexed if indexed is not None else query.compile_query(request)
         if indexed is not None:
+            # Logged after the build, so a build that refuses the corpus does not leave
+            # a line claiming the index answered a query nothing ran.
             self._occurrences()
+            logger.info(
+                "the occurrence index answers this query at %s",
+                getattr(request.where, "path", None),
+            )
         else:
             logger.info("the projection answers this query")
         # Cached across the whole search: a compound named in both a value and a

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -41,14 +41,28 @@ each other's rows rather than raising; each search therefore takes its own curso
 cursor in turn sees only the catalog, not the objects ``register`` attaches to the
 connection that registered them, so every relation here is a catalog table or view.
 
+Finding the reactions that hold a match is a scan of every reaction, which costs more
+than the chemistry for all but the narrowest queries. An **occurrence index** -- one row
+per structure occurrence, carrying the corpus-wide ID, the path it sat at, and the
+element's own ``reaction_role`` -- turns that scan into a filter over a narrow table.
+Keeping the role beside the structure is what preserves element binding: "pyridine as
+the solvent" stays a condition on a single row rather than an intersection of two
+reaction sets, which over-returns. A query the index cannot answer, because it reaches
+an element field the index does not carry or needs a projection column to group or sort
+by, runs against the projection unchanged; both paths screen and verify through the same
+compiler, so they differ only in how they reach the reactions.
+
 The grammar bounds what a query can cost (one pass and a sort), and ``search``
 takes a wall-clock timeout that interrupts the final query. Name resolution, the
-one-time library build, screening, and verification all run before the timer starts:
-each is bounded by the corpus rather than by the query, so a slow one is slow for every
-caller and shows up in the logs rather than in a timeout. The first substructure search
-therefore takes the build's several seconds on top of whatever timeout it was given.
+one-time library and index builds, screening, and verification all run before the timer
+starts: each is bounded by the corpus rather than by the query, so a slow one is slow
+for every caller and shows up in the logs rather than in a timeout. The first
+substructure search therefore takes both builds -- upwards of a minute over the whole
+corpus, the index being four passes over the projections -- on top of whatever timeout
+it was given.
 """
 
+import dataclasses
 import glob
 import math
 import threading
@@ -125,6 +139,52 @@ def _max_structure_id(path: str) -> int | None:
 _UNPARSEABLE = Chem.Mol().ToBinary()
 _NO_BITS = DataStructs.ExplicitBitVect(structures.PATTERN_FP_SIZE)
 
+# The one element field the occurrence index carries besides the structure. A query
+# binding anything else to the element runs against the projection instead.
+_INDEXED_FIELD = "reaction_role"
+
+
+def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
+    """Returns the paths an occurrence index covers, mapped to their traversals.
+
+    Walked from the schema and resolved through the compiler, so the index reaches the
+    same elements the projection does by construction rather than by a list here
+    agreeing with one there.
+
+    Args:
+        schema: The projection schema.
+
+    Returns:
+        Dotted query paths to the DuckDB expression yielding their elements, for every
+        repeated level whose elements carry both a structure and ``_INDEXED_FIELD``.
+    """
+    paths: dict[str, str] = {}
+
+    def walk(dtype: pa.DataType, prefix: str) -> None:
+        if pa.types.is_struct(dtype):
+            names = [field.name for field in dtype]
+            if "structure_id" in names and _INDEXED_FIELD in names:
+                # The schema walk speaks Parquet; the grammar has no wrapper levels.
+                path = prefix.replace(".list.element", "").replace(
+                    ".key_value.value", ""
+                )
+                resolved = query.resolve(path, allow_internal=True)
+                if resolved.repeated:
+                    paths[path] = resolved.expression
+            for child in dtype:
+                walk(child.type, f"{prefix}.{child.name}")
+        elif pa.types.is_list(dtype):
+            walk(dtype.value_type, f"{prefix}.list.element")
+        elif pa.types.is_map(dtype):
+            walk(dtype.item_type, f"{prefix}.key_value.value")
+
+    for field in schema:
+        walk(field.type, field.name)
+    return paths
+
+
+INDEXED_PATHS = _indexed_paths()
+
 
 class Corpus:
     """A searchable pairing of projections with their structures artifacts.
@@ -170,6 +230,9 @@ class Corpus:
         # Built on first substructure query; see _library.
         self._substructure_library: rdSubstructLibrary.SubstructLibrary | None = None
         self._library_lock = threading.Lock()
+        # Built on the first query that can use it; see _occurrences.
+        self._occurrences_built = False
+        self._occurrences_lock = threading.Lock()
         pairs = self._pair(projection_pattern, structures_pattern, require_current)
         self._connection = duckdb.connect()
         try:
@@ -459,6 +522,139 @@ class Corpus:
             self._substructure_library = library
             return self._substructure_library
 
+    @staticmethod
+    def _index_terms(where: query.Predicate) -> tuple[bool, str | None] | None:
+        """Returns whether an element predicate is one the index holds.
+
+        Args:
+            where: The predicate inside a quantifier, relative to the element.
+
+        Returns:
+            ``(has_structure, role)`` if every clause is a structure predicate on the
+            element's own structure or an equality on the indexed field, or None if any
+            clause reaches something the index does not carry.
+        """
+        clauses = where.clauses if isinstance(where, query.And) else [where]
+        structures_seen = 0
+        role: str | None = None
+        for clause in clauses:
+            if isinstance(clause, (query.Substructure, query.Similarity)):
+                if clause.path != "smiles":
+                    return None
+                structures_seen += 1
+            elif (
+                isinstance(clause, query.Comparison)
+                and clause.op == "eq"
+                and clause.path == _INDEXED_FIELD
+                and isinstance(clause.value.literal, str)
+                and role is None
+            ):
+                role = clause.value.literal
+            else:
+                return None
+        # Two structure predicates on one element are two bitmaps, and one pass over one
+        # column cannot apply both to the same row.
+        if structures_seen != 1:
+            return None
+        return True, role
+
+    @staticmethod
+    def _plan(request: query.Query) -> query.Compiled | None:
+        """Returns a compiled occurrence-index query, or None to use the projection.
+
+        The index carries a structure and one field per element, so it answers exactly
+        the shape it holds: some element at an indexed path contains a structure, and
+        optionally equals a role. Everything else -- another element field, a scalar
+        outside the quantifier, a group-by column, an ordering -- lives only in the
+        projection, and asking the index for it would answer a different question.
+
+        Args:
+            request: The query to plan.
+
+        Returns:
+            A compiled query over ``occurrences``, or None if the projection has to
+            answer it.
+        """
+        where = request.where
+        if (
+            request.aggregate is not None
+            or request.order_by
+            or not isinstance(where, query.Quantifier)
+            or where.op != "exists"
+            or where.path not in INDEXED_PATHS
+        ):
+            return None
+        terms = Corpus._index_terms(where.where)
+        if terms is None:
+            return None
+        _, role = terms
+        compiled = query.compile_query(request)
+        # The bitmap and the molecule behind it are the compiler's, so the two paths
+        # screen and verify identically and differ only in how they reach the reactions
+        # holding a match.
+        if len(compiled.structures) != 1:
+            return None
+        conditions = [
+            f"path = '{where.path}'",
+            f"get_bit(CAST(${compiled.structures[0].name} AS BITSTRING), "
+            "global_id::INTEGER) = 1",
+        ]
+        if role is not None:
+            escaped = role.replace("'", "''")
+            conditions.append(f"{_INDEXED_FIELD} = '{escaped}'")
+        limit = f" LIMIT {request.limit}" if request.limit is not None else ""
+        # S608: every fragment is a schema-derived path, a compiler-issued parameter
+        # name, or an escaped literal.
+        sql = (
+            "SELECT DISTINCT reaction_id FROM occurrences "  # noqa: S608
+            f"WHERE {' AND '.join(conditions)}{limit}"
+        )
+        return dataclasses.replace(compiled, sql=sql)
+
+    def _occurrences(self) -> None:
+        """Builds the occurrence index, once, if it is not already built.
+
+        One row per structure occurrence, carrying the corpus-wide ID, the path it sat
+        at, and the element's own ``reaction_role``. Keeping the role beside the
+        structure is what preserves element binding: "pyridine as the solvent" stays a
+        condition on one row rather than an intersection of two reaction sets, which
+        over-returns.
+
+        Costs a full pass over the projections, so it is built when a query first wants
+        it rather than at open. Concurrent first queries serialize here and share the
+        result.
+        """
+        with self._occurrences_lock:
+            if self._occurrences_built:
+                return
+            start = time.perf_counter()
+            # A path's elements are already a list, so unnest yields one row each. The
+            # offset comes from the row's own file, which the reactions view carries.
+            selects = "\nUNION ALL\n".join(
+                f"""
+                SELECT reaction_id, '{path}' AS path,
+                       (element.structure_id + {query.STRUCTURE_OFFSET})::UINTEGER
+                           AS global_id,
+                       element.{_INDEXED_FIELD} AS {_INDEXED_FIELD}
+                FROM {query.TABLE}, unnest({expression}) AS unnested(element)
+                WHERE element.structure_id IS NOT NULL
+                """  # noqa: S608
+                for path, expression in INDEXED_PATHS.items()
+            )
+            # S608: the fragments are this module's own schema walk and the compiler's
+            # traversals, not anything a query supplies.
+            self._connection.execute(f"CREATE TABLE occurrences AS {selects}")
+            count = self._connection.execute(
+                "SELECT count(*) FROM occurrences"
+            ).fetchone()
+            assert count is not None  # An aggregate over any relation returns one row.
+            logger.info(
+                "indexed %d structure occurrences in %.1fs",
+                count[0],
+                time.perf_counter() - start,
+            )
+            self._occurrences_built = True
+
     def _substructure_ids(
         self, parameter: query.StructureParameter, resolve: Callable[[str], str]
     ) -> list[int]:
@@ -536,12 +732,17 @@ class Corpus:
         each other's results. They still serialize on the library build, and only on
         that: the first substructure search builds it while the others wait.
 
+        A query the occurrence index can answer runs against it instead of the
+        projection, which is the same answer reached without scanning every reaction.
+        The screening and verification are the compiler's either way, so the two paths
+        differ only in how they find the reactions holding a match.
+
         Args:
             request: The query to run.
             timeout_seconds: Wall-clock bound on the final query. Name resolution, the
-                library build, screening, and verification run before the timer starts
-                and are not counted, so a first substructure search can take seconds
-                longer than this allows. None runs unbounded.
+                library and index builds, screening, and verification run before the
+                timer starts and are not counted, so a first substructure search can
+                take seconds longer than this allows. None runs unbounded.
 
         Returns:
             The selected columns: ``reaction_id`` for a plain query, the group and
@@ -553,7 +754,10 @@ class Corpus:
             PairingError: If the library does not come out one entry per structure.
             TimeoutError: If the query exceeds ``timeout_seconds``.
         """
-        compiled = query.compile_query(request)
+        indexed = self._plan(request)
+        compiled = indexed if indexed is not None else query.compile_query(request)
+        if indexed is not None:
+            self._occurrences()
         # Cached across the whole search: a compound named in both a value and a
         # structure predicate is one external lookup, not two.
         resolved: dict[str, str] = {}

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -49,17 +49,17 @@ Keeping the role beside the structure is what preserves element binding: "pyridi
 the solvent" stays a condition on a single row rather than an intersection of two
 reaction sets, which over-returns. A query the index cannot answer, because it reaches
 an element field the index does not carry or needs a projection column to group or sort
-by, runs against the projection unchanged; both paths screen and verify through the same
-compiler, so they differ only in how they reach the reactions.
+by, runs against the projection; both paths screen and verify through the same compiler,
+so they differ only in how they reach the reactions.
 
 The grammar bounds what a query can cost (one pass and a sort), and ``search``
 takes a wall-clock timeout that interrupts the final query. Name resolution, the
 one-time library and index builds, screening, and verification all run before the timer
 starts: each is bounded by the corpus rather than by the query, so a slow one is slow
-for every caller and shows up in the logs rather than in a timeout. The first
-substructure search therefore takes both builds -- upwards of a minute over the whole
-corpus, the index being four passes over the projections -- on top of whatever timeout
-it was given.
+for every caller and shows up in the logs rather than in a timeout. The two builds have
+separate triggers -- the library on the first substructure predicate, the index on the
+first query the planner routes -- and a search wanting both pays both, upwards of a
+minute over the whole corpus, on top of whatever timeout it was given.
 """
 
 import dataclasses
@@ -184,6 +184,19 @@ def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
 
 
 INDEXED_PATHS = _indexed_paths()
+
+
+@dataclasses.dataclass(frozen=True)
+class _IndexTerms:
+    """What a predicate the occurrence index can answer asks of one row.
+
+    Attributes:
+        role: The role the element must hold, or None if the query does not bind one.
+            Absence is not a wildcard the index applies -- it is a query that named no
+            role, so the condition is left off.
+    """
+
+    role: str | None
 
 
 class Corpus:
@@ -523,16 +536,16 @@ class Corpus:
             return self._substructure_library
 
     @staticmethod
-    def _index_terms(where: query.Predicate) -> tuple[bool, str | None] | None:
-        """Returns whether an element predicate is one the index holds.
+    def _index_terms(where: query.Predicate) -> _IndexTerms | None:
+        """Returns what an element predicate asks of one occurrence row, or None.
 
         Args:
             where: The predicate inside a quantifier, relative to the element.
 
         Returns:
-            ``(has_structure, role)`` if every clause is a structure predicate on the
-            element's own structure or an equality on the indexed field, or None if any
-            clause reaches something the index does not carry.
+            The terms, if every clause is a structure predicate on the element's own
+            structure or an equality on the indexed field, or None if any clause reaches
+            something the index does not carry.
         """
         clauses = where.clauses if isinstance(where, query.And) else [where]
         structures_seen = 0
@@ -556,17 +569,24 @@ class Corpus:
         # column cannot apply both to the same row.
         if structures_seen != 1:
             return None
-        return True, role
+        return _IndexTerms(role=role)
 
     @staticmethod
     def _plan(request: query.Query) -> query.Compiled | None:
         """Returns a compiled occurrence-index query, or None to use the projection.
 
-        The index carries a structure and one field per element, so it answers exactly
-        the shape it holds: some element at an indexed path contains a structure, and
-        optionally equals a role. Everything else -- another element field, a scalar
-        outside the quantifier, a group-by column, an ordering -- lives only in the
-        projection, and asking the index for it would answer a different question.
+        An occurrence row carries a structure and one element field, so the index
+        answers exactly one shape: a bare ``exists`` at an indexed path whose body is a
+        conjunction of one structure predicate on the element's own ``smiles`` and at
+        most one ``reaction_role`` equality, with nothing aggregated and nothing
+        ordered. Every other query -- a ``forall``, a negation or a disjunction,
+        another element field, a scalar outside the quantifier, a group-by column, an
+        ordering -- reaches something an occurrence row does not hold, and the
+        projection answers it.
+
+        A ``limit`` rides along. Neither relation orders what a query did not ask to be
+        ordered, so a limited query with no ``order_by`` selects some rows of the match
+        set on both paths, and which ones differs between them.
 
         Args:
             request: The query to plan.
@@ -574,6 +594,11 @@ class Corpus:
         Returns:
             A compiled query over ``occurrences``, or None if the projection has to
             answer it.
+
+        Raises:
+            query.QueryError: If the query does not compile. Planning compiles it to
+                reach the structure parameter, so a malformed query fails here rather
+                than on the projection path.
         """
         where = request.where
         if (
@@ -587,7 +612,6 @@ class Corpus:
         terms = Corpus._index_terms(where.where)
         if terms is None:
             return None
-        _, role = terms
         compiled = query.compile_query(request)
         # The bitmap and the molecule behind it are the compiler's, so the two paths
         # screen and verify identically and differ only in how they reach the reactions
@@ -599,8 +623,8 @@ class Corpus:
             f"get_bit(CAST(${compiled.structures[0].name} AS BITSTRING), "
             "global_id::INTEGER) = 1",
         ]
-        if role is not None:
-            escaped = role.replace("'", "''")
+        if terms.role is not None:
+            escaped = terms.role.replace("'", "''")
             conditions.append(f"{_INDEXED_FIELD} = '{escaped}'")
         limit = f" LIMIT {request.limit}" if request.limit is not None else ""
         # S608: every fragment is a schema-derived path, a compiler-issued parameter
@@ -609,6 +633,9 @@ class Corpus:
             "SELECT DISTINCT reaction_id FROM occurrences "  # noqa: S608
             f"WHERE {' AND '.join(conditions)}{limit}"
         )
+        # Which relation answered is the one thing a result does not show, and the two
+        # are supposed to agree, so a disagreement is only ever debugged from here.
+        logger.info("the occurrence index answers %s", where.path)
         return dataclasses.replace(compiled, sql=sql)
 
     def _occurrences(self) -> None:
@@ -620,9 +647,16 @@ class Corpus:
         condition on one row rather than an intersection of two reaction sets, which
         over-returns.
 
-        Costs a full pass over the projections, so it is built when a query first wants
-        it rather than at open. Concurrent first queries serialize here and share the
-        result.
+        Costs one pass over the projections per indexed path, so it is built when a
+        query first wants it rather than at open. Concurrent first queries serialize
+        here and share the result.
+
+        Raises:
+            PairingError: If a corpus holding structures indexes none of them. Every
+                path the projection can carry a structure at is indexed, so an empty
+                index means a traversal reached nothing -- and an empty index answers
+                every structure query with "no matches", which reads like an answer
+                rather than like a corpus that cannot be searched.
         """
         with self._occurrences_lock:
             if self._occurrences_built:
@@ -641,19 +675,38 @@ class Corpus:
                 """  # noqa: S608
                 for path, expression in INDEXED_PATHS.items()
             )
-            # S608: the fragments are this module's own schema walk and the compiler's
-            # traversals, not anything a query supplies.
-            self._connection.execute(f"CREATE TABLE occurrences AS {selects}")
-            count = self._connection.execute(
-                "SELECT count(*) FROM occurrences"
-            ).fetchone()
-            assert count is not None  # An aggregate over any relation returns one row.
+            # Its own cursor: this runs while other searches are in flight, and the
+            # shared connection holds their results.
+            cursor = self._connection.cursor()
+            try:
+                # OR REPLACE, so a build interrupted after the table exists is a build
+                # the next query repeats rather than one that collides with itself
+                # forever. S608: the fragments are this module's own schema walk and
+                # the compiler's traversals, not anything a query supplies.
+                cursor.execute(f"CREATE OR REPLACE TABLE occurrences AS {selects}")
+                indexed = cursor.execute(
+                    "SELECT path, count(*) FROM occurrences GROUP BY path"
+                ).fetchall()
+                counts = dict(indexed)
+                total = sum(counts.values())
+                if self._total and not total:
+                    raise PairingError(
+                        f"the occurrence index came out empty over {self._total} "
+                        f"structures; none of {sorted(INDEXED_PATHS)} reached an "
+                        "element, so the projections are not the schema this walk was "
+                        "built from"
+                    )
+                self._occurrences_built = True
+            finally:
+                cursor.close()
+            # Per path, so one that reaches nothing is visible here rather than only in
+            # the answers it fails to contribute to.
             logger.info(
-                "indexed %d structure occurrences in %.1fs",
-                count[0],
+                "indexed %d structure occurrences in %.1fs: %s",
+                total,
                 time.perf_counter() - start,
+                ", ".join(f"{path} {counts.get(path, 0)}" for path in INDEXED_PATHS),
             )
-            self._occurrences_built = True
 
     def _substructure_ids(
         self, parameter: query.StructureParameter, resolve: Callable[[str], str]
@@ -729,13 +782,15 @@ class Corpus:
         """Compiles and runs a query, returning the result as an Arrow table.
 
         Runs on its own cursor, so concurrent searches sharing this corpus do not read
-        each other's results. They still serialize on the library build, and only on
-        that: the first substructure search builds it while the others wait.
+        each other's results. They serialize on the library build and on the index
+        build, each of which the first search wanting it performs while the others wait.
 
         A query the occurrence index can answer runs against it instead of the
         projection, which is the same answer reached without scanning every reaction.
         The screening and verification are the compiler's either way, so the two paths
-        differ only in how they find the reactions holding a match.
+        differ only in how they find the reactions holding a match. Which one answered
+        is logged, because it is the one thing about a search that the result does not
+        show.
 
         Args:
             request: The query to run.
@@ -751,13 +806,16 @@ class Corpus:
         Raises:
             query.QueryError: If the query does not compile.
             ValueError: If a compound name cannot be resolved.
-            PairingError: If the library does not come out one entry per structure.
+            PairingError: If the corpus IDs do not come out one unbroken run, or a
+                corpus holding structures indexes none of them.
             TimeoutError: If the query exceeds ``timeout_seconds``.
         """
         indexed = self._plan(request)
         compiled = indexed if indexed is not None else query.compile_query(request)
         if indexed is not None:
             self._occurrences()
+        else:
+            logger.info("the projection answers this query")
         # Cached across the whole search: a compound named in both a value and a
         # structure predicate is one external lookup, not two.
         resolved: dict[str, str] = {}

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -910,6 +910,185 @@ def test_concurrent_first_searches_build_one_library(corpus_dir, monkeypatch):
     assert results == [["ord-aa01", "ord-aa02"]] * threads_count
 
 
+_SUBSTRUCTURE = {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"}
+_SOLVENT = {"op": "eq", "path": "reaction_role", "value": {"literal": "SOLVENT"}}
+
+# Every shape the planner accepts, so the agreement below covers the whole surface
+# rather than the one case that prompted the index.
+_ROUTABLE = {
+    "structure alone": {"where": _exists(_SUBSTRUCTURE)},
+    "structure and role": {
+        "where": _exists({"op": "and", "clauses": [_SUBSTRUCTURE, _SOLVENT]})
+    },
+    "role and structure, reversed": {
+        "where": _exists({"op": "and", "clauses": [_SOLVENT, _SUBSTRUCTURE]})
+    },
+    "similarity": {
+        "where": _exists(
+            {"op": "similarity", "path": "smiles", "smiles": "OCC", "threshold": 0.4}
+        )
+    },
+    "a compound name": {
+        "where": _exists(
+            {"op": "substructure", "path": "smiles", "compound": "pyridine"}
+        )
+    },
+    "products rather than inputs": {
+        "where": {
+            "op": "exists",
+            "path": "outcomes.products",
+            "where": {"op": "substructure", "path": "smiles", "smarts": "Cc1ccccc1"},
+        }
+    },
+    "matches nothing": {
+        "where": _exists({"op": "substructure", "path": "smiles", "smarts": "[Pt]"})
+    },
+    # Toluene is every reaction's product and nobody's input, so asking for it among
+    # the inputs must come back empty. An index that lost the path it was asked about
+    # would answer with the products and return all three reactions.
+    "a structure that lives only at another path": {
+        "where": _exists(
+            {"op": "substructure", "path": "smiles", "smarts": "Cc1ccccc1"}
+        )
+    },
+    # Matches pyridine and benzene both, which are two components of aa01: one reaction
+    # reached through two occurrence rows.
+    "several components of one reaction": {
+        "where": _exists({"op": "substructure", "path": "smiles", "smarts": "c1ccccc1"})
+    },
+}
+
+_NOT_ROUTABLE = {
+    # The index holds no column to group by.
+    "an aggregate": {
+        "where": _exists(_SUBSTRUCTURE),
+        "aggregate": {"measures": [{"fn": "count", "name": "n"}]},
+    },
+    # Nor one to sort on beyond the reaction.
+    "an ordering": {
+        "where": _exists(_SUBSTRUCTURE),
+        "order_by": [{"key": "reaction_id"}],
+    },
+    # No structure means no bitmap, and the index is only worth its scan with one.
+    "a role alone": {"where": _exists(_SOLVENT)},
+    # amount lives on the element but not in the index.
+    "an unindexed element field": {
+        "where": _exists(
+            {
+                "op": "and",
+                "clauses": [
+                    _SUBSTRUCTURE,
+                    {"op": "gt", "path": "amount.mass.value", "value": {"literal": 1}},
+                ],
+            }
+        )
+    },
+    # A negated or disjoint element predicate is not a row filter.
+    "a negation": {"where": _exists({"op": "not", "clause": _SUBSTRUCTURE})},
+    "a disjunction": {
+        "where": _exists({"op": "or", "clauses": [_SUBSTRUCTURE, _SOLVENT]})
+    },
+    # forall is not exists: the index sees matching rows, never their absence.
+    "a universal": {
+        "where": {"op": "forall", "path": "inputs.components", "where": _SUBSTRUCTURE}
+    },
+    # A scalar outside the quantifier is a projection column.
+    "a scalar beside the quantifier": {
+        "where": {
+            "op": "and",
+            "clauses": [
+                _exists(_SUBSTRUCTURE),
+                {
+                    "op": "gt",
+                    "path": "conditions.temperature.setpoint_kelvin",
+                    "value": {"literal": 300},
+                },
+            ],
+        }
+    },
+}
+
+
+@pytest.mark.parametrize("label", sorted(_ROUTABLE))
+def test_the_index_answers_exactly_what_the_projection_would(corpus, label):
+    # The index is a second way to reach the same reactions, so the only thing that
+    # makes it safe is that it never reaches different ones. Both paths screen and
+    # verify through the same compiler, so any disagreement is the index's traversal
+    # or its role column, which is what this compares.
+    request = query.Query.model_validate(_ROUTABLE[label])
+    planned = execute.Corpus._plan(request)
+    assert planned is not None, "expected this to route"
+    through_index = set(corpus.search(request).column("reaction_id").to_pylist())
+    projected = query.compile_query(request)
+    assert projected.sql != planned.sql  # Two paths, or this compares one to itself.
+    parameters = {
+        parameter.name: corpus._bitmap(
+            corpus._substructure_ids(parameter, corpus._resolver)
+            if parameter.op == "substructure"
+            else corpus._similarity_ids(corpus._connection, parameter, corpus._resolver)
+        )
+        for parameter in projected.structures
+    }
+    through_projection = set(
+        corpus._connection.execute(projected.sql, parameters)
+        .to_arrow_table()
+        .column("reaction_id")
+        .to_pylist()
+    )
+    assert through_index == through_projection
+
+
+@pytest.mark.parametrize("label", sorted(_NOT_ROUTABLE))
+def test_the_planner_leaves_the_projection_what_the_index_cannot_answer(label):
+    # Routing one of these would answer a different question than it was asked, so the
+    # planner has to decline rather than approximate.
+    assert (
+        execute.Corpus._plan(query.Query.model_validate(_NOT_ROUTABLE[label])) is None
+    )
+
+
+def test_the_index_names_each_reaction_once(corpus):
+    # A reaction holding two matching components is two rows in the index and one row
+    # in the projection. Comparing the two as sets would hide that, so the count is
+    # asserted here: a caller reading the table sees the duplicate, not a set.
+    matched = corpus.search(
+        query.Query.model_validate(
+            {
+                "where": _exists(
+                    # Both of aa01's inputs are aromatic carbocycles or contain one.
+                    {"op": "substructure", "path": "smiles", "smarts": "c"}
+                )
+            }
+        )
+    ).column("reaction_id")
+    assert len(matched) == len(set(matched.to_pylist()))
+
+
+def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        # A scalar query cannot use the index, so it must not pay to build one.
+        value.search(
+            query.Query.model_validate(
+                {
+                    "where": _exists(
+                        {"op": "eq", "path": "smiles", "value": {"literal": "CCO"}}
+                    )
+                }
+            )
+        )
+        assert not value._occurrences_built
+        request = query.Query.model_validate(_ROUTABLE["structure alone"])
+        assert value.search(request).num_rows == 2
+        assert value._occurrences_built
+        # A second search reuses it rather than rebuilding, which CREATE TABLE would
+        # refuse anyway -- so this failing looks like an error, not a slow query.
+        assert value.search(request).num_rows == 2
+
+
 def test_the_match_limit_has_to_be_passed_or_matches_are_dropped():
     # GetMatches defaults to 1000 results and truncates in silence, which at corpus
     # scale would turn a broad pattern into a wrong answer rather than a slow one. The

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -97,11 +97,13 @@ def corpus_dir(tmp_path_factory) -> pathlib.Path:
 
 @pytest.fixture(scope="module")
 def deep_corpus(tmp_path_factory) -> Iterator[execute.Corpus]:
-    """A corpus holding a structure at each of the two deepest indexed paths.
+    """A corpus holding a structure at every indexed path.
 
     A workup's components and a product measurement's authentic standard are reached by
     the longest traversals the index generates, and the main fixture has neither, so
-    every assertion about them would otherwise compare nothing to nothing.
+    every assertion about them would otherwise compare nothing to nothing. The inputs
+    and the products carry structures too, which is what lets a query at one deep path
+    assert that a structure living at another is not found there.
     """
     reaction = reaction_pb2.Reaction(reaction_id="ord-cc01")
     _component(reaction.inputs["in"], "CCO", _ROLE.REACTANT)
@@ -1005,7 +1007,7 @@ _ROUTABLE = {
 
 _NOT_ROUTABLE = {
     # The planner declines every aggregate rather than reason about which ones the
-    # index's three columns could serve.
+    # index's four columns could serve.
     "an aggregate": {
         "where": _exists(_SUBSTRUCTURE),
         "aggregate": {"measures": [{"fn": "count", "name": "n"}]},
@@ -1024,7 +1026,7 @@ _NOT_ROUTABLE = {
                 "op": "and",
                 "clauses": [
                     _SUBSTRUCTURE,
-                    {"op": "gt", "path": "amount.mass.value", "value": {"literal": 1}},
+                    {"op": "gt", "path": "amount.mass_grams", "value": {"literal": 1}},
                 ],
             }
         )
@@ -1165,6 +1167,30 @@ def test_the_planner_leaves_the_projection_what_the_index_cannot_answer(label):
     )
 
 
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        # A pyridine that is not the solvent, which is aa02's reactant. Routed as an
+        # equality, this would come back as aa01 -- the one reaction it excludes.
+        ("a role inequality", {"ord-aa02"}),
+        # One component required to be two roles at once, which nothing is. Routed with
+        # only the last role kept, this would come back as every pyridine reactant.
+        ("two roles at once", set()),
+    ],
+)
+def test_a_declined_query_is_answered_rather_than_only_declined(
+    corpus, label, expected
+):
+    # The planner declining is half the property; the other half is that the projection
+    # answers, and answers what the comments beside these cases say routing would get
+    # wrong. Asserted for the two whose routed answer would not merely differ but invert
+    # or over-return.
+    assert (
+        _reactions(corpus.search(query.Query.model_validate(_NOT_ROUTABLE[label])))
+        == expected
+    )
+
+
 def test_the_index_names_each_reaction_once(corpus):
     # A reaction holding two matching components is two rows in the index and one row in
     # the projection. A caller gets the table rather than a set, so a duplicate would
@@ -1204,13 +1230,14 @@ def test_a_role_literal_cannot_close_its_quote(corpus):
     assert matched == set()
 
 
-def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
+def test_the_index_is_built_once_and_only_when_wanted(corpus_dir, caplog):
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
     ) as value:
-        # A scalar query cannot use the index, so it must not pay to build one.
+        # An element predicate with no structure in it cannot use the index, so it must
+        # not pay to build one.
         value.search(
             query.Query.model_validate(
                 {
@@ -1221,11 +1248,17 @@ def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
             )
         )
         assert not value._occurrences_built
+        caplog.set_level(logging.INFO, logger="ord_schema.agent.execute")
         request = query.Query.model_validate(_ROUTABLE["structure alone"])
         assert value.search(request).num_rows == 2
         assert value._occurrences_built
-        # A second search reuses it rather than rebuilding.
+        # A second search reuses it rather than rebuilding, which the answer alone
+        # cannot show -- a rebuild answers identically and costs a pass per path.
         assert value.search(request).num_rows == 2
+    builds = [
+        record for record in caplog.records if record.message.startswith("indexed ")
+    ]
+    assert len(builds) == 1
 
 
 @pytest.mark.parametrize(
@@ -1234,8 +1267,7 @@ def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
         # A workup component: a structure at a path the inputs do not reach.
         ("workups.input.components", "c1ccncc1", {"ord-cc01"}),
         ("workups.input.components", "CCO", set()),
-        # An authentic standard, the deepest indexed path -- reached by flattening twice
-        # and holding a role of its own that no query in the fixture sets.
+        # An authentic standard: the deepest path, reached by flattening twice.
         ("outcomes.products.measurements.authentic_standard", "c1ccccc1", {"ord-cc01"}),
         ("outcomes.products.measurements.authentic_standard", "CCO", set()),
     ],
@@ -1269,6 +1301,57 @@ def test_the_index_reaches_the_deep_paths_the_projection_does(
     assert _reactions(deep_corpus.search(declined)) == expected
 
 
+@pytest.mark.parametrize(
+    ("role", "expected"), [("SOLVENT", {"ord-cc01"}), ("REACTANT", set())]
+)
+def test_a_role_binds_to_the_element_at_a_deep_path(deep_corpus, role, expected):
+    # The index writes reaction_role for all four paths, and every other role condition
+    # here asks about inputs.components. A role that came out right for the inputs and
+    # NULL elsewhere would answer "pyridine as the solvent in the workup" with nothing,
+    # silently, while the same query without the role still worked.
+    request = query.Query.model_validate(
+        {
+            "where": {
+                "op": "exists",
+                "path": "workups.input.components",
+                "where": {
+                    "op": "and",
+                    "clauses": [
+                        {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"},
+                        {
+                            "op": "eq",
+                            "path": "reaction_role",
+                            "value": {"literal": role},
+                        },
+                    ],
+                },
+            }
+        }
+    )
+    assert execute.Corpus._plan(request) is not None, "expected this to route"
+    assert _reactions(deep_corpus.search(request)) == expected
+
+
+def test_a_routed_query_is_bounded_by_the_timeout(corpus, monkeypatch):
+    # The timeout is the only bound on what a query costs, and the routed path is a
+    # different statement reached by a different branch. The fixture is too small to
+    # outlast any timeout worth setting, so what is asserted is that the bound is
+    # carried: a routed query dropping it would run unbounded on a real corpus.
+    seen: list[tuple[str, float]] = []
+    original = execute.Corpus._run_with_timeout
+
+    def recording(cursor, sql, parameters, timeout_seconds):
+        seen.append((sql, timeout_seconds))
+        return original(cursor, sql, parameters, timeout_seconds)
+
+    monkeypatch.setattr(execute.Corpus, "_run_with_timeout", staticmethod(recording))
+    request = query.Query.model_validate(_ROUTABLE["structure and role"])
+    assert execute.Corpus._plan(request) is not None, "expected this to route"
+    assert _reactions(corpus.search(request, timeout_seconds=60)) == {"ord-aa01"}
+    assert [timeout for _, timeout in seen] == [60]
+    assert "FROM occurrences" in seen[0][0]
+
+
 def test_a_routed_query_reads_the_index_and_an_unrouted_one_does_not(corpus_dir):
     # Everything else here compares the two paths, which agree -- so a search that
     # quietly stopped routing would keep passing while the index cost a build and
@@ -1289,31 +1372,44 @@ def test_a_routed_query_reads_the_index_and_an_unrouted_one_does_not(corpus_dir)
             "WHERE reaction_id = 'ord-aa01' AND reaction_role = 'SOLVENT'"
         )
         assert _reactions(value.search(routed)) == {"ord-aa01", "ord-planted"}
+        # The same question with a scalar the fixture satisfies, so the projection's
+        # answer is a set with something in it rather than one that is empty either way.
         declined = query.Query.model_validate(
-            _NOT_ROUTABLE["a scalar beside the quantifier"]
+            {
+                "where": {
+                    "op": "and",
+                    "clauses": [
+                        _ROUTABLE["structure and role"]["where"],
+                        {"op": "not_null", "path": "reaction_id"},
+                    ],
+                }
+            }
         )
-        assert "ord-planted" not in _reactions(value.search(declined))
+        assert execute.Corpus._plan(declined) is None
+        assert _reactions(value.search(declined)) == {"ord-aa01"}
 
 
-def test_concurrent_first_searches_build_one_index(corpus_dir, caplog):
-    # The index is a materialized table, minutes to build at corpus scale. First
+def test_concurrent_first_searches_build_one_index(corpus_dir, caplog, monkeypatch):
+    # The index is a materialized table, several passes over the projections. First
     # searches arriving together must not each build their own; whoever waits takes the
-    # finished one. Counted off the build's own log line rather than left to a second
-    # CREATE TABLE failing, since the build replaces the table rather than colliding
-    # with it -- without the lock this is a wasted rebuild, not an error.
+    # finished one. The barrier sits at the door of the build rather than in the
+    # resolver, which a search reaches only afterwards, so the race is arranged rather
+    # than hoped for -- and the build's own log line is what counts them, since
+    # concurrent CREATEs would also collide in DuckDB's catalog and raise.
     caplog.set_level(logging.INFO, logger="ord_schema.agent.execute")
     threads_count = 4
     ready = threading.Barrier(threads_count)
+    building = execute.Corpus._occurrences
 
-    def resolver(name):
-        # Releases every thread together, so they meet at the build.
+    def synchronized(self):
         ready.wait(timeout=_WAIT)
-        return {"pyridine": "c1ccncc1"}[name]
+        return building(self)
 
+    monkeypatch.setattr(execute.Corpus, "_occurrences", synchronized)
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
-        resolver=resolver,
+        resolver={"pyridine": "c1ccncc1"}.__getitem__,
     ) as value:
         request = query.Query.model_validate(_ROUTABLE["a compound name"])
         results: list[int] = []
@@ -1341,10 +1437,10 @@ def test_concurrent_first_searches_build_one_index(corpus_dir, caplog):
 
 
 def test_an_index_that_reaches_nothing_is_refused(corpus_dir, monkeypatch):
-    # An empty index answers every structure query with no matches, which reads like an
-    # answer rather than like a corpus nobody can search. The fixture has no authentic
-    # standards, so indexing that path alone is a traversal that reaches nothing --
-    # which is what a path binding against the wrong schema would look like.
+    # An index that reaches no structure at all answers every structure query with no
+    # matches, which reads like an answer rather than like a corpus nobody can search.
+    # The fixture has no authentic standards, so indexing that path alone is a traversal
+    # that reaches nothing -- what a path binding against the wrong schema looks like.
     path = "outcomes.products.measurements.authentic_standard"
     monkeypatch.setattr(execute, "INDEXED_PATHS", {path: execute.INDEXED_PATHS[path]})
     request = query.Query.model_validate(
@@ -1361,13 +1457,113 @@ def test_an_index_that_reaches_nothing_is_refused(corpus_dir, monkeypatch):
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
     ) as value:
-        with pytest.raises(execute.PairingError, match="came out empty"):
+        with pytest.raises(execute.PairingError, match="reached 0 of the corpus's 5"):
             value.search(request)
-        # Nothing was published, so the next query builds again rather than reading an
-        # index that was never there.
+        # The table is in the catalog, holding nothing; what was not set is the flag, so
+        # nobody reads it.
         assert not value._occurrences_built
-        with pytest.raises(execute.PairingError, match="came out empty"):
+        value._connection = counter = _CursorCounter(value._connection)
+        with pytest.raises(execute.PairingError, match="reached 0 of the corpus's 5"):
             value.search(request)
+        # A corpus does not change under an open Corpus, so the second refusal is the
+        # first one's reason rather than several more passes to reach it again.
+        assert counter.cursors == 0
+
+
+def test_an_index_that_misses_one_path_is_refused(corpus_dir, monkeypatch):
+    # The dangerous shape is not an index that reaches nothing -- it is one that reaches
+    # almost everything. A single traversal that binds and finds no element leaves the
+    # other paths carrying the total, so a count of occurrences looks healthy while
+    # every query at the dead path answers with silence. Counting the structures reached
+    # is what tells the two apart. Dropping a path is what a schema walk that fell out
+    # of step with the projection would do.
+    kept = {
+        path: expression
+        for path, expression in execute.INDEXED_PATHS.items()
+        if path != "outcomes.products"
+    }
+    monkeypatch.setattr(execute, "INDEXED_PATHS", kept)
+    # Toluene is every reaction's product and nobody's input, so dropping the products
+    # path leaves exactly its two structures unreached.
+    with (
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+        ) as value,
+        pytest.raises(execute.PairingError, match="reached 3 of the corpus's 5"),
+    ):
+        value.search(query.Query.model_validate(_ROUTABLE["structure alone"]))
+
+
+def test_a_path_the_index_does_not_cover_is_left_to_the_projection(
+    corpus_dir, monkeypatch
+):
+    # The planner's path check is unfalsifiable against the real schema, since every
+    # path a structure can sit at is indexed. It becomes load-bearing the moment that
+    # stops being true, and routing a query to a path the index does not carry answers
+    # it with the empty set.
+    kept = {
+        path: expression
+        for path, expression in execute.INDEXED_PATHS.items()
+        if path != "outcomes.products"
+    }
+    monkeypatch.setattr(execute, "INDEXED_PATHS", kept)
+    request = query.Query.model_validate(_ROUTABLE["products rather than inputs"])
+    assert execute.Corpus._plan(request) is None
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        # Answered from the projection, which needs no index and so never builds one.
+        assert _reactions(value.search(request)) == {"ord-aa01", "ord-aa02", "ord-bb01"}
+        assert not value._occurrences_built
+
+
+def test_the_indexed_paths_are_the_ones_a_structure_can_sit_at():
+    # Derived from the projection schema, so what the walk accepts and refuses is worth
+    # pinning against schemas built for the purpose: today's projection exercises only
+    # the accepting branch, and the refusals exist for the schema change that will.
+    assert sorted(execute.INDEXED_PATHS) == [
+        "inputs.components",
+        "outcomes.products",
+        "outcomes.products.measurements.authentic_standard",
+        "workups.input.components",
+    ]
+    # A structure at a path with no role is one the index cannot carry -- and one it
+    # would then report as a structure it failed to reach.
+    with pytest.raises(ValueError, match="no reaction_role"):
+        execute._indexed_paths(
+            pa.schema(
+                [
+                    pa.field(
+                        "inputs",
+                        pa.list_(pa.struct([pa.field("structure_id", pa.uint32())])),
+                    )
+                ]
+            )
+        )
+    # A structure on a level that is not repeated is one the build cannot unnest.
+    with pytest.raises(ValueError, match="rather than a repeated expression"):
+        execute._indexed_paths(
+            pa.schema(
+                [
+                    pa.field(
+                        "setup",
+                        pa.struct(
+                            [
+                                pa.field("structure_id", pa.uint32()),
+                                pa.field("reaction_role", pa.string()),
+                            ]
+                        ),
+                    )
+                ]
+            )
+        )
+    # A schema with no structure anywhere would assemble a build with no SQL in it.
+    with pytest.raises(ValueError, match="no structure at any path"):
+        execute._indexed_paths(pa.schema([pa.field("reaction_id", pa.string())]))
 
 
 def test_the_match_limit_has_to_be_passed_or_matches_are_dropped():

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -15,6 +15,7 @@
 """Tests for ord_schema.agent.execute."""
 
 import contextlib
+import logging
 import pathlib
 import threading
 import time
@@ -95,6 +96,46 @@ def corpus_dir(tmp_path_factory) -> pathlib.Path:
 
 
 @pytest.fixture(scope="module")
+def deep_corpus(tmp_path_factory) -> Iterator[execute.Corpus]:
+    """A corpus holding a structure at each of the two deepest indexed paths.
+
+    A workup's components and a product measurement's authentic standard are reached by
+    the longest traversals the index generates, and the main fixture has neither, so
+    every assertion about them would otherwise compare nothing to nothing.
+    """
+    reaction = reaction_pb2.Reaction(reaction_id="ord-cc01")
+    _component(reaction.inputs["in"], "CCO", _ROLE.REACTANT)
+    _component(reaction.workups.add(type="EXTRACTION").input, "c1ccncc1", _ROLE.SOLVENT)
+    outcome = reaction.outcomes.add()
+    product = outcome.products.add()
+    product.identifiers.add(type="SMILES", value="Cc1ccccc1")
+    standard = product.measurements.add(analysis_key="nmr").authentic_standard
+    standard.identifiers.add(type="SMILES", value="c1ccccc1")
+    root = tmp_path_factory.mktemp("deep")
+    source = root / "data" / "ord_dataset-cc.parquet"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    parquet.save_dataset(
+        dataset_pb2.Dataset(
+            dataset_id="ord_dataset-cc",
+            name="test",
+            description="test",
+            reactions=[reaction],
+        ),
+        str(source),
+    )
+    projected = root / "projections" / source.name
+    projected.parent.mkdir(parents=True, exist_ok=True)
+    projection.write_projection(source, projected)
+    structured = root / "structures" / source.name
+    structured.parent.mkdir(parents=True, exist_ok=True)
+    structures.write_structures(projected, structured)
+    with execute.Corpus(
+        str(projected), str(structured), resolver={}.__getitem__
+    ) as value:
+        yield value
+
+
+@pytest.fixture(scope="module")
 def corpus(corpus_dir) -> Iterator[execute.Corpus]:
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
@@ -108,9 +149,12 @@ def _exists(where):
     return {"op": "exists", "path": "inputs.components", "where": where}
 
 
-def _search(corpus, where) -> set[str]:
-    table = corpus.search(query.Query.model_validate({"where": where}))
+def _reactions(table) -> set[str]:
     return set(table.column("reaction_id").to_pylist())
+
+
+def _search(corpus, where) -> set[str]:
+    return _reactions(corpus.search(query.Query.model_validate({"where": where})))
 
 
 def _role_and_structure(smarts, role):
@@ -913,8 +957,9 @@ def test_concurrent_first_searches_build_one_library(corpus_dir, monkeypatch):
 _SUBSTRUCTURE = {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"}
 _SOLVENT = {"op": "eq", "path": "reaction_role", "value": {"literal": "SOLVENT"}}
 
-# Every shape the planner accepts, so the agreement below covers the whole surface
-# rather than the one case that prompted the index.
+# Every shape the planner accepts whose two paths must agree exactly, which is all of
+# them but a limit: a limited query with no ordering takes some of the match set, and
+# the two paths take different rows of it. That one has its own test below.
 _ROUTABLE = {
     "structure alone": {"where": _exists(_SUBSTRUCTURE)},
     "structure and role": {
@@ -951,20 +996,21 @@ _ROUTABLE = {
             {"op": "substructure", "path": "smiles", "smarts": "Cc1ccccc1"}
         )
     },
-    # Matches pyridine and benzene both, which are two components of aa01: one reaction
-    # reached through two occurrence rows.
+    # One aromatic carbon matches pyridine and benzene both, which are aa01's two
+    # inputs: one reaction reached through two occurrence rows.
     "several components of one reaction": {
-        "where": _exists({"op": "substructure", "path": "smiles", "smarts": "c1ccccc1"})
+        "where": _exists({"op": "substructure", "path": "smiles", "smarts": "c"})
     },
 }
 
 _NOT_ROUTABLE = {
-    # The index holds no column to group by.
+    # The planner declines every aggregate rather than reason about which ones the
+    # index's three columns could serve.
     "an aggregate": {
         "where": _exists(_SUBSTRUCTURE),
         "aggregate": {"measures": [{"fn": "count", "name": "n"}]},
     },
-    # Nor one to sort on beyond the reaction.
+    # And every ordering, including this one, which is on a column the index does hold.
     "an ordering": {
         "where": _exists(_SUBSTRUCTURE),
         "order_by": [{"key": "reaction_id"}],
@@ -983,8 +1029,80 @@ _NOT_ROUTABLE = {
             }
         )
     },
-    # A negated or disjoint element predicate is not a row filter.
+    # An equality on an element field the index does not carry. Routed, the condition
+    # would be dropped and the answer would be the unconditioned one.
+    "an equality on another element field": {
+        "where": _exists(
+            {
+                "op": "and",
+                "clauses": [
+                    _SUBSTRUCTURE,
+                    {
+                        "op": "eq",
+                        "path": "smiles",
+                        "value": {"literal": "c1ccncc1"},
+                    },
+                ],
+            }
+        )
+    },
+    # The index carries the role a row has, never the roles it does not have, so an
+    # inequality routed as an equality would invert the answer.
+    "a role inequality": {
+        "where": _exists(
+            {
+                "op": "and",
+                "clauses": [
+                    _SUBSTRUCTURE,
+                    {
+                        "op": "ne",
+                        "path": "reaction_role",
+                        "value": {"literal": "SOLVENT"},
+                    },
+                ],
+            }
+        )
+    },
+    # A role naming a compound binds a parameter, and the index SQL binds none: it
+    # carries the structure parameter and nothing else.
+    "a role given as a compound": {
+        "where": _exists(
+            {
+                "op": "and",
+                "clauses": [
+                    _SUBSTRUCTURE,
+                    {
+                        "op": "eq",
+                        "path": "reaction_role",
+                        "value": {"compound": "pyridine"},
+                    },
+                ],
+            }
+        )
+    },
+    # Two roles on one element is a contradiction the projection answers with no rows.
+    # An index keeping only the last would answer with the rows holding that one.
+    "two roles at once": {
+        "where": _exists(
+            {
+                "op": "and",
+                "clauses": [
+                    _SUBSTRUCTURE,
+                    _SOLVENT,
+                    {
+                        "op": "eq",
+                        "path": "reaction_role",
+                        "value": {"literal": "REACTANT"},
+                    },
+                ],
+            }
+        )
+    },
+    # Absence is not a row: the index sees the rows that match, so a negation would have
+    # to be read off rows that are not there.
     "a negation": {"where": _exists({"op": "not", "clause": _SUBSTRUCTURE})},
+    # A disjunction is expressible as a row filter, but the planner reads conjunctions
+    # only, so it declines rather than carry a second way to build a condition.
     "a disjunction": {
         "where": _exists({"op": "or", "clauses": [_SUBSTRUCTURE, _SOLVENT]})
     },
@@ -1048,20 +1166,42 @@ def test_the_planner_leaves_the_projection_what_the_index_cannot_answer(label):
 
 
 def test_the_index_names_each_reaction_once(corpus):
-    # A reaction holding two matching components is two rows in the index and one row
-    # in the projection. Comparing the two as sets would hide that, so the count is
-    # asserted here: a caller reading the table sees the duplicate, not a set.
+    # A reaction holding two matching components is two rows in the index and one row in
+    # the projection. A caller gets the table rather than a set, so a duplicate would
+    # reach them; this asserts none does, which comparing the two paths as sets cannot.
     matched = corpus.search(
         query.Query.model_validate(
             {
                 "where": _exists(
-                    # Both of aa01's inputs are aromatic carbocycles or contain one.
+                    # Both of aa01's inputs hold aromatic carbon, so both are rows.
                     {"op": "substructure", "path": "smiles", "smarts": "c"}
                 )
             }
         )
     ).column("reaction_id")
     assert len(matched) == len(set(matched.to_pylist()))
+
+
+def test_a_limited_query_takes_some_of_the_match_set(corpus):
+    # A limit rides along to the index. Neither path orders what it was not asked to
+    # order, so the two take different rows of one match set and equality is the wrong
+    # assertion; what has to hold is that the rows are the match set's and that there
+    # are as many as were asked for. A limit dropped on the way to the index would
+    # return the whole set, which the count catches.
+    request = query.Query.model_validate({"where": _exists(_SUBSTRUCTURE), "limit": 1})
+    assert execute.Corpus._plan(request) is not None, "expected this to route"
+    limited = corpus.search(request).column("reaction_id").to_pylist()
+    assert len(limited) == 1
+    assert set(limited) <= {"ord-aa01", "ord-aa02"}
+
+
+def test_a_role_literal_cannot_close_its_quote(corpus):
+    # The role is the one thing a query supplies that reaches the index SQL as text
+    # rather than as a parameter. Unescaped, this literal closes the string and leaves
+    # `OR '1'='1` as a condition, which matches every row at every path -- so the
+    # assertion that bites is that nothing comes back, not that nothing raises.
+    matched = _search(corpus, _role_and_structure("c1ccncc1", "SOLVENT' OR '1'='1"))
+    assert matched == set()
 
 
 def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
@@ -1084,9 +1224,150 @@ def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
         request = query.Query.model_validate(_ROUTABLE["structure alone"])
         assert value.search(request).num_rows == 2
         assert value._occurrences_built
-        # A second search reuses it rather than rebuilding, which CREATE TABLE would
-        # refuse anyway -- so this failing looks like an error, not a slow query.
+        # A second search reuses it rather than rebuilding.
         assert value.search(request).num_rows == 2
+
+
+@pytest.mark.parametrize(
+    ("path", "smarts", "expected"),
+    [
+        # A workup component: a structure at a path the inputs do not reach.
+        ("workups.input.components", "c1ccncc1", {"ord-cc01"}),
+        ("workups.input.components", "CCO", set()),
+        # An authentic standard, the deepest indexed path -- reached by flattening twice
+        # and holding a role of its own that no query in the fixture sets.
+        ("outcomes.products.measurements.authentic_standard", "c1ccccc1", {"ord-cc01"}),
+        ("outcomes.products.measurements.authentic_standard", "CCO", set()),
+    ],
+)
+def test_the_index_reaches_the_deep_paths_the_projection_does(
+    deep_corpus, path, smarts, expected
+):
+    # Four paths are indexed and the main fixture holds structures at two of them, so
+    # the other two are asserted here: the same query, routed and declined, over a
+    # corpus that actually has something at each.
+    where = {"op": "substructure", "path": "smiles", "smarts": smarts}
+    request = query.Query.model_validate(
+        {"where": {"op": "exists", "path": path, "where": where}}
+    )
+    assert execute.Corpus._plan(request) is not None, "expected this to route"
+    assert _reactions(deep_corpus.search(request)) == expected
+    # The same question with a scalar beside it, which the planner declines, so the
+    # projection answers a query the index just answered.
+    declined = query.Query.model_validate(
+        {
+            "where": {
+                "op": "and",
+                "clauses": [
+                    {"op": "exists", "path": path, "where": where},
+                    {"op": "not_null", "path": "reaction_id"},
+                ],
+            }
+        }
+    )
+    assert execute.Corpus._plan(declined) is None
+    assert _reactions(deep_corpus.search(declined)) == expected
+
+
+def test_a_routed_query_reads_the_index_and_an_unrouted_one_does_not(corpus_dir):
+    # Everything else here compares the two paths, which agree -- so a search that
+    # quietly stopped routing would keep passing while the index cost a build and
+    # answered nothing. A row only the index holds separates them: a routed query
+    # returns it, and one the planner declines cannot see it.
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        routed = query.Query.model_validate(_ROUTABLE["structure and role"])
+        assert _reactions(value.search(routed)) == {"ord-aa01"}
+        # aa01's solvent is its pyridine, so this copies the row the query just matched
+        # on and attributes it to a reaction that exists nowhere else.
+        value._connection.execute(
+            "INSERT INTO occurrences SELECT 'ord-planted', path, global_id, "
+            "reaction_role FROM occurrences "
+            "WHERE reaction_id = 'ord-aa01' AND reaction_role = 'SOLVENT'"
+        )
+        assert _reactions(value.search(routed)) == {"ord-aa01", "ord-planted"}
+        declined = query.Query.model_validate(
+            _NOT_ROUTABLE["a scalar beside the quantifier"]
+        )
+        assert "ord-planted" not in _reactions(value.search(declined))
+
+
+def test_concurrent_first_searches_build_one_index(corpus_dir, caplog):
+    # The index is a materialized table, minutes to build at corpus scale. First
+    # searches arriving together must not each build their own; whoever waits takes the
+    # finished one. Counted off the build's own log line rather than left to a second
+    # CREATE TABLE failing, since the build replaces the table rather than colliding
+    # with it -- without the lock this is a wasted rebuild, not an error.
+    caplog.set_level(logging.INFO, logger="ord_schema.agent.execute")
+    threads_count = 4
+    ready = threading.Barrier(threads_count)
+
+    def resolver(name):
+        # Releases every thread together, so they meet at the build.
+        ready.wait(timeout=_WAIT)
+        return {"pyridine": "c1ccncc1"}[name]
+
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver=resolver,
+    ) as value:
+        request = query.Query.model_validate(_ROUTABLE["a compound name"])
+        results: list[int] = []
+        failures: list[BaseException] = []
+
+        def search():
+            try:
+                results.append(value.search(request).num_rows)
+            except BaseException as error:  # noqa: BLE001
+                failures.append(error)
+
+        threads = [threading.Thread(target=search) for _ in range(threads_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=_WAIT)
+        alive = [thread for thread in threads if thread.is_alive()]
+    builds = [
+        record for record in caplog.records if record.message.startswith("indexed ")
+    ]
+    assert failures == []
+    assert alive == []
+    assert len(builds) == 1
+    assert results == [2] * threads_count
+
+
+def test_an_index_that_reaches_nothing_is_refused(corpus_dir, monkeypatch):
+    # An empty index answers every structure query with no matches, which reads like an
+    # answer rather than like a corpus nobody can search. The fixture has no authentic
+    # standards, so indexing that path alone is a traversal that reaches nothing --
+    # which is what a path binding against the wrong schema would look like.
+    path = "outcomes.products.measurements.authentic_standard"
+    monkeypatch.setattr(execute, "INDEXED_PATHS", {path: execute.INDEXED_PATHS[path]})
+    request = query.Query.model_validate(
+        {
+            "where": {
+                "op": "exists",
+                "path": path,
+                "where": {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"},
+            }
+        }
+    )
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        with pytest.raises(execute.PairingError, match="came out empty"):
+            value.search(request)
+        # Nothing was published, so the next query builds again rather than reading an
+        # index that was never there.
+        assert not value._occurrences_built
+        with pytest.raises(execute.PairingError, match="came out empty"):
+            value.search(request)
 
 
 def test_the_match_limit_has_to_be_passed_or_matches_are_dropped():


### PR DESCRIPTION
## Summary

"Which reactions contain this molecule, in this role?" no longer scans every reaction. An occurrence index — one row per structure occurrence, carrying the corpus-wide ID, the path it sat at, and the element's own `reaction_role` — turns that scan into a filter over a narrow table: 14.1M rows and 130 MB against the projections' 1.65 GB.

**Read the scope before the speedups.** The planner is all-or-nothing: it replaces the whole query or declines. So the index answers exactly one shape today — a bare `exists` at an indexed path with one structure predicate and an optional role — and the numbers below are that shape's. See [What routes, and what does not](#what-routes-and-what-does-not).

## Changes

- `Corpus._occurrences` builds the index lazily, under a lock, on the first query that can use it.
- `Corpus._plan` routes a query to the index when the index can answer it, and returns None otherwise.
- Paths and traversals come from the same schema walk and the same `query.resolve` the compiler uses, so the index reaches the elements the projection does by construction rather than by one list agreeing with another.

## Why the index carries `reaction_role`

A plain `structure_id → reaction_ids` index answers "reactions containing pyridine" but not "reactions where pyridine is the *solvent*" — that is the intersection which over-returns by 94%, and the reason element binding exists at all. Keeping the role beside the structure keeps the bound query a condition on one row.

## Measurements

End to end over the whole corpus through `Corpus.search`, with identical match sets on every row. All three are the shape the planner routes; a query one clause away from these pays the projection column:

| query | projection | index | speedup | reactions |
| --- | --- | --- | --- | --- |
| pyridine among the inputs | 7.56s | 1.46s | 5.2x | 660,671 |
| pyridine as the solvent | 5.00s | 1.74s | 2.9x | 25,805 |
| a boronic acid | 2.93s | 0.15s | 19.8x | 132,600 |

The SQL alone is 17-67x faster (0.220s vs 3.755s unbound, 0.046s vs 3.072s bound). End to end is lower because the RDKit screen and verify is untouched and now dominates: pyridine's match alone is about 1.4s of its 1.46s, so the SQL fell from roughly 3.5s to 0.2s and the bottleneck moved rather than shrank. Boronic acid, whose match is cheap, shows the full effect.

Cost: the build is four passes over the projections, upwards of a minute at corpus scale alongside the library build. Paid on the first query that can use it, not at open. Collapsing it to a single pass is an obvious follow-up.

## What routes, and what does not

Every query below is one somebody would actually ask. Only the first routes:

| query | answered by |
| --- | --- |
| pyridine as the solvent | **index** |
| yield > 50% **and** pyridine as the solvent | projection |
| how many reactions use pyridine as a solvent | projection |
| pyridine as the solvent, ordered | projection |
| pyridine as the solvent **and** a boronic acid input | projection |

The cause is `Corpus._plan`'s shape rather than the index's contents. An occurrence row is perfectly able to contribute to a bigger query; what is missing is a way to use it for *part* of one. So a second structure predicate, a scalar beside the quantifier, an aggregate, an ordering, a negation, a disjunction, or a `forall` all fall back, and the projection answers them exactly as it did before this.

The generalization is a substitution one level down, where `query._quantifier` compiles an element predicate to `len(list_filter(inputs.components, e -> get_bit(...) AND e.reaction_role = 'SOLVENT')) > 0`. When the index can answer that clause, emit `reaction_id IN (SELECT reaction_id FROM occurrences WHERE ...)` instead and let the rest of the query compile unchanged. Aggregates, orderings, and limits then compose for free; negation and disjunction work too, since `NOT (reaction_id IN ...)` means what the negated `list_filter` means; two structure predicates become two index lookups. Only `forall` stays out, because "every element matches" is not a membership test.

That rewrite deletes `_plan` and `_index_terms` — about 100 lines of this PR. Everything else, which is most of it, is what the rewrite needs: the schema walk deriving the indexed paths from the compiler's own traversals, the build, the pairing, and the differential tests. Follow-up rather than a blocker, but it is where the value is, and nothing further should be built on `_plan`.

## What the review round changed

Eight reviewers went over this. What they found:

**An empty index answered every structure query with "no matches."** Every path the projection can carry a structure at is indexed, so a corpus holding structures and indexing none of them means a traversal reached nothing — now a `PairingError`, with a per-path count logged so a path contributing nothing is visible before it costs an answer.

**The build could wedge the corpus.** It ran on the shared connection, which the module docstring forbids for anything running while a search is in flight, and `CREATE TABLE` left an interruption between the create and the flag colliding with itself forever. It takes a cursor and replaces the table.

**Neither path said it answered.** The two relations are supposed to agree, so a disagreement was only debuggable from process state nobody recorded. Both log now.

**`limit` is where the two paths visibly differ.** Neither orders what it was not asked to order, so a limited query with no `order_by` takes some of the match set and they take different rows of it. Stated in the planner, the module docstring, and the README; tested for what holds — the count is the limit, the rows are the match set's.

`_index_terms` returned `(True, role)` where the bool could not be `False` and the caller discarded it.

## Testing

Two paths to one answer is the risk here, so the tests are differential: every shape the planner accepts is run both ways and the results compared. Sabotages confirm they bite — dropping the role condition, dropping the path condition, and dropping `DISTINCT` each fail the suite.

Worth recording: my first version of these tests caught only the first of those three. The fixture's chemistry made the path-condition sabotage agree by accident, and comparing results as *sets* hid the duplicate rows that losing `DISTINCT` produces. Both gaps are covered by cases chosen to discriminate — a structure that lives only at another path, and a query matching two components of one reaction.

**But the suite verified what `_plan` decided, not what `search` ran.** Replacing `compiled = indexed ...` with the projection compile passed all 56 tests: the feature became a no-op that still paid the build, and the differential test compared the projection to itself. A routed query now reads a row planted only in `occurrences`, so a search that stops routing fails.

Nine more sabotages, each previously missed and now caught: the routing discarded, the role literal unescaped (`SOLVENT' OR '1'='1` matches every row at every path), the limit dropped, the index lock removed, the empty-index guard removed, and the four role guards relaxed one at a time — any element field, any comparison, any value type, last role wins.

A second fixture holds a workup component and an authentic standard, so `workups.input.components` and `outcomes.products.measurements.authentic_standard` — the two deepest traversals, and the two the main fixture had no data for — are compared against the projection rather than comparing nothing to nothing.

`pytest -n auto` — 1054 passed, 2 skipped. `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a lazily built occurrence index and narrowly routes eligible structure queries through it while retaining projection execution as the fallback.
- Derives indexed structure-bearing paths from the projection schema and compiler traversal logic.
- Preserves element-level role binding and corpus-wide structure IDs in occurrence rows.
- Adds locking, index-completeness checks, path-level logging, and extensive differential and concurrency tests.
- Documents planner scope, initialization cost, and unordered-limit behavior.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/agent/execute.py | Adds schema-derived occurrence indexing, narrow query planning, synchronized lazy construction, completeness validation, and routed execution without an accepted blocking issue. |
| ord_schema/agent/execute_test.py | Adds broad planner-shape, differential-result, deep-path, escaping, deduplication, refusal, routing, and concurrent-build coverage. |
| ord_schema/agent/README.md | Documents occurrence-index semantics, routing limits, build costs, role binding, and unordered-limit behavior consistently with the implementation. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Q[Corpus.search request] --> P{Occurrence planner accepts shape?}
  P -->|No| C[Compile against projection]
  P -->|Yes| B{Occurrence index built?}
  B -->|No| I[Build occurrence rows under lock]
  B -->|Yes| O[Use occurrence relation]
  I --> O
  C --> M[Resolve and evaluate structure predicates]
  O --> M
  M --> E[Execute compiled SQL]
  E --> R[Arrow result]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Count the structures the index reached, ..."](https://github.com/open-reaction-database/ord-schema/commit/02b38a0b1cb4b66fa40d9e230fbaff6aa1d43447) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51697038)</sub>

**Context used:**

- Knowledge Base — [Agent Query Surface](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/agent-query.md)

<!-- /greptile_comment -->