### PR TITLE
Hold the columns the corpus is actually asked about

### DIFF
--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -133,6 +133,90 @@ is built on the first query that spends it, one pass over the projections per in
 path, so a server that wants its first real query to be fast should issue a throwaway
 structure query at startup.
 
+## Pivoted levels
+
+The occurrence index answers a quantifier about a *structure*. A **pivot** answers one
+about anything else: one row per element of a repeated level, carrying `reaction_id`,
+the ordinal of every repeated level from the root down to that one, and the element's
+own fields with the repeated ones removed recursively. A quantifier over a covered level
+becomes `EXISTS (SELECT 1 FROM <pivot> AS x WHERE x.reaction_id = reactions.reaction_id
+AND …)`, and a `forall` the same with `NOT EXISTS` and the body negated.
+
+Two properties do the work. The pivot is **complete** — every element gets a row,
+including one whose fields are all NULL — which is what lets it answer `forall`, where
+the occurrence index cannot, since that one holds only elements carrying a structure.
+And struct nesting is **kept**, so `percentage.value` is `x.element.percentage.value`
+here and `e0.percentage.value` over the elements: the same path by the same spelling,
+which is what makes the two routes comparable. Removing only the repeated fields is
+where the size goes; the cost was never struct access but the reconstruction of lists of
+structs, and a scalar pulled out of a deep struct across the whole corpus is seconds.
+
+That also decides coverage without a list anybody maintains. A body reaching a field the
+pivot dropped fails to resolve against the pruned element type, so the quantifier falls
+back to the elements. What a pivot does carry is `structure_id`, so a structure
+predicate inside a pivoted quantifier works too, reading `structure_offset` from the
+enclosing reaction. A quantifier's path need not name a level either: descending from
+one through singular struct fields reaches one value per element rather than a list of
+its own — an authentic standard is one compound per measurement — so the level it ranges
+over is the nearest repeated ancestor, whose pivot already carries the struct.
+
+The ordinals are what a flat row needs to say *which* element it was, and a **nested**
+quantifier is where they are spent: an `exists` inside a pivoted one becomes a semi-join
+against the child level's pivot, joined on the reaction and every ordinal the enclosing
+level carries.
+
+```sql
+EXISTS (SELECT 1 FROM pivot_outcomes_products_measurements AS x1
+        WHERE x1.reaction_id = x0.reaction_id
+          AND x1.outcome_index = x0.outcome_index
+          AND x1.product_index = x0.product_index AND …)
+```
+
+Correlating on anything short of that whole prefix returns reactions where the two
+clauses hold of *different* elements: "a desired product with a yield above 50%" answers
+23,608 reactions on `(reaction_id, outcome_index)` where the answer is 22,666 — 942
+wrong, silently. ORD is effectively single-outcome, so dropping the *outcome* ordinal
+changes nothing at all, which is exactly why the product-level error looks correct until
+it is checked.
+
+Over the whole corpus, warm, against the same queries answered from the elements:
+
+| query | pivot | elements |
+| --- | --- | --- |
+| a white product | 0.050s | 0.936s |
+| yield > 50% | 0.086s | 2.758s |
+| every product is desired | 0.070s | 2.055s |
+| **not** a yield above 50% | 0.098s | 3.480s |
+| a solvent input | 0.178s | 4.229s |
+| an extraction workup | 3.660s | 7.816s |
+| above 350 K | 0.041s | 0.035s |
+
+Every one returns the same reactions either way. The last two are the shape of the
+thing: `above 350 K` is a scalar path with no quantifier, so no pivot is involved and
+nothing moves, and the workup query is one whose pivot the budget refused — the
+projection answered it, which is the fallback working rather than the pivot helping.
+
+Building one unnests the projection down to its level, which over ORD is minutes:
+`outcomes.products` is 487.8 MB in 478s and `outcomes.products.measurements` 1.7 GB in
+783s, charged against the same `narrow_budget_bytes` as a materialized column set and
+evicted by the same LRU.
+
+How much a pivot saves depends on how wide its elements are, and pruning only the
+repeated fields is coarse. `workups` is the case that shows it: its elements carry a
+whole `ReactionInput` besides, so the pivot is **4.4 GB** against 5.08 GB for the nested
+column — over the 4 GB default, refused, and answered from the projection. A level whose
+elements are narrow behaves the other way, which is why the two `outcomes` levels are
+tenths of a second and the workup query is seconds.
+
+That build cost belongs offline, which is what
+`scripts/derive_pivots.py` is for — one subdirectory per level, one file per projection
+within it, stamped like any other derived artifact and read by
+`Corpus(..., pivots_dir=...)`. Artifacts are refused unless they were derived from this
+corpus's own projections: a pivot names its reactions by ID, so one derived elsewhere
+answers against rows this corpus does not hold, confidently and wrongly. A level with no
+artifacts is still built in process, so a partial set is a partial speedup rather than a
+missing answer.
+
 What remains is the chemistry itself, and two things cut it. Structures are deduplicated
 per dataset, so the library holds one entry per **distinct** molecule — 1,435,426 of the
 corpus's 2,016,224 rows, so 29% of the matching disappears — and maps each entry back to

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -159,7 +159,20 @@ search whose columns are already materialized is answered while another is being
 same rows either way, in an order neither relation promises — a query wanting one has to
 say so.
 
-**The budget is the cliff.** Materialized, ORD's `inputs` is 4.07 GB and its `outcomes`
+**The budget is the cliff, and it says so.** A refused column set logs a **warning** on
+every query that names it, giving what the set costs, what the budget is, and the
+argument that changes them — so a query that suddenly takes seconds explains itself in
+the log rather than by profiling:
+
+```text
+WARNING materializing ['outcomes', 'reaction_id'] takes 3.3 GB, over this corpus's
+2.0 GB budget, so every query naming those columns reads the Parquet files instead --
+seconds rather than tenths of a second at ORD's scale. Open the Corpus with a larger
+narrow_budget_bytes, or give the process more memory: the default budget is a quarter
+of what it may hold.
+```
+
+Materialized, ORD's `inputs` is 4.07 GB and its `outcomes`
 3.26 GB, against 1.71 GB for `conditions` and 1.46 GB for `notes`. A column set the
 budget refuses is read from the 53 Parquet files on every query that names it, and
 scattered rows do not let a reader skip row groups, so the same question costs seconds

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -192,9 +192,19 @@ default is a fixed **4 GB**, which holds any single one of the large columns —
 query pairing a structure clause with a projection one needs — and
 `Corpus(narrow_budget_bytes=...)` states otherwise on a machine with room to spare.
 Building a set costs its size whether or not it is kept, so the peak is the budget plus
-the largest set, not the budget alone. This is also the second thing the index buys: a
-query whose structure clause becomes a semi-join never names `inputs` at all, so what
-has to be resident is far smaller than for the same question answered from the elements.
+the largest set, not the budget alone — `narrow_budget_bytes=0` is the one figure that
+avoids the build entirely, and so the one that bounds a small machine. This is also the
+second thing the index buys: a query whose structure clause becomes a semi-join never
+names `inputs` at all, so what has to be resident is far smaller than for the same
+question answered from the elements.
+
+**Sizing a deployment.** What must be resident is the RDKit library (about 1.5 GB), the
+occurrence index (about 130 MB), and the runtime — call it 3 GB, and nothing about that
+is optional for substructure search, since the screen and verify are RDKit in this
+process rather than SQL in an engine. Everything above that is latency: a container held
+to `narrow_budget_bytes=0` answers every query from Parquet in seconds, and one given
+room to hold `outcomes` answers the same query in tenths. There is no managed service to
+move this to — Athena and its kin can scan the Parquet, but the chemistry is not SQL.
 
 Over the whole corpus (2,428,291 reactions, 53 files, a 6 GB budget, warm), a mixed set
 of queries pairing an indexed clause with one only the projection can answer:

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -159,6 +159,33 @@ search whose columns are already materialized is answered while another is being
 same rows either way, in an order neither relation promises — a query wanting one has to
 say so.
 
+**The budget is the cliff.** Materialized, ORD's `inputs` is 4.07 GB and its `outcomes`
+3.26 GB, against 1.71 GB for `conditions` and 1.46 GB for `notes`. A column set the
+budget refuses is read from the 53 Parquet files on every query that names it, and
+scattered rows do not let a reader skip row groups, so the same question costs seconds
+instead of tenths — "pyridine as the solvent with a yield above 50%" is 3.34s where
+`outcomes` is refused and 0.41s where it is held. The default is therefore a **quarter of
+the machine's memory** rather than a fixed figure, and `Corpus(narrow_budget_bytes=...)`
+states it outright where the machine is shared or more can be spent. This is also the
+second thing the index buys: a query whose structure clause becomes a semi-join never
+names `inputs` at all, so what has to be resident is far smaller than the same question
+answered from the elements.
+
+Over the whole corpus (2,428,291 reactions, 53 files, a 6 GB budget, warm), a mixed set
+of queries pairing an indexed clause with one only the projection can answer:
+
+| query | index | projection |
+| --- | --- | --- |
+| pyridine solvent, above 350 K | 0.02s | 0.20s |
+| pyridine solvent, yield > 50% | 0.41s | 4.82s |
+| pyridine solvent, white product | 0.24s | 4.30s |
+| pyridine solvent, "reflux" in the procedure | 0.05s | 0.20s |
+| yields by product color (grouped) | 0.40s | 1.53s |
+| hottest with a yield (ordered, limited) | 0.41s | 0.99s |
+| boronic acid, pyridine solvent, yield > 50% | 0.43s | 12.75s |
+| any aromatic carbon, yield > 50% | 0.45s | 14.79s |
+| **not** pyridine anywhere, with a yield | 0.55s | 14.86s |
+
 The screen itself is not a lever. It is the same `PatternFingerprint` the RDKit
 PostgreSQL cartridge screens with (`rdkit.sss_fp_size`, via `makeMolSignature`), and for
 a small common query it admits most of the corpus — 80% for pyridine, of which 73% then

--- a/ord_schema/agent/README.md
+++ b/ord_schema/agent/README.md
@@ -165,24 +165,36 @@ argument that changes them — so a query that suddenly takes seconds explains i
 the log rather than by profiling:
 
 ```text
-WARNING materializing ['outcomes', 'reaction_id'] takes 3.3 GB, over this corpus's
-2.0 GB budget, so every query naming those columns reads the Parquet files instead --
-seconds rather than tenths of a second at ORD's scale. Open the Corpus with a larger
-narrow_budget_bytes, or give the process more memory: the default budget is a quarter
-of what it may hold.
+WARNING materializing ['outcomes', 'reaction_id'] takes 3.0 GB, over this corpus's
+budget of 4.0 GB, so every query naming those columns reads the Parquet files instead
+-- seconds rather than tenths of a second at ORD's scale. Open the Corpus with a larger
+narrow_budget_bytes if the machine has the memory to spare.
 ```
 
-Materialized, ORD's `inputs` is 4.07 GB and its `outcomes`
-3.26 GB, against 1.71 GB for `conditions` and 1.46 GB for `notes`. A column set the
-budget refuses is read from the 53 Parquet files on every query that names it, and
-scattered rows do not let a reader skip row groups, so the same question costs seconds
-instead of tenths — "pyridine as the solvent with a yield above 50%" is 3.34s where
-`outcomes` is refused and 0.41s where it is held. The default is therefore a **quarter of
-the machine's memory** rather than a fixed figure, and `Corpus(narrow_budget_bytes=...)`
-states it outright where the machine is shared or more can be spent. This is also the
-second thing the index buys: a query whose structure clause becomes a semi-join never
-names `inputs` at all, so what has to be resident is far smaller than the same question
-answered from the elements.
+A column set the budget refuses is read from the 53 Parquet files on every query that
+names it, and scattered rows do not let a reader skip row groups, so the same question
+costs seconds instead of tenths — "pyridine as the solvent with a yield above 50%" is
+3.34s where `outcomes` is refused and 0.41s where it is held.
+
+The projection is **18.46 GB in memory**, from 1.53 GB of Parquet — a twelvefold
+expansion, and more than any default should claim:
+
+| column | in memory | | column | in memory |
+| --- | --- | --- | --- | --- |
+| `workups` | 5.08 GB | | `notes` | 1.33 GB |
+| `inputs` | 3.93 GB | | `smiles` | 0.89 GB |
+| `outcomes` | 3.04 GB | | `setup` | 0.59 GB |
+| `provenance` | 1.65 GB | | `observations` | 0.13 GB |
+| `conditions` | 1.61 GB | | `identifiers`, `reaction_id` | 0.21 GB |
+
+So every budget is a partial cache and the only question is which columns fit. The
+default is a fixed **4 GB**, which holds any single one of the large columns — what a
+query pairing a structure clause with a projection one needs — and
+`Corpus(narrow_budget_bytes=...)` states otherwise on a machine with room to spare.
+Building a set costs its size whether or not it is kept, so the peak is the budget plus
+the largest set, not the budget alone. This is also the second thing the index buys: a
+query whose structure clause becomes a semi-join never names `inputs` at all, so what
+has to be resident is far smaller than for the same question answered from the elements.
 
 Over the whole corpus (2,428,291 reactions, 53 files, a 6 GB budget, warm), a mixed set
 of queries pairing an indexed clause with one only the projection can answer:

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -719,10 +719,12 @@ class Corpus:
         self._narrowed: collections.OrderedDict[frozenset[str], _Narrow] = (
             collections.OrderedDict()
         )
-        # Column sets that came out larger than the whole budget. Kept because the
-        # projection they are built from does not change while this object is open, so
-        # building one again costs a pass over the corpus to reach the same refusal.
-        self._narrow_refused: set[frozenset[str]] = set()
+        # Column sets that came out larger than the whole budget, and what each cost.
+        # Kept because the projection they are built from does not change while this
+        # object is open, so building one again costs a pass over the corpus to reach
+        # the same refusal -- and because every query naming one is slow for a reason
+        # worth restating; see _refusal_warning.
+        self._narrow_refused: dict[frozenset[str], int] = {}
         self._narrow_serial = 0
         self._narrow_lock = threading.Lock()
         # Held across a materialization, so the two memory readings bracket one table
@@ -1224,7 +1226,33 @@ class Corpus:
             self._narrowed.move_to_end(columns)
             cached.readers += 1
             return True, cached
-        return columns in self._narrow_refused, None
+        refused = self._narrow_refused.get(columns)
+        if refused is not None:
+            self._warn_refused(columns, refused)
+            return True, None
+        return False, None
+
+    def _warn_refused(self, columns: frozenset[str], held: int) -> None:
+        """Says that a query is about to be answered the slow way, and what to change.
+
+        Warned on every query that names the columns rather than once when they were
+        first refused, because the query is slow every time and whoever is asking why is
+        reading the log now, not the one line printed when the corpus opened.
+
+        Args:
+            columns: Top-level projection columns the query names.
+            held: What materializing them cost when it was measured.
+        """
+        logger.warning(
+            "materializing %s takes %.1f GB, over this corpus's %.1f GB budget, so "
+            "every query naming those columns reads the Parquet files instead -- "
+            "seconds rather than tenths of a second at ORD's scale. Open the Corpus "
+            "with a larger narrow_budget_bytes, or give the process more memory: the "
+            "default budget is a quarter of what it may hold.",
+            sorted(columns),
+            held / 1024**3,
+            self._narrow_budget / 1024**3,
+        )
 
     def _build(self, columns: frozenset[str]) -> _Narrow | None:
         """Materializes ``columns``, recording its cost or that it costs too much.
@@ -1262,12 +1290,8 @@ class Corpus:
                 # Too big to keep, and keeping it is the only reason to build it.
                 cursor.execute(f"DROP TABLE {name}")
                 with self._narrow_lock:
-                    self._narrow_refused.add(columns)
-                logger.info(
-                    "not caching %s: %.1f GB exceeds the budget",
-                    sorted(columns),
-                    held / 1024**3,
-                )
+                    self._narrow_refused[columns] = held
+                self._warn_refused(columns, held)
                 return None
         except Exception:
             # A table nobody tracks is memory nobody frees, and the failure the

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -116,9 +116,21 @@ _CACHED_MATCHES = 16
 # tenths, which is the difference the materialization exists to make.
 _NARROW_BUDGET_FRACTION = 0.25
 
-# What to allow where the machine's memory cannot be read, and the least this will claim
-# anywhere. Enough for the columns a scalar query names, not for the largest.
-_NARROW_BUDGET_FLOOR_BYTES = 2 * 1024**3
+# What to allow where nothing states how much memory this process may use. Enough for
+# the columns a scalar query names, not for the largest.
+_NARROW_BUDGET_UNKNOWN_BYTES = 2 * 1024**3
+
+# Where a container states what its processes may hold, most specific first. The host's
+# memory is what ``sysconf`` reports whether or not a limit applies to this process, so
+# a corpus in a container would otherwise budget against memory it cannot have.
+_CGROUP_LIMITS = (
+    "/sys/fs/cgroup/memory.max",  # cgroup v2
+    "/sys/fs/cgroup/memory/memory.limit_in_bytes",  # cgroup v1
+)
+
+# cgroup v1 spells "no limit" as a number near the word size rather than as a word, so a
+# figure this large is a limit in name only.
+_CGROUP_UNLIMITED = 1 << 62
 
 # Top-level projection columns, which is the granularity a compiled query names them at.
 # A narrower table holding only the ones a query mentions answers it identically, so the
@@ -152,21 +164,71 @@ class PairingError(ValueError):
     """The projections and structures artifacts do not form a consistent corpus."""
 
 
-def _default_narrow_budget() -> int:
-    """Returns what the materialized column sets may hold on this machine.
+def _host_memory_bytes() -> int | None:
+    """Returns the machine's memory, or None where it cannot be read.
 
-    A share of the machine's memory, since the alternative is a figure that is either
-    too small for the corpus it is asked about or too large for the machine it runs on.
-    Where the memory cannot be read -- ``sysconf`` is a Unix interface -- the floor
-    stands, which serves scalar queries and refuses the largest columns.
+    ``sysconf`` is a Unix interface, and even where the names exist a platform may
+    refuse the question or answer -1 for it.
 
     Returns:
-        Bytes the cache may hold, never below ``_NARROW_BUDGET_FLOOR_BYTES``.
+        Bytes of physical memory, or None if nothing readable says.
     """
-    if not hasattr(os, "sysconf") or "SC_PHYS_PAGES" not in os.sysconf_names:
-        return _NARROW_BUDGET_FLOOR_BYTES
-    memory = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
-    return max(int(memory * _NARROW_BUDGET_FRACTION), _NARROW_BUDGET_FLOOR_BYTES)
+    names = {"SC_PAGE_SIZE", "SC_PHYS_PAGES"}
+    if not hasattr(os, "sysconf") or not names.issubset(os.sysconf_names):
+        return None
+    try:
+        size = os.sysconf("SC_PAGE_SIZE")
+        pages = os.sysconf("SC_PHYS_PAGES")
+    except (OSError, ValueError):
+        return None
+    if size <= 0 or pages <= 0:
+        return None
+    return size * pages
+
+
+def _cgroup_memory_bytes() -> int | None:
+    """Returns what a container limits this process to, or None if nothing does.
+
+    The limit a container runs under is stated here and nowhere ``sysconf`` looks,
+    which reports the host's memory to a process that may hold a fraction of it.
+
+    Returns:
+        Bytes this process may hold, or None outside a container and where the limit
+        is stated as unlimited.
+    """
+    for path in _CGROUP_LIMITS:
+        try:
+            with open(path) as stated:  # noqa: PTH123 - a sysfs file, not a data path.
+                limit = int(stated.read().strip())
+        except (OSError, ValueError):
+            # Absent outside a container, and "max" rather than a number when a cgroup
+            # v2 states no limit; either way the next path may still say.
+            continue
+        if 0 < limit < _CGROUP_UNLIMITED:
+            return limit
+    return None
+
+
+def _default_narrow_budget() -> int:
+    """Returns what the materialized column sets may hold, absent a stated budget.
+
+    A share of what this process may use, since the alternative is a figure either too
+    small for the corpus it is asked about or too large for the machine it runs on. The
+    share is of the smaller of the machine and any container limit, so a corpus in a
+    container budgets against what it can have rather than against the host.
+
+    Returns:
+        Bytes the cache may hold; ``_NARROW_BUDGET_UNKNOWN_BYTES`` where nothing states
+        a limit at all.
+    """
+    limits = [
+        limit
+        for limit in (_host_memory_bytes(), _cgroup_memory_bytes())
+        if limit is not None
+    ]
+    if not limits:
+        return _NARROW_BUDGET_UNKNOWN_BYTES
+    return int(min(limits) * _NARROW_BUDGET_FRACTION)
 
 
 def _resolve_with_resolvers(name: str) -> str:

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -80,8 +80,6 @@ import contextlib
 import dataclasses
 import glob
 import math
-import os
-import pathlib
 import re
 import threading
 import time
@@ -109,36 +107,18 @@ _BUILD_BATCH = 50_000
 # seconds.
 _CACHED_MATCHES = 16
 
-# What share of the machine the materialized column sets may hold between them, when the
-# caller states no budget of its own. A share rather than a figure because what the sets
-# cost is set by the corpus: ORD's ``inputs`` is 4.07 GB and its ``outcomes`` 3.26 GB,
-# so any fixed default small enough to be safe on a laptop refuses both on a server. A
-# query whose columns are refused reads the Parquet files instead -- seconds rather than
-# tenths, which is the difference the materialization exists to make.
-_NARROW_BUDGET_FRACTION = 0.25
-
-# What to allow where nothing states how much memory this process may use. Enough for
-# the columns a scalar query names, not for the largest.
-_NARROW_BUDGET_UNKNOWN_BYTES = 2 * 1024**3
-
-# Where a cgroup states what its processes may hold: the mount, the file naming the
-# limit, and the controller the process's own path is listed under. The host's memory is
-# what ``sysconf`` reports whether or not a limit applies to this process, so a corpus
-# under one would otherwise budget against memory it cannot have.
-_CGROUP_HIERARCHIES = (
-    ("/sys/fs/cgroup", "memory.max", ""),  # v2, whose unified hierarchy has no name
-    ("/sys/fs/cgroup/memory", "memory.limit_in_bytes", "memory"),  # v1
-)
-
-# Where a process's own cgroup path is written. What sits at the mount root is the limit
-# of the whole hierarchy, which is not this process's unless it happens to sit there --
-# a service under a systemd slice takes its limit from an ancestor, and every level from
-# the process's own up to the root can state one.
-_PROC_CGROUP = "/proc/self/cgroup"
-
-# cgroup v1 spells "no limit" as a number near the word size rather than as a word, so a
-# figure this large is a limit in name only.
-_CGROUP_UNLIMITED = 1 << 62
+# How much memory the materialized column sets may hold between them, when the caller
+# states no budget. Fixed rather than a share of the machine: the whole projection is
+# 18.46 GB in memory at ORD's scale and no default holds it, so every budget is a
+# partial cache and the question is only which columns fit. This holds any single one
+# of the large ones -- workups is 5.08 GB, inputs 3.93 GB, outcomes 3.04 GB -- which is
+# what a query pairing a structure clause with a projection one needs. A corpus asked
+# for more says so on every query it costs, naming this argument; see _warn_refused.
+#
+# Held to after a set is built rather than before, since what one costs is known only
+# once it exists: the peak is this plus the largest single set, and building a set costs
+# its size whether or not it is kept.
+_NARROW_BUDGET_BYTES = 4 * 1024**3
 
 # Top-level projection columns, which is the granularity a compiled query names them at.
 # A narrower table holding only the ones a query mentions answers it identically, so the
@@ -172,110 +152,21 @@ class PairingError(ValueError):
     """The projections and structures artifacts do not form a consistent corpus."""
 
 
-def _host_memory_bytes() -> int | None:
-    """Returns the machine's memory, or None where it cannot be read.
-
-    ``sysconf`` is a Unix interface, and even where the names exist a platform may
-    refuse the question or answer -1 for it.
-
-    Returns:
-        Bytes of physical memory, or None if nothing readable says.
-    """
-    names = {"SC_PAGE_SIZE", "SC_PHYS_PAGES"}
-    if not hasattr(os, "sysconf") or not names.issubset(os.sysconf_names):
-        return None
-    try:
-        size = os.sysconf("SC_PAGE_SIZE")
-        pages = os.sysconf("SC_PHYS_PAGES")
-    except (OSError, ValueError):
-        return None
-    if size <= 0 or pages <= 0:
-        return None
-    return size * pages
-
-
-def _stated_limit(path: pathlib.Path) -> int | None:
-    """Returns the memory limit a cgroup file states, or None if it states none.
+def _format_bytes(value: float) -> str:
+    """Returns a byte count in the largest unit it reaches, for a person to read.
 
     Args:
-        path: A cgroup memory-limit file, which need not exist.
+        value: Bytes.
 
     Returns:
