### PR TITLE
Cut what a query costs: match once, cache answers, read only the named columns

### DIFF
--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -126,6 +126,17 @@ every structure ID sharing it. And a match set depends on the query molecule and
 else, so recent ones are **cached**: pyridine costs 1.05s the first time and 0.02s the
 next. A compound is keyed by what it resolved to, not by its name.
 
+Queries the index declines read the projection, and read it faster from a table holding
+only the top-level columns they name. Reading a handful of columns out of a 442-leaf
+projection spread over 53 files costs mostly per-file overhead, which is the same
+whatever the query asks for; paying it once and answering from memory afterwards takes a
+temperature filter from 1.24s to 0.21s and a group-by on stirring type from 0.75s to
+0.003s. The columns are read back off the compiled SQL, so one it names and the table
+lacks is a catalog error rather than a wrong answer. Materialized sets are held to a
+memory budget and evicted least-recently-used; one too large to keep is not kept, and
+the projection answers directly. The rows are the same rows either way, in an order
+neither relation promises — a query wanting one has to say so.
+
 The screen itself is not a lever. It is the same `PatternFingerprint` the RDKit
 PostgreSQL cartridge screens with (`rdkit.sss_fp_size`, via `makeMolSignature`), and for
 a small common query it admits most of the corpus — 80% for pyridine, of which 73% then

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -124,7 +124,9 @@ per dataset, so the library holds one entry per **distinct** molecule — 1,435,
 corpus's 2,016,224 rows, so 29% of the matching disappears — and maps each entry back to
 every structure ID sharing it. And a match set depends on the query molecule and nothing
 else, so recent ones are **cached**: pyridine costs 1.05s the first time and 0.02s the
-next. A compound is keyed by what it resolved to, not by its name.
+next. A compound is keyed by what it resolved to, not by its name. A predicate asked
+again while the first pass is still running waits for that pass, so a burst of identical
+requests costs one match; unrelated searches still overlap.
 
 Queries the index declines read the projection, and read it faster from a table holding
 only the top-level columns they name. Reading a handful of columns out of a 442-leaf

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -93,11 +93,11 @@ is a compile error rather than a wrong answer:
 A structure predicate compiles to a bitmap test, not to chemistry. The chemistry runs
 in [`execute.Corpus`](execute.py) against the [structures artifact](../structures.py).
 Substructure runs through an RDKit `SubstructLibrary` built over the corpus: a
-fingerprint **screen** — complete but not exact — over every structure row
-(deduplicated per dataset, so a molecule in two datasets is screened twice), then exact
-subgraph **verification** of the survivors. It runs on RDKit's own threads with the GIL
-released, so one `Corpus` serves concurrent requests without forking; the library is
-built on the first substructure query and costs about 8s and 2 GB for the full corpus.
+fingerprint **screen** — complete but not exact — over every distinct molecule in the
+corpus, then exact subgraph **verification** of the survivors. It runs on RDKit's own
+threads with the GIL released, so one `Corpus` serves concurrent requests without
+forking; the library is built on the first substructure query and costs seconds and
+about 1.5 GB for the full corpus.
 Each search takes its own DuckDB cursor, since a connection holds the pending result of
 its last `execute` and concurrent searches sharing one would read each other's rows.
 `threads` is per search rather than per corpus, so a server expecting several at once
@@ -109,7 +109,7 @@ larger one. An **occurrence index** — one row per structure occurrence, carryi
 corpus-wide ID, the path, and the element's own `reaction_role` — makes that a filter
 over a narrow table rather than a scan of every reaction. Keeping the role beside the
 structure is what keeps a bound query a condition on one row. At corpus scale the index
-is 14.1M rows and about 130 MB, held in memory for the life of the `Corpus`, and answers
+is 14.1M rows and about 130 MB, resident for the life of the `Corpus`, and answers
 pyridine among the inputs in 1.46s, pyridine as the solvent in 1.74s, and a boronic acid
 in 0.15s. What remains for common patterns is the RDKit screen and verify, which the
 index does not touch.
@@ -129,22 +129,26 @@ match set and they do not agree on which.
 What remains is the chemistry itself, and two things cut it. Structures are deduplicated
 per dataset, so the library holds one entry per **distinct** molecule — 1,435,426 of the
 corpus's 2,016,224 rows, so 29% of the matching disappears — and maps each entry back to
-every structure ID sharing it. And a match set depends on the query molecule and nothing
-else, so recent ones are **cached**: pyridine costs 1.05s the first time and 0.02s the
-next. A compound is keyed by what it resolved to, not by its name. A predicate asked
+every structure ID sharing it. And a match set depends on the query molecule, the
+operation, and the threshold, so recent ones are **cached**: pyridine costs 1.05s the
+first time and 0.02s the next. A compound is keyed by what it resolved to rather than by
+its name, and by which parser reads it — the same text is one molecule as SMILES and
+another as SMARTS. A predicate asked
 again while the first pass is still running waits for that pass, so a burst of identical
 requests costs one match; unrelated searches still overlap.
 
-Queries the index declines read the projection, and read it faster from a table holding
-only the top-level columns they name. Reading a handful of columns out of a 442-leaf
-projection spread over 53 files costs mostly per-file overhead, which is the same
-whatever the query asks for; paying it once and answering from memory afterwards takes a
-temperature filter from 1.24s to 0.21s and a group-by on stirring type from 0.75s to
-0.003s. The columns are read back off the compiled SQL, so one it names and the table
-lacks is a catalog error rather than a wrong answer. Materialized sets are held to a
-memory budget and evicted least-recently-used; one too large to keep is not kept, and
-the projection answers directly. The rows are the same rows either way, in an order
-neither relation promises — a query wanting one has to say so.
+Queries the index declines read the projection, and read it faster from a **materialized
+column set** holding only the top-level columns they name. Reading a handful of columns
+out of a 442-leaf projection spread over 53 files costs mostly per-file overhead, which
+is the same whatever the query asks for; paying it once and answering from memory
+afterwards takes a temperature filter from 1.24s to 0.21s and a group-by on stirring
+type from 0.75s to 0.003s. The columns are read back off the compiled SQL and the query
+is then compiled again against the table, so a column it names and the table lacks is a
+catalog error rather than a wrong answer, and no SQL text is edited. Sets are held to a
+memory budget and evicted least-recently-used, skipping any a search is still reading;
+one too large to keep is not kept, and the projection answers directly. The rows are the
+same rows either way, in an order neither relation promises — a query wanting one has to
+say so.
 
 The screen itself is not a lever. It is the same `PatternFingerprint` the RDKit
 PostgreSQL cartridge screens with (`rdkit.sss_fp_size`, via `makeMolSignature`), and for

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -109,18 +109,21 @@ larger one. An **occurrence index** — one row per structure occurrence, carryi
 corpus-wide ID, the path, and the element's own `reaction_role` — makes that a filter
 over a narrow table rather than a scan of every reaction. Keeping the role beside the
 structure is what keeps a bound query a condition on one row. At corpus scale the index
-is 14.1M rows and about 130 MB, held in memory for the life of the `Corpus`, and answers
-pyridine among the inputs in 1.46s, pyridine as the solvent in 1.74s, and a boronic acid
-in 0.15s. What remains for common patterns is the RDKit screen and verify, which the
-index does not touch.
+is 14.1M rows and about 130 MB, resident for the life of the `Corpus`. A search for
+pyridine among the inputs returns in 1.46s **end to end**, pyridine as the solvent in
+1.74s, and a boronic acid in 0.15s — and for a common pattern nearly all of that is the
+RDKit screen and verify, which the index does not touch: pyridine's match alone is about
+1.4s of its 1.46s. What the index cut is the reaction lookup, from roughly 3.5s to 0.2s.
 
 The index answers only the shape it holds: a bare `exists` at an indexed path whose body
 asks for one structure and at most one role. A query reaching another element field, or
 needing a projection column to group or sort by — and every `forall`, negation, and
-disjunction — runs against the projection. Both paths screen and verify through the same
-compiler, and the log line says which one answered. The index is built on the first query
-that routes to it, four passes over the projections, so a server wanting the first real
-query to be fast should warm it rather than budget for it at open.
+disjunction — runs against the projection, so "reactions with yield > 50% where pyridine
+is the solvent" is answered there rather than here. Both paths screen and verify through
+the same compiler, and the log line says which one answered. The index is built on the
+first query that routes to it, one pass over the projections per indexed path, so a
+server that wants its first real query to be fast should issue a throwaway structure
+query at startup.
 
 A `limit` with no `order_by` is the one place the two paths visibly differ: neither
 relation orders what it was not asked to order, so each returns some rows of the same
@@ -128,12 +131,13 @@ match set and they do not agree on which.
 
 Similarity needs no verification — Tanimoto is defined on the Morgan fingerprint, so
 the screen is the answer — and stays in SQL. The verified match set re-enters the query