-        Bytes, or None where the file is absent, unreadable, or says no limit -- which
-        cgroup v2 spells as the word ``max`` and v1 as a number near the word size.
+        The figure and its unit, e.g. ``3.3 GB``. A budget stated in gigabytes says
+        nothing about a table that costs kilobytes, and a warning naming both has to
+        make the two comparable.
     """
-    try:
-        limit = int(path.read_text().strip())
-    except (OSError, ValueError):
-        return None
-    return limit if 0 < limit < _CGROUP_UNLIMITED else None
-
-
-def _own_cgroup(controller: str) -> str:
-    """Returns this process's path within a cgroup hierarchy.
-
-    Args:
-        controller: The hierarchy's name in ``/proc/self/cgroup``; empty for the v2
-            unified hierarchy, which lists itself as ``0::<path>``.
-
-    Returns:
-        The path relative to the hierarchy's mount, or ``/`` where nothing says -- which
-        is the root, and reads the whole hierarchy's limit.
-    """
-    try:
-        for line in pathlib.Path(_PROC_CGROUP).read_text().splitlines():
-            _, controllers, path = line.split(":", 2)
-            if controller in controllers.split(","):
-                return path
-            if controller == "" and controllers == "":
-                return path
-    except (OSError, ValueError):
-        return "/"
-    return "/"
-
-
-def _cgroup_memory_bytes() -> int | None:
-    """Returns what a cgroup limits this process to, or None if none does.
-
-    Every level from the process's own cgroup up to the mount root may state a limit,
-    and the process is held to the smallest: a service under a systemd slice, or a
-    container run without its own cgroup namespace, takes its limit from an ancestor
-    while the root states none at all.
-
-    Returns:
-        The smallest limit stated over this process, or None where nothing states one.
-    """
-    limits = []
-    for mount, filename, controller in _CGROUP_HIERARCHIES:
-        parts = [part for part in _own_cgroup(controller).split("/") if part]
-        # Its own cgroup first, then each ancestor, ending at the mount root.
-        for depth in range(len(parts), -1, -1):
-            limit = _stated_limit(pathlib.Path(mount, *parts[:depth], filename))
-            if limit is not None:
-                limits.append(limit)
-    return min(limits) if limits else None
-
-
-def _default_narrow_budget() -> int:
-    """Returns what the materialized column sets may hold, absent a stated budget.
-
-    A share of what this process may use, since the alternative is a figure either too
-    small for the corpus it is asked about or too large for the machine it runs on. The
-    share is of the smaller of the machine and any container limit, so a corpus in a
-    container budgets against what it can have rather than against the host.
-
-    Returns:
-        Bytes the cache may hold; ``_NARROW_BUDGET_UNKNOWN_BYTES`` where nothing states
-        a limit at all.
-    """
-    limits = [
-        limit
-        for limit in (_host_memory_bytes(), _cgroup_memory_bytes())
-        if limit is not None
-    ]
-    if not limits:
-        return _NARROW_BUDGET_UNKNOWN_BYTES
-    return int(min(limits) * _NARROW_BUDGET_FRACTION)
+    for unit, scale in (("GB", 1024**3), ("MB", 1024**2), ("kB", 1024)):
+        if abs(value) >= scale:
+            return f"{value / scale:.1f} {unit}"
+    return f"{value:.0f} B"
 
 
 def _resolve_with_resolvers(name: str) -> str:
@@ -673,23 +564,36 @@ class Corpus:
                 artifact, and RDKit versions. The screen's completeness guarantee
                 assumes the query and the artifact fingerprint identically, so turning
                 this off is only for reading a corpus known to match anyway.
-            narrow_budget_bytes: How much memory the materialized column sets may hold
-                between them; a quarter of the machine's by default. Worth stating
-                where the machine serves something else too, or where more of it can be
-                spent than that: a column set the budget refuses is read from the
-                Parquet files on every query that names it, which over ORD is seconds
-                against tenths of a second.
+            narrow_budget_bytes: How much memory the materialized column sets may
+                hold between them; 4 GB by default. Worth stating on a machine that can
+                spend more, since a column set the budget refuses is read from the
+                Parquet files on every query that names it -- over ORD, seconds against
+                tenths of a second. The whole projection is 18.46 GB in memory, so a
+                corpus asked about most of it wants most of that.
 
         Raises:
             PairingError: If either pattern matches nothing, a file on one side has no
                 partner on the other, a pair's stamps disagree about the source
                 dataset, or -- with ``require_current`` -- any artifact is stale.
+            ValueError: If ``narrow_budget_bytes`` is negative, which no amount of
+                memory is; zero is allowed, and materializes nothing.
         """
         self._resolver = resolver if resolver is not None else _resolve_with_resolvers
+        if narrow_budget_bytes is not None and narrow_budget_bytes < 0:
+            raise ValueError(
+                f"narrow_budget_bytes is {narrow_budget_bytes}, which is not an amount "
+                "of memory; pass zero to materialize nothing"
+            )
         self._narrow_budget = (
             narrow_budget_bytes
             if narrow_budget_bytes is not None
-            else _default_narrow_budget()
+            else _NARROW_BUDGET_BYTES
+        )
+        # Said at open because the alternative is saying it nowhere: a process killed
+        # for holding too much leaves no log of its own, and what it thought it was
+        # allowed to hold is the first thing worth knowing afterwards.
+        logger.info(
+            "materialized column sets may hold %s", _format_bytes(self._narrow_budget)
         )
         self._threads = threads
         # Built on first substructure query; see _library. The library holds one entry
@@ -1056,11 +960,15 @@ class Corpus:
                         "glob one artifact per reaction"
                     )
                     raise PairingError(self._refused)
+                # Under the build lock, so the only other thing that puts a table
+                # in this database does not do it while a materialization is measuring
+                # what one costs -- a difference of two readings taken across everyone.
                 # OR REPLACE, so a build interrupted after the table exists is a build
                 # the next query repeats rather than one that collides with itself
                 # forever. S608: the fragments are this module's own schema walk and
                 # the compiler's traversals, not anything a query supplies.