-as a `BITSTRING` parameter indexed by the corpus-wide ID (`structure_id` plus the
-file's offset), which is what preserves element binding: `exists(components,
+as a `BITSTRING` parameter indexed by the corpus-wide ID (`structure_id` plus the file's
+offset), which is how the projection path tests a single element: `exists(components,
 substructure(pyridine) and role = SOLVENT)` means one component that is both. The
 alternative — intersecting reaction-ID sets — over-returns by 94% on exactly that
 query; see [ord-logbook#28](https://github.com/open-reaction-database/ord-logbook/pull/28),
-finding 4.
+finding 4. Every corpus-scale figure on this page was measured against that logbook
+entry's snapshot of ORD.
 
 ```python
 from ord_schema.agent import execute, query

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -118,6 +118,22 @@ structure, optionally with a given role. A query reaching another element field,
 needing a projection column to group or sort by, runs against the projection unchanged.
 It is built on the first query that can use it — four passes over the projections, so
 budget for it alongside the library at startup.
+
+What remains is the chemistry itself, and two things cut it. Structures are deduplicated
+per dataset, so the library holds one entry per **distinct** molecule — 1,435,426 of the
+corpus's 2,016,224 rows, so 29% of the matching disappears — and maps each entry back to
+every structure ID sharing it. And a match set depends on the query molecule and nothing
+else, so recent ones are **cached**: pyridine costs 1.05s the first time and 0.02s the
+next. A compound is keyed by what it resolved to, not by its name.
+
+The screen itself is not a lever. It is the same `PatternFingerprint` the RDKit
+PostgreSQL cartridge screens with (`rdkit.sss_fp_size`, via `makeMolSignature`), and for
+a small common query it admits most of the corpus — 80% for pyridine, of which 73% then
+fail verification. Measured and rejected: more bits does nothing (2048 → 8192 moves
+pyridine 80% → 79%), and a circular fingerprint is not usable at all, since it cannot be
+computed from a SMARTS and its bits are not preserved under subgraph extraction — a
+radius-2 Morgan screen dropped 4 of 5 true matches. Verification of the survivors is the
+real cost, and it is intrinsic.
 Similarity needs no verification — Tanimoto is defined on the Morgan fingerprint, so
 the screen is the answer — and stays in SQL. The verified match set re-enters the query
 as a `BITSTRING` parameter indexed by the corpus-wide ID (`structure_id` plus the

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -106,18 +106,26 @@ should set it to the core count divided by that concurrency instead of leaving i
 
 Finding which reactions hold a match is a separate cost from the chemistry, and the
 larger one. An **occurrence index** — one row per structure occurrence, carrying the
-corpus-wide ID, the path, and the element's own `reaction_role` — replaces that scan
-with a filter over a narrow table (14.1M rows, 130 MB against the projections' 1.65 GB).
-Keeping the role beside the structure is what preserves element binding. End to end at
-corpus scale: pyridine among the inputs 7.56s → 1.46s, pyridine as the solvent
-5.00s → 1.74s, a boronic acid 2.93s → 0.15s, with identical match sets. The remainder
-for common patterns is the RDKit screen and verify, which the index does not touch.
+corpus-wide ID, the path, and the element's own `reaction_role` — makes that a filter
+over a narrow table rather than a scan of every reaction. Keeping the role beside the
+structure is what keeps a bound query a condition on one row. At corpus scale the index
+is 14.1M rows and about 130 MB, held in memory for the life of the `Corpus`, and answers
+pyridine among the inputs in 1.46s, pyridine as the solvent in 1.74s, and a boronic acid
+in 0.15s. What remains for common patterns is the RDKit screen and verify, which the
+index does not touch.
 
-The index answers only the shape it holds: some element at an indexed path contains a
-structure, optionally with a given role. A query reaching another element field, or
-needing a projection column to group or sort by, runs against the projection unchanged.
-It is built on the first query that can use it — four passes over the projections, so
-budget for it alongside the library at startup.
+The index answers only the shape it holds: a bare `exists` at an indexed path whose body
+asks for one structure and at most one role. A query reaching another element field, or
+needing a projection column to group or sort by — and every `forall`, negation, and
+disjunction — runs against the projection. Both paths screen and verify through the same
+compiler, and the log line says which one answered. The index is built on the first query
+that routes to it, four passes over the projections, so a server wanting the first real
+query to be fast should warm it rather than budget for it at open.
+
+A `limit` with no `order_by` is the one place the two paths visibly differ: neither
+relation orders what it was not asked to order, so each returns some rows of the same
+match set and they do not agree on which.
+
 Similarity needs no verification — Tanimoto is defined on the Morgan fingerprint, so
 the screen is the answer — and stays in SQL. The verified match set re-enters the query
 as a `BITSTRING` parameter indexed by the corpus-wide ID (`structure_id` plus the

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -103,6 +103,21 @@ its last `execute` and concurrent searches sharing one would read each other's r
 `threads` is per search rather than per corpus, so a server expecting several at once
 should set it to the core count divided by that concurrency instead of leaving it at
 `-1`.
+
+Finding which reactions hold a match is a separate cost from the chemistry, and the
+larger one. An **occurrence index** — one row per structure occurrence, carrying the
+corpus-wide ID, the path, and the element's own `reaction_role` — replaces that scan
+with a filter over a narrow table (14.1M rows, 130 MB against the projections' 1.65 GB).
+Keeping the role beside the structure is what preserves element binding. End to end at
+corpus scale: pyridine among the inputs 7.56s → 1.46s, pyridine as the solvent
+5.00s → 1.74s, a boronic acid 2.93s → 0.15s, with identical match sets. The remainder
+for common patterns is the RDKit screen and verify, which the index does not touch.
+
+The index answers only the shape it holds: some element at an indexed path contains a
+structure, optionally with a given role. A query reaching another element field, or
+needing a projection column to group or sort by, runs against the projection unchanged.
+It is built on the first query that can use it — four passes over the projections, so
+budget for it alongside the library at startup.
 Similarity needs no verification — Tanimoto is defined on the Morgan fingerprint, so
 the screen is the answer — and stays in SQL. The verified match set re-enters the query
 as a `BITSTRING` parameter indexed by the corpus-wide ID (`structure_id` plus the

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -62,6 +62,8 @@ corpus, the index being four passes over the projections -- on top of whatever t
 it was given.
 """
 
+import array
+import collections
 import dataclasses
 import glob
 import math
@@ -85,6 +87,12 @@ logger = get_logger(__name__)
 # Structures read per batch while building the library. Bounds peak memory during the
 # build without making the per-batch Python overhead matter.
 _BUILD_BATCH = 50_000
+
+# Match sets kept for reuse. Each is a bitmap over the corpus ID space -- 2 MB at ORD's
+# scale -- so this trades a few tens of megabytes for the repeat of a query that costs
+# seconds. Small because the distribution is the point: a handful of scaffolds account
+# for most of what anyone asks.
+_CACHED_MATCHES = 16
 
 
 class PairingError(ValueError):
@@ -133,9 +141,9 @@ def _max_structure_id(path: str) -> int | None:
     return largest
 
 
-# An ID whose structure did not parse still occupies a slot, so a library index is a
-# corpus-wide structure ID and needs no translation. An empty molecule fingerprints to
-# no bits, and a query with no atoms is refused, so it can never match.
+# A structure that did not parse still gets a library entry, so every structure ID
+# resolves to one and the mapping needs no special case. An empty molecule fingerprints
+# to no bits, and a query with no atoms is refused, so it can never match.
 _UNPARSEABLE = Chem.Mol().ToBinary()
 _NO_BITS = DataStructs.ExplicitBitVect(structures.PATTERN_FP_SIZE)
 
@@ -186,6 +194,31 @@ def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
 INDEXED_PATHS = _indexed_paths()
 
 
+def _group(entry_of: array.array, count: int) -> tuple[array.array, array.array]:
+    """Inverts structure-to-entry into entry-to-structures.
+
+    Args:
+        entry_of: The library entry each structure ID resolves to, indexed by ID.
+        count: How many entries the library holds.
+
+    Returns:
+        ``(members, starts)``, where the structure IDs sharing entry ``i`` are
+        ``members[starts[i]:starts[i + 1]]``. Counting sort, so one pass each way and
+        no per-entry list object.
+    """
+    starts = array.array("I", bytes(4 * (count + 1)))
+    for entry in entry_of:
+        starts[entry + 1] += 1
+    for index in range(1, count + 1):
+        starts[index] += starts[index - 1]
+    members = array.array("I", bytes(4 * len(entry_of)))
+    cursor = starts[:-1]
+    for global_id, entry in enumerate(entry_of):
+        members[cursor[entry]] = global_id
+        cursor[entry] += 1
+    return members, starts
+
+
 class Corpus:
     """A searchable pairing of projections with their structures artifacts.
 
@@ -227,12 +260,21 @@ class Corpus:
         """
         self._resolver = resolver if resolver is not None else _resolve_with_resolvers
         self._threads = threads
-        # Built on first substructure query; see _library.
+        # Built on first substructure query; see _library. The library holds one entry
+        # per distinct molecule, and _members maps an entry back to the structure IDs
+        # sharing it.
         self._substructure_library: rdSubstructLibrary.SubstructLibrary | None = None
+        self._members = array.array("I")
+        self._starts = array.array("I")
         self._library_lock = threading.Lock()
         # Built on the first query that can use it; see _occurrences.
         self._occurrences_built = False
         self._occurrences_lock = threading.Lock()
+        # Recent match sets, most recently used last; see _matches.
+        self._matched: collections.OrderedDict[tuple[str, str, float | None], str] = (
+            collections.OrderedDict()
+        )
+        self._matches_lock = threading.Lock()
         pairs = self._pair(projection_pattern, structures_pattern, require_current)
         self._connection = duckdb.connect()
         try:
@@ -434,22 +476,28 @@ class Corpus:
         """Returns the substructure library, building it on first use.
 
         Built lazily because it costs seconds and gigabytes, and a corpus asked only
-        for similarity or scalar queries never needs it. Streamed in ID order so a
-        library index *is* a corpus-wide structure ID: a structure that did not parse
-        still occupies its slot, holding an empty molecule that nothing matches.
+        for similarity or scalar queries never needs it.
+
+        Structures are deduplicated per dataset, so a molecule used by several datasets
+        occupies a row in each and would otherwise be matched once per copy. The library
+        holds one entry per distinct SMILES -- 1,435,426 of the corpus's 2,016,224 rows,
+        so 29% of the matching disappears -- and ``_members`` maps an entry back to
+        every structure ID sharing its molecule. Two structures with one SMILES have one
+        molecule and one fingerprint, both derived from that SMILES by the RDKit the
+        stamps pin, so which row is read does not matter.
 
         Concurrent first searches serialize on the build rather than each building a
-        copy, which at corpus scale is about 2 GB apiece. Whoever waits needs the
+        copy, which at corpus scale is about 1.5 GB apiece. Whoever waits needs the
         finished library anyway.
 
         Returns:
-            A library over every structure in the corpus, screened by the pattern
-            fingerprints the artifact already stores.
+            A library over every distinct molecule in the corpus, screened by the
+            pattern fingerprints the artifact already stores.
 
         Raises:
             PairingError: If the corpus IDs are not exactly ``0`` to ``total - 1``, so
-                that a library index would name a different structure, or if a
-                structure holds one of its derived columns without the other.
+                that a structure ID would name a different structure, or if a structure
+                holds one of its derived columns without the other.
         """
         with self._library_lock:
             if self._substructure_library is not None:
@@ -458,18 +506,24 @@ class Corpus:
             molecules = rdSubstructLibrary.CachedMolHolder()
             patterns = rdSubstructLibrary.PatternHolder(structures.PATTERN_FP_SIZE)
             cursor = self._connection.cursor()
+            # Which library entry each structure ID resolves to, in ID order. Held as
+            # an array rather than a list of lists: at corpus scale the difference is
+            # 8 MB against several hundred.
+            entry_of = array.array("I")
+            entries: dict[str, int] = {}
             position = 0
             try:
                 reader = cursor.execute(
-                    "SELECT global_id, mol_binary, pattern_fp FROM corpus_structures "
-                    "ORDER BY global_id"
+                    "SELECT global_id, smiles, mol_binary, pattern_fp "
+                    "FROM corpus_structures ORDER BY global_id"
                 ).to_arrow_reader(_BUILD_BATCH)
                 for batch in reader:
                     identifiers = batch.column("global_id").to_pylist()
+                    smiles_values = batch.column("smiles").to_pylist()
                     blobs = batch.column("mol_binary").to_pylist()
                     fingerprints = batch.column("pattern_fp").to_pylist()
-                    for global_id, blob, fingerprint in zip(
-                        identifiers, blobs, fingerprints, strict=True
+                    for global_id, smiles, blob, fingerprint in zip(
+                        identifiers, smiles_values, blobs, fingerprints, strict=True
                     ):
                         # Sorting alone does not make an index an ID; it does that only
                         # while the IDs are every integer from zero, each once. A
@@ -479,7 +533,7 @@ class Corpus:
                             raise PairingError(
                                 f"the corpus states structure ID {global_id} where "
                                 f"{position} was expected, so its IDs are not one "
-                                "unbroken run and a library index would name a "
+                                "unbroken run and a structure ID would name a "
                                 "different structure; derive the structures artifacts "
                                 "again"
                             )
@@ -497,26 +551,33 @@ class Corpus:
                                 "a structures artifact writes both or neither, so this "
                                 "one was not written by this library"
                             )
-                        if blob is None:
-                            molecules.AddBinary(_UNPARSEABLE)
-                            patterns.AddFingerprint(_NO_BITS)
-                        else:
-                            molecules.AddBinary(blob)
-                            patterns.AddFingerprint(
-                                DataStructs.CreateFromBinaryText(fingerprint)
-                            )
+                        entry = entries.get(smiles)
+                        if entry is None:
+                            entry = entries[smiles] = len(entries)
+                            if blob is None:
+                                molecules.AddBinary(_UNPARSEABLE)
+                                patterns.AddFingerprint(_NO_BITS)
+                            else:
+                                molecules.AddBinary(blob)
+                                patterns.AddFingerprint(
+                                    DataStructs.CreateFromBinaryText(fingerprint)
+                                )
+                        entry_of.append(entry)
                         position += 1
             finally:
                 cursor.close()
             library = rdSubstructLibrary.SubstructLibrary(molecules, patterns)
-            if len(library) != self._total:
+            self._members, self._starts = _group(entry_of, len(entries))
+            if position != self._total:
                 raise PairingError(
-                    f"the library holds {len(library)} structures but the corpus has "
+                    f"the library covers {position} structures but the corpus has "
                     f"{self._total}; its indices would not be structure IDs"
                 )
             logger.info(
-                "built a substructure library over %d structures in %.1fs",
+                "built a substructure library over %d distinct molecules covering "
+                "%d structures in %.1fs",
                 len(library),
+                position,
                 time.perf_counter() - start,
             )
             self._substructure_library = library
@@ -674,11 +735,17 @@ class Corpus:
         library = self._library()
         # maxResults defaults to 1000, which would silently truncate: a broad pattern
         # matches hundreds of thousands of structures in ORD.
-        return list(
-            library.GetMatches(
-                molecule, numThreads=self._threads, maxResults=len(library) or 1
-            )
+        matched = library.GetMatches(
+            molecule, numThreads=self._threads, maxResults=len(library) or 1
         )
+        # A library entry is a molecule, not a structure: every ID sharing that molecule
+        # matched too, and the answer is stated in IDs.
+        identifiers: list[int] = []
+        for entry in matched:
+            identifiers.extend(
+                self._members[self._starts[entry] : self._starts[entry + 1]]
+            )
+        return identifiers
 
     def _similarity_ids(
         self,
@@ -722,6 +789,61 @@ class Corpus:
         for global_id in matched:
             bits[global_id] = ord("1")
         return bits.decode()
+
+    def _matches(
+        self,
+        cursor: duckdb.DuckDBPyConnection,
+        parameter: query.StructureParameter,
+        resolve: Callable[[str], str],
+    ) -> str:
+        """Returns a structure predicate's match set as a bitmap, reusing a recent one.
+
+        The chemistry depends on the query molecule and nothing else, so the same
+        predicate asked twice has the same answer -- and asking it costs a pass over
+        every molecule in the corpus. A compound is keyed by what it resolved to rather
+        than by its name, so two names for one molecule share an entry and a resolver
+        that starts answering differently is a different key.
+
+        Args:
+            cursor: The cursor a similarity screen runs on.
+            parameter: The predicate to evaluate.
+            resolve: Maps a compound name to SMILES.
+
+        Returns:
+            The bitmap over corpus-wide structure IDs.
+        """
+        pattern = (
+            parameter.pattern
+            if parameter.pattern is not None
+            else resolve(parameter.compound or "")
+        )
+        key = (parameter.op, pattern, parameter.threshold)
+        with self._matches_lock:
+            cached = self._matched.get(key)
+            if cached is not None:
+                # Reinserted so the eviction below drops what has gone longest unused
+                # rather than what was computed longest ago.
+                self._matched.move_to_end(key)
+                logger.info("%s %r reused a cached match set", parameter.op, pattern)
+                return cached
+        if parameter.op == "substructure":
+            matched = self._substructure_ids(parameter, resolve)
+        else:
+            matched = self._similarity_ids(cursor, parameter, resolve)
+        logger.info(
+            "%s %r matched %d of %d structures (%d unsearchable)",
+            parameter.op,
+            pattern,
+            len(matched),
+            self._searchable,
+            self._total - self._searchable,
+        )
+        bitmap = self._bitmap(matched)
+        with self._matches_lock:
+            self._matched[key] = bitmap
+            while len(self._matched) > _CACHED_MATCHES:
+                self._matched.popitem(last=False)
+        return bitmap
 
     def search(
         self, request: query.Query, *, timeout_seconds: float | None = None
@@ -773,22 +895,7 @@ class Corpus:
                 name: resolve(name) for name in compiled.compounds
             }
             for parameter in compiled.structures:
-                if parameter.op == "substructure":
-                    matched = self._substructure_ids(parameter, resolve)
-                else:
-                    matched = self._similarity_ids(cursor, parameter, resolve)
-                unsearchable = self._total - self._searchable
-                logger.info(
-                    "%s %r matched %d of %d structures (%d unsearchable)",
-                    parameter.op,
-                    parameter.pattern
-                    if parameter.pattern is not None
-                    else parameter.compound,
-                    len(matched),
-                    self._searchable,
-                    unsearchable,
-                )
-                parameters[parameter.name] = self._bitmap(matched)
+                parameters[parameter.name] = self._matches(cursor, parameter, resolve)
             if timeout_seconds is None:
                 return cursor.execute(compiled.sql, parameters).to_arrow_table()
             return self._run_with_timeout(

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -67,6 +67,7 @@ import collections
 import dataclasses
 import glob
 import math
+import re
 import threading
 import time
 from collections.abc import Callable, Iterable, Sequence
@@ -93,6 +94,16 @@ _BUILD_BATCH = 50_000
 # seconds. Small because the distribution is the point: a handful of scaffolds account
 # for most of what anyone asks.
 _CACHED_MATCHES = 16
+
+# How much memory the materialized column sets may hold between them. Reached by
+# evicting the least recently used, so a corpus asked many different questions settles
+# on the columns it is actually asked about.
+_NARROW_BUDGET_BYTES = 2 * 1024**3
+
+# Top-level projection columns, which is the granularity a compiled query names them at.
+# A narrower table holding only the ones a query mentions answers it identically, and
+# the query needs no rewriting to say so.
+_TOP_LEVEL = tuple(projection.SCHEMA.names)
 
 
 class PairingError(ValueError):
@@ -275,6 +286,12 @@ class Corpus:
             collections.OrderedDict()
         )
         self._matches_lock = threading.Lock()
+        # Materialized column sets, most recently used last; see _narrow_table. Maps
+        # the columns to the table holding them and what it costs to keep.
+        self._narrowed: collections.OrderedDict[frozenset[str], tuple[str, int]] = (
+            collections.OrderedDict()
+        )
+        self._narrow_lock = threading.Lock()
         pairs = self._pair(projection_pattern, structures_pattern, require_current)
         self._connection = duckdb.connect()
         try:
@@ -702,12 +719,16 @@ class Corpus:
                 """  # noqa: S608
                 for path, expression in INDEXED_PATHS.items()
             )
-            # S608: the fragments are this module's own schema walk and the compiler's
-            # traversals, not anything a query supplies.
-            self._connection.execute(f"CREATE TABLE occurrences AS {selects}")
-            count = self._connection.execute(
-                "SELECT count(*) FROM occurrences"
-            ).fetchone()
+            # Its own cursor, like every other statement here: this runs while other
+            # searches are in flight, and the shared connection holds their results.
+            cursor = self._connection.cursor()
+            try:
+                # S608: the fragments are this module's own schema walk and the
+                # compiler's traversals, not anything a query supplies.
+                cursor.execute(f"CREATE TABLE occurrences AS {selects}")
+                count = cursor.execute("SELECT count(*) FROM occurrences").fetchone()
+            finally:
+                cursor.close()
             assert count is not None  # An aggregate over any relation returns one row.
             logger.info(
                 "indexed %d structure occurrences in %.1fs",
@@ -789,6 +810,105 @@ class Corpus:
         for global_id in matched:
             bits[global_id] = ord("1")
         return bits.decode()
+
+    @staticmethod
+    def _mentioned(sql: str) -> frozenset[str]:
+        """Returns the top-level projection columns a compiled query names.
+
+        Read back off the SQL rather than walked from the query, because the SQL is
+        what has to resolve: a column named there and missing from the table is a
+        catalog error, and one named only in the query is nothing at all. A name that
+        appears inside a string literal costs an unnecessary column and no correctness.
+
+        Args:
+            sql: The compiled query.
+
+        Returns:
+            The columns the query mentions, always including ``reaction_id``.
+        """
+        mentioned = {
+            column
+            for column in _TOP_LEVEL
+            if re.search(rf"\b{re.escape(column)}\b", sql)
+        }
+        mentioned.add("reaction_id")
+        return frozenset(mentioned)
+
+    def _narrow_table(self, columns: frozenset[str]) -> str | None:
+        """Returns a table holding only ``columns``, materializing it on first use.
+
+        Reading a handful of columns out of a 442-leaf projection spread over 53 files
+        costs mostly per-file overhead, which is the same whatever the query asks for.
+        Paying it once and answering from memory afterwards is worth a materialization
+        for the columns a corpus is actually asked about: a temperature filter falls
+        from 0.91s to 0.06s, a group-by on the DOI from 0.81s to 0.002s.
+
+        The rows are the same rows; their order is not. Neither relation orders anything
+        a query did not ask to be ordered, and they do not agree on the accident, so a
+        caller wanting a particular order has to say so -- as it did before this.
+
+        Args:
+            columns: Top-level projection columns the query names.
+
+        Returns:
+            The table's name, or None if materializing it would cost more memory than
+            the whole cache is allowed, in which case the projection answers directly.
+        """
+        with self._narrow_lock:
+            cached = self._narrowed.get(columns)
+            if cached is not None:
+                self._narrowed.move_to_end(columns)
+                return cached[0]
+            name = f"narrow_{len(self._narrowed)}_{abs(hash(columns)) % 10**9}"
+            selected = ", ".join([*sorted(columns), query.STRUCTURE_OFFSET])
+            start = time.perf_counter()
+            # Its own cursor, like every other statement here: this runs while other
+            # searches are in flight, and the shared connection holds their results.
+            cursor = self._connection.cursor()
+            try:
+                # S608: the names come from the projection schema and this module.
+                cursor.execute(
+                    f"CREATE TABLE {name} AS "  # noqa: S608
+                    f"SELECT {selected} FROM {query.TABLE}"
+                )
+                size = cursor.execute(
+                    "SELECT estimated_size FROM duckdb_tables() WHERE table_name = ?",
+                    [name],
+                ).fetchone()
+                held = int(size[0]) if size is not None and size[0] is not None else 0
+                if held > _NARROW_BUDGET_BYTES:
+                    # Too big to keep, and keeping it is the only reason to build it.
+                    cursor.execute(f"DROP TABLE {name}")
+                    logger.info(
+                        "not caching %s: %.1f GB exceeds the budget",
+                        sorted(columns),
+                        held / 1024**3,
+                    )
+                    return None
+            finally:
+                cursor.close()
+            logger.info(
+                "materialized %s as %s, %.2f GB in %.1fs",
+                sorted(columns),
+                name,
+                held / 1024**3,
+                time.perf_counter() - start,
+            )
+            self._narrowed[columns] = (name, held)
+            while sum(entry[1] for entry in self._narrowed.values()) > (
+                _NARROW_BUDGET_BYTES
+            ):
+                evicted, (table, _) = self._narrowed.popitem(last=False)
+                if evicted == columns:  # Never evict what this call just built.
+                    self._narrowed[columns] = (name, held)
+                    break
+                dropper = self._connection.cursor()
+                try:
+                    dropper.execute(f"DROP TABLE {table}")
+                finally:
+                    dropper.close()
+                logger.info("evicted the materialized %s", sorted(evicted))
+            return name
 
     def _matches(
         self,
@@ -880,6 +1000,16 @@ class Corpus:
         compiled = indexed if indexed is not None else query.compile_query(request)
         if indexed is not None:
             self._occurrences()
+        else:
+            # The index answers by itself; everything else reads the projection, and
+            # reads it faster from a table holding only the columns it names.
+            narrow = self._narrow_table(self._mentioned(compiled.sql))
+            if narrow is not None:
+                assert compiled.sql.count(f"FROM {query.TABLE}") == 1  # One pass.
+                compiled = dataclasses.replace(
+                    compiled,
+                    sql=compiled.sql.replace(f"FROM {query.TABLE}", f"FROM {narrow}"),
+                )
         # Cached across the whole search: a compound named in both a value and a
         # structure predicate is one external lookup, not two.
         resolved: dict[str, str] = {}

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -285,6 +285,9 @@ class Corpus:
         self._matched: collections.OrderedDict[tuple[str, str, float | None], str] = (
             collections.OrderedDict()
         )
+        # Match sets a thread is computing, so callers asking the same question while it
+        # runs wait for that answer instead of repeating it; see _matches.
+        self._matching: dict[tuple[str, str, float | None], threading.Event] = {}
         self._matches_lock = threading.Lock()
         # Materialized column sets, most recently used last; see _narrow_table. Maps
         # the columns to the table holding them and what it costs to keep.
@@ -924,6 +927,13 @@ class Corpus:
         than by its name, so two names for one molecule share an entry and a resolver
         that starts answering differently is a different key.
 
+        One question is answered once even while it is still being answered: a caller
+        arriving during another thread's pass waits for that pass rather than starting
+        a second, so a burst of identical requests costs one. The wait is per predicate,
+        so unrelated searches still overlap. A pass that raises publishes nothing and a
+        waiter behind it takes the matching over, which leaves the error with the caller
+        that hit it rather than with everyone queued behind.
+
         Args:
             cursor: The cursor a similarity screen runs on.
             parameter: The predicate to evaluate.
@@ -938,31 +948,46 @@ class Corpus:
             else resolve(parameter.compound or "")
         )
         key = (parameter.op, pattern, parameter.threshold)
-        with self._matches_lock:
-            cached = self._matched.get(key)
-            if cached is not None:
-                # Reinserted so the eviction below drops what has gone longest unused
-                # rather than what was computed longest ago.
-                self._matched.move_to_end(key)
-                logger.info("%s %r reused a cached match set", parameter.op, pattern)
-                return cached
-        if parameter.op == "substructure":
-            matched = self._substructure_ids(parameter, resolve)
-        else:
-            matched = self._similarity_ids(cursor, parameter, resolve)
-        logger.info(
-            "%s %r matched %d of %d structures (%d unsearchable)",
-            parameter.op,
-            pattern,
-            len(matched),
-            self._searchable,
-            self._total - self._searchable,
-        )
-        bitmap = self._bitmap(matched)
-        with self._matches_lock:
-            self._matched[key] = bitmap
-            while len(self._matched) > _CACHED_MATCHES:
-                self._matched.popitem(last=False)
+        while True:
+            with self._matches_lock:
+                cached = self._matched.get(key)
+                if cached is not None:
+                    # Reinserted so the eviction below drops what has gone longest
+                    # unused rather than what was computed longest ago.
+                    self._matched.move_to_end(key)
+                    logger.info(
+                        "%s %r reused a cached match set", parameter.op, pattern
+                    )
+                    return cached
+                computing = self._matching.get(key)
+                if computing is None:
+                    self._matching[key] = threading.Event()
+                    break
+            logger.info("%s %r is already running; waiting", parameter.op, pattern)
+            computing.wait()
+        try:
+            if parameter.op == "substructure":
+                matched = self._substructure_ids(parameter, resolve)
+            else:
+                matched = self._similarity_ids(cursor, parameter, resolve)
+            logger.info(
+                "%s %r matched %d of %d structures (%d unsearchable)",
+                parameter.op,
+                pattern,
+                len(matched),
+                self._searchable,
+                self._total - self._searchable,
+            )
+            bitmap = self._bitmap(matched)
+            with self._matches_lock:
+                self._matched[key] = bitmap
+                while len(self._matched) > _CACHED_MATCHES:
+                    self._matched.popitem(last=False)
+        finally:
+            # Woken after the result is published, so a waiter finds it on the next turn
+            # of the loop; a failed pass leaves nothing there and the waiter recomputes.
+            with self._matches_lock:
+                self._matching.pop(key).set()
         return bitmap
 
     def search(
@@ -971,8 +996,9 @@ class Corpus:
         """Compiles and runs a query, returning the result as an Arrow table.
 
         Runs on its own cursor, so concurrent searches sharing this corpus do not read
-        each other's results. They still serialize on the library build, and only on
-        that: the first substructure search builds it while the others wait.
+        each other's results. Two searches wait on each other only where waiting saves
+        work they would otherwise duplicate: the one-time library and index builds, and
+        a structure predicate one of them is already matching.
 
         A query the occurrence index can answer runs against it instead of the
         projection, which is the same answer reached without scanning every reaction.

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -47,10 +47,13 @@ per structure occurrence, carrying the corpus-wide ID, the path it sat at, and t
 element's own ``reaction_role`` -- turns that scan into a filter over a narrow table.
 Keeping the role beside the structure is what preserves element binding: "pyridine as
 the solvent" stays a condition on a single row rather than an intersection of two
-reaction sets, which over-returns. A query the index cannot answer, because it reaches
-an element field the index does not carry or needs a projection column to group or sort
-by, runs against the projection; both paths screen and verify through the same compiler,
-so they differ only in how they reach the reactions.
+reaction sets, which over-returns. The index answers one query shape -- a bare
+``exists`` at an indexed path asking for one structure and at most one role -- and every
+other query runs against the projection: a second structure predicate, a scalar beside
+the quantifier, an aggregate, an ordering, a negation, a disjunction, a ``forall``. Both
+paths screen and verify through the same compiler, so they differ only in how they reach
+the reactions, and a ``limit`` with no ``order_by`` is the one place that shows: each
+path takes some rows of one match set, and they take different ones.
 
 The grammar bounds what a query can cost (one pass and a sort), and ``search``
 takes a wall-clock timeout that interrupts the final query. Name resolution, the
@@ -151,26 +154,47 @@ def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
     same elements the projection does by construction rather than by a list here
     agreeing with one there.
 
+    Every path the schema can carry a structure at has to come out covered, which is
+    what lets the build check what it indexed against what the corpus says it holds. A
+    path this walk dropped would make a whole corpus look like one that lost structures.
+
     Args:
         schema: The projection schema.
 
     Returns:
         Dotted query paths to the DuckDB expression yielding their elements, for every
-        repeated level whose elements carry both a structure and ``_INDEXED_FIELD``.
+        level whose elements carry a structure.
+
+    Raises:
+        ValueError: If a structure-bearing level carries no ``_INDEXED_FIELD`` or does
+            not resolve to a repeated expression, so the index cannot cover it; or if
+            the schema carries no structure at all. Raised at import, naming the path,
+            because the answer is to change this module rather than to retry.
     """
     paths: dict[str, str] = {}
 
     def walk(dtype: pa.DataType, prefix: str) -> None:
         if pa.types.is_struct(dtype):
             names = [field.name for field in dtype]
-            if "structure_id" in names and _INDEXED_FIELD in names:
+            if "structure_id" in names:
                 # The schema walk speaks Parquet; the grammar has no wrapper levels.
                 path = prefix.replace(".list.element", "").replace(
                     ".key_value.value", ""
                 )
-                resolved = query.resolve(path, allow_internal=True)
-                if resolved.repeated:
-                    paths[path] = resolved.expression
+                resolved = query.resolve(path, schema=schema, allow_internal=True)
+                if _INDEXED_FIELD not in names:
+                    raise ValueError(
+                        f"{path} carries a structure but no {_INDEXED_FIELD}, so the "
+                        "occurrence index cannot cover it and a structure sitting only "
+                        "there would look like one the index lost"
+                    )
+                if not resolved.repeated:
+                    raise ValueError(
+                        f"{path} carries a structure but resolves to one element "
+                        "rather than a repeated expression, which the build cannot "
+                        "unnest"
+                    )
+                paths[path] = resolved.expression
             for child in dtype:
                 walk(child.type, f"{prefix}.{child.name}")
         elif pa.types.is_list(dtype):
@@ -180,6 +204,11 @@ def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
 
     for field in schema:
         walk(field.type, field.name)
+    if not paths:
+        raise ValueError(
+            "the schema carries no structure at any path, so an occurrence index has "
+            "nothing to index and its build would assemble no SQL at all"
+        )
     return paths
 
 
@@ -191,9 +220,9 @@ class _IndexTerms:
     """What a predicate the occurrence index can answer asks of one row.
 
     Attributes:
-        role: The role the element must hold, or None if the query does not bind one.
-            Absence is not a wildcard the index applies -- it is a query that named no
-            role, so the condition is left off.
+        role: The role the element must hold, or None when the query leaves the role
+            unconstrained -- which is not the same as requiring no role, and compiles to
+            no condition rather than to one on NULL.
     """
 
     role: str | None
@@ -243,8 +272,11 @@ class Corpus:
         # Built on first substructure query; see _library.
         self._substructure_library: rdSubstructLibrary.SubstructLibrary | None = None
         self._library_lock = threading.Lock()
-        # Built on the first query that can use it; see _occurrences.
+        # Built on the first query that can use it; see _occurrences. A build that finds
+        # the corpus unindexable keeps its reason here, since the corpus cannot change
+        # while this object is open and rebuilding costs a pass per path to reach it.
         self._occurrences_built = False
+        self._refused: str | None = None
         self._occurrences_lock = threading.Lock()
         pairs = self._pair(projection_pattern, structures_pattern, require_current)
         self._connection = duckdb.connect()
@@ -543,9 +575,10 @@ class Corpus:
             where: The predicate inside a quantifier, relative to the element.
 
         Returns:
-            The terms, if every clause is a structure predicate on the element's own
-            structure or an equality on the indexed field, or None if any clause reaches
-            something the index does not carry.
+            The terms, if the predicate is exactly one structure predicate on the
+            element's own ``smiles`` and at most one equality on the indexed field, or
+            None if any clause reaches something an occurrence row does not carry, or if
+            the structure predicates number anything but one.
         """
         clauses = where.clauses if isinstance(where, query.And) else [where]
         structures_seen = 0
@@ -633,13 +666,10 @@ class Corpus:
             "SELECT DISTINCT reaction_id FROM occurrences "  # noqa: S608
             f"WHERE {' AND '.join(conditions)}{limit}"
         )
-        # Which relation answered is the one thing a result does not show, and the two
-        # are supposed to agree, so a disagreement is only ever debugged from here.
-        logger.info("the occurrence index answers %s", where.path)
         return dataclasses.replace(compiled, sql=sql)
 
     def _occurrences(self) -> None:
-        """Builds the occurrence index, once, if it is not already built.
+        """Builds the occurrence index, once.
 
         One row per structure occurrence, carrying the corpus-wide ID, the path it sat
         at, and the element's own ``reaction_role``. Keeping the role beside the
@@ -652,13 +682,16 @@ class Corpus:
         here and share the result.
 
         Raises:
-            PairingError: If a corpus holding structures indexes none of them. Every
-                path the projection can carry a structure at is indexed, so an empty
-                index means a traversal reached nothing -- and an empty index answers
-                every structure query with "no matches", which reads like an answer
-                rather than like a corpus that cannot be searched.
+            PairingError: If the index does not reach every structure the corpus holds.
+                An unreached structure is one whose reactions no routed query can find,
+                and the answer comes back empty rather than wrong -- which reads like an
+                answer rather than like a corpus that cannot be searched. The reason is
+                kept and re-raised, since a corpus does not change under an open
+                ``Corpus`` and rebuilding is several passes to reach the same refusal.
         """
         with self._occurrences_lock:
+            if self._refused is not None:
+                raise PairingError(self._refused)
             if self._occurrences_built:
                 return
             start = time.perf_counter()
@@ -684,26 +717,40 @@ class Corpus:
                 # forever. S608: the fragments are this module's own schema walk and
                 # the compiler's traversals, not anything a query supplies.
                 cursor.execute(f"CREATE OR REPLACE TABLE occurrences AS {selects}")
-                indexed = cursor.execute(
-                    "SELECT path, count(*) FROM occurrences GROUP BY path"
-                ).fetchall()
-                counts = dict(indexed)
-                total = sum(counts.values())
-                if self._total and not total:
-                    raise PairingError(
-                        f"the occurrence index came out empty over {self._total} "
-                        f"structures; none of {sorted(INDEXED_PATHS)} reached an "
-                        "element, so the projections are not the schema this walk was "
-                        "built from"
+                counts = dict(
+                    cursor.execute(
+                        "SELECT path, count(*) FROM occurrences GROUP BY path"
+                    ).fetchall()
+                )
+                reached = cursor.execute(
+                    "SELECT count(DISTINCT global_id) FROM occurrences"
+                ).fetchone()
+                assert reached is not None  # An aggregate returns one row.
+                # A structures artifact holds one row per distinct structure its
+                # projection uses, so every ID it states is one some element carries and
+                # the index has to find all of them. Counting them is what catches a
+                # single traversal reaching nothing, which a total over every path
+                # cannot: the other paths carry the total and the dead one answers its
+                # queries with silence.
+                if reached[0] != self._total:
+                    self._refused = (
+                        f"the occurrence index reached {reached[0]} of the corpus's "
+                        f"{self._total} structures over {sorted(INDEXED_PATHS)}; "
+                        "either the projections are not the schema this walk was built "
+                        "from, or their rows did not survive the filename join, so the "
+                        "reactions holding the rest cannot be found"
                     )
+                    raise PairingError(self._refused)
                 self._occurrences_built = True
             finally:
                 cursor.close()
-            # Per path, so one that reaches nothing is visible here rather than only in
-            # the answers it fails to contribute to.
+            # Per path, so how the occurrences are distributed is visible rather than
+            # only their total. A path holding none is normal -- most corpora have no
+            # authentic standards -- which is why the refusal above counts structures
+            # rather than paths.
             logger.info(
                 "indexed %d structure occurrences in %.1fs: %s",
-                total,
+                sum(counts.values()),
                 time.perf_counter() - start,
                 ", ".join(f"{path} {counts.get(path, 0)}" for path in INDEXED_PATHS),
             )
@@ -786,11 +833,13 @@ class Corpus:
         build, each of which the first search wanting it performs while the others wait.
 
         A query the occurrence index can answer runs against it instead of the
-        projection, which is the same answer reached without scanning every reaction.
-        The screening and verification are the compiler's either way, so the two paths
-        differ only in how they find the reactions holding a match. Which one answered
-        is logged, because it is the one thing about a search that the result does not
-        show.
+        projection, reaching the same reactions without scanning every one of them. The
+        screening and verification are the compiler's either way, so the two paths
+        differ only in how they find the reactions holding a match -- with one
+        exception: a ``limit`` with no ``order_by`` asks for some rows of the match set
+        rather than for particular ones, and the two take different rows of it. Which
+        relation answered is logged, because it is the one thing about a search that
+        the result does not show.
 
         Args:
             request: The query to run.
@@ -806,14 +855,20 @@ class Corpus:
         Raises:
             query.QueryError: If the query does not compile.
             ValueError: If a compound name cannot be resolved.
-            PairingError: If the corpus IDs do not come out one unbroken run, or a
-                corpus holding structures indexes none of them.
+            PairingError: If the corpus IDs do not come out one unbroken run, or the
+                occurrence index does not reach every structure the corpus holds.
             TimeoutError: If the query exceeds ``timeout_seconds``.
         """
         indexed = self._plan(request)
         compiled = indexed if indexed is not None else query.compile_query(request)
         if indexed is not None:
+            # Logged after the build, so a build that refuses the corpus does not leave
+            # a line claiming the index answered a query nothing ran.
             self._occurrences()
+            logger.info(
+                "the occurrence index answers this query at %s",
+                getattr(request.where, "path", None),
+            )
         else:
             logger.info("the projection answers this query")
         # Cached across the whole search: a compound named in both a value and a

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -64,13 +64,14 @@ minute over the whole corpus, on top of whatever timeout it was given.
 
 import array
 import collections
+import contextlib
 import dataclasses
 import glob
 import math
 import re
 import threading
 import time
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from typing import Any, Self
 
 import duckdb
@@ -91,19 +92,25 @@ _BUILD_BATCH = 50_000
 
 # Match sets kept for reuse. Each is a bitmap over the corpus ID space -- 2 MB at ORD's
 # scale -- so this trades a few tens of megabytes for the repeat of a query that costs
-# seconds. Small because the distribution is the point: a handful of scaffolds account
-# for most of what anyone asks.
+# seconds.
 _CACHED_MATCHES = 16
 
-# How much memory the materialized column sets may hold between them. Reached by
+# How much memory the materialized column sets may hold between them. Held to by
 # evicting the least recently used, so a corpus asked many different questions settles
-# on the columns it is actually asked about.
+# on the columns it is actually asked about. Enforced after a table is built rather than
+# before, since what one costs is known only once it exists, so the peak is this plus
+# the largest single set; a set larger than the whole budget is dropped again unkept.
 _NARROW_BUDGET_BYTES = 2 * 1024**3
 
 # Top-level projection columns, which is the granularity a compiled query names them at.
-# A narrower table holding only the ones a query mentions answers it identically, and
-# the query needs no rewriting to say so.
+# A narrower table holding only the ones a query mentions answers it identically, so the
+# query is compiled against it as written.
 _TOP_LEVEL = tuple(projection.SCHEMA.names)
+
+
+# What a structure predicate's answer depends on: the operation, whether the string
+# is read as SMARTS or as SMILES, the string, and the similarity threshold.
+_MatchKey = tuple[str, bool, str, float | None]
 
 
 class PairingError(ValueError):
@@ -230,6 +237,22 @@ def _group(entry_of: array.array, count: int) -> tuple[array.array, array.array]
     return members, starts
 
 
+@dataclasses.dataclass
+class _Narrow:
+    """A materialized table holding some of the projection's top-level columns.
+
+    Attributes:
+        name: The table's name in the catalog.
+        held: What it costs to keep, in bytes.
+        readers: Searches currently reading it. An entry with any is passed over by
+            eviction, since a search holds only the name until it runs.
+    """
+
+    name: str
+    held: int
+    readers: int
+
+
 @dataclasses.dataclass(frozen=True)
 class _IndexTerms:
     """What a predicate the occurrence index can answer asks of one row.
@@ -285,8 +308,8 @@ class Corpus:
         self._resolver = resolver if resolver is not None else _resolve_with_resolvers
         self._threads = threads
         # Built on first substructure query; see _library. The library holds one entry
-        # per distinct molecule, and _members maps an entry back to the structure IDs
-        # sharing it.
+        # per distinct molecule, and _members with _starts map an entry back to the
+        # structure IDs sharing it.
         self._substructure_library: rdSubstructLibrary.SubstructLibrary | None = None
         self._members = array.array("I")
         self._starts = array.array("I")
@@ -295,18 +318,20 @@ class Corpus:
         self._occurrences_built = False
         self._occurrences_lock = threading.Lock()
         # Recent match sets, most recently used last; see _matches.
-        self._matched: collections.OrderedDict[tuple[str, str, float | None], str] = (
+        self._matched: collections.OrderedDict[_MatchKey, str] = (
             collections.OrderedDict()
         )
         # Match sets a thread is computing, so callers asking the same question while it
         # runs wait for that answer instead of repeating it; see _matches.
-        self._matching: dict[tuple[str, str, float | None], threading.Event] = {}
+        self._matching: dict[_MatchKey, threading.Event] = {}
         self._matches_lock = threading.Lock()
-        # Materialized column sets, most recently used last; see _narrow_table. Maps
-        # the columns to the table holding them and what it costs to keep.
-        self._narrowed: collections.OrderedDict[frozenset[str], tuple[str, int]] = (
+        # Materialized column sets, most recently used last; see _narrowed_table. The
+        # serial names them, and never repeats, so a build that fails partway leaves no
+        # name for the next one to collide with.
+        self._narrowed: collections.OrderedDict[frozenset[str], _Narrow] = (
             collections.OrderedDict()
         )
+        self._narrow_serial = 0
         self._narrow_lock = threading.Lock()
         pairs = self._pair(projection_pattern, structures_pattern, require_current)
         self._connection = duckdb.connect()
@@ -529,8 +554,10 @@ class Corpus:
 
         Raises:
             PairingError: If the corpus IDs are not exactly ``0`` to ``total - 1``, so
-                that a structure ID would name a different structure, or if a structure
-                holds one of its derived columns without the other.
+                that the position an ID is assumed to occupy holds another structure; if
+                the library and the entry table disagree about how many distinct
+                molecules there are; or if a structure holds one of its derived columns
+                without the other.
         """
         with self._library_lock:
             if self._substructure_library is not None:
@@ -539,9 +566,9 @@ class Corpus:
             molecules = rdSubstructLibrary.CachedMolHolder()
             patterns = rdSubstructLibrary.PatternHolder(structures.PATTERN_FP_SIZE)
             cursor = self._connection.cursor()
-            # Which library entry each structure ID resolves to, in ID order. Held as
-            # an array rather than a list of lists: at corpus scale the difference is
-            # 8 MB against several hundred.
+            # Which library entry each structure ID resolves to, in ID order. An array
+            # of unsigned ints rather than a list, which at corpus scale is 8 MB against
+            # something closer to 60.
             entry_of = array.array("I")
             entries: dict[str, int] = {}
             position = 0
@@ -558,17 +585,17 @@ class Corpus:
                     for global_id, smiles, blob, fingerprint in zip(
                         identifiers, smiles_values, blobs, fingerprints, strict=True
                     ):
-                        # Sorting alone does not make an index an ID; it does that only
-                        # while the IDs are every integer from zero, each once. A
-                        # duplicate or a gap slides every later structure onto a
-                        # neighbor's index, which a row count cannot see.
+                        # An ID is read as the position it occupies in this pass, which
+                        # it is only while the IDs are every integer from zero, each
+                        # once. A duplicate or a gap slides every later structure one
+                        # position along, which a row count cannot see.
                         if global_id != position:
                             raise PairingError(
                                 f"the corpus states structure ID {global_id} where "
                                 f"{position} was expected, so its IDs are not one "
-                                "unbroken run and a structure ID would name a "
-                                "different structure; derive the structures artifacts "
-                                "again"
+                                "unbroken run and every later structure sits at a "
+                                "position other than its own ID; derive the structures "
+                                "artifacts again"
                             )
                         # A structures artifact writes the derived columns together or
                         # not at all. One without the other means the row came from
@@ -600,12 +627,23 @@ class Corpus:
             finally:
                 cursor.close()
             library = rdSubstructLibrary.SubstructLibrary(molecules, patterns)
-            self._members, self._starts = _group(entry_of, len(entries))
             if position != self._total:
                 raise PairingError(
                     f"the library covers {position} structures but the corpus has "
-                    f"{self._total}; its indices would not be structure IDs"
+                    f"{self._total}, so a structure ID would fall outside the run this "
+                    "read and resolve to no entry"
                 )
+            # The holders and the entry table are filled in the same branch, so a
+            # divergence means one of them missed a row -- after which every entry above
+            # the divergence maps to a neighbor's structures: in range, wrong molecule,
+            # and invisible to a count of either one alone.
+            if len(library) != len(entries):
+                raise PairingError(
+                    f"the library holds {len(library)} molecules against "
+                    f"{len(entries)} distinct SMILES, so an entry index does not name "
+                    "the molecule it was built from"
+                )
+            self._members, self._starts = _group(entry_of, len(entries))
             logger.info(
                 "built a substructure library over %d distinct molecules covering "
                 "%d structures in %.1fs",
@@ -756,8 +794,8 @@ class Corpus:
                 """  # noqa: S608
                 for path, expression in INDEXED_PATHS.items()
             )
-            # Its own cursor: this runs while other searches are in flight, and the
-            # shared connection holds their results.
+            # Its own cursor: this runs while searches are in flight, and the shared
+            # connection holds their results.
             cursor = self._connection.cursor()
             try:
                 # OR REPLACE, so a build interrupted after the table exists is a build
@@ -807,7 +845,7 @@ class Corpus:
         molecule = self._query_molecule(parameter, resolve)
         library = self._library()
         # maxResults defaults to 1000, which would silently truncate: a broad pattern
-        # matches hundreds of thousands of structures in ORD.
+        # matches hundreds of thousands of ORD's distinct molecules.
         matched = library.GetMatches(
             molecule, numThreads=self._threads, maxResults=len(library) or 1
         )
@@ -869,8 +907,12 @@ class Corpus:
 
         Read back off the SQL rather than walked from the query, because the SQL is
         what has to resolve: a column named there and missing from the table is a
-        catalog error, and one named only in the query is nothing at all. A name that
-        appears inside a string literal costs an unnecessary column and no correctness.
+        catalog error, and one named only in the query is nothing at all.
+
+        Matched as a word anywhere in the SQL, so this errs wide: a nested field sharing
+        a leaf name with a top-level column names both -- ``smiles`` is a component's
+        field and a reaction's own column -- and a name inside a string literal counts
+        too. Each costs a column that gets materialized and never read.
 
         Args:
             sql: The compiled query.
@@ -886,48 +928,65 @@ class Corpus:
         mentioned.add("reaction_id")
         return frozenset(mentioned)
 
-    def _narrow_table(self, columns: frozenset[str]) -> str | None:
-        """Returns a table holding only ``columns``, materializing it on first use.
+    @staticmethod
+    def _memory_bytes(cursor: duckdb.DuckDBPyConnection) -> int:
+        """Returns the bytes DuckDB holds in its in-memory tables.
 
-        Reading a handful of columns out of a 442-leaf projection spread over 53 files
-        costs mostly per-file overhead, which is the same whatever the query asks for.
-        Paying it once and answering from memory afterwards is worth a materialization
-        for the columns a corpus is actually asked about: a temperature filter falls
-        from 0.91s to 0.06s, a group-by on the DOI from 0.81s to 0.002s.
+        The database-wide figure, so the cost of one table is the difference across
+        creating it. ``duckdb_tables`` reports a row *count* rather than a size, which
+        is why this asks the memory accounting instead.
 
-        The rows are the same rows; their order is not. Neither relation orders anything
-        a query did not ask to be ordered, and they do not agree on the accident, so a
-        caller wanting a particular order has to say so -- as it did before this.
+        Args:
+            cursor: Any cursor on the corpus connection.
+
+        Returns:
+            Bytes held, across every table in the database.
+        """
+        row = cursor.execute(
+            "SELECT coalesce(sum(memory_usage_bytes), 0) FROM duckdb_memory() "
+            "WHERE tag = 'IN_MEMORY_TABLE'"
+        ).fetchone()
+        return int(row[0]) if row is not None and row[0] is not None else 0
+
+    def _materialize(self, columns: frozenset[str]) -> _Narrow | None:
+        """Returns a held table of ``columns``, building it if the cache lacks one.
+
+        The caller owns a read on whatever comes back and has to release it, which
+        ``_narrowed_table`` does; an entry with a reader is never evicted.
 
         Args:
             columns: Top-level projection columns the query names.
 
         Returns:
-            The table's name, or None if materializing it would cost more memory than
-            the whole cache is allowed, in which case the projection answers directly.
+            The entry, or None if this column set costs more than the cache may hold in
+            total, in which case nothing is kept and the projection answers directly.
         """
         with self._narrow_lock:
             cached = self._narrowed.get(columns)
             if cached is not None:
                 self._narrowed.move_to_end(columns)
-                return cached[0]
-            name = f"narrow_{len(self._narrowed)}_{abs(hash(columns)) % 10**9}"
+                cached.readers += 1
+                return cached
+            # Never reused, so a build that fails between the CREATE and the entry
+            # cannot leave a name the next attempt collides with.
+            self._narrow_serial += 1
+            name = f"narrow_{self._narrow_serial}"
             selected = ", ".join([*sorted(columns), query.STRUCTURE_OFFSET])
             start = time.perf_counter()
-            # Its own cursor, like every other statement here: this runs while other
-            # searches are in flight, and the shared connection holds their results.
+            # Its own cursor, for the same reason the index build takes one: searches
+            # are in flight, and the shared connection holds their results.
             cursor = self._connection.cursor()
             try:
+                before = self._memory_bytes(cursor)
                 # S608: the names come from the projection schema and this module.
                 cursor.execute(
                     f"CREATE TABLE {name} AS "  # noqa: S608
                     f"SELECT {selected} FROM {query.TABLE}"
                 )
-                size = cursor.execute(
-                    "SELECT estimated_size FROM duckdb_tables() WHERE table_name = ?",
-                    [name],
-                ).fetchone()
-                held = int(size[0]) if size is not None and size[0] is not None else 0
+                # Measured under the lock, so no other materialization moves the figure
+                # between the two reads. An index build can, which costs an
+                # overstatement and an eviction, never a wrong answer.
+                held = max(self._memory_bytes(cursor) - before, 0)
                 if held > _NARROW_BUDGET_BYTES:
                     # Too big to keep, and keeping it is the only reason to build it.
                     cursor.execute(f"DROP TABLE {name}")
@@ -937,6 +996,12 @@ class Corpus:
                         held / 1024**3,
                     )
                     return None
+            except Exception:
+                # A table nobody tracks is memory nobody frees, and the failure the
+                # caller sees has to be the one that happened.
+                with contextlib.suppress(duckdb.Error):
+                    cursor.execute(f"DROP TABLE IF EXISTS {name}")
+                raise
             finally:
                 cursor.close()
             logger.info(
@@ -946,21 +1011,74 @@ class Corpus:
                 held / 1024**3,
                 time.perf_counter() - start,
             )
-            self._narrowed[columns] = (name, held)
-            while sum(entry[1] for entry in self._narrowed.values()) > (
+            entry = _Narrow(name=name, held=held, readers=1)
+            self._narrowed[columns] = entry
+            self._evict()
+            return entry
+
+    def _evict(self) -> None:
+        """Drops materialized tables, least recently used first, down to the budget.
+
+        Called with ``_narrow_lock`` held. An entry a search is reading is passed over
+        rather than dropped: the search bound the table's name into its SQL and reads it
+        only after resolving names and matching structures, so dropping it there would
+        fail a query that had already been answered correctly. Passing over every
+        candidate leaves the cache above its budget until a reader finishes, which is
+        the direction that keeps answers right.
+        """
+        for held in list(self._narrowed):
+            if sum(entry.held for entry in self._narrowed.values()) <= (
                 _NARROW_BUDGET_BYTES
             ):
-                evicted, (table, _) = self._narrowed.popitem(last=False)
-                if evicted == columns:  # Never evict what this call just built.
-                    self._narrowed[columns] = (name, held)
-                    break
-                dropper = self._connection.cursor()
-                try:
-                    dropper.execute(f"DROP TABLE {table}")
-                finally:
-                    dropper.close()
-                logger.info("evicted the materialized %s", sorted(evicted))
-            return name
+                return
+            entry = self._narrowed[held]
+            if entry.readers:
+                continue
+            cursor = self._connection.cursor()
+            try:
+                cursor.execute(f"DROP TABLE {entry.name}")
+            except duckdb.Error:
+                # Bookkeeping, not the caller's query: the entry goes either way, since
+                # keeping one whose table may be gone would answer from a name that
+                # does not resolve.
+                logger.exception("could not drop the materialized %s", entry.name)
+            finally:
+                cursor.close()
+            del self._narrowed[held]
+            logger.info("evicted the materialized %s", sorted(held))
+
+    @contextlib.contextmanager
+    def _narrowed_table(self, columns: frozenset[str]) -> Iterator[str | None]:
+        """Yields a table holding only ``columns``, held against eviction while read.
+
+        Reading a handful of columns out of a 442-leaf projection spread over 53 files
+        costs mostly per-file overhead, which is the same whatever the query asks for.
+        Paying it once and answering from memory afterwards is worth a materialization
+        for the columns a corpus is actually asked about: a temperature filter falls
+        from 1.24s to 0.21s, a group-by on stirring type from 0.75s to 0.003s.
+
+        The rows are the same rows; their order is not. Neither relation orders anything
+        a query did not ask to be ordered, and they do not agree on the accident, so a
+        caller wanting a particular order has to say so -- and a caller wanting a
+        particular *subset*, which is what a ``limit`` with no ordering asks for, is
+        asking a question neither relation answers the same way twice.
+
+        Args:
+            columns: Top-level projection columns the query names.
+
+        Yields:
+            The table's name, or None if materializing it would cost more memory than
+            the whole cache is allowed, in which case the projection answers directly.
+        """
+        entry = self._materialize(columns)
+        if entry is None:
+            yield None
+            return
+        try:
+            yield entry.name
+        finally:
+            with self._narrow_lock:
+                entry.readers -= 1
 
     def _matches(
         self,
@@ -970,11 +1088,11 @@ class Corpus:
     ) -> str:
         """Returns a structure predicate's match set as a bitmap, reusing a recent one.
 
-        The chemistry depends on the query molecule and nothing else, so the same
-        predicate asked twice has the same answer -- and asking it costs a pass over
-        every molecule in the corpus. A compound is keyed by what it resolved to rather
-        than by its name, so two names for one molecule share an entry and a resolver
-        that starts answering differently is a different key.
+        The chemistry depends on the query molecule, the operation, and the threshold,
+        so the same predicate asked twice has the same answer -- and asking it costs a
+        pass over every molecule in the corpus. A compound is keyed by what it resolved
+        to rather than by its name, so two names for one molecule share an entry and a
+        resolver that starts answering differently is a different key.
 
         One question is answered once even while it is still being answered: a caller
         arriving during another thread's pass waits for that pass rather than starting
@@ -990,13 +1108,29 @@ class Corpus:
 
         Returns:
             The bitmap over corpus-wide structure IDs.
+
+        Raises:
+            ValueError: If the predicate names neither a pattern nor a compound, or if
+                a resolved compound's SMILES does not parse.
+            PairingError: If the library does not come out one entry per distinct
+                molecule over an unbroken run of IDs.
         """
-        pattern = (
-            parameter.pattern
-            if parameter.pattern is not None
-            else resolve(parameter.compound or "")
-        )
-        key = (parameter.op, pattern, parameter.threshold)
+        if parameter.pattern is not None:
+            pattern = parameter.pattern
+        elif parameter.compound is not None:
+            pattern = resolve(parameter.compound)
+        else:
+            raise ValueError(
+                f"structure parameter {parameter.name!r} names neither a pattern nor a "
+                "compound, which the grammar does not allow"
+            )
+        # Which parser reads the string is part of what the string means, so it is part
+        # of the key: _query_molecule reads a stated substructure pattern as SMARTS and
+        # everything else as SMILES, and one text is two query molecules across them --
+        # C1=CC=CC=C1 is benzene as SMILES and six aliphatic carbons as SMARTS.
+        # Resolvers answer in that Kekule form, so a name and a pattern do collide.
+        from_smarts = parameter.pattern is not None and parameter.op == "substructure"
+        key = (parameter.op, from_smarts, pattern, parameter.threshold)
         while True:
             with self._matches_lock:
                 cached = self._matched.get(key)
@@ -1036,7 +1170,9 @@ class Corpus:
             # Woken after the result is published, so a waiter finds it on the next turn
             # of the loop; a failed pass leaves nothing there and the waiter recomputes.
             with self._matches_lock:
-                self._matching.pop(key).set()
+                waiters = self._matching.pop(key, None)
+            if waiters is not None:
+                waiters.set()
         return bitmap
 
     def search(
@@ -1045,9 +1181,11 @@ class Corpus:
         """Compiles and runs a query, returning the result as an Arrow table.
 
         Runs on its own cursor, so concurrent searches sharing this corpus do not read
-        each other's results. Two searches wait on each other only where waiting saves
-        work they would otherwise duplicate: the one-time library and index builds, and
-        a structure predicate one of them is already matching.
+        each other's results. Two searches wait on each other at the one-time library
+        and index builds, at a structure predicate one of them is already matching, and
+        at a materialization, which is one lock for all column sets: the cost of a table
+        is read as the difference two memory readings make, and two builds interleaved
+        would each be charged the other's.
 
         A query the occurrence index can answer runs against it instead of the
         projection, which is the same answer reached without scanning every reaction.
@@ -1055,6 +1193,11 @@ class Corpus:
         differ only in how they find the reactions holding a match. Which one answered
         is logged, because it is the one thing about a search that the result does not
         show.
+
+        A query the index declines is compiled a second time, against a table holding
+        only the columns the first compilation named. The narrow table is held for the
+        life of the search, since the query names it seconds before it reads it and
+        eviction would otherwise drop it in between.
 
         Args:
             request: The query to run.
@@ -1076,19 +1219,6 @@ class Corpus:
         """
         indexed = self._plan(request)
         compiled = indexed if indexed is not None else query.compile_query(request)
-        if indexed is not None:
-            self._occurrences()
-        else:
-            logger.info("the projection answers this query")
-            # The index answers by itself; everything else reads the projection, and
-            # reads it faster from a table holding only the columns it names.
-            narrow = self._narrow_table(self._mentioned(compiled.sql))
-            if narrow is not None:
-                assert compiled.sql.count(f"FROM {query.TABLE}") == 1  # One pass.
-                compiled = dataclasses.replace(
-                    compiled,
-                    sql=compiled.sql.replace(f"FROM {query.TABLE}", f"FROM {narrow}"),
-                )
         # Cached across the whole search: a compound named in both a value and a
         # structure predicate is one external lookup, not two.
         resolved: dict[str, str] = {}
@@ -1098,20 +1228,38 @@ class Corpus:
                 resolved[name] = self._resolver(name)
             return resolved[name]
 
-        cursor = self._connection.cursor()
-        try:
-            parameters: dict[str, Any] = {
-                name: resolve(name) for name in compiled.compounds
-            }
-            for parameter in compiled.structures:
-                parameters[parameter.name] = self._matches(cursor, parameter, resolve)
-            if timeout_seconds is None:
-                return cursor.execute(compiled.sql, parameters).to_arrow_table()
-            return self._run_with_timeout(
-                cursor, compiled.sql, parameters, timeout_seconds
-            )
-        finally:
-            cursor.close()
+        with contextlib.ExitStack() as reading:
+            if indexed is not None:
+                self._occurrences()
+            else:
+                logger.info("the projection answers this query")
+                # The index answers by itself; everything else reads the projection, and
+                # reads it faster from a table holding only the columns it names. Which
+                # ones those are is read off the compiled SQL, so the second compilation
+                # is over the same query against a different relation -- no rewriting of
+                # SQL text, which a query whose own string literal named the relation
+                # would otherwise corrupt.
+                narrow = reading.enter_context(
+                    self._narrowed_table(self._mentioned(compiled.sql))
+                )
+                if narrow is not None:
+                    compiled = query.compile_query(request, table=narrow)
+            cursor = self._connection.cursor()
+            try:
+                parameters: dict[str, Any] = {
+                    name: resolve(name) for name in compiled.compounds
+                }
+                for parameter in compiled.structures:
+                    parameters[parameter.name] = self._matches(
+                        cursor, parameter, resolve
+                    )
+                if timeout_seconds is None:
+                    return cursor.execute(compiled.sql, parameters).to_arrow_table()
+                return self._run_with_timeout(
+                    cursor, compiled.sql, parameters, timeout_seconds
+                )
+            finally:
+                cursor.close()
 
     @staticmethod
     def _run_with_timeout(

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -41,14 +41,28 @@ each other's rows rather than raising; each search therefore takes its own curso
 cursor in turn sees only the catalog, not the objects ``register`` attaches to the
 connection that registered them, so every relation here is a catalog table or view.
 
+Finding the reactions that hold a match is a scan of every reaction, which costs more
+than the chemistry for all but the narrowest queries. An **occurrence index** -- one row
+per structure occurrence, carrying the corpus-wide ID, the path it sat at, and the
+element's own ``reaction_role`` -- turns that scan into a filter over a narrow table.
+Keeping the role beside the structure is what preserves element binding: "pyridine as
+the solvent" stays a condition on a single row rather than an intersection of two
+reaction sets, which over-returns. A query the index cannot answer, because it reaches
+an element field the index does not carry or needs a projection column to group or sort
+by, runs against the projection unchanged; both paths screen and verify through the same
+compiler, so they differ only in how they reach the reactions.
+
 The grammar bounds what a query can cost (one pass and a sort), and ``search``
 takes a wall-clock timeout that interrupts the final query. Name resolution, the
-one-time library build, screening, and verification all run before the timer starts:
-each is bounded by the corpus rather than by the query, so a slow one is slow for every
-caller and shows up in the logs rather than in a timeout. The first substructure search
-therefore takes the build's several seconds on top of whatever timeout it was given.
+one-time library and index builds, screening, and verification all run before the timer
+starts: each is bounded by the corpus rather than by the query, so a slow one is slow
+for every caller and shows up in the logs rather than in a timeout. The first
+substructure search therefore takes both builds -- upwards of a minute over the whole
+corpus, the index being four passes over the projections -- on top of whatever timeout
+it was given.
 """
 
+import dataclasses
 import glob
 import math
 import threading
@@ -125,6 +139,52 @@ def _max_structure_id(path: str) -> int | None:
 _UNPARSEABLE = Chem.Mol().ToBinary()
 _NO_BITS = DataStructs.ExplicitBitVect(structures.PATTERN_FP_SIZE)
 
+# The one element field the occurrence index carries besides the structure. A query
+# binding anything else to the element runs against the projection instead.
+_INDEXED_FIELD = "reaction_role"
+
+
+def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
+    """Returns the paths an occurrence index covers, mapped to their traversals.
+
+    Walked from the schema and resolved through the compiler, so the index reaches the
+    same elements the projection does by construction rather than by a list here
+    agreeing with one there.
+
+    Args:
+        schema: The projection schema.
+
+    Returns:
+        Dotted query paths to the DuckDB expression yielding their elements, for every
+        repeated level whose elements carry both a structure and ``_INDEXED_FIELD``.
+    """
+    paths: dict[str, str] = {}
+
+    def walk(dtype: pa.DataType, prefix: str) -> None:
+        if pa.types.is_struct(dtype):
+            names = [field.name for field in dtype]
+            if "structure_id" in names and _INDEXED_FIELD in names:
+                # The schema walk speaks Parquet; the grammar has no wrapper levels.
+                path = prefix.replace(".list.element", "").replace(
+                    ".key_value.value", ""
+                )
+                resolved = query.resolve(path, allow_internal=True)
+                if resolved.repeated:
+                    paths[path] = resolved.expression
+            for child in dtype:
+                walk(child.type, f"{prefix}.{child.name}")
+        elif pa.types.is_list(dtype):
+            walk(dtype.value_type, f"{prefix}.list.element")
+        elif pa.types.is_map(dtype):
+            walk(dtype.item_type, f"{prefix}.key_value.value")
+
+    for field in schema:
+        walk(field.type, field.name)
+    return paths
+
+
+INDEXED_PATHS = _indexed_paths()
+
 
 class Corpus:
     """A searchable pairing of projections with their structures artifacts.
@@ -170,6 +230,9 @@ class Corpus:
         # Built on first substructure query; see _library.
         self._substructure_library: rdSubstructLibrary.SubstructLibrary | None = None
         self._library_lock = threading.Lock()
+        # Built on the first query that can use it; see _occurrences.
+        self._occurrences_built = False
+        self._occurrences_lock = threading.Lock()
         pairs = self._pair(projection_pattern, structures_pattern, require_current)
         self._connection = duckdb.connect()
         try:
@@ -459,6 +522,139 @@ class Corpus:
             self._substructure_library = library
             return self._substructure_library
 
+    @staticmethod
+    def _index_terms(where: query.Predicate) -> tuple[bool, str | None] | None:
+        """Returns whether an element predicate is one the index holds.
+
+        Args:
+            where: The predicate inside a quantifier, relative to the element.
+
+        Returns:
+            ``(has_structure, role)`` if every clause is a structure predicate on the
+            element's own structure or an equality on the indexed field, or None if any
+            clause reaches something the index does not carry.
+        """
+        clauses = where.clauses if isinstance(where, query.And) else [where]
+        structures_seen = 0
+        role: str | None = None
+        for clause in clauses:
+            if isinstance(clause, (query.Substructure, query.Similarity)):
+                if clause.path != "smiles":
+                    return None
+                structures_seen += 1
+            elif (
+                isinstance(clause, query.Comparison)
+                and clause.op == "eq"
+                and clause.path == _INDEXED_FIELD
+                and isinstance(clause.value.literal, str)
+                and role is None
+            ):
+                role = clause.value.literal
+            else:
+                return None
+        # Two structure predicates on one element are two bitmaps, and one pass over one
+        # column cannot apply both to the same row.
+        if structures_seen != 1:
+            return None
+        return True, role
+
+    @staticmethod
+    def _plan(request: query.Query) -> query.Compiled | None:
+        """Returns a compiled occurrence-index query, or None to use the projection.
+
+        The index carries a structure and one field per element, so it answers exactly
+        the shape it holds: some element at an indexed path contains a structure, and
+        optionally equals a role. Everything else -- another element field, a scalar
+        outside the quantifier, a group-by column, an ordering -- lives only in the
+        projection, and asking the index for it would answer a different question.
+
+        Args:
+            request: The query to plan.
+
+        Returns:
+            A compiled query over ``occurrences``, or None if the projection has to
+            answer it.
+        """
+        where = request.where
+        if (
+            request.aggregate is not None
+            or request.order_by
+            or not isinstance(where, query.Quantifier)
+            or where.op != "exists"
+            or where.path not in INDEXED_PATHS
+        ):
+            return None
+        terms = Corpus._index_terms(where.where)
+        if terms is None:
+            return None
+        _, role = terms
+        compiled = query.compile_query(request)
+        # The bitmap and the molecule behind it are the compiler's, so the two paths
+        # screen and verify identically and differ only in how they reach the reactions
+        # holding a match.
+        if len(compiled.structures) != 1:
+            return None
+        conditions = [
+            f"path = '{where.path}'",
+            f"get_bit(CAST(${compiled.structures[0].name} AS BITSTRING), "
+            "global_id::INTEGER) = 1",
+        ]
+        if role is not None:
+            escaped = role.replace("'", "''")
+            conditions.append(f"{_INDEXED_FIELD} = '{escaped}'")
+        limit = f" LIMIT {request.limit}" if request.limit is not None else ""
+        # S608: every fragment is a schema-derived path, a compiler-issued parameter
+        # name, or an escaped literal.
+        sql = (
+            "SELECT DISTINCT reaction_id FROM occurrences "  # noqa: S608
+            f"WHERE {' AND '.join(conditions)}{limit}"
+        )
+        return dataclasses.replace(compiled, sql=sql)
+
+    def _occurrences(self) -> None:
+        """Builds the occurrence index, once, if it is not already built.
+
+        One row per structure occurrence, carrying the corpus-wide ID, the path it sat
+        at, and the element's own ``reaction_role``. Keeping the role beside the
+        structure is what preserves element binding: "pyridine as the solvent" stays a
+        condition on one row rather than an intersection of two reaction sets, which
+        over-returns.
+
+        Costs a full pass over the projections, so it is built when a query first wants
+        it rather than at open. Concurrent first queries serialize here and share the
+        result.
+        """
+        with self._occurrences_lock:
+            if self._occurrences_built:
+                return
+            start = time.perf_counter()
+            # A path's elements are already a list, so unnest yields one row each. The
+            # offset comes from the row's own file, which the reactions view carries.
+            selects = "\nUNION ALL\n".join(
+                f"""
+                SELECT reaction_id, '{path}' AS path,
+                       (element.structure_id + {query.STRUCTURE_OFFSET})::UINTEGER
+                           AS global_id,
+                       element.{_INDEXED_FIELD} AS {_INDEXED_FIELD}
+                FROM {query.TABLE}, unnest({expression}) AS unnested(element)
+                WHERE element.structure_id IS NOT NULL
+                """  # noqa: S608
+                for path, expression in INDEXED_PATHS.items()
+            )
+            # S608: the fragments are this module's own schema walk and the compiler's
+            # traversals, not anything a query supplies.
+            self._connection.execute(f"CREATE TABLE occurrences AS {selects}")
+            count = self._connection.execute(
+                "SELECT count(*) FROM occurrences"
+            ).fetchone()
+            assert count is not None  # An aggregate over any relation returns one row.
+            logger.info(
+                "indexed %d structure occurrences in %.1fs",
+                count[0],
+                time.perf_counter() - start,
+            )
+            self._occurrences_built = True
+
     def _substructure_ids(
         self, parameter: query.StructureParameter, resolve: Callable[[str], str]
     ) -> list[int]:
@@ -536,12 +732,17 @@ class Corpus:
         each other's results. They still serialize on the library build, and only on
         that: the first substructure search builds it while the others wait.
 
+        A query the occurrence index can answer runs against it instead of the
+        projection, which is the same answer reached without scanning every reaction.
+        The screening and verification are the compiler's either way, so the two paths
+        differ only in how they find the reactions holding a match.
+
         Args:
             request: The query to run.
             timeout_seconds: Wall-clock bound on the final query. Name resolution, the
-                library build, screening, and verification run before the timer starts
-                and are not counted, so a first substructure search can take seconds
-                longer than this allows. None runs unbounded.
+                library and index builds, screening, and verification run before the
+                timer starts and are not counted, so a first substructure search can
+                take seconds longer than this allows. None runs unbounded.
 
         Returns:
             The selected columns: ``reaction_id`` for a plain query, the group and
@@ -553,7 +754,10 @@ class Corpus:
             PairingError: If the library does not come out one entry per structure.
             TimeoutError: If the query exceeds ``timeout_seconds``.
         """
-        compiled = query.compile_query(request)
+        indexed = self._plan(request)
+        compiled = indexed if indexed is not None else query.compile_query(request)
+        if indexed is not None:
+            self._occurrences()
         # Cached across the whole search: a compound named in both a value and a
         # structure predicate is one external lookup, not two.
         resolved: dict[str, str] = {}

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -49,17 +49,17 @@ Keeping the role beside the structure is what preserves element binding: "pyridi
 the solvent" stays a condition on a single row rather than an intersection of two
 reaction sets, which over-returns. A query the index cannot answer, because it reaches
 an element field the index does not carry or needs a projection column to group or sort
-by, runs against the projection unchanged; both paths screen and verify through the same
-compiler, so they differ only in how they reach the reactions.
+by, runs against the projection; both paths screen and verify through the same compiler,
+so they differ only in how they reach the reactions.
 
 The grammar bounds what a query can cost (one pass and a sort), and ``search``
 takes a wall-clock timeout that interrupts the final query. Name resolution, the
 one-time library and index builds, screening, and verification all run before the timer
 starts: each is bounded by the corpus rather than by the query, so a slow one is slow
-for every caller and shows up in the logs rather than in a timeout. The first
-substructure search therefore takes both builds -- upwards of a minute over the whole
-corpus, the index being four passes over the projections -- on top of whatever timeout
-it was given.
+for every caller and shows up in the logs rather than in a timeout. The two builds have
+separate triggers -- the library on the first substructure predicate, the index on the
+first query the planner routes -- and a search wanting both pays both, upwards of a
+minute over the whole corpus, on top of whatever timeout it was given.
 """
 
 import dataclasses
@@ -184,6 +184,19 @@ def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
 
 
 INDEXED_PATHS = _indexed_paths()
+
+
+@dataclasses.dataclass(frozen=True)
+class _IndexTerms:
+    """What a predicate the occurrence index can answer asks of one row.
+
+    Attributes:
+        role: The role the element must hold, or None if the query does not bind one.
+            Absence is not a wildcard the index applies -- it is a query that named no
+            role, so the condition is left off.
+    """
+
+    role: str | None
 
 
 class Corpus:
@@ -523,16 +536,16 @@ class Corpus:
             return self._substructure_library
 
     @staticmethod
-    def _index_terms(where: query.Predicate) -> tuple[bool, str | None] | None:
-        """Returns whether an element predicate is one the index holds.
+    def _index_terms(where: query.Predicate) -> _IndexTerms | None:
+        """Returns what an element predicate asks of one occurrence row, or None.
 
         Args:
             where: The predicate inside a quantifier, relative to the element.
 
         Returns:
-            ``(has_structure, role)`` if every clause is a structure predicate on the
-            element's own structure or an equality on the indexed field, or None if any
-            clause reaches something the index does not carry.
+            The terms, if every clause is a structure predicate on the element's own
+            structure or an equality on the indexed field, or None if any clause reaches
+            something the index does not carry.
         """
         clauses = where.clauses if isinstance(where, query.And) else [where]
         structures_seen = 0
@@ -556,17 +569,24 @@ class Corpus:
         # column cannot apply both to the same row.
         if structures_seen != 1:
             return None
-        return True, role
+        return _IndexTerms(role=role)
 
     @staticmethod
     def _plan(request: query.Query) -> query.Compiled | None:
         """Returns a compiled occurrence-index query, or None to use the projection.
 
-        The index carries a structure and one field per element, so it answers exactly
-        the shape it holds: some element at an indexed path contains a structure, and
-        optionally equals a role. Everything else -- another element field, a scalar
-        outside the quantifier, a group-by column, an ordering -- lives only in the
-        projection, and asking the index for it would answer a different question.
+        An occurrence row carries a structure and one element field, so the index
+        answers exactly one shape: a bare ``exists`` at an indexed path whose body is a
+        conjunction of one structure predicate on the element's own ``smiles`` and at
+        most one ``reaction_role`` equality, with nothing aggregated and nothing
+        ordered. Every other query -- a ``forall``, a negation or a disjunction,
+        another element field, a scalar outside the quantifier, a group-by column, an
+        ordering -- reaches something an occurrence row does not hold, and the
+        projection answers it.
+
+        A ``limit`` rides along. Neither relation orders what a query did not ask to be
+        ordered, so a limited query with no ``order_by`` selects some rows of the match
+        set on both paths, and which ones differs between them.
 
         Args:
             request: The query to plan.
@@ -574,6 +594,11 @@ class Corpus:
         Returns:
             A compiled query over ``occurrences``, or None if the projection has to
             answer it.
+
+        Raises:
+            query.QueryError: If the query does not compile. Planning compiles it to
+                reach the structure parameter, so a malformed query fails here rather
+                than on the projection path.
         """
         where = request.where
         if (
@@ -587,7 +612,6 @@ class Corpus:
         terms = Corpus._index_terms(where.where)
         if terms is None:
             return None
-        _, role = terms
         compiled = query.compile_query(request)
         # The bitmap and the molecule behind it are the compiler's, so the two paths
         # screen and verify identically and differ only in how they reach the reactions
@@ -599,8 +623,8 @@ class Corpus:
             f"get_bit(CAST(${compiled.structures[0].name} AS BITSTRING), "
             "global_id::INTEGER) = 1",
         ]
-        if role is not None:
-            escaped = role.replace("'", "''")
+        if terms.role is not None:
+            escaped = terms.role.replace("'", "''")
             conditions.append(f"{_INDEXED_FIELD} = '{escaped}'")
         limit = f" LIMIT {request.limit}" if request.limit is not None else ""
         # S608: every fragment is a schema-derived path, a compiler-issued parameter
@@ -609,6 +633,9 @@ class Corpus:
             "SELECT DISTINCT reaction_id FROM occurrences "  # noqa: S608
             f"WHERE {' AND '.join(conditions)}{limit}"
         )
+        # Which relation answered is the one thing a result does not show, and the two
+        # are supposed to agree, so a disagreement is only ever debugged from here.
+        logger.info("the occurrence index answers %s", where.path)
         return dataclasses.replace(compiled, sql=sql)
 
     def _occurrences(self) -> None:
@@ -620,9 +647,16 @@ class Corpus:
         condition on one row rather than an intersection of two reaction sets, which
         over-returns.
 
-        Costs a full pass over the projections, so it is built when a query first wants
-        it rather than at open. Concurrent first queries serialize here and share the
-        result.
+        Costs one pass over the projections per indexed path, so it is built when a
+        query first wants it rather than at open. Concurrent first queries serialize
+        here and share the result.
+
+        Raises:
+            PairingError: If a corpus holding structures indexes none of them. Every
+                path the projection can carry a structure at is indexed, so an empty
+                index means a traversal reached nothing -- and an empty index answers
+                every structure query with "no matches", which reads like an answer
+                rather than like a corpus that cannot be searched.
         """
         with self._occurrences_lock:
             if self._occurrences_built:
@@ -641,19 +675,38 @@ class Corpus:
                 """  # noqa: S608
                 for path, expression in INDEXED_PATHS.items()
             )
-            # S608: the fragments are this module's own schema walk and the compiler's
-            # traversals, not anything a query supplies.
-            self._connection.execute(f"CREATE TABLE occurrences AS {selects}")
-            count = self._connection.execute(
-                "SELECT count(*) FROM occurrences"
-            ).fetchone()
-            assert count is not None  # An aggregate over any relation returns one row.
+            # Its own cursor: this runs while other searches are in flight, and the
+            # shared connection holds their results.
+            cursor = self._connection.cursor()
+            try:
+                # OR REPLACE, so a build interrupted after the table exists is a build
+                # the next query repeats rather than one that collides with itself
+                # forever. S608: the fragments are this module's own schema walk and
+                # the compiler's traversals, not anything a query supplies.
+                cursor.execute(f"CREATE OR REPLACE TABLE occurrences AS {selects}")
+                indexed = cursor.execute(
+                    "SELECT path, count(*) FROM occurrences GROUP BY path"
+                ).fetchall()
+                counts = dict(indexed)
+                total = sum(counts.values())
+                if self._total and not total:
+                    raise PairingError(
+                        f"the occurrence index came out empty over {self._total} "
+                        f"structures; none of {sorted(INDEXED_PATHS)} reached an "
+                        "element, so the projections are not the schema this walk was "
+                        "built from"
+                    )
+                self._occurrences_built = True
+            finally:
+                cursor.close()
+            # Per path, so one that reaches nothing is visible here rather than only in
+            # the answers it fails to contribute to.
             logger.info(
-                "indexed %d structure occurrences in %.1fs",
-                count[0],
+                "indexed %d structure occurrences in %.1fs: %s",
+                total,
                 time.perf_counter() - start,
+                ", ".join(f"{path} {counts.get(path, 0)}" for path in INDEXED_PATHS),
             )
-            self._occurrences_built = True
 
     def _substructure_ids(
         self, parameter: query.StructureParameter, resolve: Callable[[str], str]
@@ -729,13 +782,15 @@ class Corpus:
         """Compiles and runs a query, returning the result as an Arrow table.
 
         Runs on its own cursor, so concurrent searches sharing this corpus do not read
-        each other's results. They still serialize on the library build, and only on
-        that: the first substructure search builds it while the others wait.
+        each other's results. They serialize on the library build and on the index
+        build, each of which the first search wanting it performs while the others wait.
 
         A query the occurrence index can answer runs against it instead of the
         projection, which is the same answer reached without scanning every reaction.
         The screening and verification are the compiler's either way, so the two paths
-        differ only in how they find the reactions holding a match.
+        differ only in how they find the reactions holding a match. Which one answered
+        is logged, because it is the one thing about a search that the result does not
+        show.
 
         Args:
             request: The query to run.
@@ -751,13 +806,16 @@ class Corpus:
         Raises:
             query.QueryError: If the query does not compile.
             ValueError: If a compound name cannot be resolved.
-            PairingError: If the library does not come out one entry per structure.
+            PairingError: If the corpus IDs do not come out one unbroken run, or a
+                corpus holding structures indexes none of them.
             TimeoutError: If the query exceeds ``timeout_seconds``.
         """
         indexed = self._plan(request)
         compiled = indexed if indexed is not None else query.compile_query(request)
         if indexed is not None:
             self._occurrences()
+        else:
+            logger.info("the projection answers this query")
         # Cached across the whole search: a compound named in both a value and a
         # structure predicate is one external lookup, not two.
         resolved: dict[str, str] = {}

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -780,8 +780,12 @@ def test_a_search_runs_on_a_cursor_rather_than_the_shared_connection(corpus_dir)
         resolver={}.__getitem__,
     ) as value:
         value._connection = counter = _CursorCounter(value._connection)
+        # The first search also materializes its columns, which is a cursor of its own.
         assert value.search(request).num_rows == 1
-        assert counter.cursors == 1
+        # Steady state, with that table already built: one search, one cursor.
+        taken = counter.cursors
+        assert value.search(request).num_rows == 1
+        assert counter.cursors == taken + 1
 
 
 def test_concurrent_searches_return_their_own_answers(corpus_dir):
@@ -1237,6 +1241,131 @@ def test_the_cache_stays_bounded(corpus_dir, monkeypatch):
         assert len(value._matched) == 2
         # The two most recent survive; the earliest are gone.
         assert [key[1] for key in value._matched] == ["c1ccccc1", "[Pt]"]
+
+
+def _no_narrow_table(self, columns: frozenset[str]) -> str | None:
+    """Stands in for _narrow_table so a search reads the projection directly."""
+    del self, columns  # Unused.
+    return None
+
+
+def test_a_narrow_table_answers_what_the_projection_would(corpus_dir):
+    # Materializing the columns a query names is a second relation to answer from, so
+    # what makes it safe is that it answers identically. Each of these is run against
+    # the narrow table and against the projection, and compared as multisets: a query
+    # with no ordering has none, and the two relations really do return the same rows
+    # in different orders at corpus scale. What must never differ is which rows.
+    requests = {
+        "a scalar leaf": {
+            "where": {
+                "op": "not_null",
+                "path": "conditions.temperature.setpoint_kelvin",
+            }
+        },
+        "a nested quantifier": {
+            "where": _exists(
+                {"op": "eq", "path": "smiles", "value": {"literal": "CCO"}}
+            )
+        },
+        "an aggregate": {
+            "where": None,
+            "aggregate": {
+                "group_by": ["conditions.stirring.type"],
+                "measures": [{"fn": "count", "name": "n"}],
+            },
+        },
+        "an ordering and a limit": {
+            "where": None,
+            "order_by": [{"key": "reaction_id"}],
+            "limit": 2,
+        },
+        "a structure predicate the index declines": {
+            "where": {
+                "op": "and",
+                "clauses": [
+                    _exists(
+                        {"op": "substructure", "path": "smiles", "smarts": "[OX2H]"}
+                    ),
+                    {"op": "not_null", "path": "reaction_id"},
+                ],
+            }
+        },
+    }
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        for label, body in requests.items():
+            request = query.Query.model_validate(body)
+            narrowed = value.search(request).to_pylist()
+            # The same request with the materialization turned off.
+            with pytest.MonkeyPatch.context() as patcher:
+                patcher.setattr(execute.Corpus, "_narrow_table", _no_narrow_table)
+                direct = value.search(request).to_pylist()
+            assert sorted(map(repr, narrowed)) == sorted(map(repr, direct)), label
+
+
+def test_the_columns_a_query_names_are_the_ones_materialized(corpus_dir):
+    # Too few and the query fails to resolve; too many and the corpus holds columns
+    # nobody asked about. A name inside a string literal costs a column, nothing more.
+    assert execute.Corpus._mentioned(
+        "SELECT reaction_id FROM reactions WHERE conditions.temperature.x > 1"
+    ) == frozenset({"reaction_id", "conditions"})
+    assert "provenance" in execute.Corpus._mentioned(
+        "SELECT provenance.doi FROM reactions"
+    )
+    # reaction_id comes along whether or not the query said so.
+    assert "reaction_id" in execute.Corpus._mentioned("SELECT 1 FROM reactions")
+    # A substring of a real column is not that column.
+    assert "conditions" not in execute.Corpus._mentioned(
+        "SELECT reaction_id FROM reactions WHERE notes.preconditions_x = 'a'"
+    )
+
+
+def test_a_materialized_column_set_is_reused(corpus_dir):
+    request = query.Query.model_validate(
+        {"where": {"op": "not_null", "path": "conditions.temperature.setpoint_kelvin"}}
+    )
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        value.search(request)
+        assert len(value._narrowed) == 1
+        built = dict(value._narrowed)
+        value.search(request)
+        assert dict(value._narrowed) == built  # Reused, not rebuilt under a new name.
+        # A query naming other columns is a different set, materialized separately.
+        value.search(
+            query.Query.model_validate(
+                {"where": {"op": "not_null", "path": "provenance.doi"}}
+            )
+        )
+        assert len(value._narrowed) == 2
+
+
+def test_a_column_set_too_large_to_keep_is_not_kept(corpus_dir, monkeypatch):
+    # Materializing is only worth it if the table survives to answer the next query.
+    monkeypatch.setattr(execute, "_NARROW_BUDGET_BYTES", 1)
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        matched = value.search(
+            query.Query.model_validate(
+                {
+                    "where": _exists(
+                        {"op": "eq", "path": "smiles", "value": {"literal": "CCO"}}
+                    )
+                }
+            )
+        )
+        # Answered anyway, straight from the projection.
+        assert matched.column("reaction_id").to_pylist() == ["ord-bb01"]
+        assert not value._narrowed
 
 
 def test_the_match_limit_has_to_be_passed_or_matches_are_dropped():

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -903,7 +903,7 @@ def test_concurrent_searches_return_their_own_answers(corpus_dir):
 
 
 def test_concurrent_first_searches_build_one_library(corpus_dir, monkeypatch):
-    # The library is about 2 GB at corpus scale. First searches arriving together must
+    # The library is about 1.5 GB at corpus scale. First searches arriving together must
     # not each build their own copy, so the build is serialized and whoever waits takes
     # the finished one.
     threads_count = 4
@@ -1468,7 +1468,9 @@ def test_a_repeated_predicate_is_matched_once(corpus_dir, monkeypatch):
         )
         assert value.search(by_name).num_rows == 2
         assert value.search(other_name).num_rows == 2
-        assert matched == 2  # Both resolve to the pattern already matched above.
+        # One match between them, and one more than before: a name resolves to SMILES,
+        # and the identical text stated as a pattern was read as SMARTS.
+        assert matched == 3
 
 
 def test_the_cache_does_not_confuse_two_predicates(corpus):
@@ -1609,13 +1611,14 @@ def test_the_cache_stays_bounded(corpus_dir, monkeypatch):
             value.search(_substructure(smarts))
         assert len(value._matched) == 2
         # The two most recent survive; the earliest are gone.
-        assert [key[1] for key in value._matched] == ["c1ccccc1", "[Pt]"]
+        assert [key[2] for key in value._matched] == ["c1ccccc1", "[Pt]"]
 
 
-def _no_narrow_table(self, columns: frozenset[str]) -> str | None:
-    """Stands in for _narrow_table so a search reads the projection directly."""
+@contextlib.contextmanager
+def _no_narrow_table(self, columns: frozenset[str]) -> Iterator[str | None]:
+    """Stands in for _narrowed_table so a search reads the projection directly."""
     del self, columns  # Unused.
-    return None
+    yield None
 
 
 def test_a_narrow_table_answers_what_the_projection_would(corpus_dir):
@@ -1670,9 +1673,14 @@ def test_a_narrow_table_answers_what_the_projection_would(corpus_dir):
             narrowed = value.search(request).to_pylist()
             # The same request with the materialization turned off.
             with pytest.MonkeyPatch.context() as patcher:
-                patcher.setattr(execute.Corpus, "_narrow_table", _no_narrow_table)
+                patcher.setattr(execute.Corpus, "_narrowed_table", _no_narrow_table)
                 direct = value.search(request).to_pylist()
-            assert sorted(map(repr, narrowed)) == sorted(map(repr, direct)), label
+            if request.order_by:
+                # An ordered query is the one case where the order is the answer, so
+                # this is the one comparison that may not sort first.
+                assert list(map(repr, narrowed)) == list(map(repr, direct)), label
+            else:
+                assert sorted(map(repr, narrowed)) == sorted(map(repr, direct)), label
 
 
 def test_the_columns_a_query_names_are_the_ones_materialized(corpus_dir):
@@ -1715,6 +1723,178 @@ def test_a_materialized_column_set_is_reused(corpus_dir):
         assert len(value._narrowed) == 2
 
 
+def _stated_bytes(*readings):
+    """Stands in for _memory_bytes, reading the given figures in order.
+
+    Stated rather than measured so a budget test admits exactly the tables it means to,
+    whatever DuckDB's allocator does with three rows.
+    """
+    figures = iter(readings)
+    return staticmethod(lambda cursor: next(figures))
+
+
+def _tables(value) -> set[str]:
+    """Returns the names of the tables the corpus connection holds."""
+    cursor = value._connection.cursor()
+    try:
+        rows = cursor.execute("SELECT table_name FROM duckdb_tables()").fetchall()
+    finally:
+        cursor.close()
+    return {row[0] for row in rows}
+
+
+def test_a_materialization_is_measured_in_bytes(corpus_dir):
+    # duckdb_tables reports a row *count* under a name that reads like a size, and
+    # spending it as one makes the budget a number that can never be crossed and the
+    # eviction below dead code. Three rows, and the table is tens of kilobytes.
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        value.search(
+            query.Query.model_validate(
+                {"where": {"op": "not_null", "path": "provenance.doi"}}
+            )
+        )
+        (entry,) = value._narrowed.values()
+        assert entry.held > 1024
+
+
+def test_the_cache_evicts_the_least_recently_used_and_drops_its_table(
+    corpus_dir, monkeypatch
+):
+    # An unevicted cache is one table per column set a server is ever asked for, none of
+    # them ever freed. Sizes are stated here rather than measured so the budget admits
+    # exactly one table whatever DuckDB's allocator does with three rows.
+    monkeypatch.setattr(execute, "_NARROW_BUDGET_BYTES", 150)
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        monkeypatch.setattr(
+            execute.Corpus, "_memory_bytes", _stated_bytes(0, 100, 0, 100, 0, 100)
+        )
+        first = frozenset({"reaction_id", "provenance"})
+        second = frozenset({"reaction_id", "conditions"})
+        with value._narrowed_table(first) as name:
+            dropped = name
+        assert dropped in _tables(value)
+        with value._narrowed_table(second) as name:
+            kept = name
+        assert list(value._narrowed) == [second]
+        assert dropped not in _tables(value)  # Dropped, not merely forgotten.
+        assert kept in _tables(value)
+
+
+def test_a_table_a_search_is_reading_is_not_evicted(corpus_dir, monkeypatch):
+    # A search takes the table's name, then resolves compounds and matches structures --
+    # seconds during which it holds nothing but a string. Evicting there would fail a
+    # query that had already been answered correctly, with a catalog error naming a
+    # table the caller has never heard of.
+    monkeypatch.setattr(execute, "_NARROW_BUDGET_BYTES", 150)
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        monkeypatch.setattr(
+            execute.Corpus, "_memory_bytes", _stated_bytes(0, 100, 0, 100, 0, 100)
+        )
+        first = frozenset({"reaction_id", "provenance"})
+        second = frozenset({"reaction_id", "conditions"})
+        with value._narrowed_table(first) as reading:
+            with value._narrowed_table(second):
+                pass
+            # Over budget, and the only candidate is being read: it stays, and the
+            # cache stays over its budget until the reader is done.
+            assert reading in _tables(value)
+            assert list(value._narrowed) == [first, second]
+        # Released, so the next materialization can take it.
+        with value._narrowed_table(frozenset({"reaction_id", "notes"})):
+            pass
+        assert first not in value._narrowed
+        assert reading not in _tables(value)
+
+
+def test_a_failed_materialization_leaves_nothing_behind(corpus_dir, monkeypatch):
+    # A table nobody tracks is memory nobody frees, and under a name a later attempt
+    # would collide with. The failure is raised after the CREATE, which is the window.
+    request = query.Query.model_validate(
+        {"where": {"op": "not_null", "path": "provenance.doi"}}
+    )
+    failing = True
+    original = execute.Corpus._memory_bytes
+    reads = 0
+
+    def sometimes(cursor):
+        # The second reading is the one taken after the CREATE, so failing there is the
+        # window where a table exists and nothing has recorded it.
+        nonlocal reads
+        reads += 1
+        if failing and reads == 2:
+            raise duckdb.Error("no memory accounting today")
+        return original(cursor)
+
+    monkeypatch.setattr(execute.Corpus, "_memory_bytes", staticmethod(sometimes))
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        with pytest.raises(duckdb.Error, match="no memory accounting"):
+            value.search(request)
+        assert not value._narrowed
+        assert not [name for name in _tables(value) if name.startswith("narrow_")]
+        failing = False
+        # The column set is still materializable, under a name of its own.
+        value.search(request)
+        assert len(value._narrowed) == 1
+
+
+def test_a_literal_naming_the_relation_is_not_a_rewrite(tmp_path):
+    # The columns are read off the compiled SQL, which carries string literals inline --
+    # so a query searching for the text "FROM reactions" puts that text in the SQL. The
+    # narrow table is reached by compiling again against it, not by editing that SQL: an
+    # edit would rewrite the literal too, and this reaction would stop being findable by
+    # what its own notes say.
+    note = "distilled FROM reactions overnight"
+    reaction = _reaction("ord-dd01", components=[("CCO", _ROLE.REACTANT)])
+    reaction.notes.procedure_details = note
+    source = tmp_path / "data" / "ord_dataset-dd.parquet"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    parquet.save_dataset(
+        dataset_pb2.Dataset(
+            dataset_id="ord_dataset-dd",
+            name="test",
+            description="test",
+            reactions=[reaction],
+        ),
+        str(source),
+    )
+    projected = tmp_path / "projections" / source.name
+    projected.parent.mkdir(parents=True, exist_ok=True)
+    projection.write_projection(source, projected)
+    structured = tmp_path / "structures" / source.name
+    structured.parent.mkdir(parents=True, exist_ok=True)
+    structures.write_structures(projected, structured)
+    request = query.Query.model_validate(
+        {
+            "where": {
+                "op": "eq",
+                "path": "notes.procedure_details",
+                "value": {"literal": note},
+            }
+        }
+    )
+    with execute.Corpus(
+        str(projected), str(structured), resolver={}.__getitem__
+    ) as value:
+        assert _reactions(value.search(request)) == {"ord-dd01"}
+        assert len(value._narrowed) == 1
+
+
 def test_a_column_set_too_large_to_keep_is_not_kept(corpus_dir, monkeypatch):
     # Materializing is only worth it if the table survives to answer the next query.
     monkeypatch.setattr(execute, "_NARROW_BUDGET_BYTES", 1)
@@ -1735,6 +1915,144 @@ def test_a_column_set_too_large_to_keep_is_not_kept(corpus_dir, monkeypatch):
         # Answered anyway, straight from the projection.
         assert matched.column("reaction_id").to_pylist() == ["ord-bb01"]
         assert not value._narrowed
+
+
+def test_a_library_that_lost_a_molecule_is_refused(corpus_dir, monkeypatch):
+    # The holders and the entry table are filled in one branch, so a divergence means
+    # one of them missed a row -- after which every entry above it maps to a neighbor's
+    # structures: in range, wrong molecule, and invisible to a count of either alone.
+    class _Short:
+        """A library that holds fewer molecules than the corpus has distinct SMILES."""
+
+        def __init__(self, molecules, patterns):
+            del molecules, patterns  # Unused: nothing gets as far as searching it.
+
+        def __len__(self):
+            return 1
+
+    monkeypatch.setattr(execute.rdSubstructLibrary, "SubstructLibrary", _Short)
+    with (
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+        ) as value,
+        pytest.raises(execute.PairingError, match="distinct SMILES"),
+    ):
+        value._library()
+
+
+def test_a_pattern_and_a_name_that_read_alike_are_not_one_answer(corpus_dir):
+    # A stated substructure pattern is SMARTS; a resolved compound is SMILES. The same
+    # text is two query molecules across those parsers -- C1=CC=CC=C1 is benzene as
+    # SMILES and six aliphatic carbons as SMARTS -- and resolvers answer in exactly that
+    # Kekule form, so a key holding only the text would answer one with the other.
+    kekule = "C1=CC=CC=C1"
+    by_name = query.Query.model_validate(
+        {"where": _exists({"op": "substructure", "path": "smiles", "compound": "b"})}
+    )
+
+    def answers(first, second):
+        with execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={"b": kekule}.__getitem__,
+        ) as value:
+            return _reactions(value.search(first)), _reactions(value.search(second))
+
+    # The corpus stores benzene aromatic, so the name matches it and the pattern, read
+    # as six aliphatic carbons, matches nothing. Whichever runs first, both hold.
+    assert answers(_substructure(kekule), by_name) == (set(), {"ord-aa01"})
+    assert answers(by_name, _substructure(kekule)) == ({"ord-aa01"}, set())
+
+
+def test_a_structure_parameter_naming_nothing_is_an_error(corpus):
+    # The grammar guarantees one of the two, so this cannot come from a query -- but
+    # resolving "" would ask the external resolver for a compound with no name and cache
+    # whatever came back, which is a long way from where the mistake was.
+    parameter = query.StructureParameter(
+        name="p0", op="substructure", pattern=None, compound=None, threshold=None
+    )
+    cursor = corpus._connection.cursor()
+    try:
+        with pytest.raises(ValueError, match="neither a pattern nor a compound"):
+            corpus._matches(cursor, parameter, {}.__getitem__)
+    finally:
+        cursor.close()
+
+
+def test_the_cache_keeps_what_was_asked_for_most_recently(corpus_dir, monkeypatch):
+    # Least recently *used*, not least recently computed: a scaffold asked for over and
+    # over is exactly what the cache is for, and it would be the first thing dropped if
+    # a hit did not count as a use.
+    monkeypatch.setattr(execute, "_CACHED_MATCHES", 2)
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        value.search(_substructure("c1ccncc1"))
+        value.search(_substructure("[OX2H]"))
+        value.search(_substructure("c1ccncc1"))  # Asked again: now the newest.
+        value.search(_substructure("[Pt]"))
+        assert [key[2] for key in value._matched] == ["c1ccncc1", "[Pt]"]
+
+
+def test_a_waiter_behind_a_failed_match_answers_for_itself(corpus_dir, monkeypatch):
+    # A pass that raises publishes nothing, so the callers queued behind it have to take
+    # the matching over rather than inherit an error they had no part in -- and none of
+    # them may be left waiting on an event that will never be set.
+    threads_count = 4
+    failing = True
+    original = execute.Corpus._substructure_ids
+    ready = threading.Barrier(threads_count)
+
+    def sometimes(self, parameter, resolve):
+        if failing:
+            time.sleep(0.5)  # Long enough that the others are waiting on this one.
+            raise RuntimeError("the library gave up")
+        return original(self, parameter, resolve)
+
+    monkeypatch.setattr(execute.Corpus, "_substructure_ids", sometimes)
+    released = threading.Event()
+
+    def resolver(name):
+        # The barrier is one-shot: every thread reaches it before any gets through, so
+        # the searches after them do not wait for a crowd that has already dispersed.
+        if not released.is_set():
+            ready.wait(timeout=_WAIT)
+            released.set()
+        return {"pyridine": "c1ccncc1"}[name]
+
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver=resolver,
+    ) as value:
+        value._library()
+        request = query.Query.model_validate(_ROUTABLE["a compound name"])
+        failures: list[BaseException] = []
+        results: list[int] = []
+
+        def search():
+            try:
+                results.append(value.search(request).num_rows)
+            except BaseException as error:  # noqa: BLE001
+                failures.append(error)
+
+        threads = [threading.Thread(target=search) for _ in range(threads_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=_WAIT)
+        alive = [thread for thread in threads if thread.is_alive()]
+        assert alive == []
+        assert results == []
+        assert [type(error) for error in failures] == [RuntimeError] * threads_count
+        assert value._matching == {}
+        # Nothing was cached, so the predicate is still askable once matching works.
+        failing = False
+        assert value.search(request).num_rows == 2
 
 
 def test_the_match_limit_has_to_be_passed_or_matches_are_dropped():

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -910,6 +910,185 @@ def test_concurrent_first_searches_build_one_library(corpus_dir, monkeypatch):
     assert results == [["ord-aa01", "ord-aa02"]] * threads_count
 
 
+_SUBSTRUCTURE = {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"}
+_SOLVENT = {"op": "eq", "path": "reaction_role", "value": {"literal": "SOLVENT"}}
+
+# Every shape the planner accepts, so the agreement below covers the whole surface
+# rather than the one case that prompted the index.
+_ROUTABLE = {
+    "structure alone": {"where": _exists(_SUBSTRUCTURE)},
+    "structure and role": {
+        "where": _exists({"op": "and", "clauses": [_SUBSTRUCTURE, _SOLVENT]})
+    },
+    "role and structure, reversed": {
+        "where": _exists({"op": "and", "clauses": [_SOLVENT, _SUBSTRUCTURE]})
+    },
+    "similarity": {
+        "where": _exists(
+            {"op": "similarity", "path": "smiles", "smiles": "OCC", "threshold": 0.4}
+        )
+    },
+    "a compound name": {
+        "where": _exists(
+            {"op": "substructure", "path": "smiles", "compound": "pyridine"}
+        )
+    },
+    "products rather than inputs": {
+        "where": {
+            "op": "exists",
+            "path": "outcomes.products",
+            "where": {"op": "substructure", "path": "smiles", "smarts": "Cc1ccccc1"},
+        }
+    },
+    "matches nothing": {
+        "where": _exists({"op": "substructure", "path": "smiles", "smarts": "[Pt]"})
+    },
+    # Toluene is every reaction's product and nobody's input, so asking for it among
+    # the inputs must come back empty. An index that lost the path it was asked about
+    # would answer with the products and return all three reactions.
+    "a structure that lives only at another path": {
+        "where": _exists(
+            {"op": "substructure", "path": "smiles", "smarts": "Cc1ccccc1"}
+        )
+    },
+    # Matches pyridine and benzene both, which are two components of aa01: one reaction
+    # reached through two occurrence rows.
+    "several components of one reaction": {
+        "where": _exists({"op": "substructure", "path": "smiles", "smarts": "c1ccccc1"})
+    },
+}
+
+_NOT_ROUTABLE = {
+    # The index holds no column to group by.
+    "an aggregate": {
+        "where": _exists(_SUBSTRUCTURE),
+        "aggregate": {"measures": [{"fn": "count", "name": "n"}]},
+    },
+    # Nor one to sort on beyond the reaction.
+    "an ordering": {
+        "where": _exists(_SUBSTRUCTURE),
+        "order_by": [{"key": "reaction_id"}],
+    },
+    # No structure means no bitmap, and the index is only worth its scan with one.
+    "a role alone": {"where": _exists(_SOLVENT)},
+    # amount lives on the element but not in the index.
+    "an unindexed element field": {
+        "where": _exists(
+            {
+                "op": "and",
+                "clauses": [
+                    _SUBSTRUCTURE,
+                    {"op": "gt", "path": "amount.mass.value", "value": {"literal": 1}},
+                ],
+            }
+        )
+    },
+    # A negated or disjoint element predicate is not a row filter.
+    "a negation": {"where": _exists({"op": "not", "clause": _SUBSTRUCTURE})},
+    "a disjunction": {
+        "where": _exists({"op": "or", "clauses": [_SUBSTRUCTURE, _SOLVENT]})
+    },
+    # forall is not exists: the index sees matching rows, never their absence.
+    "a universal": {
+        "where": {"op": "forall", "path": "inputs.components", "where": _SUBSTRUCTURE}
+    },
+    # A scalar outside the quantifier is a projection column.
+    "a scalar beside the quantifier": {
+        "where": {
+            "op": "and",
+            "clauses": [
+                _exists(_SUBSTRUCTURE),
+                {
+                    "op": "gt",
+                    "path": "conditions.temperature.setpoint_kelvin",
+                    "value": {"literal": 300},
+                },
+            ],
+        }
+    },
+}
+
+
+@pytest.mark.parametrize("label", sorted(_ROUTABLE))
+def test_the_index_answers_exactly_what_the_projection_would(corpus, label):
+    # The index is a second way to reach the same reactions, so the only thing that
+    # makes it safe is that it never reaches different ones. Both paths screen and
+    # verify through the same compiler, so any disagreement is the index's traversal
+    # or its role column, which is what this compares.
+    request = query.Query.model_validate(_ROUTABLE[label])
+    planned = execute.Corpus._plan(request)
+    assert planned is not None, "expected this to route"
+    through_index = set(corpus.search(request).column("reaction_id").to_pylist())
+    projected = query.compile_query(request)
+    assert projected.sql != planned.sql  # Two paths, or this compares one to itself.
+    parameters = {
+        parameter.name: corpus._bitmap(
+            corpus._substructure_ids(parameter, corpus._resolver)
+            if parameter.op == "substructure"
+            else corpus._similarity_ids(corpus._connection, parameter, corpus._resolver)
+        )
+        for parameter in projected.structures
+    }
+    through_projection = set(
+        corpus._connection.execute(projected.sql, parameters)
+        .to_arrow_table()
+        .column("reaction_id")
+        .to_pylist()
+    )
+    assert through_index == through_projection
+
+
+@pytest.mark.parametrize("label", sorted(_NOT_ROUTABLE))
+def test_the_planner_leaves_the_projection_what_the_index_cannot_answer(label):
+    # Routing one of these would answer a different question than it was asked, so the
+    # planner has to decline rather than approximate.
+    assert (
+        execute.Corpus._plan(query.Query.model_validate(_NOT_ROUTABLE[label])) is None
+    )
+
+
+def test_the_index_names_each_reaction_once(corpus):
+    # A reaction holding two matching components is two rows in the index and one row
+    # in the projection. Comparing the two as sets would hide that, so the count is
+    # asserted here: a caller reading the table sees the duplicate, not a set.
+    matched = corpus.search(
+        query.Query.model_validate(
+            {
+                "where": _exists(
+                    # Both of aa01's inputs are aromatic carbocycles or contain one.
+                    {"op": "substructure", "path": "smiles", "smarts": "c"}
+                )
+            }
+        )
+    ).column("reaction_id")
+    assert len(matched) == len(set(matched.to_pylist()))
+
+
+def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        # A scalar query cannot use the index, so it must not pay to build one.
+        value.search(
+            query.Query.model_validate(
+                {
+                    "where": _exists(
+                        {"op": "eq", "path": "smiles", "value": {"literal": "CCO"}}
+                    )
+                }
+            )
+        )
+        assert not value._occurrences_built
+        request = query.Query.model_validate(_ROUTABLE["structure alone"])
+        assert value.search(request).num_rows == 2
+        assert value._occurrences_built
+        # A second search reuses it rather than rebuilding, which CREATE TABLE would
+        # refuse anyway -- so this failing looks like an error, not a slow query.
+        assert value.search(request).num_rows == 2
+
+
 def test_the_match_limit_has_to_be_passed_or_matches_are_dropped():
     # GetMatches defaults to 1000 results and truncates in silence, which at corpus
     # scale would turn a broad pattern into a wrong answer rather than a slow one. The

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -97,11 +97,13 @@ def corpus_dir(tmp_path_factory) -> pathlib.Path:
 
 @pytest.fixture(scope="module")
 def deep_corpus(tmp_path_factory) -> Iterator[execute.Corpus]:
-    """A corpus holding a structure at each of the two deepest indexed paths.
+    """A corpus holding a structure at every indexed path.
 
     A workup's components and a product measurement's authentic standard are reached by
     the longest traversals the index generates, and the main fixture has neither, so
-    every assertion about them would otherwise compare nothing to nothing.
+    every assertion about them would otherwise compare nothing to nothing. The inputs
+    and the products carry structures too, which is what lets a query at one deep path
+    assert that a structure living at another is not found there.
     """
     reaction = reaction_pb2.Reaction(reaction_id="ord-cc01")
     _component(reaction.inputs["in"], "CCO", _ROLE.REACTANT)
@@ -1005,7 +1007,7 @@ _ROUTABLE = {
 
 _NOT_ROUTABLE = {
     # The planner declines every aggregate rather than reason about which ones the
-    # index's three columns could serve.
+    # index's four columns could serve.
     "an aggregate": {
         "where": _exists(_SUBSTRUCTURE),
         "aggregate": {"measures": [{"fn": "count", "name": "n"}]},
@@ -1024,7 +1026,7 @@ _NOT_ROUTABLE = {
                 "op": "and",
                 "clauses": [
                     _SUBSTRUCTURE,
-                    {"op": "gt", "path": "amount.mass.value", "value": {"literal": 1}},
+                    {"op": "gt", "path": "amount.mass_grams", "value": {"literal": 1}},
                 ],
             }
         )
@@ -1165,6 +1167,30 @@ def test_the_planner_leaves_the_projection_what_the_index_cannot_answer(label):
     )
 
 
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        # A pyridine that is not the solvent, which is aa02's reactant. Routed as an
+        # equality, this would come back as aa01 -- the one reaction it excludes.
+        ("a role inequality", {"ord-aa02"}),
+        # One component required to be two roles at once, which nothing is. Routed with
+        # only the last role kept, this would come back as every pyridine reactant.
+        ("two roles at once", set()),
+    ],
+)
+def test_a_declined_query_is_answered_rather_than_only_declined(
+    corpus, label, expected
+):
+    # The planner declining is half the property; the other half is that the projection
+    # answers, and answers what the comments beside these cases say routing would get
+    # wrong. Asserted for the two whose routed answer would not merely differ but invert
+    # or over-return.
+    assert (
+        _reactions(corpus.search(query.Query.model_validate(_NOT_ROUTABLE[label])))
+        == expected
+    )
+
+
 def test_the_index_names_each_reaction_once(corpus):
     # A reaction holding two matching components is two rows in the index and one row in
     # the projection. A caller gets the table rather than a set, so a duplicate would
@@ -1204,13 +1230,14 @@ def test_a_role_literal_cannot_close_its_quote(corpus):
     assert matched == set()
 
 
-def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
+def test_the_index_is_built_once_and_only_when_wanted(corpus_dir, caplog):
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
     ) as value:
-        # A scalar query cannot use the index, so it must not pay to build one.
+        # An element predicate with no structure in it cannot use the index, so it must
+        # not pay to build one.
         value.search(
             query.Query.model_validate(
                 {
@@ -1221,11 +1248,17 @@ def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
             )
         )
         assert not value._occurrences_built
+        caplog.set_level(logging.INFO, logger="ord_schema.agent.execute")
         request = query.Query.model_validate(_ROUTABLE["structure alone"])
         assert value.search(request).num_rows == 2
         assert value._occurrences_built
-        # A second search reuses it rather than rebuilding.
+        # A second search reuses it rather than rebuilding, which the answer alone
+        # cannot show -- a rebuild answers identically and costs a pass per path.
         assert value.search(request).num_rows == 2
+    builds = [
+        record for record in caplog.records if record.message.startswith("indexed ")
+    ]
+    assert len(builds) == 1
 
 
 @pytest.mark.parametrize(
@@ -1234,8 +1267,7 @@ def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
         # A workup component: a structure at a path the inputs do not reach.
         ("workups.input.components", "c1ccncc1", {"ord-cc01"}),
         ("workups.input.components", "CCO", set()),
-        # An authentic standard, the deepest indexed path -- reached by flattening twice
-        # and holding a role of its own that no query in the fixture sets.
+        # An authentic standard: the deepest path, reached by flattening twice.
         ("outcomes.products.measurements.authentic_standard", "c1ccccc1", {"ord-cc01"}),
         ("outcomes.products.measurements.authentic_standard", "CCO", set()),
     ],
@@ -1269,6 +1301,57 @@ def test_the_index_reaches_the_deep_paths_the_projection_does(
     assert _reactions(deep_corpus.search(declined)) == expected
 
 
+@pytest.mark.parametrize(
+    ("role", "expected"), [("SOLVENT", {"ord-cc01"}), ("REACTANT", set())]
+)
+def test_a_role_binds_to_the_element_at_a_deep_path(deep_corpus, role, expected):
+    # The index writes reaction_role for all four paths, and every other role condition
+    # here asks about inputs.components. A role that came out right for the inputs and
+    # NULL elsewhere would answer "pyridine as the solvent in the workup" with nothing,
+    # silently, while the same query without the role still worked.
+    request = query.Query.model_validate(
+        {
+            "where": {
+                "op": "exists",
+                "path": "workups.input.components",
+                "where": {
+                    "op": "and",
+                    "clauses": [
+                        {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"},
+                        {
+                            "op": "eq",
+                            "path": "reaction_role",
+                            "value": {"literal": role},
+                        },
+                    ],
+                },
+            }
+        }
+    )
+    assert execute.Corpus._plan(request) is not None, "expected this to route"
+    assert _reactions(deep_corpus.search(request)) == expected
+
+
+def test_a_routed_query_is_bounded_by_the_timeout(corpus, monkeypatch):
+    # The timeout is the only bound on what a query costs, and the routed path is a
+    # different statement reached by a different branch. The fixture is too small to
+    # outlast any timeout worth setting, so what is asserted is that the bound is
+    # carried: a routed query dropping it would run unbounded on a real corpus.
+    seen: list[tuple[str, float]] = []
+    original = execute.Corpus._run_with_timeout
+
+    def recording(cursor, sql, parameters, timeout_seconds):
+        seen.append((sql, timeout_seconds))
+        return original(cursor, sql, parameters, timeout_seconds)
+
+    monkeypatch.setattr(execute.Corpus, "_run_with_timeout", staticmethod(recording))
+    request = query.Query.model_validate(_ROUTABLE["structure and role"])
+    assert execute.Corpus._plan(request) is not None, "expected this to route"
+    assert _reactions(corpus.search(request, timeout_seconds=60)) == {"ord-aa01"}
+    assert [timeout for _, timeout in seen] == [60]
+    assert "FROM occurrences" in seen[0][0]
+
+
 def test_a_routed_query_reads_the_index_and_an_unrouted_one_does_not(corpus_dir):
     # Everything else here compares the two paths, which agree -- so a search that
     # quietly stopped routing would keep passing while the index cost a build and
@@ -1289,31 +1372,44 @@ def test_a_routed_query_reads_the_index_and_an_unrouted_one_does_not(corpus_dir)
             "WHERE reaction_id = 'ord-aa01' AND reaction_role = 'SOLVENT'"
         )
         assert _reactions(value.search(routed)) == {"ord-aa01", "ord-planted"}
+        # The same question with a scalar the fixture satisfies, so the projection's
+        # answer is a set with something in it rather than one that is empty either way.
         declined = query.Query.model_validate(
-            _NOT_ROUTABLE["a scalar beside the quantifier"]
+            {
+                "where": {
+                    "op": "and",
+                    "clauses": [
+                        _ROUTABLE["structure and role"]["where"],
+                        {"op": "not_null", "path": "reaction_id"},
+                    ],
+                }
+            }
         )
-        assert "ord-planted" not in _reactions(value.search(declined))
+        assert execute.Corpus._plan(declined) is None
+        assert _reactions(value.search(declined)) == {"ord-aa01"}
 
 
-def test_concurrent_first_searches_build_one_index(corpus_dir, caplog):
-    # The index is a materialized table, minutes to build at corpus scale. First
+def test_concurrent_first_searches_build_one_index(corpus_dir, caplog, monkeypatch):
+    # The index is a materialized table, several passes over the projections. First
     # searches arriving together must not each build their own; whoever waits takes the
-    # finished one. Counted off the build's own log line rather than left to a second
-    # CREATE TABLE failing, since the build replaces the table rather than colliding
-    # with it -- without the lock this is a wasted rebuild, not an error.
+    # finished one. The barrier sits at the door of the build rather than in the
+    # resolver, which a search reaches only afterwards, so the race is arranged rather
+    # than hoped for -- and the build's own log line is what counts them, since
+    # concurrent CREATEs would also collide in DuckDB's catalog and raise.
     caplog.set_level(logging.INFO, logger="ord_schema.agent.execute")
     threads_count = 4
     ready = threading.Barrier(threads_count)
+    building = execute.Corpus._occurrences
 
-    def resolver(name):
-        # Releases every thread together, so they meet at the build.
+    def synchronized(self):
         ready.wait(timeout=_WAIT)
-        return {"pyridine": "c1ccncc1"}[name]
+        return building(self)
 
+    monkeypatch.setattr(execute.Corpus, "_occurrences", synchronized)
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
-        resolver=resolver,
+        resolver={"pyridine": "c1ccncc1"}.__getitem__,
     ) as value:
         request = query.Query.model_validate(_ROUTABLE["a compound name"])
         results: list[int] = []
@@ -1341,10 +1437,10 @@ def test_concurrent_first_searches_build_one_index(corpus_dir, caplog):
 
 
 def test_an_index_that_reaches_nothing_is_refused(corpus_dir, monkeypatch):
-    # An empty index answers every structure query with no matches, which reads like an
-    # answer rather than like a corpus nobody can search. The fixture has no authentic
-    # standards, so indexing that path alone is a traversal that reaches nothing --
-    # which is what a path binding against the wrong schema would look like.
+    # An index that reaches no structure at all answers every structure query with no
+    # matches, which reads like an answer rather than like a corpus nobody can search.
+    # The fixture has no authentic standards, so indexing that path alone is a traversal
+    # that reaches nothing -- what a path binding against the wrong schema looks like.
     path = "outcomes.products.measurements.authentic_standard"
     monkeypatch.setattr(execute, "INDEXED_PATHS", {path: execute.INDEXED_PATHS[path]})
     request = query.Query.model_validate(
@@ -1361,13 +1457,113 @@ def test_an_index_that_reaches_nothing_is_refused(corpus_dir, monkeypatch):
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
     ) as value:
-        with pytest.raises(execute.PairingError, match="came out empty"):
+        with pytest.raises(execute.PairingError, match="reached 0 of the corpus's 5"):
             value.search(request)
-        # Nothing was published, so the next query builds again rather than reading an
-        # index that was never there.
+        # The table is in the catalog, holding nothing; what was not set is the flag, so
+        # nobody reads it.
         assert not value._occurrences_built
-        with pytest.raises(execute.PairingError, match="came out empty"):
+        value._connection = counter = _CursorCounter(value._connection)
+        with pytest.raises(execute.PairingError, match="reached 0 of the corpus's 5"):
             value.search(request)
+        # A corpus does not change under an open Corpus, so the second refusal is the
+        # first one's reason rather than several more passes to reach it again.
+        assert counter.cursors == 0
+
+
+def test_an_index_that_misses_one_path_is_refused(corpus_dir, monkeypatch):
+    # The dangerous shape is not an index that reaches nothing -- it is one that reaches
+    # almost everything. A single traversal that binds and finds no element leaves the
+    # other paths carrying the total, so a count of occurrences looks healthy while
+    # every query at the dead path answers with silence. Counting the structures reached
+    # is what tells the two apart. Dropping a path is what a schema walk that fell out
+    # of step with the projection would do.
+    kept = {
+        path: expression
+        for path, expression in execute.INDEXED_PATHS.items()
+        if path != "outcomes.products"
+    }
+    monkeypatch.setattr(execute, "INDEXED_PATHS", kept)
+    # Toluene is every reaction's product and nobody's input, so dropping the products
+    # path leaves exactly its two structures unreached.
+    with (
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+        ) as value,
+        pytest.raises(execute.PairingError, match="reached 3 of the corpus's 5"),
+    ):
+        value.search(query.Query.model_validate(_ROUTABLE["structure alone"]))
+
+
+def test_a_path_the_index_does_not_cover_is_left_to_the_projection(
+    corpus_dir, monkeypatch
+):
+    # The planner's path check is unfalsifiable against the real schema, since every
+    # path a structure can sit at is indexed. It becomes load-bearing the moment that
+    # stops being true, and routing a query to a path the index does not carry answers
+    # it with the empty set.
+    kept = {
+        path: expression
+        for path, expression in execute.INDEXED_PATHS.items()
+        if path != "outcomes.products"
+    }
+    monkeypatch.setattr(execute, "INDEXED_PATHS", kept)
+    request = query.Query.model_validate(_ROUTABLE["products rather than inputs"])
+    assert execute.Corpus._plan(request) is None
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        # Answered from the projection, which needs no index and so never builds one.
+        assert _reactions(value.search(request)) == {"ord-aa01", "ord-aa02", "ord-bb01"}
+        assert not value._occurrences_built
+
+
+def test_the_indexed_paths_are_the_ones_a_structure_can_sit_at():
+    # Derived from the projection schema, so what the walk accepts and refuses is worth
+    # pinning against schemas built for the purpose: today's projection exercises only
+    # the accepting branch, and the refusals exist for the schema change that will.
+    assert sorted(execute.INDEXED_PATHS) == [
+        "inputs.components",
+        "outcomes.products",
+        "outcomes.products.measurements.authentic_standard",
+        "workups.input.components",
+    ]
+    # A structure at a path with no role is one the index cannot carry -- and one it
+    # would then report as a structure it failed to reach.
+    with pytest.raises(ValueError, match="no reaction_role"):
+        execute._indexed_paths(
+            pa.schema(
+                [
+                    pa.field(
+                        "inputs",
+                        pa.list_(pa.struct([pa.field("structure_id", pa.uint32())])),
+                    )
+                ]
+            )
+        )
+    # A structure on a level that is not repeated is one the build cannot unnest.
+    with pytest.raises(ValueError, match="rather than a repeated expression"):
+        execute._indexed_paths(
+            pa.schema(
+                [
+                    pa.field(
+                        "setup",
+                        pa.struct(
+                            [
+                                pa.field("structure_id", pa.uint32()),
+                                pa.field("reaction_role", pa.string()),
+                            ]
+                        ),
+                    )
+                ]
+            )
+        )
+    # A schema with no structure anywhere would assemble a build with no SQL in it.
+    with pytest.raises(ValueError, match="no structure at any path"):
+        execute._indexed_paths(pa.schema([pa.field("reaction_id", pa.string())]))
 
 
 def test_the_match_limit_has_to_be_passed_or_matches_are_dropped():

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -1227,6 +1227,94 @@ def test_the_cache_does_not_confuse_two_predicates(corpus):
     assert similarity(0.25) == tight  # Still itself after the others went through.
 
 
+def test_one_predicate_asked_at_once_is_matched_once(corpus_dir, monkeypatch):
+    # Several clients asking for the same scaffold at once is what a popular query looks
+    # like, and the cache alone does not cover it: it holds finished answers, so callers
+    # arriving while the first pass runs would each start their own. The pass below is
+    # held open long enough that they all arrive during it.
+    threads_count = 4
+    matched = 0
+    counting = threading.Lock()
+    original = execute.Corpus._substructure_ids
+
+    def held(self, parameter, resolve):
+        nonlocal matched
+        with counting:
+            matched += 1
+        time.sleep(0.5)
+        return original(self, parameter, resolve)
+
+    monkeypatch.setattr(execute.Corpus, "_substructure_ids", held)
+    ready = threading.Barrier(threads_count)
+
+    def resolver(name):
+        # Releases every thread together, which is what puts them in one another's way.
+        ready.wait(timeout=_WAIT)
+        return {"pyridine": "c1ccncc1"}[name]
+
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver=resolver,
+    ) as value:
+        value._library()  # Built up front, so the threads race on matching alone.
+        request = query.Query.model_validate(
+            {
+                "where": _exists(
+                    {"op": "substructure", "path": "smiles", "compound": "pyridine"}
+                )
+            }
+        )
+        results: list[list[str]] = []
+        failures: list[BaseException] = []
+
+        def search():
+            try:
+                matches = value.search(request).column("reaction_id").to_pylist()
+                results.append(sorted(matches))
+            except BaseException as error:  # noqa: BLE001
+                failures.append(error)
+
+        threads = [threading.Thread(target=search) for _ in range(threads_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=_WAIT)
+        alive = [thread for thread in threads if thread.is_alive()]
+        waiting = dict(value._matching)
+    assert failures == []
+    assert alive == []
+    assert matched == 1
+    assert results == [["ord-aa01", "ord-aa02"]] * threads_count
+    assert waiting == {}  # The bookkeeping is dropped with the answer published.
+
+
+def test_a_failed_match_is_not_left_in_the_way(corpus_dir, monkeypatch):
+    # A pass that raises publishes nothing, so the predicate has to be left askable: the
+    # error belongs to the caller that hit it, not to the corpus.
+    failing = True
+    original = execute.Corpus._substructure_ids
+
+    def sometimes(self, parameter, resolve):
+        if failing:
+            raise RuntimeError("the library gave up")
+        return original(self, parameter, resolve)
+
+    monkeypatch.setattr(execute.Corpus, "_substructure_ids", sometimes)
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        with pytest.raises(RuntimeError, match="gave up"):
+            value.search(_substructure("c1ccncc1"))
+        assert value._matching == {}
+        failing = False
+        assert set(
+            value.search(_substructure("c1ccncc1")).column("reaction_id").to_pylist()
+        ) == {"ord-aa01", "ord-aa02"}
+
+
 def test_the_cache_stays_bounded(corpus_dir, monkeypatch):
     # Each entry is a bitmap over the whole corpus, so an unbounded cache would grow
     # without limit on a server asked many different questions.

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -15,6 +15,7 @@
 """Tests for ord_schema.agent.execute."""
 
 import contextlib
+import logging
 import pathlib
 import threading
 import time
@@ -95,6 +96,46 @@ def corpus_dir(tmp_path_factory) -> pathlib.Path:
 
 
 @pytest.fixture(scope="module")
+def deep_corpus(tmp_path_factory) -> Iterator[execute.Corpus]:
+    """A corpus holding a structure at each of the two deepest indexed paths.
+
+    A workup's components and a product measurement's authentic standard are reached by
+    the longest traversals the index generates, and the main fixture has neither, so
+    every assertion about them would otherwise compare nothing to nothing.
+    """
+    reaction = reaction_pb2.Reaction(reaction_id="ord-cc01")
+    _component(reaction.inputs["in"], "CCO", _ROLE.REACTANT)
+    _component(reaction.workups.add(type="EXTRACTION").input, "c1ccncc1", _ROLE.SOLVENT)
+    outcome = reaction.outcomes.add()
+    product = outcome.products.add()
+    product.identifiers.add(type="SMILES", value="Cc1ccccc1")
+    standard = product.measurements.add(analysis_key="nmr").authentic_standard
+    standard.identifiers.add(type="SMILES", value="c1ccccc1")
+    root = tmp_path_factory.mktemp("deep")
+    source = root / "data" / "ord_dataset-cc.parquet"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    parquet.save_dataset(
+        dataset_pb2.Dataset(
+            dataset_id="ord_dataset-cc",
+            name="test",
+            description="test",
+            reactions=[reaction],
+        ),
+        str(source),
+    )
+    projected = root / "projections" / source.name
+    projected.parent.mkdir(parents=True, exist_ok=True)
+    projection.write_projection(source, projected)
+    structured = root / "structures" / source.name
+    structured.parent.mkdir(parents=True, exist_ok=True)
+    structures.write_structures(projected, structured)
+    with execute.Corpus(
+        str(projected), str(structured), resolver={}.__getitem__
+    ) as value:
+        yield value
+
+
+@pytest.fixture(scope="module")
 def corpus(corpus_dir) -> Iterator[execute.Corpus]:
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
@@ -108,9 +149,12 @@ def _exists(where):
     return {"op": "exists", "path": "inputs.components", "where": where}
 
 
-def _search(corpus, where) -> set[str]:
-    table = corpus.search(query.Query.model_validate({"where": where}))
+def _reactions(table) -> set[str]:
     return set(table.column("reaction_id").to_pylist())
+
+
+def _search(corpus, where) -> set[str]:
+    return _reactions(corpus.search(query.Query.model_validate({"where": where})))
 
 
 def _role_and_structure(smarts, role):
@@ -913,8 +957,9 @@ def test_concurrent_first_searches_build_one_library(corpus_dir, monkeypatch):
 _SUBSTRUCTURE = {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"}
 _SOLVENT = {"op": "eq", "path": "reaction_role", "value": {"literal": "SOLVENT"}}
 
-# Every shape the planner accepts, so the agreement below covers the whole surface
-# rather than the one case that prompted the index.
+# Every shape the planner accepts whose two paths must agree exactly, which is all of
+# them but a limit: a limited query with no ordering takes some of the match set, and
+# the two paths take different rows of it. That one has its own test below.
 _ROUTABLE = {
     "structure alone": {"where": _exists(_SUBSTRUCTURE)},
     "structure and role": {
@@ -951,20 +996,21 @@ _ROUTABLE = {
             {"op": "substructure", "path": "smiles", "smarts": "Cc1ccccc1"}
         )
     },
-    # Matches pyridine and benzene both, which are two components of aa01: one reaction
-    # reached through two occurrence rows.
+    # One aromatic carbon matches pyridine and benzene both, which are aa01's two
+    # inputs: one reaction reached through two occurrence rows.
     "several components of one reaction": {
-        "where": _exists({"op": "substructure", "path": "smiles", "smarts": "c1ccccc1"})
+        "where": _exists({"op": "substructure", "path": "smiles", "smarts": "c"})
     },
 }
 
 _NOT_ROUTABLE = {
-    # The index holds no column to group by.
+    # The planner declines every aggregate rather than reason about which ones the
+    # index's three columns could serve.
     "an aggregate": {
         "where": _exists(_SUBSTRUCTURE),
         "aggregate": {"measures": [{"fn": "count", "name": "n"}]},
     },
-    # Nor one to sort on beyond the reaction.
+    # And every ordering, including this one, which is on a column the index does hold.
     "an ordering": {
         "where": _exists(_SUBSTRUCTURE),
         "order_by": [{"key": "reaction_id"}],
@@ -983,8 +1029,80 @@ _NOT_ROUTABLE = {
             }
         )
     },
-    # A negated or disjoint element predicate is not a row filter.
+    # An equality on an element field the index does not carry. Routed, the condition
+    # would be dropped and the answer would be the unconditioned one.
+    "an equality on another element field": {
+        "where": _exists(
+            {
+                "op": "and",
+                "clauses": [
+                    _SUBSTRUCTURE,
+                    {
+                        "op": "eq",
+                        "path": "smiles",
+                        "value": {"literal": "c1ccncc1"},
+                    },
+                ],
+            }
+        )
+    },
+    # The index carries the role a row has, never the roles it does not have, so an
+    # inequality routed as an equality would invert the answer.
+    "a role inequality": {
+        "where": _exists(
+            {
+                "op": "and",
+                "clauses": [
+                    _SUBSTRUCTURE,
+                    {
+                        "op": "ne",
+                        "path": "reaction_role",
+                        "value": {"literal": "SOLVENT"},
+                    },
+                ],
+            }
+        )
+    },
+    # A role naming a compound binds a parameter, and the index SQL binds none: it
+    # carries the structure parameter and nothing else.
+    "a role given as a compound": {
+        "where": _exists(
+            {
+                "op": "and",
+                "clauses": [
+                    _SUBSTRUCTURE,
+                    {
+                        "op": "eq",
+                        "path": "reaction_role",
+                        "value": {"compound": "pyridine"},
+                    },
+                ],
+            }
+        )
+    },
+    # Two roles on one element is a contradiction the projection answers with no rows.
+    # An index keeping only the last would answer with the rows holding that one.
+    "two roles at once": {
+        "where": _exists(
+            {
+                "op": "and",
+                "clauses": [
+                    _SUBSTRUCTURE,
+                    _SOLVENT,
+                    {
+                        "op": "eq",
+                        "path": "reaction_role",
+                        "value": {"literal": "REACTANT"},
+                    },
+                ],
+            }
+        )
+    },
+    # Absence is not a row: the index sees the rows that match, so a negation would have
+    # to be read off rows that are not there.
     "a negation": {"where": _exists({"op": "not", "clause": _SUBSTRUCTURE})},
+    # A disjunction is expressible as a row filter, but the planner reads conjunctions
+    # only, so it declines rather than carry a second way to build a condition.
     "a disjunction": {
         "where": _exists({"op": "or", "clauses": [_SUBSTRUCTURE, _SOLVENT]})
     },
@@ -1048,20 +1166,42 @@ def test_the_planner_leaves_the_projection_what_the_index_cannot_answer(label):
 
 
 def test_the_index_names_each_reaction_once(corpus):
-    # A reaction holding two matching components is two rows in the index and one row
-    # in the projection. Comparing the two as sets would hide that, so the count is
-    # asserted here: a caller reading the table sees the duplicate, not a set.
+    # A reaction holding two matching components is two rows in the index and one row in
+    # the projection. A caller gets the table rather than a set, so a duplicate would
+    # reach them; this asserts none does, which comparing the two paths as sets cannot.
     matched = corpus.search(
         query.Query.model_validate(
             {
                 "where": _exists(
-                    # Both of aa01's inputs are aromatic carbocycles or contain one.
+                    # Both of aa01's inputs hold aromatic carbon, so both are rows.
                     {"op": "substructure", "path": "smiles", "smarts": "c"}
                 )
             }
         )
     ).column("reaction_id")
     assert len(matched) == len(set(matched.to_pylist()))
+
+
+def test_a_limited_query_takes_some_of_the_match_set(corpus):
+    # A limit rides along to the index. Neither path orders what it was not asked to
+    # order, so the two take different rows of one match set and equality is the wrong
+    # assertion; what has to hold is that the rows are the match set's and that there
+    # are as many as were asked for. A limit dropped on the way to the index would
+    # return the whole set, which the count catches.
+    request = query.Query.model_validate({"where": _exists(_SUBSTRUCTURE), "limit": 1})
+    assert execute.Corpus._plan(request) is not None, "expected this to route"
+    limited = corpus.search(request).column("reaction_id").to_pylist()
+    assert len(limited) == 1
+    assert set(limited) <= {"ord-aa01", "ord-aa02"}
+
+
+def test_a_role_literal_cannot_close_its_quote(corpus):
+    # The role is the one thing a query supplies that reaches the index SQL as text
+    # rather than as a parameter. Unescaped, this literal closes the string and leaves
+    # `OR '1'='1` as a condition, which matches every row at every path -- so the
+    # assertion that bites is that nothing comes back, not that nothing raises.
+    matched = _search(corpus, _role_and_structure("c1ccncc1", "SOLVENT' OR '1'='1"))
+    assert matched == set()
 
 
 def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
@@ -1084,9 +1224,150 @@ def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
         request = query.Query.model_validate(_ROUTABLE["structure alone"])
         assert value.search(request).num_rows == 2
         assert value._occurrences_built
-        # A second search reuses it rather than rebuilding, which CREATE TABLE would
-        # refuse anyway -- so this failing looks like an error, not a slow query.
+        # A second search reuses it rather than rebuilding.
         assert value.search(request).num_rows == 2
+
+
+@pytest.mark.parametrize(
+    ("path", "smarts", "expected"),
+    [
+        # A workup component: a structure at a path the inputs do not reach.
+        ("workups.input.components", "c1ccncc1", {"ord-cc01"}),
+        ("workups.input.components", "CCO", set()),
+        # An authentic standard, the deepest indexed path -- reached by flattening twice
+        # and holding a role of its own that no query in the fixture sets.
+        ("outcomes.products.measurements.authentic_standard", "c1ccccc1", {"ord-cc01"}),
+        ("outcomes.products.measurements.authentic_standard", "CCO", set()),
+    ],
+)
+def test_the_index_reaches_the_deep_paths_the_projection_does(
+    deep_corpus, path, smarts, expected
+):
+    # Four paths are indexed and the main fixture holds structures at two of them, so
+    # the other two are asserted here: the same query, routed and declined, over a
+    # corpus that actually has something at each.
+    where = {"op": "substructure", "path": "smiles", "smarts": smarts}
+    request = query.Query.model_validate(
+        {"where": {"op": "exists", "path": path, "where": where}}
+    )
+    assert execute.Corpus._plan(request) is not None, "expected this to route"
+    assert _reactions(deep_corpus.search(request)) == expected
+    # The same question with a scalar beside it, which the planner declines, so the
+    # projection answers a query the index just answered.
+    declined = query.Query.model_validate(
+        {
+            "where": {
+                "op": "and",
+                "clauses": [
+                    {"op": "exists", "path": path, "where": where},
+                    {"op": "not_null", "path": "reaction_id"},
+                ],
+            }
+        }
+    )
+    assert execute.Corpus._plan(declined) is None
+    assert _reactions(deep_corpus.search(declined)) == expected
+
+
+def test_a_routed_query_reads_the_index_and_an_unrouted_one_does_not(corpus_dir):
+    # Everything else here compares the two paths, which agree -- so a search that
+    # quietly stopped routing would keep passing while the index cost a build and
+    # answered nothing. A row only the index holds separates them: a routed query
+    # returns it, and one the planner declines cannot see it.
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        routed = query.Query.model_validate(_ROUTABLE["structure and role"])
+        assert _reactions(value.search(routed)) == {"ord-aa01"}
+        # aa01's solvent is its pyridine, so this copies the row the query just matched
+        # on and attributes it to a reaction that exists nowhere else.
+        value._connection.execute(
+            "INSERT INTO occurrences SELECT 'ord-planted', path, global_id, "
+            "reaction_role FROM occurrences "
+            "WHERE reaction_id = 'ord-aa01' AND reaction_role = 'SOLVENT'"
+        )
+        assert _reactions(value.search(routed)) == {"ord-aa01", "ord-planted"}
+        declined = query.Query.model_validate(
+            _NOT_ROUTABLE["a scalar beside the quantifier"]
+        )
+        assert "ord-planted" not in _reactions(value.search(declined))
+
+
+def test_concurrent_first_searches_build_one_index(corpus_dir, caplog):
+    # The index is a materialized table, minutes to build at corpus scale. First
+    # searches arriving together must not each build their own; whoever waits takes the
+    # finished one. Counted off the build's own log line rather than left to a second
+    # CREATE TABLE failing, since the build replaces the table rather than colliding
+    # with it -- without the lock this is a wasted rebuild, not an error.
+    caplog.set_level(logging.INFO, logger="ord_schema.agent.execute")
+    threads_count = 4
+    ready = threading.Barrier(threads_count)
+
+    def resolver(name):
+        # Releases every thread together, so they meet at the build.
+        ready.wait(timeout=_WAIT)
+        return {"pyridine": "c1ccncc1"}[name]
+
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver=resolver,
+    ) as value:
+        request = query.Query.model_validate(_ROUTABLE["a compound name"])
+        results: list[int] = []
+        failures: list[BaseException] = []
+
+        def search():
+            try:
+                results.append(value.search(request).num_rows)
+            except BaseException as error:  # noqa: BLE001
+                failures.append(error)
+
+        threads = [threading.Thread(target=search) for _ in range(threads_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=_WAIT)
+        alive = [thread for thread in threads if thread.is_alive()]
+    builds = [
+        record for record in caplog.records if record.message.startswith("indexed ")
+    ]
+    assert failures == []
+    assert alive == []
+    assert len(builds) == 1
+    assert results == [2] * threads_count
+
+
+def test_an_index_that_reaches_nothing_is_refused(corpus_dir, monkeypatch):
+    # An empty index answers every structure query with no matches, which reads like an
+    # answer rather than like a corpus nobody can search. The fixture has no authentic
+    # standards, so indexing that path alone is a traversal that reaches nothing --
+    # which is what a path binding against the wrong schema would look like.
+    path = "outcomes.products.measurements.authentic_standard"
+    monkeypatch.setattr(execute, "INDEXED_PATHS", {path: execute.INDEXED_PATHS[path]})
+    request = query.Query.model_validate(
+        {
+            "where": {
+                "op": "exists",
+                "path": path,
+                "where": {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"},
+            }
+        }
+    )
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        with pytest.raises(execute.PairingError, match="came out empty"):
+            value.search(request)
+        # Nothing was published, so the next query builds again rather than reading an
+        # index that was never there.
+        assert not value._occurrences_built
+        with pytest.raises(execute.PairingError, match="came out empty"):
+            value.search(request)
 
 
 def test_the_match_limit_has_to_be_passed_or_matches_are_dropped():

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -256,7 +256,12 @@ def test_an_unparseable_structure_holds_its_slot(corpus_dir, tmp_path):
         str(root / "structures" / "*.parquet"),
         resolver={}.__getitem__,
     ) as value:
-        assert len(value._library()) == value._total
+        # The library holds distinct molecules, so its length is not the corpus's. What
+        # has to hold is that every structure ID resolves to exactly one entry.
+        library = value._library()
+        assert len(value._starts) - 1 == len(library)
+        assert len(value._members) == value._total
+        assert sorted(value._members) == list(range(value._total))
         # Benzene sits after the hole in aa, ethanol after it in bb. Both still name
         # their own reactions, which holds only while the empty slot is there.
         assert _search(
@@ -1087,6 +1092,151 @@ def test_the_index_is_built_once_and_only_when_wanted(corpus_dir):
         # A second search reuses it rather than rebuilding, which CREATE TABLE would
         # refuse anyway -- so this failing looks like an error, not a slow query.
         assert value.search(request).num_rows == 2
+
+
+def test_one_molecule_in_two_datasets_is_matched_once_and_found_twice(corpus):
+    # Structures are deduplicated per dataset, so toluene holds a row in aa and another
+    # in bb. The library matches it once; the answer still has to name both structures,
+    # and through them every reaction that made it.
+    library = corpus._library()
+    assert len(library) < corpus._total, "expected the corpus to hold a duplicate"
+    entries = {
+        corpus._members[corpus._starts[entry]]: corpus._starts[entry + 1]
+        - corpus._starts[entry]
+        for entry in range(len(library))
+    }
+    assert max(entries.values()) == 2, "toluene should cover two structure IDs"
+    assert sum(entries.values()) == corpus._total
+    matched = corpus.search(
+        query.Query.model_validate(
+            {
+                "where": {
+                    "op": "exists",
+                    "path": "outcomes.products",
+                    "where": {
+                        "op": "substructure",
+                        "path": "smiles",
+                        "smarts": "Cc1ccccc1",
+                    },
+                }
+            }
+        )
+    )
+    assert set(matched.column("reaction_id").to_pylist()) == {
+        "ord-aa01",
+        "ord-aa02",
+        "ord-bb01",
+    }
+
+
+def _substructure(smarts):
+    return query.Query.model_validate(
+        {"where": _exists({"op": "substructure", "path": "smiles", "smarts": smarts})}
+    )
+
+
+def test_a_repeated_predicate_is_matched_once(corpus_dir, monkeypatch):
+    # Matching is a pass over every molecule in the corpus and depends on nothing but
+    # the query, so asking twice must cost once -- and must answer the same.
+    matched = 0
+    original = execute.Corpus._substructure_ids
+
+    def counted(self, parameter, resolve):
+        nonlocal matched
+        matched += 1
+        return original(self, parameter, resolve)
+
+    monkeypatch.setattr(execute.Corpus, "_substructure_ids", counted)
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={"pyridine": "c1ccncc1", "azabenzene": "c1ccncc1"}.__getitem__,
+    ) as value:
+        first = set(
+            value.search(_substructure("c1ccncc1")).column("reaction_id").to_pylist()
+        )
+        second = set(
+            value.search(_substructure("c1ccncc1")).column("reaction_id").to_pylist()
+        )
+        assert first == second == {"ord-aa01", "ord-aa02"}
+        assert matched == 1
+        # A different pattern is a different question, cache or no cache.
+        assert set(
+            value.search(_substructure("[OX2H]")).column("reaction_id").to_pylist()
+        ) == {"ord-bb01"}
+        assert matched == 2
+        # Two names for one molecule are one match, since the key is what they resolve
+        # to rather than what they were called.
+        by_name = query.Query.model_validate(
+            {
+                "where": _exists(
+                    {"op": "substructure", "path": "smiles", "compound": "pyridine"}
+                )
+            }
+        )
+        other_name = query.Query.model_validate(
+            {
+                "where": _exists(
+                    {"op": "substructure", "path": "smiles", "compound": "azabenzene"}
+                )
+            }
+        )
+        assert value.search(by_name).num_rows == 2
+        assert value.search(other_name).num_rows == 2
+        assert matched == 2  # Both resolve to the pattern already matched above.
+
+
+def test_the_cache_does_not_confuse_two_predicates(corpus):
+    # One molecule, several questions. Toluene's Tanimoto against the inputs is benzene
+    # 0.273, pyridine 0.176, ethanol 0.062, so each threshold below selects a different
+    # set of reactions -- a key that ignored the threshold would answer one with
+    # another. The same SMILES read as a substructure is a different operation again.
+    def similarity(threshold):
+        return set(
+            corpus.search(
+                query.Query.model_validate(
+                    {
+                        "where": _exists(
+                            {
+                                "op": "similarity",
+                                "path": "smiles",
+                                "smiles": "Cc1ccccc1",
+                                "threshold": threshold,
+                            }
+                        )
+                    }
+                )
+            )
+            .column("reaction_id")
+            .to_pylist()
+        )
+
+    tight = similarity(0.25)
+    assert tight == {"ord-aa01"}  # Benzene only.
+    assert similarity(0.15) == {"ord-aa01", "ord-aa02"}  # Pyridine joins it.
+    assert similarity(0.05) == {"ord-aa01", "ord-aa02", "ord-bb01"}  # Ethanol too.
+    # Substructure with that SMILES read as a SMARTS matches no input at all.
+    assert (
+        set(corpus.search(_substructure("Cc1ccccc1")).column("reaction_id").to_pylist())
+        == set()
+    )
+    assert similarity(0.25) == tight  # Still itself after the others went through.
+
+
+def test_the_cache_stays_bounded(corpus_dir, monkeypatch):
+    # Each entry is a bitmap over the whole corpus, so an unbounded cache would grow
+    # without limit on a server asked many different questions.
+    monkeypatch.setattr(execute, "_CACHED_MATCHES", 2)
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        for smarts in ("c1ccncc1", "[OX2H]", "c1ccccc1", "[Pt]"):
+            value.search(_substructure(smarts))
+        assert len(value._matched) == 2
+        # The two most recent survive; the earliest are gone.
+        assert [key[1] for key in value._matched] == ["c1ccccc1", "[Pt]"]
 
 
 def test_the_match_limit_has_to_be_passed_or_matches_are_dropped():

--- a/ord_schema/agent/query.py
+++ b/ord_schema/agent/query.py
@@ -525,6 +525,13 @@ def _structure_parameter(
 
     Deduplicated by content so the executor screens and verifies each distinct
     predicate once, however many times the query states it.
+
+    Args:
+        node: The structure predicate to name.
+        structures: Parameters named so far, appended to when this one is new.
+
+    Returns:
+        The parameter name to bind the predicate's bitmap under.
     """
     pattern = node.smarts if isinstance(node, Substructure) else node.smiles
     threshold = node.threshold if isinstance(node, Similarity) else None
@@ -558,6 +565,19 @@ def _structure(
     The chemistry happens in the executor; what compiles here is only the re-entry of
     its match set. The null guard keeps a compound with no recorded structure from
     reading as a match under negation-free semantics: no structure, no match.
+
+    Args:
+        node: The structure predicate to compile.
+        scope: Bound variable the path is relative to, or None at the row.
+        schema: Schema or struct type the path resolves within.
+        structures: Parameters named so far, appended to when this one is new.
+
+    Returns:
+        The DuckDB expression testing the element's ID against the predicate's bitmap.
+
+    Raises:
+        QueryError: If the path does not name a compound's ``smiles``, or crosses a
+            repeated level without a quantifier to say which element is meant.
     """
     parts = node.path.split(".")
     if parts[-1] != "smiles":
@@ -600,6 +620,22 @@ def _quantifier(
     The element is bound to a fresh variable, and the body compiles against *it* rather
     than against the row, which is what lets one component be required to satisfy
     several conditions at once.
+
+    Args:
+        node: The quantifier to compile.
+        scope: Bound variable the path is relative to, or None at the row.
+        schema: Schema or struct type the path resolves within.
+        compounds: Compound names collected so far, appended to by the body.
+        structures: Structure parameters collected so far, appended to by the body.
+        depth: How many quantifiers enclose this one, which names its variable.
+
+    Returns:
+        The DuckDB expression filtering the level, true when the quantifier holds.
+        ``forall`` is stated as the absence of a counterexample, so it is vacuously
+        true of an empty level.
+
+    Raises:
+        QueryError: If the path does not reach a repeated level.
     """
     resolved = resolve(node.path, schema=schema, root=scope)
     if not resolved.repeated:

--- a/ord_schema/artifacts.py
+++ b/ord_schema/artifacts.py
@@ -313,7 +313,8 @@ def glob_root(pattern: str) -> pathlib.PurePath:
         pattern: Glob pattern, with ``*``, ``?``, or ``[`` marking the first wildcard.
 
     Returns:
-        The wildcard-free leading directories, empty for a pattern with no directory.
+        The wildcard-free leading directories, or ``.`` when the pattern names no
+        directory or begins with a wildcard.
     """
     parts = pathlib.PurePath(pattern).parts
     fixed = []

--- a/ord_schema/artifacts.py
+++ b/ord_schema/artifacts.py
@@ -215,6 +215,14 @@ def is_current(path: str | os.PathLike[str], artifact: str, source_md5: str) -> 
     All of the source content, the library version, the artifact version, and the RDKit
     version must match; any of them changing can change a value. A missing, unreadable,
     or wrong-artifact file is not current.
+
+    Args:
+        path: Path to check. Need not exist.
+        artifact: Artifact name the file is expected to hold.
+        source_md5: Hash the file is expected to restate.
+
+    Returns:
+        Whether the file is one this library would write today.
     """
     try:
         value = load_stamps(path)
@@ -226,7 +234,7 @@ def is_current(path: str | os.PathLike[str], artifact: str, source_md5: str) -> 
 
 
 def stamps_are_current(value: Stamps, artifact: str) -> bool:
-    """Returns whether ``value`` records ``artifact`` as this library defines it now.
+    """Returns whether ``value`` records ``artifact`` as this library defines it.
 
     The source content is deliberately not compared: a caller holding the stamps of a
     parent asks whether the file was written by the current definition, and the hash it
@@ -300,6 +308,12 @@ def glob_root(pattern: str) -> pathlib.PurePath:
     ``output_dir=structures`` lands at ``structures/<subdir>/x.parquet``. A pattern
     naming a single file has no wildcard to stop at, so its own last component is the
     file rather than a directory and the root is the directory holding it.
+
+    Args:
+        pattern: Glob pattern, with ``*``, ``?``, or ``[`` marking the first wildcard.
+
+    Returns:
+        The wildcard-free leading directories, empty for a pattern with no directory.
     """
     parts = pathlib.PurePath(pattern).parts
     fixed = []

--- a/ord_schema/scripts/derive_projection.py
+++ b/ord_schema/scripts/derive_projection.py
@@ -56,6 +56,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(args: argparse.Namespace) -> None:
     """Derives a projection for every dataset matching the input pattern.
 
+    Args:
+        args: Parsed arguments, read for ``input_pattern``, ``output_dir``, and
+            ``force``.
+
     Raises:
         ValueError: If the pattern matched only derived artifacts, which means it was
             aimed at an output tree rather than a source tree. Silence there would let a

--- a/ord_schema/scripts/derive_structures.py
+++ b/ord_schema/scripts/derive_structures.py
@@ -63,7 +63,8 @@ def main(args: argparse.Namespace) -> None:
     """Derives a structures artifact for every projection matching the input pattern.
 
     Args:
-        args: Parsed command-line arguments.
+        args: Parsed arguments, read for ``input_pattern``, ``output_dir``, and
+            ``force``.
 
     Raises:
         ValueError: If the pattern matched no projections, which usually means it was

--- a/ord_schema/structures.py
+++ b/ord_schema/structures.py
@@ -86,6 +86,12 @@ def morgan_fingerprint(molecule: Chem.Mol) -> DataStructs.ExplicitBitVect:
 
     The query side of a similarity search must fingerprint identically to the artifact
     or the comparison is meaningless, so this is the one place the parameters live.
+
+    Args:
+        molecule: The molecule to fingerprint.
+
+    Returns:
+        A ``MORGAN_FP_SIZE``-bit fingerprint at radius ``MORGAN_RADIUS``.
     """
     return _MORGAN.GetFingerprint(molecule)
 
@@ -279,6 +285,14 @@ def is_current(path: str | os.PathLike[str], source_md5: str) -> bool:
     Delegates to ``artifacts.is_current``, which requires the artifact name, the source
     content, the library version, and the artifact version to all match. A missing or
     unreadable file is not current.
+
+    Args:
+        path: Path to check. Need not exist.
+        source_md5: Hash of the source dataset the artifact should restate, which is
+            the dataset's own even though the artifact derives from a projection.
+
+    Returns:
+        Whether the file is a structures artifact this library would write today.
     """
     return artifacts.is_current(path, ARTIFACT, source_md5)
 


### PR DESCRIPTION
## Summary

Three cuts to what a structure predicate costs, and one thing that turned out not to be worth cutting.

Stacks on #960 — merge that first.

## Changes

**One entry per distinct molecule.** Structures are deduplicated per dataset, so a molecule several datasets use occupies a row in each and was matched once per copy. The library now holds one entry per distinct SMILES — 1,435,426 of the corpus's 2,016,224 rows, so 29% of the matching disappears — and maps each entry back to every structure ID sharing it.

**Recent match sets are kept.** A match set depends on the query molecule and nothing else, so asking twice costs once. A compound is keyed by what it resolved to rather than by its name, so two names for one molecule share an entry and a resolver that changes its mind is a different key. Bounded, since each entry is a bitmap over the whole corpus.

**One pass per question, even while it is running.** The cache holds *finished* answers, so identical requests arriving mid-pass each started their own — a burst of one scaffold from several clients at once, which is what a popular query looks like, multiplied a corpus-wide match by however many arrived. A predicate being matched is registered beside the cache, and a caller finding one there waits for it and takes the published answer. The wait is per predicate, so unrelated searches still overlap; the registration is dropped in a `finally`, so a pass that raises leaves the predicate askable and the error with the caller that hit it rather than with everyone queued behind.

A library index consequently stops being a structure ID, which the comments and the unparseable-slot test both claimed. Both now state the invariant that survives: every structure ID resolves to exactly one entry.

**Answering from the columns a query names.** A query the occurrence index declines reads the projection — 442 leaves across 53 files, of which it touches a handful. The cost is mostly per-file overhead and is the same whatever the query asks for, so the columns a query names are materialized once and answered from memory afterwards.

| query | projection | narrow |
| --- | --- | --- |
| temperature not null | 1.241s | **0.205s** |
| group-by on the DOI | 0.752s | **0.020s** |
| group-by on stirring type | 0.750s | **0.003s** |

The columns are read back off the compiled SQL rather than walked from the query IR, because the SQL is what has to resolve: a column it names and the table lacks is a catalog error, while one the query names and the SQL does not is nothing at all. Sets are held to a memory budget and evicted least-recently-used; one too large to keep is not kept, and the projection answers it directly.

**Row order is not preserved, and never was promised.** At corpus scale the two relations return 607,307 rows each, equal as multisets and different as lists, for a query with no `order_by`. Neither orders what it was not asked to order. The differential test compares multisets, which is the property that holds — my first version compared lists and passed only because the fixture is small enough to be incidentally stable.

**This caught a concurrency bug in #960 and one I had just written.** Both the occurrence index and the new materialization built their tables on the *shared* connection, which holds the pending result of whatever search is in flight — the exact hazard #958 fixed for searches. `test_a_search_runs_on_a_cursor_rather_than_the_shared_connection` found them. Both now take a cursor.

## Measurements

Full corpus, identical answers throughout:

| query | before (#960) | cold | cached | reactions |
| --- | --- | --- | --- | --- |
| pyridine | 1.46s | 1.05s | **0.02s** | 660,671 |
| hydroxyl | — | 0.99s | **0.07s** | 1,473,581 |
| boronic acid | — | 0.06s | **0.01s** | 132,600 |

## The screen is not a lever

Recording this so nobody re-derives it.

It is the **same** `PatternFingerprint` the RDKit PostgreSQL cartridge screens with — verified from the cartridge binary, which imports `RDKit::PatternFingerprintMol` and exposes `rdkit.sss_fp_size` ("Size (in bits) of the fingerprint used for substructure screening") via `makeMolSignature`. For a small common query it admits most of the corpus: 80% for pyridine, of which 73% then fail verification.

Measured and rejected:

| lever | effect |
| --- | --- |
| more bits (2048 → 8192) | pyridine 80% → 79% |
| composition prefilter | 80% → 76%; 3% → 1% on selective queries |
| circular fingerprint, any radius | **breaks correctness** |

A Morgan fingerprint cannot serve as a substructure screen. It cannot be computed from a SMARTS at all (`RingInfo not initialized`), and its bits are not preserved under subgraph extraction, so the subset test is unsound: radius 2 dropped 4 of 5 true matches and radius 3 dropped all 5. The query's boundary atoms see different neighbourhoods once embedded in a larger molecule. `PatternFingerprint` enumerates small paths precisely because those *are* monotone, and it dropped 0 of 5.

Verifying the survivors is the intrinsic cost, and it now dominates: pyridine's 1.05s is nearly all matching.

## What the review round changed

Eight reviewers went over the caches. Two of what they found were wrong answers waiting to happen.

**`duckdb_tables().estimated_size` is a row count.** Spent as bytes it made the memory budget a number a narrow table could never cross: nothing was ever refused, nothing was ever evicted, every materialization logged `0.00 GB`, and a long-lived corpus kept one table per column set it was ever asked for. The cost is now the difference two readings of DuckDB's own memory accounting make across the `CREATE`, which is why the whole materialization sits under one lock — two interleaved builds would each be charged the other's.

**A pattern and a name that read alike shared one answer.** A stated substructure pattern is SMARTS; a resolved compound is SMILES. `C1=CC=CC=C1` is benzene under one parser and six aliphatic carbons under the other, resolvers answer in exactly that Kekulé form, and the key held only the text — so whichever query ran first decided what the other got. The key carries which parser reads the string.

**Eviction could drop a table out from under a search.** A search takes the table's name, then resolves compounds and matches structures — seconds holding nothing but a string. Tables are held for the life of the search, and eviction passes over anything being read, leaving the cache above its budget rather than failing a query that was already answered.

**A failed materialization killed its column set permanently.** The table survived, under a name the next attempt would derive again and collide with. Names come from a serial that never repeats, and a failure drops what it built.

**The `FROM` rewrite could corrupt a query.** Reaching the narrow table by replacing `FROM reactions` in the compiled SQL was guarded by an `assert`; a query whose own string literal contained that text tripped it, and under `-O` had its literal rewritten and answered zero rows. The query is compiled a second time against the table instead, which `compile_query` already takes a `table=` argument for.

Smaller: a structure parameter naming neither a pattern nor a compound asked the resolver for `""` rather than saying so; a library and entry table disagreeing on how many distinct molecules exist are refused, since every entry above the divergence maps to a neighbor's structures.

## Testing

The threshold sabotage passed the first version of its test — the two thresholds compared happened to select the same reactions in the fixture. It now uses thresholds measured against the fixture's actual Tanimoto values (benzene 0.273, pyridine 0.176, ethanol 0.062 against toluene) to select three different reaction sets.

Ten more sabotages, every one of which the suite previously missed: the cache key ignoring the parser, the size read as a row count, eviction removed, eviction forgetting without dropping, eviction ignoring readers, a failed build leaving its table, a cache hit not counting as a use, a waiter reading the cache slot directly instead of re-checking, the library and entry counts unchecked, and the narrow table reached by rewriting SQL.

Coverage the reviewers named and that is now real: the eviction loop (previously never executed — the only budget test set the budget to `1`, which trips the pre-insert refusal and never reaches it), a failed match with three callers queued behind it, LRU recency, and the ordered query compared as a list rather than a multiset.

`pytest -n auto` — 1074 passed, 2 skipped. `pre-commit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR reduces structure-query costs by deduplicating molecules, caching and sharing match results, routing eligible predicates through an occurrence index, and materializing only referenced projection columns.
- Maps each distinct molecule back to all corresponding structure IDs.
- Shares in-flight matching work and retains recent bitmap results.
- Adds occurrence-index and narrow-table execution paths with concurrency-aware lifecycle handling.
- Updates artifact derivation, query compilation, tests, and documentation for the new invariants.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/agent/execute.py | Adds molecule deduplication, occurrence indexing, shared match caching, and bounded narrow-table materialization without leaving an eligible blocking issue. |
| ord_schema/agent/execute_test.py | Expands coverage for cache concurrency, failure recovery, eviction, artifact consistency, and query-path equivalence. |
| ord_schema/agent/query.py | Supports compiling queries against alternate materialized relations while retaining typed input validation. |
| ord_schema/structures.py | Updates structure-artifact behavior and invariants supporting deduplicated corpus matching. |
| ord_schema/artifacts.py | Adjusts shared artifact derivation behavior for the updated projection and structures pipeline. |
| ord_schema/scripts/derive_projection.py | Updates projection derivation integration with the artifact pipeline. |
| ord_schema/scripts/derive_structures.py | Updates structures derivation integration and paired-artifact handling. |
| ord_schema/agent/README.md | Documents the new occurrence-index, match-cache, deduplication, and narrow-table execution model. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Q[Typed query] --> P{Occurrence index eligible?}
  P -->|Yes| I[Build or reuse occurrence index]
  P -->|No| C[Compile against projection]
  C --> N[Build or reuse narrow column table]
  I --> M[Resolve or reuse structure match bitmap]
  N --> M
  M --> E[Execute query on dedicated cursor]
  E --> R[Arrow result]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;agent/occurrence-index&#39; in..."](https://github.com/open-reaction-database/ord-schema/commit/d47bd1d0f26b52e80ab280ac867a0f56647dd669) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51700840)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Agent Query Surface](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/agent-query.md)
- Knowledge Base — [Derived Parquet Artifacts](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/derived-artifacts.md)
- Knowledge Base — [Dataset Scripts](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/dataset-scripts.md)
</details>

<!-- /greptile_comment -->