-                cursor.execute(f"CREATE OR REPLACE TABLE occurrences AS {selects}")
+                with self._narrow_build_lock:
+                    cursor.execute(f"CREATE OR REPLACE TABLE occurrences AS {selects}")
                 counts = dict(
                     cursor.execute(
                         "SELECT path, count(*) FROM occurrences GROUP BY path"
@@ -1194,21 +1102,29 @@ class Corpus:
             build them again to throw them away again.
         """
         with self._narrow_lock:
-            settled, entry = self._cached(columns)
+            settled, entry, refused = self._cached(columns)
         if settled:
+            # Warned outside the lock: it is the one every search takes to read the
+            # cache, and a log handler is not something to hold it through.
+            if refused is not None:
+                self._warn_refused(columns, refused)
             return entry
         with self._narrow_build_lock:
             # Asked again under the build lock: whoever held it may have been building
             # exactly these columns, and a second table of them would be memory held
             # twice for one answer.
             with self._narrow_lock:
-                settled, entry = self._cached(columns)
+                settled, entry, refused = self._cached(columns)
             if settled:
+                if refused is not None:
+                    self._warn_refused(columns, refused)
                 return entry
             return self._build(columns)
 
-    def _cached(self, columns: frozenset[str]) -> tuple[bool, _Narrow | None]:
-        """Returns whether the cache settles ``columns``, and the entry if it holds one.
+    def _cached(
+        self, columns: frozenset[str]
+    ) -> tuple[bool, _Narrow | None, int | None]:
+        """Returns whether the cache settles ``columns``, and how.
 
         Called with ``_narrow_lock`` held. A hit takes the read on the caller's behalf,
         since an entry released back to the cache between the lookup and the read could
@@ -1218,19 +1134,19 @@ class Corpus:
             columns: Top-level projection columns the query names.
 
         Returns:
-            ``(True, entry)`` for a hit, ``(True, None)`` for a set already refused as
-            too large, and ``(False, None)`` for one nobody has built yet.
+            Whether the cache settles the question, the entry for a hit, and what the
+            set cost where it was refused as too large -- which the caller says out
+            loud once it is no longer holding the lock.
         """
         cached = self._narrowed.get(columns)
         if cached is not None:
             self._narrowed.move_to_end(columns)
             cached.readers += 1
-            return True, cached
+            return True, cached, None
         refused = self._narrow_refused.get(columns)
         if refused is not None:
-            self._warn_refused(columns, refused)
-            return True, None
-        return False, None
+            return True, None, refused
+        return False, None, None
 
     def _warn_refused(self, columns: frozenset[str], held: int) -> None:
         """Says that a query is about to be answered the slow way, and what to change.
@@ -1244,23 +1160,22 @@ class Corpus:
             held: What materializing them cost when it was measured.
         """
         logger.warning(
-            "materializing %s takes %.1f GB, over this corpus's %.1f GB budget, so "
-            "every query naming those columns reads the Parquet files instead -- "
-            "seconds rather than tenths of a second at ORD's scale. Open the Corpus "
-            "with a larger narrow_budget_bytes, or give the process more memory: the "
-            "default budget is a quarter of what it may hold.",
+            "materializing %s takes %s, over this corpus's budget of %s, so every "
+            "query naming those columns reads the Parquet files instead -- seconds "
+            "rather than tenths of a second at ORD's scale. Open the Corpus with a "
+            "larger narrow_budget_bytes if the machine has the memory to spare.",
             sorted(columns),
-            held / 1024**3,
-            self._narrow_budget / 1024**3,
+            _format_bytes(held),
+            _format_bytes(self._narrow_budget),
         )
 
     def _build(self, columns: frozenset[str]) -> _Narrow | None:
         """Materializes ``columns``, recording its cost or that it costs too much.
 
         Called with ``_narrow_build_lock`` held and ``_narrow_lock`` free, so the two
-        memory readings bracket this table and nothing else the cache does. An index
-        build can still move the figure between them, which costs an overstatement and
-        an eviction, never a wrong answer.
+        memory readings bracket this table and nothing else: every other statement that
+        puts a table in this database -- another materialization, or the index build --
+        takes the same lock.
 
         Args:
             columns: Top-level projection columns the query names.
@@ -1295,17 +1210,22 @@ class Corpus:
                 return None
         except Exception:
             # A table nobody tracks is memory nobody frees, and the failure the
-            # caller sees has to be the one that happened.
-            with contextlib.suppress(duckdb.Error):
+            # caller sees has to be the one that happened -- so the cleanup swallows
+            # everything, and says what it swallowed. A DROP that fails here leaves
+            # memory the cache will never account for, which is worth a line even
+            # though it is not what the caller asked about.
+            try:
                 cursor.execute(f"DROP TABLE IF EXISTS {name}")
+            except Exception:
+                logger.exception("could not drop %s after a failed build", name)
             raise
         finally:
             cursor.close()
         logger.info(
-            "materialized %s as %s, %.2f GB in %.1fs",
+            "materialized %s as %s, %s in %.1fs",
             sorted(columns),
             name,
-            held / 1024**3,
+            _format_bytes(held),
             time.perf_counter() - start,
         )
         entry = _Narrow(name=name, held=held, readers=1)

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -81,6 +81,7 @@ import dataclasses
 import glob
 import math
 import os
+import pathlib
 import re
 import threading
 import time
@@ -120,13 +121,20 @@ _NARROW_BUDGET_FRACTION = 0.25
 # the columns a scalar query names, not for the largest.
 _NARROW_BUDGET_UNKNOWN_BYTES = 2 * 1024**3
 
-# Where a container states what its processes may hold, most specific first. The host's
-# memory is what ``sysconf`` reports whether or not a limit applies to this process, so
-# a corpus in a container would otherwise budget against memory it cannot have.
-_CGROUP_LIMITS = (
-    "/sys/fs/cgroup/memory.max",  # cgroup v2
-    "/sys/fs/cgroup/memory/memory.limit_in_bytes",  # cgroup v1
+# Where a cgroup states what its processes may hold: the mount, the file naming the
+# limit, and the controller the process's own path is listed under. The host's memory is
+# what ``sysconf`` reports whether or not a limit applies to this process, so a corpus
+# under one would otherwise budget against memory it cannot have.
+_CGROUP_HIERARCHIES = (
+    ("/sys/fs/cgroup", "memory.max", ""),  # v2, whose unified hierarchy has no name
+    ("/sys/fs/cgroup/memory", "memory.limit_in_bytes", "memory"),  # v1
 )
+
+# Where a process's own cgroup path is written. What sits at the mount root is the limit
+# of the whole hierarchy, which is not this process's unless it happens to sit there --
+# a service under a systemd slice takes its limit from an ancestor, and every level from
+# the process's own up to the root can state one.
+_PROC_CGROUP = "/proc/self/cgroup"
 
 # cgroup v1 spells "no limit" as a number near the word size rather than as a word, so a
 # figure this large is a limit in name only.
@@ -186,27 +194,66 @@ def _host_memory_bytes() -> int | None:
     return size * pages
 
 
-def _cgroup_memory_bytes() -> int | None:
-    """Returns what a container limits this process to, or None if nothing does.
+def _stated_limit(path: pathlib.Path) -> int | None:
+    """Returns the memory limit a cgroup file states, or None if it states none.
 
-    The limit a container runs under is stated here and nowhere ``sysconf`` looks,
-    which reports the host's memory to a process that may hold a fraction of it.
+    Args:
+        path: A cgroup memory-limit file, which need not exist.
 
     Returns:
-        Bytes this process may hold, or None outside a container and where the limit
-        is stated as unlimited.
+        Bytes, or None where the file is absent, unreadable, or says no limit -- which
+        cgroup v2 spells as the word ``max`` and v1 as a number near the word size.
     """
-    for path in _CGROUP_LIMITS:
-        try:
-            with open(path) as stated:  # noqa: PTH123 - a sysfs file, not a data path.
-                limit = int(stated.read().strip())
-        except (OSError, ValueError):
-            # Absent outside a container, and "max" rather than a number when a cgroup
-            # v2 states no limit; either way the next path may still say.
-            continue
-        if 0 < limit < _CGROUP_UNLIMITED:
-            return limit
-    return None
+    try:
+        limit = int(path.read_text().strip())
+    except (OSError, ValueError):
+        return None
+    return limit if 0 < limit < _CGROUP_UNLIMITED else None
+
+
+def _own_cgroup(controller: str) -> str:
+    """Returns this process's path within a cgroup hierarchy.
+
+    Args:
+        controller: The hierarchy's name in ``/proc/self/cgroup``; empty for the v2
+            unified hierarchy, which lists itself as ``0::<path>``.
+
+    Returns:
+        The path relative to the hierarchy's mount, or ``/`` where nothing says -- which
+        is the root, and reads the whole hierarchy's limit.
+    """
+    try:
+        for line in pathlib.Path(_PROC_CGROUP).read_text().splitlines():
+            _, controllers, path = line.split(":", 2)
+            if controller in controllers.split(","):
+                return path
+            if controller == "" and controllers == "":
+                return path
+    except (OSError, ValueError):
+        return "/"
+    return "/"
+
+
+def _cgroup_memory_bytes() -> int | None:
+    """Returns what a cgroup limits this process to, or None if none does.
+
+    Every level from the process's own cgroup up to the mount root may state a limit,
+    and the process is held to the smallest: a service under a systemd slice, or a
+    container run without its own cgroup namespace, takes its limit from an ancestor
+    while the root states none at all.
+
+    Returns:
+        The smallest limit stated over this process, or None where nothing states one.
+    """
+    limits = []
+    for mount, filename, controller in _CGROUP_HIERARCHIES:
+        parts = [part for part in _own_cgroup(controller).split("/") if part]
+        # Its own cgroup first, then each ancestor, ending at the mount root.
+        for depth in range(len(parts), -1, -1):
+            limit = _stated_limit(pathlib.Path(mount, *parts[:depth], filename))
+            if limit is not None:
+                limits.append(limit)
+    return min(limits) if limits else None
 
 
 def _default_narrow_budget() -> int:

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -108,12 +108,12 @@ _BUILD_BATCH = 50_000
 _CACHED_MATCHES = 16
 
 # How much memory the materialized column sets may hold between them, when the caller
-# states no budget. Fixed rather than a share of the machine: the whole projection is
-# 18.46 GB in memory at ORD's scale and no default holds it, so every budget is a
-# partial cache and the question is only which columns fit. This holds any single one
-# of the large ones -- workups is 5.08 GB, inputs 3.93 GB, outcomes 3.04 GB -- which is
-# what a query pairing a structure clause with a projection one needs. A corpus asked
-# for more says so on every query it costs, naming this argument; see _warn_refused.
+# states no budget. The whole projection is 18.46 GB in memory at ORD's scale and no
+# default holds it, so every budget is a partial cache and the question is only which
+# columns fit. This holds any single one of the large ones -- workups is 5.08 GB,
+# inputs 3.93 GB, outcomes 3.04 GB -- which is what a query pairing a structure clause
+# with a projection one needs. A corpus asked for more says so on every query it costs,
+# naming this argument; see _warn_refused.
 #
 # Held to after a set is built rather than before, since what one costs is known only
 # once it exists: the peak is this plus the largest single set, and building a set costs
@@ -569,7 +569,10 @@ class Corpus:
                 spend more, since a column set the budget refuses is read from the
                 Parquet files on every query that names it -- over ORD, seconds against
                 tenths of a second. The whole projection is 18.46 GB in memory, so a
-                corpus asked about most of it wants most of that.
+                corpus asked about most of it wants most of that. Zero materializes
+                nothing at all, which is what bounds a small machine: a set is measured
+                by building it, so any other figure has a peak of itself plus the
+                largest set a query names, whether or not that set is then kept.
 
         Raises:
             PairingError: If either pattern matches nothing, a file on one side has no
@@ -627,7 +630,7 @@ class Corpus:
         # Kept because the projection they are built from does not change while this
         # object is open, so building one again costs a pass over the corpus to reach
         # the same refusal -- and because every query naming one is slow for a reason
-        # worth restating; see _refusal_warning.
+        # worth restating; see _warn_refused.
         self._narrow_refused: dict[frozenset[str], int] = {}
         self._narrow_serial = 0
         self._narrow_lock = threading.Lock()
@@ -911,12 +914,13 @@ class Corpus:
         here and share the result.
 
         Raises:
-            PairingError: If the index does not reach every structure the corpus holds.
-                An unreached structure is one whose reactions no routed query can find,
-                and the answer comes back empty rather than wrong -- which reads like an
-                answer rather than like a corpus that cannot be searched. The reason is
-                kept and re-raised, since a corpus does not change under an open
-                ``Corpus`` and rebuilding is several passes to reach the same refusal.
+            PairingError: If the corpus states a reaction more than once, or the index
+                does not reach every structure the corpus holds. An unreached structure
+                is one whose reactions no routed query can find, and the answer comes
+                back empty rather than wrong -- which reads like an answer rather than
+                like a corpus that cannot be searched. The reason is kept and re-raised,
+                since a corpus does not change under an open ``Corpus`` and rebuilding
+                is several passes to reach the same refusal.
         """
         with self._occurrences_lock:
             if self._refused is not None:
@@ -1096,11 +1100,17 @@ class Corpus:
             columns: Top-level projection columns the query names.
 
         Returns:
-            The entry, or None if this column set costs more than the cache may hold in
-            total, in which case nothing is kept, the projection answers directly, and
-            the refusal is remembered so the next query naming these columns does not
-            build them again to throw them away again.
+            The entry, or None when the budget is zero or this column set costs more
+            than the cache may hold in total. Nothing is kept either way and the
+            projection answers directly; a set refused as too large is remembered, so
+            the next query naming those columns does not build them again to throw them
+            away again.
         """
+        if not self._narrow_budget:
+            # The one budget that can be settled without building, since what a set
+            # costs is known only once it exists. A small container spends nothing and
+            # answers from Parquet.
+            return None
         with self._narrow_lock:
             settled, entry, refused = self._cached(columns)
         if settled:
@@ -1244,13 +1254,13 @@ class Corpus:
         candidate leaves the cache above its budget until a reader finishes, which is
         the direction that keeps answers right.
         """
-        for held in list(self._narrowed):
+        for columns in list(self._narrowed):
             if (
                 sum(entry.held for entry in self._narrowed.values())
                 <= self._narrow_budget
             ):
                 return
-            entry = self._narrowed[held]
+            entry = self._narrowed[columns]
             if entry.readers:
                 continue
             cursor = self._connection.cursor()
@@ -1263,8 +1273,8 @@ class Corpus:
                 logger.exception("could not drop the materialized %s", entry.name)
             finally:
                 cursor.close()
-            del self._narrowed[held]
-            logger.info("evicted the materialized %s", sorted(held))
+            del self._narrowed[columns]
+            logger.info("evicted the materialized %s", sorted(columns))
 
     @contextlib.contextmanager
     def _narrowed_table(self, columns: frozenset[str]) -> Iterator[str | None]:
@@ -1286,8 +1296,9 @@ class Corpus:
             columns: Top-level projection columns the query names.
 
         Yields:
-            The table's name, or None if materializing it would cost more memory than
-            the whole cache is allowed, in which case the projection answers directly.
+            The table's name, or None when nothing is materialized -- a budget of zero,
+            or a set costing more memory than the whole cache is allowed -- in which
+            case the projection answers directly.
         """
         entry = self._materialize(columns)
         if entry is None:
@@ -1433,7 +1444,8 @@ class Corpus:
             query.QueryError: If the query does not compile.
             ValueError: If a compound name cannot be resolved.
             PairingError: If the corpus IDs do not come out one unbroken run, or the
-                occurrence index does not reach every structure the corpus holds.
+                occurrence index refuses the corpus -- a reaction stated by more than
+                one row, or a structure no indexed path reaches.
             TimeoutError: If the query exceeds ``timeout_seconds``.
         """
         # Records into this search rather than onto the corpus: two searches share one

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -93,7 +93,7 @@ from rdkit import Chem, DataStructs
 from rdkit.Chem import rdSubstructLibrary
 
 from ord_schema import artifacts, projection, resolvers, structures
-from ord_schema.agent import query
+from ord_schema.agent import pivot, query
 from ord_schema.logging import get_logger
 
 logger = get_logger(__name__)
@@ -514,6 +514,25 @@ def _run_with_timeout(
             running = False
 
 
+@dataclasses.dataclass(frozen=True)
+class _Held:
+    """Something worth keeping in memory, and the statement that builds it.
+
+    One cache and one budget cover both kinds, so eviction can weigh a column set
+    against a pivot rather than each starving the other in its own pool.
+
+    Attributes:
+        key: Identity in the cache. Carries the kind, so a pivot over a path and a
+            column set naming it cannot collide.
+        select: The query ``CREATE TABLE`` wraps.
+        description: How the entry is named in a log line or a warning.
+    """
+
+    key: tuple[str, ...]
+    select: str
+    description: str
+
+
 @dataclasses.dataclass
 class _Narrow:
     """A materialized table holding some of the projection's top-level columns.
@@ -546,6 +565,7 @@ class Corpus:
         threads: int = -1,
         require_current: bool = True,
         narrow_budget_bytes: int | None = None,
+        pivots_dir: str | None = None,
     ) -> None:
         """Pairs the artifacts, checks their stamps, and prepares the relations.
 
@@ -573,6 +593,12 @@ class Corpus:
                 nothing at all, which is what bounds a small machine: a set is measured
                 by building it, so any other figure has a peak of itself plus the
                 largest set a query names, whether or not that set is then kept.
+            pivots_dir: Directory holding derived pivot artifacts, one subdirectory per
+                repeated level. Given one, a quantifier over a level reads the artifact
+                instead of unnesting the projection to build it, which is minutes per
+                level over ORD and is paid by whichever query asks first. A level with
+                no subdirectory is still built in process, so a partial set of
+                artifacts is a partial speedup rather than a missing answer.
 
         Raises:
             PairingError: If either pattern matches nothing, a file on one side has no
@@ -623,7 +649,7 @@ class Corpus:
         # Materialized column sets, most recently used last; see _narrowed_table. The
         # serial names them, and never repeats, so a build that fails partway leaves no
         # name for the next one to collide with.
-        self._narrowed: collections.OrderedDict[frozenset[str], _Narrow] = (
+        self._narrowed: collections.OrderedDict[tuple[str, ...], _Narrow] = (
             collections.OrderedDict()
         )
         # Column sets that came out larger than the whole budget, and what each cost.
@@ -631,13 +657,20 @@ class Corpus:
         # object is open, so building one again costs a pass over the corpus to reach
         # the same refusal -- and because every query naming one is slow for a reason
         # worth restating; see _warn_refused.
-        self._narrow_refused: dict[frozenset[str], int] = {}
+        self._narrow_refused: dict[tuple[str, ...], int] = {}
         self._narrow_serial = 0
         self._narrow_lock = threading.Lock()
         # Held across a materialization, so the two memory readings bracket one table
         # and no search waits on a build to be told what the cache already holds.
         self._narrow_build_lock = threading.Lock()
         pairs = _pair(projection_pattern, structures_pattern, require_current)
+        self._pivots_dir = pivots_dir
+        self._require_current = require_current
+        # The projections a pivot artifact has to have been derived from, and the views
+        # already published over the artifacts that were; see _pivot_view.
+        self._projections = [pair[0] for pair in pairs]
+        self._pivot_views: dict[str, str | None] = {}
+        self._pivot_lock = threading.Lock()
         self._connection = duckdb.connect()
         try:
             self._total, self._searchable = self._prepare(pairs)
@@ -729,6 +762,45 @@ class Corpus:
                 "to their offsets; a path did not survive read_parquet"
             )
         return total, searchable
+
+    def check_pivots(self) -> dict[str, int]:
+        """Publishes every pivot artifact this corpus can read, and returns the counts.
+
+        Meant for startup. Artifacts are otherwise found by the first query that wants
+        a level, so a tree derived from another corpus, filed under the wrong level, or
+        left stale is a ``PairingError`` raised at whatever hour that query arrives.
+        Calling this makes the same refusal happen while a server is still starting,
+        where it is a failed deployment rather than a failed request.
+
+        Publishing is the check: a level whose artifacts are wrong cannot be published,
+        and one that is fine is left ready, so the first real query does not pay the
+        glob. Cheap either way -- a view over Parquet reads footers, not rows.
+
+        Returns:
+            The number of artifacts found per level, for the levels that have any.
+            Empty when the corpus was opened without ``pivots_dir``, which is not an
+            error: every level is then built in process.
+
+        Raises:
+            PairingError: If any level's artifacts were not derived from this corpus's
+                projections, hold a different level than the one they are filed under,
+                or -- with ``require_current`` -- are stale.
+        """
+        if self._pivots_dir is None:
+            return {}
+        found = {}
+        for path in sorted(pivot.LEVELS):
+            if self._pivot_view(path) is not None:
+                found[path] = len(
+                    glob.glob(f"{self._pivots_dir}/{path}/**/*.parquet", recursive=True)
+                )
+        logger.info(
+            "%d of %d levels are held as artifacts: %s",
+            len(found),
+            len(pivot.LEVELS),
+            ", ".join(f"{path} {count}" for path, count in found.items()) or "none",
+        )
+        return found
 
     def __enter__(self) -> Self:
         """Returns the corpus itself; closing on exit is the whole protocol."""
@@ -1085,8 +1157,8 @@ class Corpus:
             bits[global_id] = ord("1")
         return bits.decode()
 
-    def _materialize(self, columns: frozenset[str]) -> _Narrow | None:
-        """Returns a held table of ``columns``, building it if the cache lacks one.
+    def _materialize(self, held: _Held) -> _Narrow | None:
+        """Returns the table ``held`` describes, building it if the cache lacks one.
 
         The caller owns a read on whatever comes back and has to release it, which
         ``_narrowed_table`` does; an entry with a reader is never evicted.
@@ -1097,14 +1169,13 @@ class Corpus:
         corpus serving several questions at once.
 
         Args:
-            columns: Top-level projection columns the query names.
+            held: What to keep, and the statement that builds it.
 
         Returns:
-            The entry, or None when the budget is zero or this column set costs more
-            than the cache may hold in total. Nothing is kept either way and the
-            projection answers directly; a set refused as too large is remembered, so
-            the next query naming those columns does not build them again to throw them
-            away again.
+            The entry, or None when the budget is zero or this costs more than the
+            cache may hold in total. Nothing is kept either way and the projection
+            answers directly; something refused as too large is remembered, so the next
+            query wanting it does not build it again to throw it away again.
         """
         if not self._narrow_budget:
             # The one budget that can be settled without building, since what a set
@@ -1112,75 +1183,73 @@ class Corpus:
             # answers from Parquet.
             return None
         with self._narrow_lock:
-            settled, entry, refused = self._cached(columns)
+            settled, entry, refused = self._cached(held.key)
         if settled:
             # Warned outside the lock: it is the one every search takes to read the
             # cache, and a log handler is not something to hold it through.
             if refused is not None:
-                self._warn_refused(columns, refused)
+                self._warn_refused(held, refused)
             return entry
         with self._narrow_build_lock:
             # Asked again under the build lock: whoever held it may have been building
-            # exactly these columns, and a second table of them would be memory held
-            # twice for one answer.
+            # exactly this, and a second table of it would be memory held twice for one
+            # answer.
             with self._narrow_lock:
-                settled, entry, refused = self._cached(columns)
+                settled, entry, refused = self._cached(held.key)
             if settled:
                 if refused is not None:
-                    self._warn_refused(columns, refused)
+                    self._warn_refused(held, refused)
                 return entry
-            return self._build(columns)
+            return self._build(held)
 
-    def _cached(
-        self, columns: frozenset[str]
-    ) -> tuple[bool, _Narrow | None, int | None]:
-        """Returns whether the cache settles ``columns``, and how.
+    def _cached(self, key: tuple[str, ...]) -> tuple[bool, _Narrow | None, int | None]:
+        """Returns whether the cache settles ``key``, and how.
 
         Called with ``_narrow_lock`` held. A hit takes the read on the caller's behalf,
         since an entry released back to the cache between the lookup and the read could
         be evicted in between.
 
         Args:
-            columns: Top-level projection columns the query names.
+            key: Identity of the entry, as ``_Held.key`` gives it.
 
         Returns:
-            Whether the cache settles the question, the entry for a hit, and what the
-            set cost where it was refused as too large -- which the caller says out
-            loud once it is no longer holding the lock.
+            Whether the cache settles the question, the entry for a hit, and what it
+            cost where it was refused as too large -- which the caller says out loud
+            once it is no longer holding the lock.
         """
-        cached = self._narrowed.get(columns)
+        cached = self._narrowed.get(key)
         if cached is not None:
-            self._narrowed.move_to_end(columns)
+            self._narrowed.move_to_end(key)
             cached.readers += 1
             return True, cached, None
-        refused = self._narrow_refused.get(columns)
+        refused = self._narrow_refused.get(key)
         if refused is not None:
             return True, None, refused
         return False, None, None
 
-    def _warn_refused(self, columns: frozenset[str], held: int) -> None:
+    def _warn_refused(self, held: _Held, cost: int) -> None:
         """Says that a query is about to be answered the slow way, and what to change.
 
-        Warned on every query that names the columns rather than once when they were
-        first refused, because the query is slow every time and whoever is asking why is
+        Warned on every query that wants the entry rather than once when it was first
+        refused, because the query is slow every time and whoever is asking why is
         reading the log now, not the one line printed when the corpus opened.
 
         Args:
-            columns: Top-level projection columns the query names.
-            held: What materializing them cost when it was measured.
+            held: What was refused, and how to name it.
+            cost: What building it took when it was measured.
         """
         logger.warning(
             "materializing %s takes %s, over this corpus's budget of %s, so every "
-            "query naming those columns reads the Parquet files instead -- seconds "
-            "rather than tenths of a second at ORD's scale. Open the Corpus with a "
-            "larger narrow_budget_bytes if the machine has the memory to spare.",
-            sorted(columns),
-            _format_bytes(held),
+            "query wanting it reads the Parquet files instead -- seconds rather than "
+            "tenths of a second at ORD's scale. Open the Corpus with a larger "
+            "narrow_budget_bytes if the machine has the memory to spare.",
+            held.description,
+            _format_bytes(cost),
             _format_bytes(self._narrow_budget),
         )
 
-    def _build(self, columns: frozenset[str]) -> _Narrow | None:
-        """Materializes ``columns``, recording its cost or that it costs too much.
+    def _build(self, held: _Held) -> _Narrow | None:
+        """Materializes ``held``, recording its cost or that it costs too much.
 
         Called with ``_narrow_build_lock`` held and ``_narrow_lock`` free, so the two
         memory readings bracket this table and nothing else: every other statement that
@@ -1188,7 +1257,7 @@ class Corpus:
         takes the same lock.
 
         Args:
-            columns: Top-level projection columns the query names.
+            held: What to keep, and the statement that builds it.
 
         Returns:
             The entry, held once for the caller, or None if it exceeds the budget.
@@ -1198,25 +1267,26 @@ class Corpus:
             # cannot leave a name the next attempt collides with.
             self._narrow_serial += 1
             name = f"narrow_{self._narrow_serial}"
-        selected = ", ".join([*sorted(columns), query.STRUCTURE_OFFSET])
         start = time.perf_counter()
         # Its own cursor, for the same reason the index build takes one: searches
         # are in flight, and the shared connection holds their results.
         cursor = self._connection.cursor()
         try:
+            # Said before the pass rather than after it, because the pass is what
+            # takes the time and whoever is watching a query hang wants to know what it
+            # is waiting for while it waits.
+            logger.info("building %s", held.description)
             before = _memory_bytes(cursor)
-            # S608: the names come from the projection schema and this module.
-            cursor.execute(
-                f"CREATE TABLE {name} AS "  # noqa: S608
-                f"SELECT {selected} FROM {query.TABLE}"
-            )
-            held = max(_memory_bytes(cursor) - before, 0)
-            if held > self._narrow_budget:
+            # The select was assembled by whoever built the _Held, which is where
+            # its fragments are accounted for.
+            cursor.execute(f"CREATE TABLE {name} AS {held.select}")
+            cost = max(_memory_bytes(cursor) - before, 0)
+            if cost > self._narrow_budget:
                 # Too big to keep, and keeping it is the only reason to build it.
                 cursor.execute(f"DROP TABLE {name}")
                 with self._narrow_lock:
-                    self._narrow_refused[columns] = held
-                self._warn_refused(columns, held)
+                    self._narrow_refused[held.key] = cost
+                self._warn_refused(held, cost)
                 return None
         except Exception:
             # A table nobody tracks is memory nobody frees, and the failure the
@@ -1233,14 +1303,14 @@ class Corpus:
             cursor.close()
         logger.info(
             "materialized %s as %s, %s in %.1fs",
-            sorted(columns),
+            held.description,
             name,
-            _format_bytes(held),
+            _format_bytes(cost),
             time.perf_counter() - start,
         )
-        entry = _Narrow(name=name, held=held, readers=1)
+        entry = _Narrow(name=name, held=cost, readers=1)
         with self._narrow_lock:
-            self._narrowed[columns] = entry
+            self._narrowed[held.key] = entry
             self._evict()
         return entry
 
@@ -1254,13 +1324,13 @@ class Corpus:
         candidate leaves the cache above its budget until a reader finishes, which is
         the direction that keeps answers right.
         """
-        for columns in list(self._narrowed):
+        for key in list(self._narrowed):
             if (
                 sum(entry.held for entry in self._narrowed.values())
                 <= self._narrow_budget
             ):
                 return
-            entry = self._narrowed[columns]
+            entry = self._narrowed[key]
             if entry.readers:
                 continue
             cursor = self._connection.cursor()
@@ -1273,8 +1343,8 @@ class Corpus:
                 logger.exception("could not drop the materialized %s", entry.name)
             finally:
                 cursor.close()
-            del self._narrowed[columns]
-            logger.info("evicted the materialized %s", sorted(columns))
+            del self._narrowed[key]
+            logger.info("evicted the materialized %s", entry.name)
 
     @contextlib.contextmanager
     def _narrowed_table(self, columns: frozenset[str]) -> Iterator[str | None]:
@@ -1300,7 +1370,151 @@ class Corpus:
             or a set costing more memory than the whole cache is allowed -- in which
             case the projection answers directly.
         """
-        entry = self._materialize(columns)
+        selected = ", ".join([*sorted(columns), query.STRUCTURE_OFFSET])
+        entry = self._materialize(
+            _Held(
+                key=("columns", *sorted(columns)),
+                # S608: the names come from the projection schema and this module.
+                select=f"SELECT {selected} FROM {query.TABLE}",  # noqa: S608
+                description=str(sorted(columns)),
+            )
+        )
+        if entry is None:
+            yield None
+            return
+        try:
+            yield entry.name
+        finally:
+            with self._narrow_lock:
+                entry.readers -= 1
+
+    def _pivot_view(self, path: str) -> str | None:
+        """Returns a view over the pivot artifacts for ``path``, or None if none exist.
+
+        Published once per level and remembered, including the answer that there is
+        nothing to publish, so a corpus without artifacts globs the directory once
+        rather than on every query.
+
+        Args:
+            path: The repeated level, as the query grammar names it.
+
+        Returns:
+            The view's name, or None to leave the level to be built in process.
+
+        Raises:
+            PairingError: If the artifacts for this level were not derived from the
+                projections this corpus reads -- a pivot of another corpus answers
+                confidently and wrongly, since its reaction IDs resolve against the
+                wrong rows -- or, with ``require_current``, if any of them is stale.
+        """
+        if self._pivots_dir is None:
+            return None
+        with self._pivot_lock:
+            if path in self._pivot_views:
+                return self._pivot_views[path]
+            # Recursive, because a pivot tree mirrors the projections it was derived
+            # from: a sharded corpus puts them under <level>/<shard>/ rather than
+            # directly under the level.
+            files = sorted(
+                glob.glob(f"{self._pivots_dir}/{path}/**/*.parquet", recursive=True)
+            )
+            if not files:
+                self._pivot_views[path] = None
+                return None
+            self._check_pivots(path, files)
+            name = pivot.table_name(path)
+            # S608: the name comes from this module's walk of the schema, and the paths
+            # from this process's own glob, quoted with their single quotes escaped.
+            self._connection.execute(
+                f"CREATE OR REPLACE VIEW {name} AS "  # noqa: S608
+                f"SELECT * FROM read_parquet({_sql_strings(files)})"
+            )
+            logger.info("read %d pivot artifacts for %s", len(files), path)
+            self._pivot_views[path] = name
+            return name
+
+    def _check_pivots(self, path: str, files: list[str]) -> None:
+        """Refuses pivot artifacts that do not belong to this corpus.
+
+        A pivot names its reactions by ID, and an ID resolves against whatever rows the
+        projections hold. Artifacts derived from another corpus therefore answer a
+        quantifier confidently and wrongly rather than failing, which is why the check
+        is on the source datasets rather than on the file count.
+
+        Args:
+            path: The repeated level the files claim to hold.
+            files: The artifacts found for it.
+
+        Raises:
+            PairingError: If a file is not a pivot over ``path``, if the set of source
+                datasets differs from the projections', or -- with ``require_current``
+                -- if any artifact is stale.
+        """
+        wanted = {artifacts.load_stamps(name).source_md5 for name in self._projections}
+        found = set()
+        for name in files:
+            stamps = artifacts.load_stamps(name)
+            if stamps.artifact != pivot.ARTIFACT:
+                raise PairingError(
+                    f"{name} is a {stamps.artifact}, not a {pivot.ARTIFACT}"
+                )
+            held = pivot.pivot_path(name)
+            if held != path:
+                raise PairingError(
+                    f"{name} holds the pivot over {held}, but sits where {path} is "
+                    "read from, so a quantifier would be answered by the wrong level"
+                )
+            if self._require_current and not artifacts.stamps_are_current(
+                stamps, pivot.ARTIFACT
+            ):
+                raise PairingError(f"{name} is a stale {pivot.ARTIFACT}")
+            found.add(stamps.source_md5)
+        if found != wanted:
+            raise PairingError(
+                f"the {pivot.ARTIFACT} artifacts for {path} were derived from "
+                f"{len(found)} source datasets and the projections from {len(wanted)}, "
+                f"and {len(wanted - found)} of the projections' are missing; a pivot "
+                "of another corpus names reactions this one does not hold"
+            )
+
+    @contextlib.contextmanager
+    def _pivoted_table(self, path: str) -> Iterator[str | None]:
+        """Yields a pivot over ``path``, held against eviction while read.
+
+        One row per element of the level, carrying the ordinals that say which element
+        it was and the element's own fields with the repeated ones removed. A quantifier
+        answered from it is a semi-join rather than a decode of the whole nested column,
+        which over ORD is milliseconds against seconds.
+
+        Building it costs a pass that unnests every level down to this one, so the first
+        query wanting a path waits for it. That cost belongs in a derived artifact
+        rather than in a query, and until there is one it is announced rather than
+        hidden.
+
+        Args:
+            path: The repeated level, as the query grammar names it.
+
+        Yields:
+            The table's name, or None when the schema has no such level or the budget
+            refuses it -- in which case the quantifier compiles over the elements.
+        """
+        level = pivot.LEVELS.get(path)
+        if level is None:
+            yield None
+            return
+        published = self._pivot_view(path)
+        if published is not None:
+            # A view over artifacts costs no memory to hold and nothing to release, so
+            # there is no reader to take and no budget to spend.
+            yield published
+            return
+        entry = self._materialize(
+            _Held(
+                key=("pivot", path),
+                select=pivot.select(level, query.TABLE),
+                description=f"the pivot over {path}",
+            )
+        )
         if entry is None:
             yield None
             return
@@ -1460,7 +1674,6 @@ class Corpus:
             indexing = indexing or condition is not None
             return condition
 
-        compiled = query.compile_query(request, index=index)
         # Cached across the whole search: a compound named in both a value and a
         # structure predicate is one external lookup, not two.
         resolved: dict[str, str] = {}
@@ -1471,6 +1684,18 @@ class Corpus:
             return resolved[name]
 
         with contextlib.ExitStack() as reading:
+            pivoted: dict[str, str | None] = {}
+
+            def pivot_table(path: str) -> str | None:
+                # Built while compiling rather than after, because the budget decides
+                # whether the table exists at all and the SQL names it either way. The
+                # answer is remembered so the second compilation, against the narrow
+                # relation, cannot route a quantifier differently from the first.
+                if path not in pivoted:
+                    pivoted[path] = reading.enter_context(self._pivoted_table(path))
+                return pivoted[path]
+
+            compiled = query.compile_query(request, index=index, pivot=pivot_table)
             if indexing:
                 # Built after compiling and before running: the condition names the
                 # table, so the table has to exist by the time the query does. Logged
@@ -1487,7 +1712,9 @@ class Corpus:
                 self._narrowed_table(_mentioned(compiled.sql))
             )
             if narrow is not None:
-                compiled = query.compile_query(request, table=narrow, index=index)
+                compiled = query.compile_query(
+                    request, table=narrow, index=index, pivot=pivot_table
+                )
             cursor = self._connection.cursor()
             try:
                 parameters: dict[str, Any] = {

--- a/ord_schema/agent/execute.py
+++ b/ord_schema/agent/execute.py
@@ -80,6 +80,7 @@ import contextlib
 import dataclasses
 import glob
 import math
+import os
 import re
 import threading
 import time
@@ -107,12 +108,17 @@ _BUILD_BATCH = 50_000
 # seconds.
 _CACHED_MATCHES = 16
 
-# How much memory the materialized column sets may hold between them. Held to by
-# evicting the least recently used, so a corpus asked many different questions settles
-# on the columns it is actually asked about. Enforced after a table is built rather than
-# before, since what one costs is known only once it exists, so the peak is this plus
-# the largest single set; a set larger than the whole budget is dropped again unkept.
-_NARROW_BUDGET_BYTES = 2 * 1024**3
+# What share of the machine the materialized column sets may hold between them, when the
+# caller states no budget of its own. A share rather than a figure because what the sets
+# cost is set by the corpus: ORD's ``inputs`` is 4.07 GB and its ``outcomes`` 3.26 GB,
+# so any fixed default small enough to be safe on a laptop refuses both on a server. A
+# query whose columns are refused reads the Parquet files instead -- seconds rather than
+# tenths, which is the difference the materialization exists to make.
+_NARROW_BUDGET_FRACTION = 0.25
+
+# What to allow where the machine's memory cannot be read, and the least this will claim
+# anywhere. Enough for the columns a scalar query names, not for the largest.
+_NARROW_BUDGET_FLOOR_BYTES = 2 * 1024**3
 
 # Top-level projection columns, which is the granularity a compiled query names them at.
 # A narrower table holding only the ones a query mentions answers it identically, so the
@@ -144,6 +150,23 @@ def _reads_as_smarts(parameter: query.StructureParameter) -> bool:
 
 class PairingError(ValueError):
     """The projections and structures artifacts do not form a consistent corpus."""
+
+
+def _default_narrow_budget() -> int:
+    """Returns what the materialized column sets may hold on this machine.
+
+    A share of the machine's memory, since the alternative is a figure that is either
+    too small for the corpus it is asked about or too large for the machine it runs on.
+    Where the memory cannot be read -- ``sysconf`` is a Unix interface -- the floor
+    stands, which serves scalar queries and refuses the largest columns.
+
+    Returns:
+        Bytes the cache may hold, never below ``_NARROW_BUDGET_FLOOR_BYTES``.
+    """
+    if not hasattr(os, "sysconf") or "SC_PHYS_PAGES" not in os.sysconf_names:
+        return _NARROW_BUDGET_FLOOR_BYTES
+    memory = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+    return max(int(memory * _NARROW_BUDGET_FRACTION), _NARROW_BUDGET_FLOOR_BYTES)
 
 
 def _resolve_with_resolvers(name: str) -> str:
@@ -522,6 +545,7 @@ class Corpus:
         resolver: Callable[[str], str] | None = None,
         threads: int = -1,
         require_current: bool = True,
+        narrow_budget_bytes: int | None = None,
     ) -> None:
         """Pairs the artifacts, checks their stamps, and prepares the relations.
 
@@ -540,6 +564,12 @@ class Corpus:
                 artifact, and RDKit versions. The screen's completeness guarantee
                 assumes the query and the artifact fingerprint identically, so turning
                 this off is only for reading a corpus known to match anyway.
+            narrow_budget_bytes: How much memory the materialized column sets may hold
+                between them; a quarter of the machine's by default. Worth stating
+                where the machine serves something else too, or where more of it can be
+                spent than that: a column set the budget refuses is read from the
+                Parquet files on every query that names it, which over ORD is seconds
+                against tenths of a second.
 
         Raises:
             PairingError: If either pattern matches nothing, a file on one side has no
@@ -547,6 +577,11 @@ class Corpus:
                 dataset, or -- with ``require_current`` -- any artifact is stale.
         """
         self._resolver = resolver if resolver is not None else _resolve_with_resolvers
+        self._narrow_budget = (
+            narrow_budget_bytes
+            if narrow_budget_bytes is not None
+            else _default_narrow_budget()
+        )
         self._threads = threads
         # Built on first substructure query; see _library. The library holds one entry
         # per distinct molecule, and _members with _starts map an entry back to the
@@ -1114,7 +1149,7 @@ class Corpus:
                 f"SELECT {selected} FROM {query.TABLE}"
             )
             held = max(_memory_bytes(cursor) - before, 0)
-            if held > _NARROW_BUDGET_BYTES:
+            if held > self._narrow_budget:
                 # Too big to keep, and keeping it is the only reason to build it.
                 cursor.execute(f"DROP TABLE {name}")
                 with self._narrow_lock:
@@ -1157,8 +1192,9 @@ class Corpus:
         the direction that keeps answers right.
         """
         for held in list(self._narrowed):
-            if sum(entry.held for entry in self._narrowed.values()) <= (
-                _NARROW_BUDGET_BYTES
+            if (
+                sum(entry.held for entry in self._narrowed.values())
+                <= self._narrow_budget
             ):
                 return
             entry = self._narrowed[held]

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -2169,13 +2169,36 @@ def test_the_budget_is_a_share_of_the_machine_unless_stated(corpus_dir, monkeypa
     # running it is whatever it is.
     machine = 64 * 1024**3
     _state_machine_memory(monkeypatch, machine)
-    monkeypatch.setattr(execute, "_CGROUP_LIMITS", ())
+    monkeypatch.setattr(execute, "_CGROUP_HIERARCHIES", ())
     assert execute._default_narrow_budget() == int(
         machine * execute._NARROW_BUDGET_FRACTION
     )
     # Where nothing states a limit, a figure stands rather than a share of nothing.
     monkeypatch.setattr(execute.os, "sysconf_names", {})
     assert execute._default_narrow_budget() == execute._NARROW_BUDGET_UNKNOWN_BYTES
+
+
+def _state_cgroup(monkeypatch, tmp_path, path: str, limits: dict[str, str]) -> None:
+    """Puts this process in a cgroup at ``path``, with the stated limits along it.
+
+    Args:
+        monkeypatch: The fixture, which points the module at the tree built here.
+        tmp_path: Where to build the tree.
+        path: The process's own cgroup, as ``/proc/self/cgroup`` states it.
+        limits: What each level from the mount down states, keyed by its path within
+            the mount; a level not named here states nothing, as most do not.
+    """
+    mount = tmp_path / "cgroup"
+    for level, stated in limits.items():
+        directory = mount.joinpath(*[part for part in level.split("/") if part])
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "memory.max").write_text(stated)
+    proc = tmp_path / "proc_self_cgroup"
+    proc.write_text(f"0::{path}\n")
+    monkeypatch.setattr(execute, "_PROC_CGROUP", str(proc))
+    monkeypatch.setattr(
+        execute, "_CGROUP_HIERARCHIES", ((str(mount), "memory.max", ""),)
+    )
 
 
 def _state_machine_memory(monkeypatch, memory: int) -> None:
@@ -2197,19 +2220,17 @@ def test_a_container_is_budgeted_by_what_it_may_hold_not_by_the_host(
     # a corpus that budgeted by the host would hold memory it cannot have and be killed
     # for it -- or starve whatever it shares the machine with.
     _state_machine_memory(monkeypatch, 64 * 1024**3)
-    limit = tmp_path / "memory.max"
-    limit.write_text("8589934592\n")  # 8 GB, as a cgroup states it.
-    monkeypatch.setattr(execute, "_CGROUP_LIMITS", (str(limit),))
+    _state_cgroup(monkeypatch, tmp_path, "/", {"/": "8589934592\n"})
     assert execute._default_narrow_budget() == int(
         8 * 1024**3 * execute._NARROW_BUDGET_FRACTION
     )
     # A cgroup that limits nothing says so in words, and the host stands.
-    limit.write_text("max\n")
+    _state_cgroup(monkeypatch, tmp_path, "/", {"/": "max\n"})
     assert execute._default_narrow_budget() == int(
         64 * 1024**3 * execute._NARROW_BUDGET_FRACTION
     )
     # cgroup v1 spells the same thing as a number near the word size.
-    limit.write_text(f"{(1 << 63) - 4096}\n")
+    _state_cgroup(monkeypatch, tmp_path, "/", {"/": f"{(1 << 63) - 4096}\n"})
     assert execute._default_narrow_budget() == int(
         64 * 1024**3 * execute._NARROW_BUDGET_FRACTION
     )
@@ -2218,6 +2239,56 @@ def test_a_container_is_budgeted_by_what_it_may_hold_not_by_the_host(
     # budget no machine can hold, and every column set would be kept.
     monkeypatch.setattr(execute.os, "sysconf_names", {})
     assert execute._default_narrow_budget() == execute._NARROW_BUDGET_UNKNOWN_BYTES
+
+
+def test_the_smallest_limit_over_a_process_is_the_one_it_is_held_to(
+    tmp_path, monkeypatch
+):
+    # A service under a systemd slice, or a container run without a cgroup namespace of
+    # its own, sits below the mount root: the root states nothing and an ancestor states
+    # the limit. Reading the root alone would budget by the whole machine again.
+    _state_machine_memory(monkeypatch, 64 * 1024**3)
+    _state_cgroup(
+        monkeypatch,
+        tmp_path,
+        "/system.slice/ord.service",
+        {
+            "/": "max\n",
+            "/system.slice": "4294967296\n",  # 4 GB over everything in the slice.
+            "/system.slice/ord.service": "max\n",
+        },
+    )
+    assert execute._default_narrow_budget() == int(
+        4 * 1024**3 * execute._NARROW_BUDGET_FRACTION
+    )
+    # Its own is what holds when it is the smaller, whatever an ancestor allows.
+    _state_cgroup(
+        monkeypatch,
+        tmp_path,
+        "/system.slice/ord.service",
+        {
+            "/system.slice": "4294967296\n",
+            "/system.slice/ord.service": "1073741824\n",  # 1 GB
+        },
+    )
+    assert execute._default_narrow_budget() == int(
+        1024**3 * execute._NARROW_BUDGET_FRACTION
+    )
+    # A cgroup may ask for more than the one above it allows, and gets what the one
+    # above it allows. Reading the nearest limit rather than the smallest would believe
+    # the 8 GB and budget past what the process can hold.
+    _state_cgroup(
+        monkeypatch,
+        tmp_path,
+        "/system.slice/ord.service",
+        {
+            "/system.slice": "2147483648\n",  # 2 GB over the slice
+            "/system.slice/ord.service": "8589934592\n",  # 8 GB asked for below it
+        },
+    )
+    assert execute._default_narrow_budget() == int(
+        2 * 1024**3 * execute._NARROW_BUDGET_FRACTION
+    )
 
 
 def test_a_machine_that_will_not_say_how_large_it_is_does_not_stop_a_corpus(
@@ -2229,7 +2300,7 @@ def test_a_machine_that_will_not_say_how_large_it_is_does_not_stop_a_corpus(
         raise OSError(f"no answer for {name}")
 
     monkeypatch.setattr(execute.os, "sysconf", refusing)
-    monkeypatch.setattr(execute, "_CGROUP_LIMITS", ())
+    monkeypatch.setattr(execute, "_CGROUP_HIERARCHIES", ())
     assert execute._default_narrow_budget() == execute._NARROW_BUDGET_UNKNOWN_BYTES
     monkeypatch.setattr(execute.os, "sysconf", lambda name: -1)
     assert execute._default_narrow_budget() == execute._NARROW_BUDGET_UNKNOWN_BYTES

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -2156,7 +2156,9 @@ def test_a_budget_no_memory_could_answer_to_is_refused(corpus_dir):
             resolver={}.__getitem__,
             narrow_budget_bytes=-1,
         )
-    # Zero is an amount of memory, and a caller asking to materialize nothing means it.
+    # Zero is an amount of memory, and a caller asking to materialize nothing means it
+    # -- including the build that would otherwise measure a set before dropping it,
+    # which is the peak a machine has to have room for.
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
@@ -2169,6 +2171,8 @@ def test_a_budget_no_memory_could_answer_to_is_refused(corpus_dir):
             )
         )
         assert not value._narrowed
+        assert value._narrow_serial == 0  # No table was built to find that out.
+        assert not [name for name in _tables(value) if name.startswith("narrow_")]
 
 
 def test_a_materialization_is_measured_in_bytes(corpus_dir):

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -1086,6 +1086,35 @@ _ROUTABLE = {
             ],
         }
     },
+    # The shape the index answers half of: over the corpus, what the other half costs
+    # is set by whether its column was materialized -- 0.43s against 3.34s for the same
+    # question, which is why the budget is what it is.
+    "a clause the projection has to answer beside it": {
+        "where": {
+            "op": "and",
+            "clauses": [
+                _exists(_SUBSTRUCTURE),
+                {
+                    "op": "exists",
+                    "path": "outcomes.products",
+                    "where": {
+                        "op": "eq",
+                        "path": "isolated_color",
+                        "value": {"literal": "white"},
+                    },
+                },
+            ],
+        }
+    },
+    "a negated clause beside the indexed one": {
+        "where": {
+            "op": "and",
+            "clauses": [
+                _exists(_SUBSTRUCTURE),
+                {"op": "not", "clause": {"op": "not_null", "path": "provenance.doi"}},
+            ],
+        }
+    },
 }
 
 # Element predicates an occurrence row cannot carry, so the quantifier compiles over
@@ -2116,6 +2145,45 @@ def _tables(value) -> set[str]:
     return {row[0] for row in rows}
 
 
+def test_the_budget_is_a_share_of_the_machine_unless_stated(corpus_dir, monkeypatch):
+    # A fixed default cannot be right: ORD's inputs column is 4.07 GB materialized, so
+    # anything safe on a small machine refuses the columns most worth holding on a large
+    # one, and a refused column set is read from Parquet on every query that names it.
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        assert value._narrow_budget == execute._default_narrow_budget()
+        assert value._narrow_budget >= execute._NARROW_BUDGET_FLOOR_BYTES
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        narrow_budget_bytes=7,
+    ) as value:
+        # A caller who knows what else the machine is doing outranks the share.
+        assert value._narrow_budget == 7
+    # The share is of the machine, so a larger machine holds more of the corpus. Stated
+    # rather than read, since what this test asserts is the arithmetic and the machine
+    # running it is whatever it is.
+    machine = 64 * 1024**3
+    monkeypatch.setattr(
+        execute.os,
+        "sysconf",
+        lambda name: {
+            "SC_PAGE_SIZE": 4096,
+            "SC_PHYS_PAGES": machine // 4096,
+        }[name],
+    )
+    assert execute._default_narrow_budget() == int(
+        machine * execute._NARROW_BUDGET_FRACTION
+    )
+    # Where the memory cannot be read, the floor stands rather than a share of nothing.
+    monkeypatch.setattr(execute.os, "sysconf_names", {})
+    assert execute._default_narrow_budget() == execute._NARROW_BUDGET_FLOOR_BYTES
+
+
 def test_a_materialization_is_measured_in_bytes(corpus_dir):
     # duckdb_tables reports a row *count* under a name that reads like a size, and
     # spending it as one makes the budget a number that can never be crossed and the
@@ -2140,11 +2208,12 @@ def test_the_cache_evicts_the_least_recently_used_and_drops_its_table(
     # An unevicted cache is one table per column set a server is ever asked for, none of
     # them ever freed. Sizes are stated here rather than measured so the budget admits
     # exactly one table whatever DuckDB's allocator does with three rows.
-    monkeypatch.setattr(execute, "_NARROW_BUDGET_BYTES", 150)
+    budget = 150
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
+        narrow_budget_bytes=budget,
     ) as value:
         monkeypatch.setattr(
             execute, "_memory_bytes", _stated_bytes(0, 100, 0, 100, 0, 100)
@@ -2166,11 +2235,12 @@ def test_a_table_a_search_is_reading_is_not_evicted(corpus_dir, monkeypatch):
     # seconds during which it holds nothing but a string. Evicting there would fail a
     # query that had already been answered correctly, with a catalog error naming a
     # table the caller has never heard of.
-    monkeypatch.setattr(execute, "_NARROW_BUDGET_BYTES", 150)
+    budget = 150
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
+        narrow_budget_bytes=budget,
     ) as value:
         monkeypatch.setattr(
             execute, "_memory_bytes", _stated_bytes(0, 100, 0, 100, 0, 100)
@@ -2308,11 +2378,12 @@ def test_a_table_a_second_search_took_from_the_cache_is_not_evicted(
     # does, so it has to take the read the same way. Held at zero readers, the table is
     # the first thing eviction takes, and the search fails on a name that no longer
     # resolves after it had already been answered correctly.
-    monkeypatch.setattr(execute, "_NARROW_BUDGET_BYTES", 150)
+    budget = 150
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
+        narrow_budget_bytes=budget,
     ) as value:
         monkeypatch.setattr(
             execute, "_memory_bytes", _stated_bytes(0, 100, 0, 100, 0, 100)
@@ -2407,11 +2478,12 @@ def test_a_literal_naming_the_relation_is_not_a_rewrite(tmp_path):
 
 def test_a_column_set_too_large_to_keep_is_not_kept(corpus_dir, monkeypatch):
     # Materializing is only worth it if the table survives to answer the next query.
-    monkeypatch.setattr(execute, "_NARROW_BUDGET_BYTES", 1)
+    budget = 1
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
+        narrow_budget_bytes=budget,
     ) as value:
         matched = value.search(
             query.Query.model_validate(
@@ -2432,12 +2504,13 @@ def test_a_column_set_too_large_to_keep_is_not_built_twice(corpus_dir, monkeypat
     # does not change while the corpus is open. Asking again is the common case -- a
     # notebook loop, a server serving one shape of question -- and rebuilding a table
     # only to drop it again holds the narrow lock against every other search each time.
-    monkeypatch.setattr(execute, "_NARROW_BUDGET_BYTES", 1)
+    budget = 1
     columns = frozenset({"reaction_id", "provenance"})
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
+        narrow_budget_bytes=budget,
     ) as value:
         with value._narrowed_table(columns) as name:
             assert name is None

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -30,7 +30,7 @@ from rdkit import Chem
 from rdkit.Chem import rdSubstructLibrary
 
 from ord_schema import parquet, projection, structures
-from ord_schema.agent import execute, query
+from ord_schema.agent import execute, pivot, query
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 _ROLE = reaction_pb2.ReactionRole
@@ -2009,6 +2009,11 @@ def test_the_cache_stays_bounded(corpus_dir, monkeypatch):
         assert [key[2] for key in value._matched] == ["c1ccccc1", "[Pt]"]
 
 
+def _columns_key(columns: frozenset[str]) -> tuple[str, ...]:
+    """Returns the cache key a materialized column set is held under."""
+    return ("columns", *sorted(columns))
+
+
 @contextlib.contextmanager
 def _no_narrow_table(self, columns: frozenset[str]) -> Iterator[str | None]:
     """Stands in for _narrowed_table so a search reads the projection directly."""
@@ -2216,7 +2221,7 @@ def test_the_cache_evicts_the_least_recently_used_and_drops_its_table(
         assert dropped in _tables(value)
         with value._narrowed_table(second) as name:
             kept = name
-        assert list(value._narrowed) == [second]
+        assert list(value._narrowed) == [_columns_key(second)]
         assert dropped not in _tables(value)  # Dropped, not merely forgotten.
         assert kept in _tables(value)
 
@@ -2244,7 +2249,10 @@ def test_a_table_a_search_is_reading_is_not_evicted(corpus_dir, monkeypatch):
             # Over budget, and the only candidate is being read: it stays, and the
             # cache stays over its budget until the reader is done.
             assert reading in _tables(value)
-            assert list(value._narrowed) == [first, second]
+            assert list(value._narrowed) == [
+                _columns_key(first),
+                _columns_key(second),
+            ]
         # Released, so the next materialization can take it.
         with value._narrowed_table(frozenset({"reaction_id", "notes"})):
             pass
@@ -2744,3 +2752,550 @@ def test_the_artifact_fingerprint_is_the_one_the_library_screens_with():
     holder.AddMol(molecule)
     stored = Chem.PatternFingerprint(molecule, fpSize=structures.PATTERN_FP_SIZE)
     assert list(holder.GetFingerprint(0).GetOnBits()) == list(stored.GetOnBits())
+
+
+def _wide_reactions() -> list[reaction_pb2.Reaction]:
+    """Reactions exercising the element shapes the ORD corpus barely holds.
+
+    Measured over the whole corpus, no reaction records a NULL or empty ``outcomes``
+    and only 119 record a NULL ``products`` under one, so corpus agreement is weak
+    evidence about levels that are absent, empty, or carry a NULL leaf. These say it
+    outright. Two outcomes on one reaction matter most: ORD is effectively
+    single-outcome, which is exactly why a correlation that dropped the outcome
+    ordinal answered identically and looked correct.
+    """
+    reactions = []
+
+    # Two outcomes. The high yield belongs to the product that is not desired, so a
+    # correlation blind to either ordinal pairs them and answers yes.
+    split = reaction_pb2.Reaction(reaction_id="ord-wd01")
+    first = split.outcomes.add()
+    undesired = first.products.add(is_desired_product=False, isolated_color="white")
+    undesired.measurements.add(type="YIELD").percentage.value = 90
+    second = split.outcomes.add()
+    desired = second.products.add(is_desired_product=True, isolated_color="yellow")
+    desired.measurements.add(type="YIELD").percentage.value = 10
+    reactions.append(split)
+
+    # One outcome, one product, both conditions on the same element.
+    together = reaction_pb2.Reaction(reaction_id="ord-wd02")
+    product = together.outcomes.add().products.add(
+        is_desired_product=True, isolated_color="white"
+    )
+    product.measurements.add(type="YIELD").percentage.value = 90
+    reactions.append(together)
+
+    # An outcome carrying no products at all: the level is present and empty.
+    empty = reaction_pb2.Reaction(reaction_id="ord-wd03")
+    empty.outcomes.add()
+    reactions.append(empty)
+
+    # No outcomes at all: the projection writes NULL rather than an empty list.
+    reactions.append(reaction_pb2.Reaction(reaction_id="ord-wd04"))
+
+    # A product carrying no isolated_color, so the leaf a body reads is NULL.
+    blank = reaction_pb2.Reaction(reaction_id="ord-wd05")
+    blank.outcomes.add().products.add(is_desired_product=True)
+    reactions.append(blank)
+
+    # Several products where only the last matches, so a filter that stopped early or
+    # read only the first element would miss it.
+    several = reaction_pb2.Reaction(reaction_id="ord-wd06")
+    outcome = several.outcomes.add()
+    outcome.products.add(is_desired_product=False, isolated_color="red")
+    outcome.products.add(is_desired_product=False, isolated_color="green")
+    outcome.products.add(is_desired_product=True, isolated_color="white")
+    reactions.append(several)
+
+    # One outcome holding both, so the *product* ordinal is what separates them. This
+    # is the shape of the 942 reactions a product-blind correlation over-returned on
+    # ORD, which an outcome-blind one could not see: the corpus is single-outcome.
+    sibling = reaction_pb2.Reaction(reaction_id="ord-wd07")
+    outcome = sibling.outcomes.add()
+    wanted = outcome.products.add(is_desired_product=True, isolated_color="blue")
+    wanted.measurements.add(type="YIELD").percentage.value = 10
+    other = outcome.products.add(is_desired_product=False, isolated_color="blue")
+    other.measurements.add(type="YIELD").percentage.value = 90
+    reactions.append(sibling)
+
+    return reactions
+
+
+@pytest.fixture(scope="module")
+def wide_corpus(tmp_path_factory) -> Iterator[execute.Corpus]:
+    """A corpus of element shapes, for comparing the pivot route against the level."""
+    root = tmp_path_factory.mktemp("wide")
+    source = root / "data" / "ord_dataset-wd.parquet"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    parquet.save_dataset(
+        dataset_pb2.Dataset(
+            dataset_id="ord_dataset-wd",
+            name="test",
+            description="test",
+            reactions=_wide_reactions(),
+        ),
+        str(source),
+    )
+    projected = root / "projections" / source.name
+    projected.parent.mkdir(parents=True, exist_ok=True)
+    projection.write_projection(source, projected)
+    structured = root / "structures" / source.name
+    structured.parent.mkdir(parents=True, exist_ok=True)
+    structures.write_structures(projected, structured)
+    with execute.Corpus(
+        str(projected), str(structured), resolver={}.__getitem__
+    ) as value:
+        yield value
+
+
+def _white(op):
+    return {
+        "op": op,
+        "path": "outcomes.products",
+        "where": {
+            "op": "eq",
+            "path": "isolated_color",
+            "value": {"literal": "white"},
+        },
+    }
+
+
+_DIFFERENTIAL = {
+    "exists a white product": _white("exists"),
+    "every product is white": _white("forall"),
+    "no white product": {"op": "not", "clause": _white("exists")},
+    "not every product is white": {"op": "not", "clause": _white("forall")},
+    # Two conditions on one element: the pivot answers this from one row, which is the
+    # co-membership the nested form gets by binding an element.
+    "a desired white product": {
+        "op": "exists",
+        "path": "outcomes.products",
+        "where": {
+            "op": "and",
+            "clauses": [
+                {
+                    "op": "eq",
+                    "path": "isolated_color",
+                    "value": {"literal": "white"},
+                },
+                {
+                    "op": "eq",
+                    "path": "is_desired_product",
+                    "value": {"literal": True},
+                },
+            ],
+        },
+    },
+    # The leaf is NULL for ord-wd05, so the comparison is NULL rather than false and
+    # both routes have to fold it the same way.
+    "a product that is not white": {
+        "op": "exists",
+        "path": "outcomes.products",
+        "where": {
+            "op": "ne",
+            "path": "isolated_color",
+            "value": {"literal": "white"},
+        },
+    },
+    "every measurement is a yield": {
+        "op": "forall",
+        "path": "outcomes.products.measurements",
+        "where": {"op": "eq", "path": "type", "value": {"literal": "YIELD"}},
+    },
+    # The nested-correlation case, and the one the wide corpus was built for: ord-wd01
+    # carries the 90% yield on the product that is *not* desired, in a different
+    # outcome from the one that is. A correlation joining on anything short of the
+    # whole ordinal prefix pairs them and answers yes.
+    "a desired product with a yield above 50%": {
+        "op": "exists",
+        "path": "outcomes.products",
+        "where": {
+            "op": "and",
+            "clauses": [
+                {
+                    "op": "eq",
+                    "path": "is_desired_product",
+                    "value": {"literal": True},
+                },
+                {
+                    "op": "exists",
+                    "path": "measurements",
+                    "where": {
+                        "op": "and",
+                        "clauses": [
+                            {"op": "eq", "path": "type", "value": {"literal": "YIELD"}},
+                            {
+                                "op": "gt",
+                                "path": "percentage.value",
+                                "value": {"literal": 50},
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+    },
+    "a yield above 50%": {
+        "op": "exists",
+        "path": "outcomes.products.measurements",
+        "where": {
+            "op": "and",
+            "clauses": [
+                {"op": "eq", "path": "type", "value": {"literal": "YIELD"}},
+                {
+                    "op": "gt",
+                    "path": "percentage.value",
+                    "value": {"literal": 50},
+                },
+            ],
+        },
+    },
+}
+
+
+@pytest.mark.parametrize("where", list(_DIFFERENTIAL.values()), ids=list(_DIFFERENTIAL))
+def test_a_pivot_answers_what_the_level_answers(wide_corpus, monkeypatch, where):
+    # The guard on two routes to one answer. A pivot that lost an ordinal, folded a
+    # NULL level the other way, or correlated on the wrong prefix shows up here as a
+    # set that differs -- which is how the 942-reaction over-match was found.
+    pivoted = _search(wide_corpus, where)
+    monkeypatch.setattr(
+        execute.Corpus, "_pivoted_table", _no_pivoted_table, raising=True
+    )
+    assert _search(wide_corpus, where) == pivoted
+
+
+@contextlib.contextmanager
+def _no_pivoted_table(self, path: str) -> Iterator[str | None]:
+    """Stands in for _pivoted_table so a quantifier compiles over the elements."""
+    del self, path  # Unused.
+    yield None
+
+
+def test_the_differential_cases_are_not_all_the_same_answer(wide_corpus):
+    # A differential test comparing two routes proves nothing if every case answers
+    # with the whole corpus, which is what a fixture that lost its variety would do.
+    answers = {
+        name: frozenset(_search(wide_corpus, where))
+        for name, where in _DIFFERENTIAL.items()
+    }
+    assert len(set(answers.values())) >= 5
+    assert any(answer for answer in answers.values())
+    assert any(len(answer) < 6 for answer in answers.values())
+
+
+def test_a_pivot_row_says_which_element_it_was(wide_corpus):
+    # Nothing in phase 1 joins on the ordinals, so the differential test cannot see
+    # them; they are what a correlation across levels will need, and a pivot that
+    # numbered its elements wrongly would look correct until then. ord-wd01 carries two
+    # outcomes of one product each, and ord-wd06 one outcome of three.
+    with wide_corpus._pivoted_table("outcomes.products") as name:
+        assert name is not None
+        rows = wide_corpus._connection.execute(
+            f"SELECT reaction_id, outcome_index, product_index, "  # noqa: S608
+            f"element.isolated_color FROM {name} "
+            "WHERE reaction_id IN ('ord-wd01', 'ord-wd06') "
+            "ORDER BY reaction_id, outcome_index, product_index"
+        ).fetchall()
+    assert rows == [
+        ("ord-wd01", 1, 1, "white"),
+        ("ord-wd01", 2, 1, "yellow"),
+        ("ord-wd06", 1, 1, "red"),
+        ("ord-wd06", 1, 2, "green"),
+        ("ord-wd06", 1, 3, "white"),
+    ]
+
+
+def test_a_pivot_holds_every_element_including_an_empty_one(wide_corpus):
+    # Completeness is what lets a pivot answer forall, so an element whose fields are
+    # all NULL still gets a row: ord-wd05 records a product with no isolated_color.
+    with wide_corpus._pivoted_table("outcomes.products") as name:
+        assert name is not None
+        blank = wide_corpus._connection.execute(
+            f"SELECT count(*) FROM {name} WHERE reaction_id = 'ord-wd05'"  # noqa: S608
+        ).fetchone()
+        # A level that is present but empty contributes no rows, and one the source
+        # never recorded contributes none either -- which is what makes forall
+        # vacuously true of both.
+        absent = wide_corpus._connection.execute(
+            f"SELECT count(*) FROM {name} "  # noqa: S608
+            "WHERE reaction_id IN ('ord-wd03', 'ord-wd04')"
+        ).fetchone()
+    assert blank == (1,)
+    assert absent == (0,)
+
+
+def _write_pivots(root: pathlib.Path, levels: tuple[str, ...]) -> pathlib.Path:
+    """Derives pivot artifacts for ``levels`` from every projection under ``root``.
+
+    Written under ``<level>/<shard>/`` rather than directly under the level, because
+    that is where ``derive_pivots`` puts them: it mirrors the projections' own layout,
+    and a helper that flattened it would test a tree nothing produces.
+    """
+    pivots = root / "pivots"
+    for level in levels:
+        for projected in sorted((root / "projections").glob("*.parquet")):
+            shard = pivots / level / projected.stem[-2:]
+            shard.mkdir(parents=True, exist_ok=True)
+            pivot.write_pivot(projected, shard / projected.name, level_path=level)
+    return pivots
+
+
+@pytest.fixture(scope="module")
+def wide_root(tmp_path_factory) -> pathlib.Path:
+    """The wide corpus on disk, so pivot artifacts can be derived beside it."""
+    root = tmp_path_factory.mktemp("wide_artifacts")
+    source = root / "data" / "ord_dataset-wd.parquet"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    parquet.save_dataset(
+        dataset_pb2.Dataset(
+            dataset_id="ord_dataset-wd",
+            name="test",
+            description="test",
+            reactions=_wide_reactions(),
+        ),
+        str(source),
+    )
+    projected = root / "projections" / source.name
+    projected.parent.mkdir(parents=True, exist_ok=True)
+    projection.write_projection(source, projected)
+    structured = root / "structures" / source.name
+    structured.parent.mkdir(parents=True, exist_ok=True)
+    structures.write_structures(projected, structured)
+    return root
+
+
+@pytest.mark.parametrize("where", list(_DIFFERENTIAL.values()), ids=list(_DIFFERENTIAL))
+def test_a_pivot_artifact_answers_what_building_one_answers(wide_root, where):
+    # The artifact is the same rows by another route, so the whole point is that it
+    # cannot answer differently from the pivot the executor would have built.
+    pivots = _write_pivots(wide_root, ("outcomes.products",))
+    projected = str(wide_root / "projections" / "*.parquet")
+    structured = str(wide_root / "structures" / "*.parquet")
+    with execute.Corpus(projected, structured, resolver={}.__getitem__) as built:
+        expected = _search(built, where)
+    with execute.Corpus(
+        projected, structured, resolver={}.__getitem__, pivots_dir=str(pivots)
+    ) as read:
+        assert _search(read, where) == expected
+
+
+def test_a_pivot_artifact_is_read_rather_than_built(wide_root, caplog):
+    pivots = _write_pivots(wide_root, ("outcomes.products",))
+    with (
+        caplog.at_level(logging.INFO, logger="ord_schema.agent.execute"),
+        execute.Corpus(
+            str(wide_root / "projections" / "*.parquet"),
+            str(wide_root / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(pivots),
+        ) as corpus,
+    ):
+        _search(corpus, _white("exists"))
+    messages = [record.message for record in caplog.records]
+    assert any("read 1 pivot artifacts" in message for message in messages)
+    assert not any("building the pivot" in message for message in messages)
+
+
+def test_a_level_without_artifacts_is_still_built(wide_root, caplog):
+    # A partial set of artifacts is a partial speedup, not a missing answer.
+    pivots = _write_pivots(wide_root, ("outcomes.products",))
+    with (
+        caplog.at_level(logging.INFO, logger="ord_schema.agent.execute"),
+        execute.Corpus(
+            str(wide_root / "projections" / "*.parquet"),
+            str(wide_root / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(pivots),
+        ) as corpus,
+    ):
+        found = _search(
+            corpus,
+            {
+                "op": "exists",
+                "path": "outcomes.products.measurements",
+                "where": {
+                    "op": "eq",
+                    "path": "type",
+                    "value": {"literal": "YIELD"},
+                },
+            },
+        )
+    assert found == {"ord-wd01", "ord-wd02", "ord-wd07"}
+    assert any(
+        "building the pivot over outcomes.products.measurements" in record.message
+        for record in caplog.records
+    )
+
+
+def test_a_pivot_from_another_corpus_is_refused(wide_root, corpus_dir, tmp_path):
+    # The failure this pins is silent: a pivot names reactions by ID, so artifacts
+    # derived elsewhere answer a quantifier against rows this corpus does not hold.
+    stranger = _write_pivots(corpus_dir, ("outcomes.products",))
+    with (
+        execute.Corpus(
+            str(wide_root / "projections" / "*.parquet"),
+            str(wide_root / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(stranger),
+        ) as corpus,
+        pytest.raises(execute.PairingError, match="another corpus"),
+    ):
+        _search(corpus, _white("exists"))
+
+
+def test_a_pivot_filed_under_the_wrong_level_is_refused(wide_root, tmp_path):
+    pivots = tmp_path / "pivots"
+    (pivots / "outcomes.products").mkdir(parents=True)
+    projected = next((wide_root / "projections").glob("*.parquet"))
+    pivot.write_pivot(
+        projected,
+        pivots / "outcomes.products" / projected.name,
+        level_path="outcomes.products.measurements",
+    )
+    with (
+        execute.Corpus(
+            str(wide_root / "projections" / "*.parquet"),
+            str(wide_root / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(pivots),
+        ) as corpus,
+        pytest.raises(execute.PairingError, match="wrong level"),
+    ):
+        _search(corpus, _white("exists"))
+
+
+def test_a_structure_predicate_inside_a_pivoted_quantifier_agrees(corpus, monkeypatch):
+    # The occurrence index declines this: its shape is one structure predicate and
+    # string equalities, and a not_null clause is neither. The pivot takes it instead,
+    # and its rows carry a structure_id but no structure_offset -- that column resolves
+    # outward to the reaction the element belongs to, which is the offset its ID is
+    # meant to be read against. Correct by name resolution rather than by construction,
+    # so it is compared against the elements rather than assumed.
+    where = {
+        "op": "exists",
+        "path": "inputs.components",
+        "where": {
+            "op": "and",
+            "clauses": [
+                {"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"},
+                {"op": "not_null", "path": "smiles"},
+            ],
+        },
+    }
+    pivoted = _search(corpus, where)
+    monkeypatch.setattr(execute.Corpus, "_pivoted_table", _no_pivoted_table)
+    assert _search(corpus, where) == pivoted
+    # And the answer is the pyridine-bearing reactions, not everything or nothing.
+    assert pivoted == {"ord-aa01", "ord-aa02"}
+
+
+def test_a_pivoted_quantifier_still_reaches_the_structures_artifact(corpus):
+    # Guards the offset arithmetic across datasets: ethanol lives in the second file,
+    # so finding it through a pivot proves the outward structure_offset is the right
+    # one rather than the first file's.
+    found = _search(
+        corpus,
+        {
+            "op": "exists",
+            "path": "inputs.components",
+            "where": {
+                "op": "and",
+                "clauses": [
+                    {"op": "substructure", "path": "smiles", "smarts": "[OX2H]"},
+                    {"op": "not_null", "path": "smiles"},
+                ],
+            },
+        },
+    )
+    assert found == {"ord-bb01"}
+
+
+def test_check_pivots_reports_the_levels_held_as_artifacts(wide_root):
+    pivots = _write_pivots(wide_root, ("outcomes.products", "workups"))
+    with execute.Corpus(
+        str(wide_root / "projections" / "*.parquet"),
+        str(wide_root / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        pivots_dir=str(pivots),
+    ) as corpus:
+        assert corpus.check_pivots() == {"outcomes.products": 1, "workups": 1}
+
+
+def test_check_pivots_is_empty_without_a_directory(wide_corpus):
+    # Not an error: every level is built in process, which is the phase the executor
+    # started in and still supports.
+    assert wide_corpus.check_pivots() == {}
+
+
+def test_check_pivots_refuses_a_stranger_at_startup(wide_root, corpus_dir):
+    # The whole point: this refusal would otherwise arrive with whichever query first
+    # wanted the level, at whatever hour that was.
+    stranger = _write_pivots(corpus_dir, ("outcomes.products",))
+    with (
+        execute.Corpus(
+            str(wide_root / "projections" / "*.parquet"),
+            str(wide_root / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(stranger),
+        ) as corpus,
+        pytest.raises(execute.PairingError, match="another corpus"),
+    ):
+        corpus.check_pivots()
+
+
+def test_check_pivots_leaves_the_levels_ready(wide_root, caplog):
+    # Publishing is the check, so a level it accepted is one the first query does not
+    # have to glob for or build.
+    pivots = _write_pivots(wide_root, ("outcomes.products",))
+    with execute.Corpus(
+        str(wide_root / "projections" / "*.parquet"),
+        str(wide_root / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        pivots_dir=str(pivots),
+    ) as corpus:
+        corpus.check_pivots()
+        # Cleared, because check_pivots logs the publish it just did and the question
+        # here is what the *query* had left to do.
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ord_schema.agent.execute"):
+            found = _search(corpus, _white("exists"))
+    assert found == {"ord-wd01", "ord-wd02", "ord-wd06"}
+    messages = [record.message for record in caplog.records]
+    assert not any("read 1 pivot artifacts" in message for message in messages)
+    assert not any("building the pivot" in message for message in messages)
+
+
+def test_a_singular_struct_under_a_level_is_answered_by_that_level_s_pivot(
+    deep_corpus, monkeypatch
+):
+    # An authentic standard is one compound per measurement rather than a list of its
+    # own, so no pivot is named for it; the measurements' pivot carries it. This is the
+    # one occurrence-indexed path that is not a repeated level, so it is also what an
+    # index the pivot was meant to subsume would have quietly stopped covering.
+    where = {
+        "op": "exists",
+        "path": "outcomes.products.measurements.authentic_standard",
+        "where": {
+            "op": "and",
+            "clauses": [
+                {"op": "substructure", "path": "smiles", "smarts": "c1ccccc1"},
+                {"op": "not_null", "path": "smiles"},
+            ],
+        },
+    }
+    pivoted = _search(deep_corpus, where)
+    assert pivoted == {"ord-cc01"}
+    monkeypatch.setattr(execute.Corpus, "_pivoted_table", _no_pivoted_table)
+    assert _search(deep_corpus, where) == pivoted
+
+
+def test_a_nested_correlation_binds_the_measurement_to_its_own_product(wide_corpus):
+    # ord-wd01 has a 90% yield on an undesired product in one outcome and a desired
+    # product with 10% in another; ord-wd02 has both on one product. Only the second
+    # answers, and a correlation that lost either ordinal would return both.
+    found = _search(
+        wide_corpus, _DIFFERENTIAL["a desired product with a yield above 50%"]
+    )
+    # ord-wd07 keeps both in one outcome, so only the product ordinal separates them.
+    assert found == {"ord-wd02"}

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -17,6 +17,7 @@
 import contextlib
 import logging
 import pathlib
+import re
 import threading
 import time
 from collections.abc import Iterator
@@ -2145,171 +2146,29 @@ def _tables(value) -> set[str]:
     return {row[0] for row in rows}
 
 
-def test_the_budget_is_a_share_of_the_machine_unless_stated(corpus_dir, monkeypatch):
-    # A fixed default cannot be right: ORD's inputs column is 4.07 GB materialized, so
-    # anything safe on a small machine refuses the columns most worth holding on a large
-    # one, and a refused column set is read from Parquet on every query that names it.
+def test_a_budget_no_memory_could_answer_to_is_refused(corpus_dir):
+    # Negative is not an amount of memory, and taken as one it makes every set too
+    # large and every eviction immediate, which reads as a corpus that cannot cache.
+    with pytest.raises(ValueError, match="not an amount of memory"):
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            narrow_budget_bytes=-1,
+        )
+    # Zero is an amount of memory, and a caller asking to materialize nothing means it.
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
+        narrow_budget_bytes=0,
     ) as value:
-        assert value._narrow_budget == execute._default_narrow_budget()
-        assert value._narrow_budget > 0
-    with execute.Corpus(
-        str(corpus_dir / "projections" / "*.parquet"),
-        str(corpus_dir / "structures" / "*.parquet"),
-        resolver={}.__getitem__,
-        narrow_budget_bytes=7,
-    ) as value:
-        # A caller who knows what else the machine is doing outranks the share.
-        assert value._narrow_budget == 7
-    # The share is of the machine, so a larger machine holds more of the corpus. Stated
-    # rather than read, since what this test asserts is the arithmetic and the machine
-    # running it is whatever it is.
-    machine = 64 * 1024**3
-    _state_machine_memory(monkeypatch, machine)
-    monkeypatch.setattr(execute, "_CGROUP_HIERARCHIES", ())
-    assert execute._default_narrow_budget() == int(
-        machine * execute._NARROW_BUDGET_FRACTION
-    )
-    # Where nothing states a limit, a figure stands rather than a share of nothing.
-    monkeypatch.setattr(execute.os, "sysconf_names", {})
-    assert execute._default_narrow_budget() == execute._NARROW_BUDGET_UNKNOWN_BYTES
-
-
-def _state_cgroup(monkeypatch, tmp_path, path: str, limits: dict[str, str]) -> None:
-    """Puts this process in a cgroup at ``path``, with the stated limits along it.
-
-    Args:
-        monkeypatch: The fixture, which points the module at the tree built here.
-        tmp_path: Where to build the tree.
-        path: The process's own cgroup, as ``/proc/self/cgroup`` states it.
-        limits: What each level from the mount down states, keyed by its path within
-            the mount; a level not named here states nothing, as most do not.
-    """
-    mount = tmp_path / "cgroup"
-    for level, stated in limits.items():
-        directory = mount.joinpath(*[part for part in level.split("/") if part])
-        directory.mkdir(parents=True, exist_ok=True)
-        (directory / "memory.max").write_text(stated)
-    proc = tmp_path / "proc_self_cgroup"
-    proc.write_text(f"0::{path}\n")
-    monkeypatch.setattr(execute, "_PROC_CGROUP", str(proc))
-    monkeypatch.setattr(
-        execute, "_CGROUP_HIERARCHIES", ((str(mount), "memory.max", ""),)
-    )
-
-
-def _state_machine_memory(monkeypatch, memory: int) -> None:
-    """Makes ``sysconf`` report a machine of the given size."""
-    monkeypatch.setattr(
-        execute.os,
-        "sysconf",
-        lambda name: {"SC_PAGE_SIZE": 4096, "SC_PHYS_PAGES": memory // 4096}[name],
-    )
-    monkeypatch.setattr(
-        execute.os, "sysconf_names", {"SC_PAGE_SIZE": 1, "SC_PHYS_PAGES": 2}
-    )
-
-
-def test_a_container_is_budgeted_by_what_it_may_hold_not_by_the_host(
-    tmp_path, monkeypatch
-):
-    # sysconf reports the host to a process a container limits to a fraction of it, so
-    # a corpus that budgeted by the host would hold memory it cannot have and be killed
-    # for it -- or starve whatever it shares the machine with.
-    _state_machine_memory(monkeypatch, 64 * 1024**3)
-    _state_cgroup(monkeypatch, tmp_path, "/", {"/": "8589934592\n"})
-    assert execute._default_narrow_budget() == int(
-        8 * 1024**3 * execute._NARROW_BUDGET_FRACTION
-    )
-    # A cgroup that limits nothing says so in words, and the host stands.
-    _state_cgroup(monkeypatch, tmp_path, "/", {"/": "max\n"})
-    assert execute._default_narrow_budget() == int(
-        64 * 1024**3 * execute._NARROW_BUDGET_FRACTION
-    )
-    # cgroup v1 spells the same thing as a number near the word size.
-    _state_cgroup(monkeypatch, tmp_path, "/", {"/": f"{(1 << 63) - 4096}\n"})
-    assert execute._default_narrow_budget() == int(
-        64 * 1024**3 * execute._NARROW_BUDGET_FRACTION
-    )
-    # Taken for a limit, that number is only harmless while something else states a
-    # smaller one. On a platform whose sysconf says nothing, a quarter of it is a
-    # budget no machine can hold, and every column set would be kept.
-    monkeypatch.setattr(execute.os, "sysconf_names", {})
-    assert execute._default_narrow_budget() == execute._NARROW_BUDGET_UNKNOWN_BYTES
-
-
-def test_the_smallest_limit_over_a_process_is_the_one_it_is_held_to(
-    tmp_path, monkeypatch
-):
-    # A service under a systemd slice, or a container run without a cgroup namespace of
-    # its own, sits below the mount root: the root states nothing and an ancestor states
-    # the limit. Reading the root alone would budget by the whole machine again.
-    _state_machine_memory(monkeypatch, 64 * 1024**3)
-    _state_cgroup(
-        monkeypatch,
-        tmp_path,
-        "/system.slice/ord.service",
-        {
-            "/": "max\n",
-            "/system.slice": "4294967296\n",  # 4 GB over everything in the slice.
-            "/system.slice/ord.service": "max\n",
-        },
-    )
-    assert execute._default_narrow_budget() == int(
-        4 * 1024**3 * execute._NARROW_BUDGET_FRACTION
-    )
-    # Its own is what holds when it is the smaller, whatever an ancestor allows.
-    _state_cgroup(
-        monkeypatch,
-        tmp_path,
-        "/system.slice/ord.service",
-        {
-            "/system.slice": "4294967296\n",
-            "/system.slice/ord.service": "1073741824\n",  # 1 GB
-        },
-    )
-    assert execute._default_narrow_budget() == int(
-        1024**3 * execute._NARROW_BUDGET_FRACTION
-    )
-    # A cgroup may ask for more than the one above it allows, and gets what the one
-    # above it allows. Reading the nearest limit rather than the smallest would believe
-    # the 8 GB and budget past what the process can hold.
-    _state_cgroup(
-        monkeypatch,
-        tmp_path,
-        "/system.slice/ord.service",
-        {
-            "/system.slice": "2147483648\n",  # 2 GB over the slice
-            "/system.slice/ord.service": "8589934592\n",  # 8 GB asked for below it
-        },
-    )
-    assert execute._default_narrow_budget() == int(
-        2 * 1024**3 * execute._NARROW_BUDGET_FRACTION
-    )
-
-
-def test_a_machine_that_will_not_say_how_large_it_is_does_not_stop_a_corpus(
-    corpus_dir, monkeypatch
-):
-    # sysconf names can exist and still be refused, and a default that raised there
-    # would fail to open a corpus rather than fall back to a figure.
-    def refusing(name):
-        raise OSError(f"no answer for {name}")
-
-    monkeypatch.setattr(execute.os, "sysconf", refusing)
-    monkeypatch.setattr(execute, "_CGROUP_HIERARCHIES", ())
-    assert execute._default_narrow_budget() == execute._NARROW_BUDGET_UNKNOWN_BYTES
-    monkeypatch.setattr(execute.os, "sysconf", lambda name: -1)
-    assert execute._default_narrow_budget() == execute._NARROW_BUDGET_UNKNOWN_BYTES
-    with execute.Corpus(
-        str(corpus_dir / "projections" / "*.parquet"),
-        str(corpus_dir / "structures" / "*.parquet"),
-        resolver={}.__getitem__,
-    ) as value:
-        assert value._narrow_budget == execute._NARROW_BUDGET_UNKNOWN_BYTES
+        value.search(
+            query.Query.model_validate(
+                {"where": {"op": "not_null", "path": "provenance.doi"}}
+            )
+        )
+        assert not value._narrowed
 
 
 def test_a_materialization_is_measured_in_bytes(corpus_dir):
@@ -2638,6 +2497,15 @@ def test_a_column_set_too_large_to_keep_says_so_and_says_what_to_change(
     request = query.Query.model_validate(
         {"where": {"op": "not_null", "path": "provenance.doi"}}
     )
+
+    def warnings() -> list[str]:
+        return [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelno >= logging.WARNING
+            and record.name == "ord_schema.agent.execute"
+        ]
+
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
@@ -2645,26 +2513,47 @@ def test_a_column_set_too_large_to_keep_says_so_and_says_what_to_change(
         narrow_budget_bytes=1,
     ) as value:
         value.search(request)
-        warned = [
-            record for record in caplog.records if record.levelno >= logging.WARNING
-        ]
-        assert len(warned) == 1
-        said = warned[0].getMessage()
+        assert len(warnings()) == 1
+        said = warnings()[0]
         assert "provenance" in said
         assert "narrow_budget_bytes" in said
+        assert execute._format_bytes(value._narrow_budget) in said
+        # Both figures have to be figures. Stated in gigabytes, a fixture costing
+        # kilobytes against a budget of one byte reads "0.0 GB over 0.0 GB", which
+        # names the problem in units that hide it.
+        assert "1 B" in said
+        assert re.search(r"takes \d+(\.\d+)? (kB|MB|GB)", said), said
         # Said again for the next query, since that query is slow for the same reason
         # and its asker was not necessarily watching when the corpus first found out.
         value.search(request)
-        assert (
-            len(
-                [
-                    record
-                    for record in caplog.records
-                    if record.levelno >= logging.WARNING
-                ]
-            )
-            == 2
-        )
+        assert len(warnings()) == 2
+
+
+def test_two_searches_wanting_one_refused_column_set_build_it_once(
+    corpus_dir, monkeypatch
+):
+    # The refusal is settled under the build lock as well as before it, so a search
+    # that waited out another's build finds the answer rather than repeating a pass
+    # over the corpus to reach the same refusal.
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        narrow_budget_bytes=1,
+    ) as value:
+        wanted = frozenset({"reaction_id", "conditions"})
+        with _stalled_build(value, monkeypatch):
+
+            def read() -> str | None:
+                with value._narrowed_table(wanted) as name:
+                    return name
+
+            second, answered = _in_a_thread(read)
+            second.join(timeout=1)
+            assert not answered, "the second ask did not wait for the build in flight"
+        second.join(timeout=30)
+        assert answered == [None]  # Refused, and told so rather than building again.
+        assert value._narrow_serial == 1
 
 
 def test_a_column_set_too_large_to_keep_is_not_built_twice(corpus_dir, monkeypatch):

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -2627,6 +2627,46 @@ def test_a_column_set_too_large_to_keep_is_not_kept(corpus_dir, monkeypatch):
         assert not value._narrowed
 
 
+def test_a_column_set_too_large_to_keep_says_so_and_says_what_to_change(
+    corpus_dir, caplog
+):
+    # The slowest thing a corpus does is answer from Parquet because a column set did
+    # not fit, and nothing about the answer says that is what happened. Whoever is
+    # asking why a query takes seconds is reading the log, so the log has to name the
+    # columns, the two figures, and the argument that changes it.
+    caplog.set_level(logging.INFO, logger="ord_schema.agent.execute")
+    request = query.Query.model_validate(
+        {"where": {"op": "not_null", "path": "provenance.doi"}}
+    )
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        narrow_budget_bytes=1,
+    ) as value:
+        value.search(request)
+        warned = [
+            record for record in caplog.records if record.levelno >= logging.WARNING
+        ]
+        assert len(warned) == 1
+        said = warned[0].getMessage()
+        assert "provenance" in said
+        assert "narrow_budget_bytes" in said
+        # Said again for the next query, since that query is slow for the same reason
+        # and its asker was not necessarily watching when the corpus first found out.
+        value.search(request)
+        assert (
+            len(
+                [
+                    record
+                    for record in caplog.records
+                    if record.levelno >= logging.WARNING
+                ]
+            )
+            == 2
+        )
+
+
 def test_a_column_set_too_large_to_keep_is_not_built_twice(corpus_dir, monkeypatch):
     # What the refusal costs is a pass over the corpus, and the projection it reads
     # does not change while the corpus is open. Asking again is the common case -- a

--- a/ord_schema/agent/execute_test.py
+++ b/ord_schema/agent/execute_test.py
@@ -2155,7 +2155,7 @@ def test_the_budget_is_a_share_of_the_machine_unless_stated(corpus_dir, monkeypa
         resolver={}.__getitem__,
     ) as value:
         assert value._narrow_budget == execute._default_narrow_budget()
-        assert value._narrow_budget >= execute._NARROW_BUDGET_FLOOR_BYTES
+        assert value._narrow_budget > 0
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
@@ -2168,20 +2168,77 @@ def test_the_budget_is_a_share_of_the_machine_unless_stated(corpus_dir, monkeypa
     # rather than read, since what this test asserts is the arithmetic and the machine
     # running it is whatever it is.
     machine = 64 * 1024**3
-    monkeypatch.setattr(
-        execute.os,
-        "sysconf",
-        lambda name: {
-            "SC_PAGE_SIZE": 4096,
-            "SC_PHYS_PAGES": machine // 4096,
-        }[name],
-    )
+    _state_machine_memory(monkeypatch, machine)
+    monkeypatch.setattr(execute, "_CGROUP_LIMITS", ())
     assert execute._default_narrow_budget() == int(
         machine * execute._NARROW_BUDGET_FRACTION
     )
-    # Where the memory cannot be read, the floor stands rather than a share of nothing.
+    # Where nothing states a limit, a figure stands rather than a share of nothing.
     monkeypatch.setattr(execute.os, "sysconf_names", {})
-    assert execute._default_narrow_budget() == execute._NARROW_BUDGET_FLOOR_BYTES
+    assert execute._default_narrow_budget() == execute._NARROW_BUDGET_UNKNOWN_BYTES
+
+
+def _state_machine_memory(monkeypatch, memory: int) -> None:
+    """Makes ``sysconf`` report a machine of the given size."""
+    monkeypatch.setattr(
+        execute.os,
+        "sysconf",
+        lambda name: {"SC_PAGE_SIZE": 4096, "SC_PHYS_PAGES": memory // 4096}[name],
+    )
+    monkeypatch.setattr(
+        execute.os, "sysconf_names", {"SC_PAGE_SIZE": 1, "SC_PHYS_PAGES": 2}
+    )
+
+
+def test_a_container_is_budgeted_by_what_it_may_hold_not_by_the_host(
+    tmp_path, monkeypatch
+):
+    # sysconf reports the host to a process a container limits to a fraction of it, so
+    # a corpus that budgeted by the host would hold memory it cannot have and be killed
+    # for it -- or starve whatever it shares the machine with.
+    _state_machine_memory(monkeypatch, 64 * 1024**3)
+    limit = tmp_path / "memory.max"
+    limit.write_text("8589934592\n")  # 8 GB, as a cgroup states it.
+    monkeypatch.setattr(execute, "_CGROUP_LIMITS", (str(limit),))
+    assert execute._default_narrow_budget() == int(
+        8 * 1024**3 * execute._NARROW_BUDGET_FRACTION
+    )
+    # A cgroup that limits nothing says so in words, and the host stands.
+    limit.write_text("max\n")
+    assert execute._default_narrow_budget() == int(
+        64 * 1024**3 * execute._NARROW_BUDGET_FRACTION
+    )
+    # cgroup v1 spells the same thing as a number near the word size.
+    limit.write_text(f"{(1 << 63) - 4096}\n")
+    assert execute._default_narrow_budget() == int(
+        64 * 1024**3 * execute._NARROW_BUDGET_FRACTION
+    )
+    # Taken for a limit, that number is only harmless while something else states a
+    # smaller one. On a platform whose sysconf says nothing, a quarter of it is a
+    # budget no machine can hold, and every column set would be kept.
+    monkeypatch.setattr(execute.os, "sysconf_names", {})
+    assert execute._default_narrow_budget() == execute._NARROW_BUDGET_UNKNOWN_BYTES
+
+
+def test_a_machine_that_will_not_say_how_large_it_is_does_not_stop_a_corpus(
+    corpus_dir, monkeypatch
+):
+    # sysconf names can exist and still be refused, and a default that raised there
+    # would fail to open a corpus rather than fall back to a figure.
+    def refusing(name):
+        raise OSError(f"no answer for {name}")
+
+    monkeypatch.setattr(execute.os, "sysconf", refusing)
+    monkeypatch.setattr(execute, "_CGROUP_LIMITS", ())
+    assert execute._default_narrow_budget() == execute._NARROW_BUDGET_UNKNOWN_BYTES
+    monkeypatch.setattr(execute.os, "sysconf", lambda name: -1)
+    assert execute._default_narrow_budget() == execute._NARROW_BUDGET_UNKNOWN_BYTES
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        assert value._narrow_budget == execute._NARROW_BUDGET_UNKNOWN_BYTES
 
 
 def test_a_materialization_is_measured_in_bytes(corpus_dir):

--- a/ord_schema/agent/pivot.py
+++ b/ord_schema/agent/pivot.py
@@ -1,0 +1,467 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The repeated levels of the projection, and what a pivot over one holds.
+
+A quantifier asks whether some element of a repeated level satisfies a body. Answering
+that from the projection means decoding the whole nested column and filtering its
+elements; answering it from a *pivot* -- one row per element -- means a semi-join
+against a flat table. Over ORD the second is milliseconds where the first is seconds,
+because the cost was never the predicate but the reconstruction of lists of structs.
+
+A pivot row carries three things:
+
+* ``reaction_id``, which is what the semi-join joins on.
+* The ordinal of every repeated level from the root down to and including this one.
+  Binding an element in the nested form gives co-membership structurally -- a
+  measurement reached through a product *belongs* to it. A flat row has to say so, and
+  a correlation joining on anything short of the full prefix over-returns.
+* ``element``, a struct holding the element's own fields with every repeated field
+  removed, recursively. Struct nesting is kept, so a path reaches the same leaf by the
+  same spelling on either route, and a body reaching a dropped field simply fails to
+  resolve -- which is how a quantifier the pivot cannot answer declines to the
+  projection without a flag anyone has to keep honest.
+
+Keeping the element's fields inside one struct rather than hoisting them is what makes
+the key columns safe: ``inputs.components.preparations`` carries a ``reaction_id`` of
+its own, and hoisted it would collide with the row's.
+
+A pivot is unfiltered -- every element gets a row, including one whose fields are all
+NULL. That completeness is what lets it answer ``forall``, which an index holding only
+the elements that match something never can.
+"""
+
+import dataclasses
+import os
+import pathlib
+
+import duckdb
+import inflection
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from ord_schema import artifacts, atomic_io, projection
+from ord_schema.logging import get_logger
+
+logger = get_logger(__name__)
+
+# The artifact name a pivot is stamped with, and the footer key naming which level it
+# holds. One artifact name covers every level, because they are one kind of thing
+# derived one way; the path is what tells them apart.
+ARTIFACT = "pivot"
+_META_PIVOT_PATH = "ord.pivot_path"
+
+# The column the element's own fields sit under, and the row's join key.
+ELEMENT = "element"
+REACTION_ID = "reaction_id"
+
+# What an ordinal is stored as. A reaction cannot hold four billion of anything at one
+# level, and the narrower column is the one a pivot carries once per row.
+ORDINAL_TYPE = pa.uint32()
+ORDINAL_SQL = "UINTEGER"
+
+
+@dataclasses.dataclass(frozen=True)
+class Step:
+    """One repeated level on the way to another, and how to reach it.
+
+    Attributes:
+        segments: The dotted hops from the previous element -- or from the row, for the
+            first step -- down to the repeated field itself.
+        is_map: Whether the repeated field is a map, whose values are the elements.
+        ordinal: The column naming this element's position among its siblings.
+    """
+
+    segments: tuple[str, ...]
+    is_map: bool
+    ordinal: str
+
+    def expression(self, source: str | None) -> str:
+        """Returns the list to unnest at this step.
+
+        Args:
+            source: The variable bound to the previous element, or None at the row.
+
+        Returns:
+            A DuckDB expression evaluating to a list. A map contributes its values,
+            since those are the elements a query quantifies over.
+        """
+        parts = self.segments if source is None else (source, *self.segments)
+        reached = ".".join(parts)
+        return f"map_values({reached})" if self.is_map else reached
+
+
+@dataclasses.dataclass(frozen=True)
+class RepeatedLevel:
+    """A repeated level of the projection, and the shape of a pivot over it.
+
+    Attributes:
+        path: The level as the query grammar names it, with no wrapper segments.
+        steps: One per repeated level from the root down to and including this one,
+            outermost first. Unnesting them in order is what a build walks, and their
+            ordinals are what a row carries to say which element it was.
+        element_type: The element's struct type with repeated fields removed
+            recursively, which is what a body must resolve against to be answerable
+            from the pivot.
+    """
+
+    path: str
+    steps: tuple[Step, ...]
+    element_type: pa.DataType
+
+    @property
+    def ordinals(self) -> tuple[str, ...]:
+        """Returns the ordinal column names, outermost first."""
+        return tuple(step.ordinal for step in self.steps)
+
+
+def _prune(dtype: pa.DataType) -> pa.DataType | None:
+    """Returns ``dtype`` without its repeated fields, or None if none are left.
+
+    Field metadata is carried through, since a comparison against an enum is checked
+    against the members recorded there and a pruned type that dropped them would refuse
+    a query the projection accepts.
+
+    Args:
+        dtype: A struct type to prune.
+
+    Returns:
+        The struct holding only the scalar and struct fields, recursively pruned, or
+        None if pruning empties it -- a level whose elements are entirely repeated has
+        nothing a pivot could hold.
+    """
+    fields = []
+    for field in dtype:
+        if pa.types.is_list(field.type) or pa.types.is_map(field.type):
+            continue
+        if pa.types.is_struct(field.type):
+            pruned = _prune(field.type)
+            if pruned is not None:
+                fields.append(
+                    pa.field(
+                        field.name,
+                        pruned,
+                        nullable=field.nullable,
+                        metadata=field.metadata,
+                    )
+                )
+        else:
+            fields.append(field)
+    return pa.struct(fields) if fields else None
+
+
+def repeated_levels(
+    schema: pa.Schema = projection.SCHEMA,
+) -> dict[str, RepeatedLevel]:
+    """Returns every repeated level of ``schema``, by the path a query names it.
+
+    Walked rather than listed by hand, in the same spirit as
+    ``structures.structure_levels``: a repeated field added upstream becomes a level
+    nobody had to remember to add, and one walk cannot disagree with itself the way two
+    lists can.
+
+    A list or a map is a repeated level; both are levels a query quantifies over, and
+    the grammar spells neither with a wrapper segment, so ``inputs.components`` names
+    the components under a map of inputs.
+
+    Args:
+        schema: Schema to walk; the projection schema by default.
+
+    Returns:
+        Each level's path mapped to what a pivot over it holds. A list of scalars is
+        absent -- there is no element struct to pivot -- and so is a level whose
+        elements carry nothing but repeated fields.
+
+    Raises:
+        ValueError: If two levels on one path yield the same ordinal name, which would
+            give a row two columns of that name and let the inner one silently win.
+            Raised at import, naming the ordinal, because the answer is to name it
+            differently here rather than to retry.
+    """
+    levels: dict[str, RepeatedLevel] = {}
+
+    def walk(
+        dtype: pa.DataType,
+        path: str,
+        steps: tuple[Step, ...],
+        pending: tuple[str, ...],
+    ) -> None:
+        if pa.types.is_list(dtype) or pa.types.is_map(dtype):
+            is_map = pa.types.is_map(dtype)
+            value = dtype.item_type if is_map else dtype.value_type
+            ordinal = f"{inflection.singularize(path.rsplit('.', 1)[-1])}_index"
+            if ordinal in [step.ordinal for step in steps]:
+                raise ValueError(
+                    f"{path} would carry two ordinals named {ordinal}, so a row's "
+                    "outer position would be overwritten by its inner one"
+                )
+            steps = (*steps, Step(pending, is_map, ordinal))
+            if pa.types.is_struct(value):
+                element = _prune(value)
+                if element is not None:
+                    levels[path] = RepeatedLevel(path, steps, element)
+            walk(value, path, steps, ())
+        elif pa.types.is_struct(dtype):
+            for field in dtype:
+                walk(
+                    field.type,
+                    f"{path}.{field.name}" if path else field.name,
+                    steps,
+                    (*pending, field.name),
+                )
+
+    for field in schema:
+        walk(field.type, field.name, (), (field.name,))
+    return levels
+
+
+def select(level: RepeatedLevel, table: str) -> str:
+    """Returns the query building the pivot over ``level``.
+
+    Unnests one repeated level at a time rather than taking the flattened traversal the
+    compiler uses, because the ordinals are what each unnest contributes and a list
+    already flattened has lost them.
+
+    Args:
+        level: The level to pivot.
+        table: The relation holding the reactions.
+
+    Returns:
+        A SELECT over ``table``, one row per element of the level.
+    """
+    froms, source = [table], None
+    for depth, step in enumerate(level.steps):
+        froms.append(
+            f"unnest({step.expression(source)}) WITH ORDINALITY "
+            f"AS u{depth}(e{depth}, {step.ordinal})"
+        )
+        source = f"e{depth}"
+    # Cast, because WITH ORDINALITY counts in BIGINT and an artifact's schema is a
+    # promise rather than whatever the build happened to produce.
+    ordinals = [f"{ordinal}::{ORDINAL_SQL} AS {ordinal}" for ordinal in level.ordinals]
+    selected = [
+        REACTION_ID,
+        *ordinals,
+        f"{element_expression(level.element_type, str(source))} AS {ELEMENT}",
+    ]
+    # S608: every fragment is this module's own walk of the projection schema.
+    return f"SELECT {', '.join(selected)} FROM {', '.join(froms)}"  # noqa: S608
+
+
+def schema(level: RepeatedLevel) -> pa.Schema:
+    """Returns the schema of a pivot artifact over ``level``.
+
+    Args:
+        level: The level the artifact holds.
+
+    Returns:
+        ``reaction_id``, one ordinal per repeated level above and including this one,
+        and the pruned element.
+    """
+    fields = [pa.field(REACTION_ID, pa.string())]
+    fields += [pa.field(ordinal, ORDINAL_TYPE) for ordinal in level.ordinals]
+    fields.append(pa.field(ELEMENT, level.element_type))
+    return pa.schema(fields)
+
+
+def element_expression(dtype: pa.DataType, source: str) -> str:
+    """Returns a struct literal rebuilding ``source`` without its repeated fields.
+
+    The pivot stores what a predicate can read rather than the whole element, which is
+    where the size comes down: the lists a build already unnested into their own levels
+    would otherwise be carried again on every row above them.
+
+    Args:
+        dtype: The pruned element type, as ``RepeatedLevel.element_type`` gives it.
+        source: The DuckDB expression bound to the element.
+
+    Returns:
+        A struct literal holding each kept field, recursing into kept structs.
+    """
+    parts = []
+    for field in dtype:
+        reached = f"{source}.{field.name}"
+        value = (
+            element_expression(field.type, reached)
+            if pa.types.is_struct(field.type)
+            else reached
+        )
+        parts.append(f"'{field.name}': {value}")
+    return "{" + ", ".join(parts) + "}"
+
+
+def reach(
+    path: str, levels: dict[str, RepeatedLevel] | None = None
+) -> tuple[RepeatedLevel, tuple[str, ...], pa.DataType] | None:
+    """Returns the pivot a quantifier over ``path`` ranges within, if one does.
+
+    A quantifier's path need not name a repeated level itself. Descending from one
+    through singular struct fields reaches one value per element rather than a list of
+    its own -- ``outcomes.products.measurements.authentic_standard`` is one compound per
+    measurement -- so the level it ranges over is the nearest repeated ancestor, and the
+    pivot over that level already carries the struct.
+
+    Args:
+        path: The dotted path the quantifier ranges over.
+        levels: Levels to search; the projection's by default.
+
+    Returns:
+        The level whose pivot holds it, the remaining segments from that level's
+        element down to the value, and the type they reach -- or None if no repeated
+        ancestor covers the path, or the descent leaves the element's pruned type,
+        which is where every repeated field it dropped would have been.
+    """
+    found = LEVELS if levels is None else levels
+    segments = path.split(".")
+    for cut in range(len(segments), 0, -1):
+        level = found.get(".".join(segments[:cut]))
+        if level is None:
+            continue
+        remainder = tuple(segments[cut:])
+        dtype = level.element_type
+        for segment in remainder:
+            if not pa.types.is_struct(dtype) or segment not in [
+                field.name for field in dtype
+            ]:
+                return None
+            dtype = dtype.field(segment).type
+        return level, remainder, dtype
+    return None
+
+
+def table_name(path: str) -> str:
+    """Returns the relation name holding the pivot over ``path``.
+
+    Args:
+        path: The level as the query grammar names it.
+
+    Returns:
+        A bare identifier, so it reaches SQL without quoting.
+    """
+    return f"pivot_{path.replace('.', '_')}"
+
+
+LEVELS = repeated_levels()
+
+
+def pivot_path(path: str | os.PathLike[str]) -> str | None:
+    """Returns the level a pivot artifact holds, or None if it holds none.
+
+    Args:
+        path: Path to a Parquet file.
+
+    Returns:
+        The dotted level path stamped in the footer, or None if the file is not a
+        pivot artifact.
+    """
+    metadata = pq.read_schema(path).metadata or {}
+    value = metadata.get(_META_PIVOT_PATH.encode())
+    return value.decode() if value is not None else None
+
+
+def write_pivot(
+    source: str | os.PathLike[str],
+    output: str | os.PathLike[str],
+    /,
+    *,
+    level_path: str,
+    source_md5: str | None = None,
+    source_dataset_id: str | None = None,
+    compression: str = "zstd",
+    row_group_size: int = 100_000,
+) -> int:
+    """Derives a pivot artifact over one repeated level and writes it.
+
+    One artifact holds one level of one projection, because the levels have different
+    schemas and a reader globs the one it wants. The rows stream out of DuckDB a batch
+    at a time, so a level that explodes -- a corpus of long measurement lists -- costs
+    a batch of memory rather than the whole level.
+
+    The output is published atomically, so a failure partway leaves any existing
+    artifact untouched.
+
+    Args:
+        source: Path to the projection to pivot.
+        output: Path to write the artifact to.
+        level_path: The repeated level to pivot, as the query grammar names it.
+        source_md5: Hash of the *source dataset* to stamp, if the caller already read
+            one. Taken from the projection's own stamps when omitted, so the artifact
+            names the dataset it reflects rather than the file it read.
+        source_dataset_id: Source dataset ID to stamp, if the caller already read one.
+            Taken from the projection's stamps when omitted.
+        compression: Parquet codec, any name ``pq.ParquetWriter`` accepts.
+        row_group_size: Rows per output row group, which is also how many elements are
+            held in memory at a time.
+
+    Returns:
+        Number of rows written: the number of elements at that level.
+
+    Raises:
+        ValueError: If ``source`` is not a current projection, or the schema has no
+            such repeated level.
+    """
+    level = LEVELS.get(level_path)
+    if level is None:
+        raise ValueError(
+            f"{level_path} is not a repeated level of the projection schema; "
+            f"a pivot has nothing to hold. Known levels: {sorted(LEVELS)}"
+        )
+    parent = artifacts.load_stamps(source)
+    if parent.artifact != projection.ARTIFACT:
+        raise ValueError(
+            f"{source} is a {parent.artifact}, not a {projection.ARTIFACT}; a pivot "
+            "unnests a projection"
+        )
+    # derive_tree refuses stale parents, but this writer is public and its output
+    # inherits the dataset hash: an artifact derived from a stale projection would
+    # claim a provenance it does not have and nothing would ever mark it stale again.
+    if not artifacts.stamps_are_current(parent, projection.ARTIFACT):
+        raise ValueError(
+            f"{source} is a stale {projection.ARTIFACT}; derive it again first"
+        )
+    if source_md5 is None:
+        source_md5 = parent.source_md5
+    if source_dataset_id is None:
+        source_dataset_id = parent.source_dataset_id
+    stamps = artifacts.current_stamps(ARTIFACT, source_dataset_id, source_md5)
+    metadata = artifacts.to_metadata(stamps) | {_META_PIVOT_PATH: level_path}
+    target = schema(level).with_metadata(metadata)
+    connection = duckdb.connect()
+    written = 0
+    try:
+        # Through the relational API rather than a path interpolated into SQL, which a
+        # filename holding a quote would otherwise close.
+        connection.read_parquet(str(pathlib.Path(source))).create_view("reactions")
+        result = connection.execute(select(level, "reactions"))
+        with (
+            atomic_io.atomic_path(output) as temp_path,
+            pq.ParquetWriter(temp_path, target, compression=compression) as writer,
+        ):
+            # A projection whose reactions record nothing at this level leaves the loop
+            # empty; the writer's close still produces a valid zero-row file carrying
+            # the schema and stamps, which is what a reader globs and finds nothing in
+            # rather than a file that is missing.
+            for batch in result.to_arrow_reader(row_group_size):
+                # Cast rather than trust: DuckDB's own widths are its business, and the
+                # artifact's schema is a promise to whoever reads it later.
+                writer.write_table(
+                    pa.Table.from_batches([batch])
+                    .cast(schema(level))
+                    .replace_schema_metadata(metadata)
+                )
+                written += batch.num_rows
+    finally:
+        connection.close()
+    logger.info("%s: %d elements at %s", source, written, level_path)
+    return written

--- a/ord_schema/agent/pivot_test.py
+++ b/ord_schema/agent/pivot_test.py
@@ -1,0 +1,278 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.agent.pivot."""
+
+import pathlib
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from ord_schema import artifacts, parquet, projection
+from ord_schema.agent import pivot
+from ord_schema.proto import dataset_pb2, reaction_pb2
+
+
+def test_covers_the_levels_a_query_quantifies_over():
+    levels = pivot.repeated_levels()
+    for path in (
+        "workups",
+        "inputs",
+        "inputs.components",
+        "outcomes",
+        "outcomes.products",
+        "outcomes.products.measurements",
+        "conditions.temperature.measurements",
+    ):
+        assert path in levels
+
+
+def test_ordinals_accumulate_down_the_path():
+    levels = pivot.repeated_levels()
+    assert levels["workups"].ordinals == ("workup_index",)
+    assert levels["outcomes"].ordinals == ("outcome_index",)
+    assert levels["outcomes.products"].ordinals == ("outcome_index", "product_index")
+    assert levels["outcomes.products.measurements"].ordinals == (
+        "outcome_index",
+        "product_index",
+        "measurement_index",
+    )
+    # A map is a repeated level too, so its components sit one ordinal deeper.
+    assert levels["inputs.components"].ordinals == ("input_index", "component_index")
+
+
+def test_element_type_drops_repeated_fields_and_keeps_structs():
+    element = pivot.repeated_levels()["outcomes.products"].element_type
+    names = [field.name for field in element]
+    assert "isolated_color" in names
+    assert "texture" in names
+    assert "measurements" not in names
+    assert "identifiers" not in names
+    assert "analyses" not in names
+    assert [field.name for field in element.field("texture").type] == [
+        "type",
+        "details",
+    ]
+
+
+def test_a_repeated_field_inside_a_kept_struct_is_dropped_too():
+    element = pivot.repeated_levels()["outcomes.products.measurements"].element_type
+    standard = element.field("authentic_standard").type
+    names = [field.name for field in standard]
+    assert "smiles" in names
+    assert "identifiers" not in names
+    assert "preparations" not in names
+
+
+def test_the_structure_id_is_kept():
+    # A pivot can answer a structure predicate, which needs the corpus-wide ID the
+    # schema marks internal for a model's benefit rather than this walk's.
+    element = pivot.repeated_levels()["inputs.components"].element_type
+    assert "structure_id" in [field.name for field in element]
+
+
+def test_a_level_whose_elements_are_all_repeated_is_not_covered():
+    schema = pa.schema(
+        [
+            pa.field(
+                "things",
+                pa.list_(pa.struct([pa.field("bits", pa.list_(pa.int32()))])),
+            )
+        ]
+    )
+    assert pivot.repeated_levels(schema) == {}
+
+
+def test_a_list_of_scalars_is_not_a_level():
+    schema = pa.schema([pa.field("names", pa.list_(pa.string()))])
+    assert pivot.repeated_levels(schema) == {}
+
+
+def test_enum_metadata_survives_pruning():
+    # The compiler validates an enum comparison against the members on the field, so a
+    # pruned type that dropped them would refuse a query the projection accepts.
+    element = pivot.repeated_levels()["inputs.components"].element_type
+    field = element.field("reaction_role")
+    assert field.metadata is not None
+
+
+def test_table_name_is_a_bare_identifier():
+    assert pivot.table_name("outcomes.products") == "pivot_outcomes_products"
+    assert pivot.table_name("workups") == "pivot_workups"
+
+
+def test_ordinals_that_would_collide_are_refused():
+    # Two segments singularizing to one name would give a row two columns of that name,
+    # and the second would silently win.
+    schema = pa.schema(
+        [
+            pa.field(
+                "analyses",
+                pa.list_(
+                    pa.struct(
+                        [
+                            pa.field(
+                                "analysis",
+                                pa.list_(pa.struct([pa.field("value", pa.int32())])),
+                            )
+                        ]
+                    )
+                ),
+            )
+        ]
+    )
+    with pytest.raises(ValueError, match="analysis_index"):
+        pivot.repeated_levels(schema)
+
+
+@pytest.fixture(scope="module")
+def projected(tmp_path_factory) -> pathlib.Path:
+    """A written projection with two outcomes on one reaction and none on another."""
+    root = tmp_path_factory.mktemp("pivot")
+    split = reaction_pb2.Reaction(reaction_id="ord-pv01")
+    first = split.outcomes.add()
+    first.products.add(isolated_color="white", is_desired_product=False)
+    second = split.outcomes.add()
+    second.products.add(isolated_color="yellow", is_desired_product=True)
+    second.products.add(isolated_color="red", is_desired_product=False)
+    source = root / "ord_dataset-pv.parquet"
+    parquet.save_dataset(
+        dataset_pb2.Dataset(
+            dataset_id="ord_dataset-pv",
+            name="test",
+            description="test",
+            reactions=[split, reaction_pb2.Reaction(reaction_id="ord-pv02")],
+        ),
+        str(source),
+    )
+    output = root / "projection.parquet"
+    projection.write_projection(source, output)
+    return output
+
+
+def test_a_written_pivot_carries_its_rows_and_its_ordinals(projected, tmp_path):
+    output = tmp_path / "products.parquet"
+    written = pivot.write_pivot(projected, output, level_path="outcomes.products")
+    assert written == 3
+    table = pq.read_table(output)
+    assert table.column_names == [
+        "reaction_id",
+        "outcome_index",
+        "product_index",
+        "element",
+    ]
+    rows = [
+        (
+            row["reaction_id"],
+            row["outcome_index"],
+            row["product_index"],
+            row["element"]["isolated_color"],
+        )
+        for row in table.to_pylist()
+    ]
+    assert sorted(rows) == [
+        ("ord-pv01", 1, 1, "white"),
+        ("ord-pv01", 2, 1, "yellow"),
+        ("ord-pv01", 2, 2, "red"),
+    ]
+
+
+def test_a_written_pivot_is_stamped_with_its_level(projected, tmp_path):
+    output = tmp_path / "products.parquet"
+    pivot.write_pivot(projected, output, level_path="outcomes.products")
+    stamps = artifacts.load_stamps(output)
+    assert stamps.artifact == pivot.ARTIFACT
+    assert stamps.source_dataset_id == "ord_dataset-pv"
+    assert stamps.source_md5 == artifacts.load_stamps(projected).source_md5
+    assert artifacts.stamps_are_current(stamps, pivot.ARTIFACT)
+    assert pivot.pivot_path(output) == "outcomes.products"
+
+
+def test_a_level_with_no_elements_still_writes_a_readable_file(projected, tmp_path):
+    # A reader globs the level it wants; a file that is missing and a file that is
+    # empty are different things, and only the second says the build ran.
+    output = tmp_path / "workups.parquet"
+    assert pivot.write_pivot(projected, output, level_path="workups") == 0
+    assert pq.read_table(output).num_rows == 0
+    assert pivot.pivot_path(output) == "workups"
+
+
+def test_a_path_that_is_not_a_level_is_refused(projected, tmp_path):
+    with pytest.raises(ValueError, match="not a repeated level"):
+        pivot.write_pivot(
+            projected, tmp_path / "x.parquet", level_path="conditions.temperature"
+        )
+
+
+def test_pivoting_something_that_is_not_a_projection_is_refused(projected, tmp_path):
+    output = tmp_path / "products.parquet"
+    pivot.write_pivot(projected, output, level_path="outcomes.products")
+    with pytest.raises(ValueError, match="not a projection"):
+        pivot.write_pivot(
+            output, tmp_path / "again.parquet", level_path="outcomes.products"
+        )
+
+
+def test_reach_finds_a_level_that_is_the_path_itself():
+    reached = pivot.reach("outcomes.products")
+    assert reached is not None
+    level, remainder, dtype = reached
+    assert level.path == "outcomes.products"
+    assert remainder == ()
+    assert dtype is level.element_type
+
+
+def test_reach_descends_to_a_singular_struct_under_a_level():
+    # One authentic standard per measurement rather than a list of its own, so the
+    # level it ranges over is the measurements, and the pivot over those carries it.
+    reached = pivot.reach("outcomes.products.measurements.authentic_standard")
+    assert reached is not None
+    level, remainder, dtype = reached
+    assert level.path == "outcomes.products.measurements"
+    assert remainder == ("authentic_standard",)
+    assert "smiles" in [field.name for field in dtype]
+
+
+def test_reach_declines_a_path_leaving_the_pruned_element():
+    # measurements is a repeated field of a product, so it is not on the pruned type;
+    # it is a level of its own, and reach finds that level rather than descending.
+    reached = pivot.reach("outcomes.products.measurements")
+    assert reached is not None
+    level, remainder, _ = reached
+    assert level.path == "outcomes.products.measurements"
+    assert remainder == ()
+    # A repeated field whose elements are scalars is no level of its own -- there is no
+    # element struct to pivot -- and pruning removed it from the measurement, so
+    # descending to it finds nothing either way.
+    assert (
+        pivot.reach("outcomes.products.measurements.mass_spec_details.eic_masses")
+        is None
+    )
+    # Whereas a repeated field of structs is a level, reached as itself rather than by
+    # descending into the measurement that holds it.
+    nested = pivot.reach(
+        "outcomes.products.measurements.authentic_standard.identifiers"
+    )
+    assert nested is not None
+    standard, remainder, _ = nested
+    assert standard.path == (
+        "outcomes.products.measurements.authentic_standard.identifiers"
+    )
+    assert remainder == ()
+
+
+def test_reach_declines_a_path_with_no_repeated_ancestor():
+    assert pivot.reach("conditions.temperature") is None
+    assert pivot.reach("reaction_id") is None

--- a/ord_schema/agent/query.py
+++ b/ord_schema/agent/query.py
@@ -22,8 +22,7 @@ function, so the worst program expressible in it is one pass over the corpus and
 sort. Expensive queries are not discouraged here; they are unwritable.
 
 It reaches every column the projection has, because a column is a *parameter* rather
-than part of the grammar. That is the difference between this and the per-predicate
-enumeration it replaces: adding a field upstream adds a queryable column and costs
+than part of the grammar: adding a field upstream adds a queryable column and costs
 nothing here.
 
 Two things the compiler settles that SQL leaves to whoever writes it:
@@ -91,7 +90,7 @@ ElementIndex = Callable[[str, dict[str, str], Callable[[], str]], str | None]
 
 
 def executable_schema(schema: pa.Schema | None = None) -> pa.Schema:
-    """Returns the schema of the relation a compiled query actually runs against.
+    """Returns the schema of the relation a compiled query runs against.
 
     The executor's relation is the projection plus ``STRUCTURE_OFFSET``, so validating
     compiled SQL (:func:`ord_schema.agent.sql.validate`) needs this schema whenever the
@@ -186,7 +185,7 @@ def _members(current: pa.Schema | pa.DataType) -> list[str]:
 def _lookup(
     current: pa.Schema | pa.DataType, name: str, path: str, allow_internal: bool
 ) -> pa.Field:
-    """Returns the field ``name`` within ``current``, or raises a helpful QueryError."""
+    """Returns the field ``name`` within ``current``, or raises QueryError."""
     members = _members(current)
     if name not in members:
         if not members:
@@ -633,8 +632,8 @@ def _element_terms(
         ``(structure, fields)``, where ``fields`` maps a field name to the literal it
         must equal, or None if the body is anything else -- a ``forall``, a negation, a
         disjunction, a nested quantifier, a comparison that is not an equality against a
-        string literal, a path that descends past the element, or a count of structure
-        predicates that is not exactly one.
+        string literal, a path that descends past the element, a field equated twice,
+        or a count of structure predicates that is not exactly one.
     """
     if node.op != "exists":
         return None

--- a/ord_schema/agent/query.py
+++ b/ord_schema/agent/query.py
@@ -69,6 +69,10 @@ from rdkit import Chem
 
 from ord_schema import projection
 
+# Aliased because ``pivot`` is the parameter name a caller passes an index under, and a
+# module shadowed inside the function that needs it is a bug waiting for an edit.
+from ord_schema.agent import pivot as pivot_levels
+
 # The relation a compiled query reads. The only one in scope, so nothing else is
 # nameable and a join has nothing to join to.
 TABLE = "reactions"
@@ -87,6 +91,38 @@ STRUCTURE_OFFSET = "structure_offset"
 # that takes the clause, because a parameter named and left unbound is an error rather
 # than a wasted name.
 ElementIndex = Callable[[str, dict[str, str], Callable[[], str]], str | None]
+
+
+# Consulted for a quantifier at the row, given the path it ranges over. Returns the
+# relation holding one row per element of that level, or None to leave the quantifier
+# compiled as a filter over the elements. What the rows carry is ``pivot.LEVELS``, which
+# this module reads from the schema rather than from the caller; the caller decides only
+# whether the relation exists.
+PivotIndex = Callable[[str], str | None]
+
+
+@dataclasses.dataclass(frozen=True)
+class _Routing:
+    """Where a quantifier may be answered, besides by filtering the elements.
+
+    Attributes:
+        table: The relation the query reads. Carried because a semi-join has to
+            qualify its correlation with it: the pivot holds a ``reaction_id`` of its
+            own, so an unqualified outer reference binds to the *inner* one and the
+            correlation compares a column to itself, which is true of every row.
+        index: An occurrence index, consulted for an ``exists`` at the row.
+        pivot: Pivoted levels, consulted after ``index`` and for ``forall`` too.
+        enclosing: The alias and level of the pivot this clause is compiling inside,
+            if it is inside one. A nested quantifier correlates to *that* rather than
+            to the row: its level's ordinals extend the enclosing level's, and joining
+            on the whole prefix is what keeps a measurement bound to the product it
+            was reached through.
+    """
+
+    table: str
+    index: ElementIndex | None = None
+    pivot: PivotIndex | None = None
+    enclosing: "tuple[str, pivot_levels.RepeatedLevel] | None" = None
 
 
 def executable_schema(schema: pa.Schema | None = None) -> pa.Schema:
@@ -660,6 +696,129 @@ def _element_terms(
     return structure, fields
 
 
+def _pivot_target(
+    path: str, routing: _Routing
+) -> "tuple[pivot_levels.RepeatedLevel, tuple[str, ...], pa.DataType] | None":
+    """Returns the pivot a quantifier over ``path`` would range within, or None.
+
+    Args:
+        path: The quantifier's path, relative to the enclosing element if there is one.
+        routing: Where this quantifier may be answered; its ``enclosing`` says which
+            element the path is relative to.
+
+    Returns:
+        The level, the remaining segments from its element down to the value, and the
+        type they reach -- or None if no pivot covers the path, or the level found is
+        not a descendant of the enclosing one, which leaves no ordinal prefix to say
+        which outer element an inner one belongs to.
+    """
+    if routing.enclosing is None:
+        return pivot_levels.reach(path)
+    alias_level = routing.enclosing[1]
+    # A nested quantifier's path is relative to the element it sits inside, so the
+    # level it names is that element's level extended by it.
+    reached = pivot_levels.reach(f"{alias_level.path}.{path}")
+    if reached is None:
+        return None
+    outer = alias_level.ordinals
+    return reached if reached[0].ordinals[: len(outer)] == outer else None
+
+
+def _pivoted(
+    node: "Quantifier",
+    compounds: list[str],
+    structures: list[StructureParameter],
+    depth: int,
+    routing: _Routing,
+) -> str | None:
+    """Returns a semi-join standing for a quantifier, or None to leave it to the level.
+
+    A pivot holds one row per element, so ``exists`` is a semi-join and ``forall`` is
+    the absence of a counterexample. Both are written as ``EXISTS`` rather than ``IN``:
+    a NULL ``reaction_id`` would make ``NOT IN`` answer NULL for every reaction and
+    return nothing, where ``NOT EXISTS`` answers the same on a corpus that has one and
+    on a corpus that does not.
+
+    The body compiles against the element's *pruned* type, so a path reaching a field
+    the pivot dropped -- anything repeated -- raises and this declines, leaving the
+    quantifier to the elements. That is what keeps the covered set honest without a
+    second list of what a pivot can answer.
+
+    A level the source never recorded has no rows here, which is what the nested form
+    means by folding NULL to an empty level: no element satisfies an ``exists``, and a
+    ``forall`` has no counterexample.
+
+    Args:
+        node: The quantifier to compile.
+        compounds: Compound names collected so far, appended to by the body.
+        structures: Structure parameters collected so far, appended to by the body.
+        depth: How many quantifiers enclose this one, which names its variable.
+        routing: Where this quantifier may be answered; its ``pivot`` names the
+            relation, and its ``table`` qualifies the correlation.
+
+    Returns:
+        The condition, or None if no pivot holds the level or the body asks for
+        something its rows do not carry.
+    """
+    if routing.pivot is None:
+        return None
+    reached = _pivot_target(node.path, routing)
+    if reached is None:
+        return None
+    level, remainder, element_type = reached
+    variable = f"x{depth}"
+    # Compiled into throwaway lists: a body that raises partway would otherwise leave
+    # this quantifier's parameters behind for a compilation that no longer wants them.
+    taken_compounds, taken_structures = list(compounds), list(structures)
+    try:
+        body = _predicate(
+            node.where,
+            ".".join([variable, pivot_levels.ELEMENT, *remainder]),
+            element_type,
+            taken_compounds,
+            taken_structures,
+            depth + 1,
+            dataclasses.replace(routing, enclosing=(variable, level)),
+        )
+    except QueryError:
+        return None
+    # Asked for only once the body is known to resolve, because supplying a pivot is
+    # what builds it: a level unnested over ORD is minutes, and a body reaching a
+    # repeated field would otherwise pay them and then decline anyway.
+    table = routing.pivot(level.path)
+    if table is None:
+        return None
+    compounds[:], structures[:] = taken_compounds, taken_structures
+    # S608: the relation is named by this module's own walk of the schema, and every
+    # fragment of the body is an expression resolved against that walk's element type.
+    if routing.enclosing is None:
+        correlation = [
+            f"{variable}.{pivot_levels.REACTION_ID} = "
+            f"{routing.table}.{pivot_levels.REACTION_ID}"
+        ]
+    else:
+        alias, outer_level = routing.enclosing
+        # Joined on the whole ordinal prefix, not merely the reaction: a measurement
+        # reached through a product belongs to *that* product, and correlating on
+        # anything less returns reactions where the two clauses hold of different
+        # elements.
+        correlation = [
+            f"{variable}.{pivot_levels.REACTION_ID} = "
+            f"{alias}.{pivot_levels.REACTION_ID}",
+            *(
+                f"{variable}.{ordinal} = {alias}.{ordinal}"
+                for ordinal in outer_level.ordinals
+            ),
+        ]
+    inner = (
+        f"SELECT 1 FROM {table} AS {variable} "  # noqa: S608
+        f"WHERE {' AND '.join(correlation)} AND "
+    )
+    if node.op == "exists":
+        return f"EXISTS ({inner}{body})"
+    return f"NOT EXISTS ({inner}NOT ({body}))"
+
+
 def _quantifier(
     node: "Quantifier",
     scope: str | None,
@@ -667,7 +826,7 @@ def _quantifier(
     compounds: list[str],
     structures: list[StructureParameter],
     depth: int,
-    index: ElementIndex | None = None,
+    routing: _Routing,
 ) -> str:
     """Compiles a quantifier to a filter over the elements at a repeated level.
 
@@ -688,7 +847,10 @@ def _quantifier(
         compounds: Compound names collected so far, appended to by the body.
         structures: Structure parameters collected so far, appended to by the body.
         depth: How many quantifiers enclose this one, which names its variable.
-        index: Consulted for an ``exists`` at the row; see ``ElementIndex``.
+        routing: Where this quantifier may be answered besides the elements. Its
+            ``index`` is consulted for an ``exists`` at the row; its ``pivot`` is
+            consulted after that, and for ``forall`` too, because a pivot holds every
+            element rather than only the ones carrying a structure.
 
     Returns:
         The DuckDB expression filtering the level, true when the quantifier holds. A
@@ -703,6 +865,13 @@ def _quantifier(
     Raises:
         QueryError: If the path does not reach a repeated level.
     """
+    # Offered before the path is resolved, because inside a pivot it cannot be: the
+    # enclosing element's type is pruned of exactly the repeated fields a nested
+    # quantifier ranges over, so resolving first would raise and decline every one.
+    if routing.pivot is not None and routing.enclosing is not None:
+        condition = _pivoted(node, compounds, structures, depth, routing)
+        if condition is not None:
+            return condition
     resolved = resolve(node.path, schema=schema, root=scope)
     if not resolved.repeated:
         raise QueryError(
@@ -712,21 +881,33 @@ def _quantifier(
     # Offered at the row only. A nested quantifier's path is element-relative and would
     # not match an index's absolute paths anyway, so the scope check is defense in
     # depth rather than the working guard.
-    if index is not None and scope is None:
+    if routing.index is not None and scope is None:
         terms = _element_terms(node)
         if terms is not None:
             structure, fields = terms
             # The thunk defers naming the structure parameter until the index accepts.
             # A declined clause allocates through its element compilation instead, and
             # _structure_parameter dedupes by content, so early or late it is one name.
-            condition = index(
+            condition = routing.index(
                 node.path, fields, lambda: _structure_parameter(structure, structures)
             )
             if condition is not None:
                 return condition
+    # A nested quantifier was offered the pivot above, before its path was resolved.
+    # Inside a list lambda there is nothing to correlate to, so the elements answer it.
+    if routing.pivot is not None and scope is None:
+        condition = _pivoted(node, compounds, structures, depth, routing)
+        if condition is not None:
+            return condition
     variable = f"e{depth}"
     body = _predicate(
-        node.where, variable, resolved.type, compounds, structures, depth + 1, index
+        node.where,
+        variable,
+        resolved.type,
+        compounds,
+        structures,
+        depth + 1,
+        routing,
     )
     if node.op == "exists":
         return (
@@ -747,7 +928,7 @@ def _predicate(
     compounds: list[str],
     structures: list[StructureParameter],
     depth: int,
-    index: ElementIndex | None = None,
+    routing: _Routing,
 ) -> str:
     """Compiles one predicate node to a boolean DuckDB expression.
 
@@ -763,7 +944,8 @@ def _predicate(
         compounds: Compound names collected so far, appended to as they are met.
         structures: Structure parameters collected so far, appended to as they are met.
         depth: How many quantifiers enclose this clause, which names their variables.
-        index: Offered to an ``exists`` at the row; see ``ElementIndex``.
+        routing: Where a quantifier may be answered besides the elements; carried
+            down unchanged. See ``_Routing``.
 
     Returns:
         The DuckDB expression, true when the clause holds of the row or element.
@@ -777,18 +959,18 @@ def _predicate(
         return (
             "("
             + keyword.join(
-                _predicate(clause, scope, schema, compounds, structures, depth, index)
+                _predicate(clause, scope, schema, compounds, structures, depth, routing)
                 for clause in node.clauses
             )
             + ")"
         )
     if isinstance(node, Not):
         inner = _predicate(
-            node.clause, scope, schema, compounds, structures, depth, index
+            node.clause, scope, schema, compounds, structures, depth, routing
         )
         return f"(NOT {inner})"
     if isinstance(node, Quantifier):
-        return _quantifier(node, scope, schema, compounds, structures, depth, index)
+        return _quantifier(node, scope, schema, compounds, structures, depth, routing)
     if isinstance(node, Substructure | Similarity):
         return _structure(node, scope, schema, structures)
     resolved = resolve(node.path, schema=schema, root=scope)
@@ -814,6 +996,7 @@ def compile_query(
     schema: pa.Schema = projection.SCHEMA,
     table: str = TABLE,
     index: ElementIndex | None = None,
+    pivot: PivotIndex | None = None,
 ) -> Compiled:
     """Compiles a query to DuckDB SQL over the projection.
 
@@ -827,6 +1010,9 @@ def compile_query(
         index: An element index to spend where it can answer a quantifier; see
             ``ElementIndex``. Without one, every quantifier compiles to a filter over
             the elements, which is what the projection alone can answer.
+        pivot: Pivoted levels to spend where they can answer a quantifier; see
+            ``PivotIndex``. Consulted after ``index``, and for ``forall`` as well as
+            ``exists``.
 
     Returns:
         The SQL, the compound names whose resolved SMILES the caller binds, and the
@@ -866,7 +1052,13 @@ def compile_query(
     sql = f"SELECT {', '.join(selected)} FROM {table}"  # noqa: S608
     if query.where is not None:
         sql += " WHERE " + _predicate(
-            query.where, None, schema, compounds, structures, 0, index
+            query.where,
+            None,
+            schema,
+            compounds,
+            structures,
+            0,
+            _Routing(table, index, pivot),
         )
     taken = {parameter.name for parameter in structures}
     collisions = sorted(taken & set(compounds))

--- a/ord_schema/agent/query_test.py
+++ b/ord_schema/agent/query_test.py
@@ -22,7 +22,7 @@ from pydantic import ValidationError
 from rdkit import Chem
 
 from ord_schema import projection
-from ord_schema.agent import query, sql
+from ord_schema.agent import pivot, query, sql
 
 
 def _compile(payload):
@@ -672,3 +672,269 @@ def test_a_compound_named_like_a_structure_parameter_is_refused():
                 }
             )
         )
+
+
+def _pivot_sql(body, pivot=None):
+    return query.compile_query(query.Query.model_validate(body), pivot=pivot).sql
+
+
+def _every_level(path):
+    return pivot.table_name(path) if path in pivot.LEVELS else None
+
+
+def test_exists_over_a_pivoted_level_becomes_a_semi_join():
+    sql = _pivot_sql(
+        {
+            "where": {
+                "op": "exists",
+                "path": "workups",
+                "where": {
+                    "op": "eq",
+                    "path": "type",
+                    "value": {"literal": "EXTRACTION"},
+                },
+            }
+        },
+        pivot=_every_level,
+    )
+    assert "EXISTS (SELECT 1 FROM pivot_workups AS x0" in sql
+    # Qualified on both sides. A pivot carries a reaction_id of its own, so an
+    # unqualified outer reference binds to the inner one and the correlation compares a
+    # column to itself -- true of every reaction that has any element at all.
+    assert "x0.reaction_id = reactions.reaction_id" in sql
+    assert "x0.element.type" in sql
+    assert "list_filter" not in sql
+
+
+def test_forall_over_a_pivoted_level_becomes_a_negated_semi_join():
+    sql = _pivot_sql(
+        {
+            "where": {
+                "op": "forall",
+                "path": "workups",
+                "where": {
+                    "op": "eq",
+                    "path": "type",
+                    "value": {"literal": "EXTRACTION"},
+                },
+            }
+        },
+        pivot=_every_level,
+    )
+    assert sql.count("NOT EXISTS (SELECT 1 FROM pivot_workups AS x0") == 1
+    assert "NOT IN" not in sql
+    assert "list_filter" not in sql
+
+
+def test_a_nested_quantifier_joins_on_the_whole_ordinal_prefix():
+    # The correctness point the ordinals exist for. Correlating a measurement to its
+    # product on the reaction alone returned 23,608 reactions over ORD where the answer
+    # is 22,666 -- and dropping only the outcome ordinal changed nothing at all, since
+    # the corpus is effectively single-outcome, which is what made it look right.
+    sql = _pivot_sql(
+        {
+            "where": {
+                "op": "exists",
+                "path": "outcomes.products",
+                "where": {
+                    "op": "and",
+                    "clauses": [
+                        {
+                            "op": "eq",
+                            "path": "is_desired_product",
+                            "value": {"literal": True},
+                        },
+                        {
+                            "op": "exists",
+                            "path": "measurements",
+                            "where": {
+                                "op": "eq",
+                                "path": "type",
+                                "value": {"literal": "YIELD"},
+                            },
+                        },
+                    ],
+                },
+            }
+        },
+        pivot=_every_level,
+    )
+    assert "FROM pivot_outcomes_products_measurements AS x1" in sql
+    assert "x1.reaction_id = x0.reaction_id" in sql
+    assert "x1.outcome_index = x0.outcome_index" in sql
+    assert "x1.product_index = x0.product_index" in sql
+    assert "list_filter" not in sql
+
+
+def test_a_quantifier_inside_a_list_lambda_is_left_to_the_elements():
+    # With the outer level unavailable there is no alias to correlate to, so the inner
+    # quantifier compiles over the elements rather than against a pivot keyed by
+    # nothing.
+    sql = _pivot_sql(
+        {
+            "where": {
+                "op": "exists",
+                "path": "outcomes.products",
+                "where": {
+                    "op": "exists",
+                    "path": "measurements",
+                    "where": {
+                        "op": "eq",
+                        "path": "type",
+                        "value": {"literal": "YIELD"},
+                    },
+                },
+            }
+        },
+        pivot=lambda path: None,
+    )
+    assert "pivot_" not in sql
+    assert sql.count("list_filter") == 2
+
+
+def test_a_declined_body_leaves_no_parameters_behind():
+    # The structure clause compiles -- and names its parameter -- before the nested
+    # quantifier reaches a field the pruned type dropped. That name must not survive
+    # the decline, or the query would carry a parameter nothing binds.
+    compiled = query.compile_query(
+        query.Query.model_validate(
+            {
+                "where": {
+                    "op": "exists",
+                    "path": "outcomes.products",
+                    "where": {
+                        "op": "and",
+                        "clauses": [
+                            {
+                                "op": "substructure",
+                                "path": "smiles",
+                                "smarts": "c1ccncc1",
+                            },
+                            {
+                                "op": "exists",
+                                "path": "measurements",
+                                "where": {
+                                    "op": "eq",
+                                    "path": "type",
+                                    "value": {"literal": "YIELD"},
+                                },
+                            },
+                        ],
+                    },
+                }
+            }
+        ),
+        # The measurements level is refused -- a budget may do exactly this -- so the
+        # inner quantifier declines, the outer body fails to resolve against the pruned
+        # type, and the outer declines with it.
+        pivot=lambda path: (
+            None if path == "outcomes.products.measurements" else _every_level(path)
+        ),
+    )
+    assert "pivot_" not in compiled.sql
+    assert len(compiled.structures) == 1
+
+
+def test_without_a_pivot_the_sql_is_unchanged():
+    body = {
+        "where": {
+            "op": "exists",
+            "path": "workups",
+            "where": {
+                "op": "eq",
+                "path": "type",
+                "value": {"literal": "EXTRACTION"},
+            },
+        }
+    }
+    assert _pivot_sql(body) == _pivot_sql(body, pivot=lambda path: None)
+
+
+def test_a_structure_predicate_routes_through_the_pivot_with_the_outer_offset():
+    # The occurrence index declines a body that is not one structure predicate plus
+    # string equalities, so this lands on the pivot. Its rows carry structure_id but no
+    # structure_offset, and the bitmap is indexed by the two added: the offset resolves
+    # outward to the reaction the element belongs to, which is the one its ID is meant
+    # to be read against. Pinned here because it holds by name resolution -- a pivot
+    # that ever carried an offset column of its own would bind inward instead.
+    compiled = query.compile_query(
+        query.Query.model_validate(
+            {
+                "where": {
+                    "op": "exists",
+                    "path": "inputs.components",
+                    "where": {
+                        "op": "and",
+                        "clauses": [
+                            {
+                                "op": "substructure",
+                                "path": "smiles",
+                                "smarts": "c1ccncc1",
+                            },
+                            {"op": "not_null", "path": "smiles"},
+                        ],
+                    },
+                }
+            }
+        ),
+        pivot=_every_level,
+    )
+    assert "EXISTS (SELECT 1 FROM pivot_inputs_components AS x0" in compiled.sql
+    assert "x0.element.structure_id" in compiled.sql
+    # Unqualified, so it is the enclosing relation's column rather than one of the
+    # pivot's; the pivot has none.
+    assert "+ structure_offset)" in compiled.sql
+    assert "x0.structure_offset" not in compiled.sql
+    assert len(compiled.structures) == 1
+
+
+def test_a_declining_body_is_never_charged_for_a_pivot():
+    # Supplying a pivot is what builds it, and over ORD that is minutes per level. A
+    # body reaching a repeated field declines, so it must not ask for one first.
+    asked = []
+
+    def watched(path):
+        asked.append(path)
+        return _every_level(path)
+
+    query.compile_query(
+        query.Query.model_validate(
+            {
+                "where": {
+                    "op": "exists",
+                    "path": "workups",
+                    "where": {
+                        "op": "exists",
+                        "path": "input.components",
+                        "where": {
+                            "op": "eq",
+                            "path": "reaction_role",
+                            "value": {"literal": "SOLVENT"},
+                        },
+                    },
+                }
+            }
+        ),
+        pivot=lambda path: (
+            None if path == "workups.input.components" else watched(path)
+        ),
+    )
+    # The inner level was refused, so the outer body could not resolve and the outer
+    # level was never asked for -- which is what stops a declining query from paying
+    # for a table it will not use.
+    assert asked == []
+
+
+def test_a_singular_struct_routes_to_its_ancestor_level_s_pivot():
+    sql = _pivot_sql(
+        {
+            "where": {
+                "op": "exists",
+                "path": "outcomes.products.measurements.authentic_standard",
+                "where": {"op": "not_null", "path": "smiles"},
+            }
+        },
+        pivot=_every_level,
+    )
+    assert "FROM pivot_outcomes_products_measurements AS x0" in sql
+    assert "x0.element.authentic_standard.smiles" in sql

--- a/ord_schema/agent/schema.py
+++ b/ord_schema/agent/schema.py
@@ -33,8 +33,7 @@ against cannot disagree.
 
 Types are named in DuckDB's vocabulary rather than Arrow's, since DuckDB is the dialect
 the model writes. Units are already in the column names -- ``setpoint_kelvin``,
-``mass_grams`` -- so the tree carries them without a word of prose, and nothing has to
-explain that temperatures are kelvin.
+``mass_grams`` -- so the tree carries them without a word of prose.
 """
 
 import pyarrow as pa

--- a/ord_schema/artifacts.py
+++ b/ord_schema/artifacts.py
@@ -12,18 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared mechanics for derived artifacts: footer stamps, and the derive-a-tree driver.
+"""Shared mechanics for derived artifacts: footer stamps and the derive-a-tree driver.
 
 A derived artifact restates a source dataset in a queryable shape. It adds no
 information, so it is wrong if it disagrees with its source and stale if its source has
 moved on. These stamps make both conditions detectable without reading column data.
 
 More than one artifact is expected -- a projection carrying every field, structures
-pulled out of it for search, and pivoted indexes over the paths that turn out to be
-hot -- so the parts that do not vary between them live here: the stamps, the
-output-path mapping, and the driver that walks a glob, refuses to write over what it
-reads, ignores matches that are not the kind of parent it derives from, and skips what
-is current. An artifact module supplies only its schema, its projection, and its name.
+pulled out of it for search, and pivoted indexes over the paths that turn out to be hot
+-- so the parts that do not vary between them live here: the stamps, the output-path
+mapping, and the driver that walks a glob, refuses to write over what it reads, and
+skips what is current. An artifact module supplies only its schema, its projection, and
+its name.
 
 An artifact may derive from another rather than from a source dataset, which is how the
 structures artifact reaches the projection's columns without recomputing them. Only the
@@ -47,10 +47,10 @@ already uses for source datasets:
 * ``ord.ord_schema_version`` -- what derived it.
 * ``ord.rdkit_version`` -- the RDKit that derived it. Every artifact leans on RDKit --
   canonical SMILES in the projection, fingerprints in the structures artifact -- and
-  RDKit releases have changed both canonicalization and pattern
-  fingerprints, either of which silently breaks an artifact whose consumers run the new
-  RDKit against files built by the old. Optional to *read* so that files stamped before
-  the key existed still load; absent reads as stale, which rebuilds them.
+  RDKit releases have changed both canonicalization and pattern fingerprints, either of
+  which silently breaks an artifact whose consumers run the new RDKit against files
+  built by the old. Optional to *read* so that a file stamped before the key existed
+  still loads; absent reads as stale, which rebuilds it.
 * ``ord.source_dataset_id`` -- the source's ID, written only when the source records
   one, and so the only key not required to read stamps back.
 
@@ -398,13 +398,13 @@ def _parent_provenance(
     derivations away it sits, and a consumer checks an artifact against the dataset in
     one hop.
 
-    Passing the hash through carries the source content across the hop but not the two
+    Passing the hash through carries the source content across the hop but not the
     version stamps, which describe whoever wrote each file. A stale parent is therefore
     refused rather than read: an artifact derived from one would stamp itself with the
     *current* versions while holding what an older definition produced, and since the
     dataset hash it inherits does not change when the parent is rebuilt, nothing would
-    ever mark it stale again. Refusing keeps the three terms ``is_current`` compares
-    true of a chained artifact as well as a directly derived one.
+    ever mark it stale again. Refusing keeps every term ``is_current`` compares true of
+    a chained artifact as well as a directly derived one.
 
     Args:
         parent: Path to the file being derived from.
@@ -449,8 +449,7 @@ def derive_tree(
     Outputs mirror the inputs' directory layout beneath ``output_dir``. Matches that are
     not the kind of parent this derivation reads are ignored, so a recursive pattern
     reaching the output tree stays re-runnable. Artifacts whose footer already records
-    the current source content, library version, and artifact version are skipped, so
-    re-running is cheap.
+    the current source content and versions are skipped, so re-running is cheap.
 
     Args:
         input_pattern: Glob matching the files to derive from.

--- a/ord_schema/scripts/derive_pivots.py
+++ b/ord_schema/scripts/derive_pivots.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Derives pivot artifacts from projections, one per repeated level.
+
+A quantifier over a repeated level is answered by a semi-join against a pivot -- one
+row per element, carrying the ordinals that say which element it was and the element's
+own fields with the repeated ones removed; see ``ord_schema.agent.pivot`` for the shape
+and why. Building one unnests the projection, which is minutes per level over ORD, so
+it belongs here rather than in whichever query asks first.
+
+Each level gets its own subdirectory, and each projection its own file within it::
+
+    derive_pivots.py --input_pattern='projections/*/*.parquet' --output_dir=pivots
+
+    projections/aa/ord_dataset-<id>.parquet
+        -> pivots/outcomes.products/aa/ord_dataset-<id>.parquet
+        -> pivots/inputs.components/aa/ord_dataset-<id>.parquet
+
+That is the layout ``Corpus(..., pivots_dir=...)`` reads. Levels are chosen with
+--levels; the default is every level the schema has, which is far more than a corpus is
+usually asked about, so naming the ones a deployment answers questions over is the
+cheaper run.
+
+Artifacts whose footer already records the current source content, library version, and
+artifact version are skipped, so re-running is cheap; --force rewrites them anyway.
+
+A match that is not a projection -- a source dataset, or an artifact from an earlier
+run -- is ignored rather than derived from, so --output_dir may sit inside a recursive
+pattern's reach. These are errors: an --output_dir that would write over any input, a
+match that cannot be read as Parquet at all, a level the schema does not have, and a
+run that finds no projections at all.
+"""
+
+import argparse
+import functools
+import pathlib
+
+from ord_schema import artifacts, projection
+from ord_schema.agent import pivot
+from ord_schema.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parses command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--input_pattern", required=True, help="Input pattern for Parquet projections"
+    )
+    parser.add_argument(
+        "--output_dir", required=True, help="Directory to write artifacts beneath"
+    )
+    parser.add_argument(
+        "--levels",
+        nargs="+",
+        default=sorted(pivot.LEVELS),
+        help="Repeated levels to pivot; every level in the schema by default",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Rewrite artifacts that are already current",
+    )
+    return parser.parse_args(argv)
+
+
+def main(args: argparse.Namespace) -> None:
+    """Derives a pivot artifact per level for every projection matching the pattern.
+
+    Args:
+        args: Parsed arguments, read for ``input_pattern``, ``output_dir``, ``levels``,
+            and ``force``.
+
+    Raises:
+        ValueError: If a requested level is not one the projection schema has, or if
+            the pattern matched no projections -- which usually means it was aimed at
+            the source tree, or at an output tree, rather than at the projections.
+            Silence there would let a pipeline step downstream proceed as though the
+            artifacts had been built.
+    """
+    unknown = sorted(set(args.levels) - set(pivot.LEVELS))
+    if unknown:
+        raise ValueError(
+            f"not repeated levels of the projection schema: {unknown}; "
+            f"known levels are {sorted(pivot.LEVELS)}"
+        )
+    for level_path in args.levels:
+        written, skipped, ignored = artifacts.derive_tree(
+            args.input_pattern,
+            str(pathlib.Path(args.output_dir) / level_path),
+            artifact=pivot.ARTIFACT,
+            write=functools.partial(pivot.write_pivot, level_path=level_path),
+            force=args.force,
+            parent_artifact=projection.ARTIFACT,
+        )
+        if not written and not skipped:
+            raise ValueError(
+                f"no pivots derived for {level_path}: none of the {ignored} matches "
+                f"for {args.input_pattern!r} are projections"
+            )
+        logger.info("%s: %d written, %d already current", level_path, written, skipped)
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/ord_schema/scripts/derive_pivots_test.py
+++ b/ord_schema/scripts/derive_pivots_test.py
@@ -1,0 +1,160 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.scripts.derive_pivots.
+
+Artifact behavior is covered in ord_schema.agent.pivot_test; these cover the CLI: the
+per-level layout a Corpus reads, which matches count as sources, the skip-if-current
+shortcut, and how an unknown level is refused.
+"""
+
+import logging
+import pathlib
+
+import pytest
+
+from ord_schema import artifacts, parquet
+from ord_schema.agent import execute, pivot, query
+from ord_schema.proto import dataset_pb2, reaction_pb2
+from ord_schema.scripts import derive_pivots, derive_projection, derive_structures
+
+
+def _dataset(dataset_id: str):
+    reaction = reaction_pb2.Reaction(reaction_id=f"ord-{dataset_id}-01")
+    reaction.inputs["a"].components.add().identifiers.add(
+        type="SMILES", value="c1ccccc1"
+    )
+    reaction.workups.add(type="EXTRACTION")
+    reaction.outcomes.add().products.add(isolated_color="white")
+    return dataset_pb2.Dataset(
+        dataset_id=dataset_id, name="test", description="desc", reactions=[reaction]
+    )
+
+
+@pytest.fixture
+def projected(tmp_path) -> pathlib.Path:
+    """Writes two shards of projections, and returns the root holding them."""
+    for shard in ("aa", "bb"):
+        directory = tmp_path / "data" / shard
+        directory.mkdir(parents=True, exist_ok=True)
+        parquet.save_dataset(
+            _dataset(f"ord_dataset-{shard}"),
+            str(directory / f"ord_dataset-{shard}.parquet"),
+        )
+    derive_projection.main(
+        derive_projection.parse_args(
+            [
+                f"--input_pattern={tmp_path / 'data' / '*' / '*.parquet'}",
+                f"--output_dir={tmp_path / 'projections'}",
+            ]
+        )
+    )
+    return tmp_path
+
+
+def _run(root: pathlib.Path, *extra: str) -> None:
+    derive_pivots.main(
+        derive_pivots.parse_args(
+            [
+                f"--input_pattern={root / 'projections' / '*' / '*.parquet'}",
+                f"--output_dir={root / 'pivots'}",
+                *extra,
+            ]
+        )
+    )
+
+
+def test_each_level_gets_its_own_tree(projected):
+    _run(projected, "--levels", "workups", "outcomes.products")
+    for level in ("workups", "outcomes.products"):
+        for shard in ("aa", "bb"):
+            written = (
+                projected / "pivots" / level / shard / f"ord_dataset-{shard}.parquet"
+            )
+            assert written.exists()
+            assert pivot.pivot_path(written) == level
+            assert artifacts.load_stamps(written).artifact == pivot.ARTIFACT
+    # A level not asked for is not derived, which is what makes naming them cheaper
+    # than deriving all 39.
+    assert not (projected / "pivots" / "inputs.components").exists()
+
+
+def test_a_second_run_skips_what_is_already_current(projected):
+    _run(projected, "--levels", "workups")
+    written = projected / "pivots" / "workups" / "aa" / "ord_dataset-aa.parquet"
+    before = written.stat().st_mtime_ns
+    _run(projected, "--levels", "workups")
+    assert written.stat().st_mtime_ns == before
+
+
+def test_force_rewrites_a_current_artifact(projected):
+    _run(projected, "--levels", "workups")
+    written = projected / "pivots" / "workups" / "aa" / "ord_dataset-aa.parquet"
+    before = written.stat().st_mtime_ns
+    _run(projected, "--levels", "workups", "--force")
+    assert written.stat().st_mtime_ns != before
+
+
+def test_an_unknown_level_is_refused_before_anything_is_written(projected):
+    with pytest.raises(ValueError, match="not repeated levels"):
+        _run(projected, "--levels", "workups", "conditions.temperature")
+    assert not (projected / "pivots").exists()
+
+
+def test_a_pattern_matching_only_non_projections_is_an_error(tmp_path):
+    # The matches are readable Parquet that derive_tree ignores, so the run finishes
+    # having written nothing -- which a pipeline step downstream would otherwise take
+    # for artifacts that were built.
+    directory = tmp_path / "projections" / "aa"
+    directory.mkdir(parents=True)
+    parquet.save_dataset(_dataset("ord_dataset-aa"), str(directory / "source.parquet"))
+    with pytest.raises(ValueError, match="no pivots derived for workups"):
+        _run(tmp_path, "--levels", "workups")
+
+
+def test_a_corpus_reads_the_tree_this_script_writes(projected, caplog):
+    # The layout is a contract between this script and Corpus(pivots_dir=...), and each
+    # side tested against its own idea of it would agree with nobody. Derived here and
+    # read there, end to end.
+    derive_structures.main(
+        derive_structures.parse_args(
+            [
+                f"--input_pattern={projected / 'projections' / '*' / '*.parquet'}",
+                f"--output_dir={projected / 'structures'}",
+            ]
+        )
+    )
+    _run(projected, "--levels", "workups")
+    where = {
+        "op": "exists",
+        "path": "workups",
+        "where": {"op": "eq", "path": "type", "value": {"literal": "EXTRACTION"}},
+    }
+    with (
+        caplog.at_level(logging.INFO, logger="ord_schema.agent.execute"),
+        execute.Corpus(
+            str(projected / "projections" / "*" / "*.parquet"),
+            str(projected / "structures" / "*" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(projected / "pivots"),
+        ) as corpus,
+    ):
+        found = corpus.search(query.Query.model_validate({"where": where}))
+    assert set(found.column("reaction_id").to_pylist()) == {
+        "ord-ord_dataset-aa-01",
+        "ord-ord_dataset-bb-01",
+    }
+    messages = [record.message for record in caplog.records]
+    assert any("read 2 pivot artifacts for workups" in message for message in messages)
+    assert not any("building the pivot" in message for message in messages)

--- a/ord_schema/structures.py
+++ b/ord_schema/structures.py
@@ -16,8 +16,8 @@
 
 Structure search runs in two steps that this artifact serves in turn. A **screen**
 tests the query's fingerprint bits against every row -- a bitwise scan a query engine
-runs in milliseconds, with no chemistry library in sight -- and is complete but not
-exact: it never misses a true match, and passes false ones. **Verification** then runs
+runs in milliseconds without a chemistry library -- and is complete but not exact: it
+never misses a true match, and passes false ones. **Verification** then runs
 real subgraph isomorphism over the survivors, from the serialized molecule carried
 here, which skips re-parsing SMILES and runs about five times faster for it. Neither
 step needs an index; the reason a structure search elsewhere needs one is the cost of
@@ -43,10 +43,9 @@ query/target pairs, including explicit-hydrogen queries, with no exception. What
 query layer still has to handle is that these molecules are built from SMILES and so
 hold their hydrogens implicitly: a SMARTS naming one as its own atom matches nothing,
 which :mod:`ord_schema.agent.query` rewrites rather than runs. Similarity needs no
-verification at all: Tanimoto
-is defined on the Morgan fingerprint, so the screen *is* the answer, and
-``morgan_popcount`` bounds it (``popcount(B)`` must lie within ``[t * popcount(A),
-popcount(A) / t]`` for Tanimoto ``>= t``).
+verification at all: Tanimoto is defined on the Morgan fingerprint, so the screen *is*
+the answer, and ``morgan_popcount`` bounds it (``popcount(B)`` must lie within ``[t *
+popcount(A), popcount(A) / t]`` for Tanimoto ``>= t``).
 
 A structure whose SMILES RDKit cannot parse keeps its row -- the ID space must stay
 dense -- with every derived column null. It can never match a structure query, and the
@@ -69,9 +68,9 @@ logger = get_logger(__name__)
 
 ARTIFACT = "structures"
 
-# Fingerprint parameters. Screen precision plateaus by 2048 bits -- the residual false
-# positives are the gap between feature containment and subgraph isomorphism, which no
-# width closes -- so wider fingerprints buy storage, not selectivity.
+# Screen precision plateaus by 2048 bits -- the residual false positives are the gap
+# between feature containment and subgraph isomorphism, which no width closes -- so
+# wider fingerprints buy storage, not selectivity.
 PATTERN_FP_SIZE = 2048
 MORGAN_FP_SIZE = 2048
 MORGAN_RADIUS = 2
@@ -135,19 +134,20 @@ def structure_levels(
 
     Walked rather than listed by hand, so a compound field added upstream is found
     wherever it lands -- components, products, workup inputs, authentic standards --
-    without anyone updating a list. Everything that has to agree about where a
+    without anyone updating a list. Every caller that has to agree about where a
     structure can sit reads this one walk, since two walks are two answers waiting to
-    disagree about a corpus.
+    disagree.
 
     Args:
-        schema: The projection schema.
+        schema: Schema to walk; the projection schema this library defines by default,
+            or a written file's ``schema_arrow`` to ask what that file holds.
 
     Returns:
         One ``(column, path, dtype)`` per structure-bearing struct, in schema order:
         ``column`` is the Parquet physical prefix, carrying the ``list.element`` and
-        ``key_value.value`` segments a file has; ``path`` is the same level as the
-        query grammar names it, which has no wrapper segments; and ``dtype`` is the
-        struct, so a caller can ask what else the element carries.
+        ``key_value.value`` segments a file has; ``path`` is the same level as the query
+        grammar names it, which has no wrapper segments; and ``dtype`` is the struct, so
+        a caller can ask what else the element carries.
     """
     levels: list[tuple[str, str, pa.DataType]] = []
 
@@ -171,7 +171,9 @@ def _structure_columns(schema: pa.Schema = projection.SCHEMA) -> list[str]:
     """Returns the projection's (smiles, structure_id) leaves as Parquet column paths.
 
     Args:
-        schema: The projection schema.
+        schema: Schema to read the leaves from; the projection schema this library
+            defines by default, or a written file's ``schema_arrow`` to ask what that
+            file holds.
 
     Returns:
         Parquet physical column paths, in schema order.
@@ -306,8 +308,8 @@ def is_current(path: str | os.PathLike[str], source_md5: str) -> bool:
     """Returns whether ``path`` is a structures artifact of ``source_md5`` by us.
 
     Delegates to ``artifacts.is_current``, which requires the artifact name, the source
-    content, the library version, and the artifact version to all match. A missing or
-    unreadable file is not current.
+    content, the library version, the artifact version, and the RDKit version to all
+    match. A missing or unreadable file is not current.
 
     Args:
         path: Path to check. Need not exist.
@@ -343,8 +345,9 @@ def write_structures(
             names the dataset it reflects rather than the file it read.
         source_dataset_id: Source dataset ID to stamp, if the caller already read one.
             Taken from the projection's stamps when omitted.
-        compression: Parquet compression codec.
-        row_group_size: Rows per output row group.
+        compression: Parquet codec, any name ``pq.ParquetWriter`` accepts.
+        row_group_size: Rows per output row group, which is also how many structures
+            are featurized and held in memory at a time.
 
     Returns:
         Number of rows written: the number of distinct structures in the projection.


### PR DESCRIPTION
## Summary

Two things the first corpus-scale benchmark forced. **The budget was the bottleneck, not the plan**: "pyridine as the solvent with a yield above 50%" cost 3.34s against 0.02s for the pyridine clause alone, because `inputs` and `outcomes` both exceeded the flat 2 GB budget and every query naming them re-read 53 Parquet files. Holding them takes that query to 0.41s. **And the nesting was the cost, not the predicate**: answering a quantifier from a flat one-row-per-element *pivot* instead of a `list_filter` over decoded structs takes `yield > 50%` from 2.758s to 0.086s over the whole corpus, with identical answers.

## Changes

- `Corpus(narrow_budget_bytes=...)`, defaulting to a fixed 4 GB. An earlier version inferred a share of machine memory; that is reverted, because a budget read from the environment has to be right about cgroup v1 versus v2, non-standard mounts, and every ancestor limit, and each is a way to over-budget silently and be OOM-killed. A deployment knows its own limit; this process does not.
- Pivots: one row per element of a repeated level, carrying `reaction_id`, the ordinal of every repeated level above it, and the element's non-repeated fields. A covered quantifier compiles to `EXISTS` / `NOT EXISTS` against one, including `forall`, which the occurrence index cannot answer because it holds only elements carrying a structure.
- One cache and one budget cover both a column set and a pivot, so eviction weighs them against each other.
- `scripts/derive_pivots.py` and `Corpus(pivots_dir=...)` ship pivots as stamped artifacts, refused unless derived from this corpus's own projections. `Corpus.check_pivots()` makes that refusal happen at startup rather than at whichever query first wants a level.

## Testing

- `pytest -n auto` — 1171 passed, 2 skipped. `pre-commit` clean.
- A differential test asserts every quantifier form answers identically with the pivot route and without it, over a fixture stating shapes the corpus barely holds: no reaction records a NULL or empty `outcomes`, only 119 record a NULL `products`, and ORD is effectively single-outcome.
- Sabotage: unqualifying the semi-join correlation fails 8 of 9 cases, emitting `EXISTS` for `forall` fails 3, filtering the pivot fails 3, and dropping either ordinal from a nested correlation fails.
- Corpus-scale, warm: the pivot route answers in 0.041–0.178s where the elements need 0.936–4.229s, same reactions either way.

## Notes

- **Correlation needs the whole ordinal prefix.** "A desired product with a yield above 50%" answers 22,666 reactions on `(reaction_id, outcome_index, product_index)` and 23,608 on anything less — 942 wrong, silently. Dropping only the *outcome* ordinal changes nothing on this corpus, which is what made the product-level error look correct until a fixture stated both products in one outcome.
- **Build cost is depth; size saving is width.** One unnest is 42s and each further repeated level costs about an order of magnitude, while the saving depends instead on how much of its column an element still carries: 86% for `outcomes.products`, 15% for `workups`, whose 4.40 GiB pivot exceeds the default and is refused. Pruning to referenced subtrees would fix that and is not built.
- A two-phase execution scheme was built, measured, and abandoned: at a budget where the columns are resident it won one query of ten and lost four.
- The occurrence index is kept rather than subsumed. A pivot answers strictly more, but the index is 130 MiB covering four structure paths where the pivots replacing it are 0.45 and 1.61 GiB for two levels — worth revisiting once pivots load as artifacts rather than build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds pivot artifacts for accelerating quantifier queries and extends the shared memory-budgeted cache to hold both pivots and materialized projection columns.
- Adds pivot derivation, artifact validation, loading, and query-planning support.
- Adds differential tests for pivot and projection execution paths.
- Documents pivot semantics, memory costs, cache behavior, and corpus-scale benchmarks.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/agent/execute.py | Integrates pivot discovery and materialization into the shared memory-budgeted cache and intentionally replaces adaptive host/cgroup sizing with a fixed configurable default. |
| ord_schema/agent/pivot.py | Defines pivot levels, schemas, artifact derivation, and SQL needed to flatten repeated elements while preserving ordinal correlation. |
| ord_schema/agent/query.py | Extends quantifier compilation to route eligible predicates through correlated pivot relations. |
| ord_schema/artifacts.py | Extends derived-artifact metadata and currentness handling for pivot artifacts. |
| ord_schema/scripts/derive_pivots.py | Adds the command-line derivation workflow for generating pivot artifacts from projections. |
| ord_schema/agent/README.md | Documents pivot execution, artifact provenance, shared cache sizing, fallback behavior, and measured performance. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Q[Typed query] --> C[Compile against projection schema]
  C --> P{Covered repeated level?}
  P -->|Yes| V{Matching pivot artifact available?}
  V -->|Yes| A[Query pivot artifact]
  V -->|No| B[Build pivot from projection]
  P -->|No| N[Query projection columns]
  B --> M[Shared memory-budgeted cache]
  N --> M
  M --> E[Execute compiled query]
  A --> E
```
</details>

<sub>Reviews (6): Last reviewed commit: ["Answer a quantifier from a pivot over it..."](https://github.com/open-reaction-database/ord-schema/commit/4bba5b650555ef86667719180e187bbead00318f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53532885)</sub>

**Context used:**

- Knowledge Base — [Agent Query Surface](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/agent-query.md)
- Knowledge Base — [Derived Parquet Artifacts](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/derived-artifacts.md)

<!-- /greptile_comment -->
