### PR TITLE
Hold the parsed Parquet footers between queries

### DIFF
--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -179,47 +179,54 @@ wrong, silently. ORD is effectively single-outcome, so dropping the *outcome* or
 changes nothing at all, which is exactly why the product-level error looks correct until
 it is checked.
 
-Over the whole corpus, warm, against the same queries answered from the elements:
+Over the whole corpus, warm, against the same queries answered from the elements — the
+pivots read as artifacts, and the same pivots built in process:
 
-| query | pivot | elements |
-| --- | --- | --- |
-| a white product | 0.050s | 0.936s |
-| yield > 50% | 0.086s | 2.758s |
-| every product is desired | 0.070s | 2.055s |
-| **not** a yield above 50% | 0.098s | 3.480s |
-| a solvent input | 0.178s | 4.229s |
-| an extraction workup | 3.660s | 7.816s |
-| above 350 K | 0.041s | 0.035s |
+| query | artifacts | in memory | elements |
+| --- | --- | --- | --- |
+| a white product | 0.061s | 0.054s | 0.737s |
+| yield > 50% | 0.099s | 0.085s | 2.384s |
+| every product is desired | 0.076s | 0.070s | 1.781s |
+| **not** a yield above 50% | 0.114s | 0.093s | 3.113s |
+| an extraction workup | 0.114s | 0.103s | 2.341s |
+| "reflux" in a workup | 0.147s | 0.105s | 2.239s |
+| a solvent input | 0.176s | 0.155s | 1.794s |
+| above 350 K | 0.033s | 0.033s | 0.032s |
 
-Every one returns the same reactions either way. The last two are the shape of the
-thing: `above 350 K` is a scalar path with no quantifier, so no pivot is involved and
-nothing moves, and the workup query is one whose pivot the budget refused — the
-projection answered it, which is the fallback working rather than the pivot helping.
+Every one returns the same reactions on all three routes. `above 350 K` is the control:
+a scalar path with no quantifier, so no pivot is involved and nothing moves. Everything
+else is 6–27× against the elements, and **a pivot read from Parquet is within a few tens
+of milliseconds of the same pivot held in memory** — which is the whole argument for
+deriving them, since the artifact costs no budget at all.
 
-Building one unnests the projection down to its level, and is charged against the same
-`narrow_budget_bytes` as a materialized column set and evicted by the same LRU. What it
-costs, measured one build per process so eviction cannot corrupt the reading, beside the
-top-level column a query would otherwise materialize (GiB):
+Building one in process unnests the projection down to its level, and is charged against
+the same `narrow_budget_bytes` as a materialized column set and evicted by the same LRU.
+What it costs, measured one build per process so eviction cannot corrupt the reading,
+beside the top-level column a query would otherwise materialize:
 
-| level | unnests | pivot | build | column | | build |
-| --- | --- | --- | --- | --- | --- | --- |
-| `workups` | 1 | 4.40 | 42s | `workups` | 5.20 | 3.3s |
-| `outcomes.products` | 2 | 0.45 | 461s | `outcomes` | 3.23 | 4.1s |
-| `inputs.components` | 2 | 2.75 | 626s | `inputs` | 4.05 | 2.5s |
-| `outcomes.products.measurements` | 3 | 1.61 | 854s | `outcomes` | 3.23 | 4.1s |
+| level | unnests | held | build | as an artifact | column | held | build |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `workups` | 1 | 4.18 GiB | 42s | 149 MB | `workups` | 5.20 GiB | 3.3s |
+| `outcomes.products` | 2 | 0.39 GiB | 461s | 104 MB | `outcomes` | 3.23 GiB | 4.1s |
+| `inputs.components` | 2 | 2.64 GiB | 626s | 224 MB | `inputs` | 4.05 GiB | 2.5s |
+| `outcomes.products.measurements` | 3 | 1.34 GiB | 854s | 37 MB | `outcomes` | 3.23 GiB | 4.1s |
 
-Two things fall out, and they are independent. **Build cost is depth**: one unnest is
-42 seconds, and each further repeated level costs roughly an order of magnitude, so a
-shallow pivot is cheap and a deep one is not. **Size saving is width**: it depends on
-how much of its column an element carries once the repeated fields are pruned away, from
-86% for `outcomes.products` down to 15% for `workups`, whose elements carry a whole
-`ReactionInput` besides. The 4.40 GiB workup pivot is over the 4 GB default, so it is
-refused and the projection answers — which is why the workup query above is seconds
-where the two `outcomes` levels are tenths.
+Three things fall out. **Build cost is depth**: one unnest is 42 seconds, and each
+further repeated level costs roughly an order of magnitude, where materializing a column
+is 2.5–4.1s whatever it holds. **Size saving is width**: how much of its column an
+element still carries once the repeated fields are pruned away. And **the two are
+anti-correlated** — `workups` is the cheapest to build and the worst to hold, at 4.18 GiB
+against a 4 GB default that refuses it.
 
-A deep pivot's build therefore belongs offline, which is what
-`scripts/derive_pivots.py` is for — one subdirectory per level, one file per projection
-within it, stamped like any other derived artifact and read by
+The third is what makes the artifact the answer rather than a further prune. All four
+levels are **514 MB on disk against 9.21 GiB held**, because Parquet charges for data
+where an in-memory column charges for shape: `workups` carries 40 leaves, most of them
+NULL in most rows, which encode to almost nothing and occupy a full-width vector and a
+validity mask apiece. Publishing all four as views takes 0.9s and no memory, against
+32 minutes and 9.21 GiB to build them in process.
+
+That is what `scripts/derive_pivots.py` is for — one subdirectory per level, one file per
+projection within it, stamped like any other derived artifact and read by
 `Corpus(..., pivots_dir=...)`. Artifacts are refused unless they were derived from this
 corpus's own projections: a pivot names its reactions by ID, so one derived elsewhere
 answers against rows this corpus does not hold, confidently and wrongly. A level with no

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -109,21 +109,24 @@ larger one. An **occurrence index** — one row per structure occurrence, carryi
 corpus-wide ID, the path, and the element's own `reaction_role` — makes that a semi-join
 against a narrow table rather than a scan of every reaction. Keeping the role beside the
 structure is what keeps a bound query a condition on one row. At corpus scale the index
-is 14.1M rows and about 130 MB, resident for the life of the `Corpus`. A search for
-pyridine among the inputs returns in 1.46s **end to end**, pyridine as the solvent in
-1.74s, and a boronic acid in 0.15s — and for a common pattern nearly all of that is the
-RDKit screen and verify, which the index does not touch: pyridine's match alone is about
-1.4s of its 1.46s. What the index cut is the reaction lookup, from roughly 3.5s to 0.2s.
+is 18,847,978 rows and **1.19 GiB**, built in 58s and resident for the life of the
+`Corpus` — a row is three strings and an integer, and the strings are what it costs. A
+search for pyridine among the inputs returns in 1.46s **end to end**, pyridine as the
+solvent in 1.74s, and a boronic acid in 0.15s — and for a common pattern nearly all of
+that is the RDKit screen and verify, which the index does not touch: pyridine's match
+alone is about 1.4s of its 1.46s. What the index cut is the reaction lookup, from roughly
+3.5s to 0.2s.
 
 The index answers one *quantifier* at a time, not one query: an `exists` whose body asks
 for one structure and at most one role becomes `reaction_id IN (...)`, and the rest of
 the query compiles as if the index did not exist. So "reactions with yield > 50% where
 pyridine is the solvent" spends the index on its pyridine clause and answers the yield
-clause from the projection, in one query — and aggregates, orderings, limits, negations,
-disjunctions, and second structure predicates all compose the same way. A quantifier the
-index cannot carry — one binding another element field, holding no structure predicate
-or two, or any `forall`, which needs every element rather than some — compiles over the
-elements, and the projection answers it. Either way it is one compiled query, screened
+clause from the pivot over `outcomes.products.measurements`, in one query — and
+aggregates, orderings, limits, negations, disjunctions, and second structure predicates
+all compose the same way. A quantifier the index cannot carry — one binding another
+element field, holding no structure predicate or two, or any `forall`, which needs every
+element rather than some — falls to the pivot, and to the elements only if no pivot holds
+the level either. Either way it is one compiled query, screened
 and verified identically; the log line says whether the index took a clause. A level the
 source never recorded — most reactions have no workups and no authentic standards — is a
 level with no elements: nothing satisfies an `exists` there and nothing contradicts a
@@ -310,8 +313,8 @@ names `inputs` at all, so what has to be resident is far smaller than for the sa
 question answered from the elements.
 
 **Sizing a deployment.** What must be resident is the RDKit library (about 1.5 GB), the
-occurrence index (about 130 MB), the parsed footers (about 200 MB), and the runtime —
-call it 3 GB, and nothing about that is optional for substructure search, since the
+occurrence index (1.19 GiB), the parsed footers (about 200 MB), and the runtime — call
+it 4 GB, and nothing about that is optional for substructure search, since the
 screen and verify are RDKit in this process rather than SQL in an engine. Everything
 above that is latency: a container held to `narrow_budget_bytes=0` answers every query
 from Parquet in hundredths of a second, and one given room to hold `outcomes` answers
@@ -323,20 +326,29 @@ stated here: it holds 752 MB at a 1 GB limit and 2.66 GB at 3 GB, filling what i
 given and evicted under pressure. The parsed footers do not shrink that way, so on a
 small limit they are a fifth of it.
 
-Over the whole corpus (2,428,291 reactions, 53 files, a 6 GB budget, warm), a mixed set
-of queries pairing an indexed clause with one only the projection can answer:
+Over the whole corpus (2,428,291 reactions, 53 files, the default budget, pivots read as
+artifacts, warm), a mixed set of queries pairing an indexed structure clause with one the
+index cannot carry. The second column refuses the index, so the pivots take every
+quantifier — which is what a corpus without an index now falls to, rather than to the
+elements:
 
-| query | index | projection |
+| query | index | pivots alone |
 | --- | --- | --- |
-| pyridine solvent, above 350 K | 0.02s | 0.20s |
-| pyridine solvent, yield > 50% | 0.41s | 4.82s |
-| pyridine solvent, white product | 0.24s | 4.30s |
-| pyridine solvent, "reflux" in the procedure | 0.05s | 0.20s |
-| yields by product color (grouped) | 0.40s | 1.53s |
-| hottest with a yield (ordered, limited) | 0.41s | 0.99s |
-| boronic acid, pyridine solvent, yield > 50% | 0.43s | 12.75s |
-| any aromatic carbon, yield > 50% | 0.45s | 14.79s |
-| **not** pyridine anywhere, with a yield | 0.55s | 14.86s |
+| pyridine solvent, above 350 K | 0.020s | 0.484s |
+| pyridine solvent, yield > 50% | 0.033s | 0.105s |
+| pyridine solvent, white product | 0.028s | 0.101s |
+| pyridine solvent, "reflux" in the procedure | 0.054s | 0.493s |
+| yields by product color (grouped) | 0.036s | 0.104s |
+| hottest with a yield (ordered, limited) | 0.033s | 0.105s |
+| boronic acid, pyridine solvent, yield > 50% | 0.041s | 0.142s |
+| any aromatic carbon, yield > 50% | 0.153s | 0.259s |
+| a benzene ring, yield > 50% | 0.142s | 0.241s |
+| **not** pyridine anywhere, with a yield | 0.123s | 0.218s |
+
+Same answers on both routes. The index is 2–24× ahead, and the gap is widest where the
+other clause is cheap — a scalar path or a substring — because there the whole query is
+the structure clause. Where the other clause is itself a quantifier the pivot answers, the
+two routes converge.
 
 The screen itself is not a lever. It is the same `PatternFingerprint` the RDKit
 PostgreSQL cartridge screens with (`rdkit.sss_fp_size`, via `makeMolSignature`), and for

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -237,37 +237,48 @@ another as SMARTS. A predicate asked
 again while the first pass is still running waits for that pass, so a burst of identical
 requests costs one match; unrelated searches still overlap.
 
-Queries the index declines read the projection, and read it faster from a **materialized
-column set** holding only the top-level columns they name. Reading a handful of columns
-out of a 442-leaf projection spread over 53 files costs mostly per-file overhead, which
-is the same whatever the query asks for; paying it once and answering from memory
-afterwards takes a temperature filter from 1.24s to 0.21s and a group-by on stirring
-type from 0.75s to 0.003s. The columns are read back off the compiled SQL and the query
-is then compiled again against the table, so a column it names and the table lacks is a
-catalog error rather than a wrong answer, and no SQL text is edited. Sets are held to a
-memory budget and evicted least-recently-used, skipping any a search is still reading;
-one too large to keep is not kept, the projection answers directly, and that is
-remembered rather than rediscovered by building it again. Only builds wait on builds: a
-search whose columns are already materialized is answered while another is being built. The rows are the
-same rows either way, in an order neither relation promises — a query wanting one has to
-say so.
+Queries the index declines read the projection, and most of what that costs is not the
+reading. A scan re-parses the footer of every file it touches, and a 442-leaf projection
+over 53 files has large footers; the parse is charged again on every query however few
+leaves the query goes on to read. DuckDB will **hold the parsed footers** between
+queries, which the corpus turns on at open, and over ORD that is most of the cost of a
+projection query:
 
-**The budget is the cliff, and it says so.** A refused column set logs a **warning** on
-every query that names it, giving what the set costs, what the budget is, and the
-argument that changes them — so a query that suddenly takes seconds explains itself in
-the log rather than by profiling:
+| query | footers reparsed | footers held | held as a column set |
+| --- | --- | --- | --- |
+| temperature filter | 0.759s | 0.096s | 0.032s |
+| group-by on stirring type | 0.728s | 0.055s | 0.003s |
+| temperature and city | 0.712s | 0.029s | 0.002s |
+| substring of a safety note | 0.713s | 0.026s | 0.001s |
+
+The footers cost about **200 MB** over the whole corpus, once, and are bounded by the
+files rather than by what is asked of them — which is why they are held unconditionally
+where the gigabytes a column set costs are weighed against a budget.
+
+The third column is a **materialized column set** holding only the top-level columns a
+query names. Sets were worth an order of magnitude before the footers were held and are
+worth tens of milliseconds after; what still justifies the budget is the pivots, which
+share it and are worth seconds. The columns are read back off the compiled SQL and the
+query is then compiled again against the table, so a column it names and the table lacks
+is a catalog error rather than a wrong answer, and no SQL text is edited. Sets are held
+to a memory budget and evicted least-recently-used, skipping any a search is still
+reading; one too large to keep is not kept, the projection answers directly, and that is
+remembered rather than rediscovered by building it again. Only builds wait on builds: a
+search whose columns are already materialized is answered while another is being built.
+The rows are the same rows either way, in an order neither relation promises — a query
+wanting one has to say so.
+
+**The budget is the cliff, and it says so.** A refused entry logs a **warning** on every
+query that wants it, giving what it costs, what the budget is, and the argument that
+changes them — so a query that suddenly takes seconds explains itself in the log rather
+than by profiling:
 
 ```text
-WARNING materializing ['outcomes', 'reaction_id'] takes 3.0 GB, over this corpus's
-budget of 4.0 GB, so every query naming those columns reads the Parquet files instead
--- seconds rather than tenths of a second at ORD's scale. Open the Corpus with a larger
-narrow_budget_bytes if the machine has the memory to spare.
+WARNING materializing the pivot over outcomes.products.measurements takes 1.6 GB, over
+this corpus's budget of 1.0 GB, so every query wanting it reads the Parquet files
+instead. Open the Corpus with a larger narrow_budget_bytes if the machine has the memory
+to spare.
 ```
-
-A column set the budget refuses is read from the 53 Parquet files on every query that
-names it, and scattered rows do not let a reader skip row groups, so the same question
-costs seconds instead of tenths — "pyridine as the solvent with a yield above 50%" is
-3.34s where `outcomes` is refused and 0.41s where it is held.
 
 The projection is **18.46 GB in memory**, from 1.53 GB of Parquet — a twelvefold
 expansion, and more than any default should claim:

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -303,12 +303,18 @@ names `inputs` at all, so what has to be resident is far smaller than for the sa
 question answered from the elements.
 
 **Sizing a deployment.** What must be resident is the RDKit library (about 1.5 GB), the
-occurrence index (about 130 MB), and the runtime — call it 3 GB, and nothing about that
-is optional for substructure search, since the screen and verify are RDKit in this
-process rather than SQL in an engine. Everything above that is latency: a container held
-to `narrow_budget_bytes=0` answers every query from Parquet in seconds, and one given
-room to hold `outcomes` answers the same query in tenths. There is no managed service to
-move this to — Athena and its kin can scan the Parquet, but the chemistry is not SQL.
+occurrence index (about 130 MB), the parsed footers (about 200 MB), and the runtime —
+call it 3 GB, and nothing about that is optional for substructure search, since the
+screen and verify are RDKit in this process rather than SQL in an engine. Everything
+above that is latency: a container held to `narrow_budget_bytes=0` answers every query
+from Parquet in hundredths of a second, and one given room to hold `outcomes` answers
+the same query in thousandths. There is no managed service to move this to — Athena and
+its kin can scan the Parquet, but the chemistry is not SQL.
+
+DuckDB's own file cache sits beside these and is bounded by `memory_limit` rather than
+stated here: it holds 752 MB at a 1 GB limit and 2.66 GB at 3 GB, filling what it is
+given and evicted under pressure. The parsed footers do not shrink that way, so on a
+small limit they are a fifth of it.
 
 Over the whole corpus (2,428,291 reactions, 53 files, a 6 GB budget, warm), a mixed set
 of queries pairing an indexed clause with one only the projection can answer:

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -112,16 +112,16 @@ _BUILD_BATCH = 50_000
 # seconds.
 _CACHED_MATCHES = 16
 
-# How much memory the materialized column sets may hold between them, when the caller
-# states no budget. The whole projection is 18.46 GB in memory at ORD's scale and no
-# default holds it, so every budget is a partial cache and the question is only which
-# columns fit. This holds any single one of the large ones -- workups is 5.08 GB,
-# inputs 3.93 GB, outcomes 3.04 GB -- which is what a query pairing a structure clause
-# with a projection one needs. A corpus asked for more says so on every query it costs,
-# naming this argument; see _warn_refused.
+# How much memory the materialized column sets and pivots may hold between them, when
+# the caller states no budget. The whole projection is 18.46 GB in memory at ORD's scale
+# and no default holds it, so every budget is a partial cache and the question is only
+# what fits. This holds any single one of the large entries -- the workups column is
+# 5.08 GB, inputs 3.93 GB, outcomes 3.04 GB, and the pivots worth the most are 0.45 to
+# 4.40 GB. A corpus asked for more says so on every query it costs, naming this
+# argument; see _warn_refused.
 #
-# Held to after a set is built rather than before, since what one costs is known only
-# once it exists: the peak is this plus the largest single set, and building a set costs
+# Held to after an entry is built rather than before, since what one costs is known only
+# once it exists: the peak is this plus the largest single entry, and building one costs
 # its size whether or not it is kept.
 _NARROW_BUDGET_BYTES = 4 * 1024**3
 

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -64,6 +64,10 @@ An occurrence names its reaction by ID, so the index is built only over a corpus
 states each reaction once; two files carrying one reaction would have each copy's
 structures answering for the other.
 
+Reading the projection at all costs a re-parse of every file's footer, and over a
+442-leaf schema in 53 files that parse is most of what a query spends however few leaves
+it goes on to read. The corpus keeps the parsed footers instead; see ``_cache_footers``.
+
 The grammar bounds what a query can cost (one pass and a sort), and ``search``
 takes a wall-clock timeout that interrupts the final query. Name resolution, the
 one-time library and index builds, screening, and verification all run before the timer
@@ -470,6 +474,32 @@ def _memory_bytes(cursor: duckdb.DuckDBPyConnection) -> int:
     return int(row[0]) if row is not None and row[0] is not None else 0
 
 
+def _cache_footers(connection: duckdb.DuckDBPyConnection) -> None:
+    """Keeps the Parquet footers parsed between queries.
+
+    A scan re-reads and re-parses the footer of every file it touches, and the
+    projection's footers are large: 442 leaves over 53 files, with statistics per row
+    group. Over ORD that parse is most of what a query costs, and it is charged again on
+    every query however little column data the query goes on to read -- a temperature
+    filter falls from 0.76s to 0.10s once the footers are held, a group-by on stirring
+    type from 0.73s to 0.055s.
+
+    Roughly 200 MB across the whole corpus, and bounded by the files rather than by what
+    is asked of them, which is what makes it worth spending unconditionally where the
+    gigabytes a materialized column set costs are worth weighing. DuckDB re-reads a file
+    that has been rewritten, so an artifact replaced under an open corpus is read as it
+    stands.
+
+    Set globally rather than on this connection: a search runs on its own cursor, which
+    is its own session, and a session-scoped setting would leave every search paying the
+    parse.
+
+    Args:
+        connection: The corpus connection, on the database every cursor shares.
+    """
+    connection.execute("SET GLOBAL parquet_metadata_cache=true")
+
+
 def _run_with_timeout(
     cursor: duckdb.DuckDBPyConnection,
     sql: str,
@@ -585,15 +615,15 @@ class Corpus:
                 artifact, and RDKit versions. The screen's completeness guarantee
                 assumes the query and the artifact fingerprint identically, so turning
                 this off is only for reading a corpus known to match anyway.
-            narrow_budget_bytes: How much memory the materialized column sets may
-                hold between them; 4 GB by default. Worth stating on a machine that can
-                spend more, since a column set the budget refuses is read from the
-                Parquet files on every query that names it -- over ORD, seconds against
-                tenths of a second. The whole projection is 18.46 GB in memory, so a
-                corpus asked about most of it wants most of that. Zero materializes
-                nothing at all, which is what bounds a small machine: a set is measured
-                by building it, so any other figure has a peak of itself plus the
-                largest set a query names, whether or not that set is then kept.
+            narrow_budget_bytes: How much memory the materialized column sets and
+                pivots may hold between them; 4 GB by default. Worth stating on a
+                machine that can spend more, since what the budget refuses is read from
+                the Parquet files on every query that wants it -- tens of milliseconds
+                for a column set, seconds for a pivot. The whole projection is 18.46 GB
+                in memory, so a corpus asked about most of it wants most of that. Zero
+                materializes nothing at all, which is what bounds a small machine: an
+                entry is measured by building it, so any other figure has a peak of
+                itself plus the largest entry a query wants, kept or not.
             pivots_dir: Directory holding derived pivot artifacts, one subdirectory per
                 repeated level. Given one, a quantifier over a level reads the artifact
                 instead of unnesting the projection to build it, which is minutes per
@@ -674,6 +704,7 @@ class Corpus:
         self._pivot_lock = threading.Lock()
         self._connection = duckdb.connect()
         try:
+            _cache_footers(self._connection)
             self._total, self._searchable = self._prepare(pairs)
         except Exception:
             # Nothing else holds the connection yet, and the caller has no object to
@@ -1241,9 +1272,8 @@ class Corpus:
         """
         logger.warning(
             "materializing %s takes %s, over this corpus's budget of %s, so every "
-            "query wanting it reads the Parquet files instead -- seconds rather than "
-            "tenths of a second at ORD's scale. Open the Corpus with a larger "
-            "narrow_budget_bytes if the machine has the memory to spare.",
+            "query wanting it reads the Parquet files instead. Open the Corpus with a "
+            "larger narrow_budget_bytes if the machine has the memory to spare.",
             held.description,
             _format_bytes(cost),
             _format_bytes(self._narrow_budget),

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -116,9 +116,11 @@ _CACHED_MATCHES = 16
 # the caller states no budget. The whole projection is 18.46 GB in memory at ORD's scale
 # and no default holds it, so every budget is a partial cache and the question is only
 # what fits. This holds any single one of the large entries -- the workups column is
-# 5.08 GB, inputs 3.93 GB, outcomes 3.04 GB, and the pivots worth the most are 0.45 to
-# 4.40 GB. A corpus asked for more says so on every query it costs, naming this
-# argument; see _warn_refused.
+# 5.08 GB, inputs 3.93 GB, outcomes 3.04 GB, and the pivots worth the most are 0.39 to
+# 4.18 GB. A corpus asked for more says so on every query it costs, naming this
+# argument; see _warn_refused. A pivot read from an artifact costs nothing here, and
+# answers within tens of milliseconds of one held, so a deployment holding much of this
+# is one that has not derived them.
 #
 # Held to after an entry is built rather than before, since what one costs is known only
 # once it exists: the peak is this plus the largest single entry, and building one costs
@@ -627,9 +629,12 @@ class Corpus:
             pivots_dir: Directory holding derived pivot artifacts, one subdirectory per
                 repeated level. Given one, a quantifier over a level reads the artifact
                 instead of unnesting the projection to build it, which is minutes per
-                level over ORD and is paid by whichever query asks first. A level with
-                no subdirectory is still built in process, so a partial set of
-                artifacts is a partial speedup rather than a missing answer.
+                level over ORD and is paid by whichever query asks first. Worth pointing
+                at wherever a deployment can: the four levels that answer the most are
+                514 MB as artifacts against 9.21 GB built, and answer within tens of
+                milliseconds of the built ones. A level with no subdirectory is still
+                built in process, so a partial set of artifacts is a partial speedup
+                rather than a missing answer.
 
         Raises:
             PairingError: If either pattern matches nothing, a file on one side has no

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -486,9 +486,9 @@ def _cache_footers(connection: duckdb.DuckDBPyConnection) -> None:
 
     Roughly 200 MB across the whole corpus, and bounded by the files rather than by what
     is asked of them, which is what makes it worth spending unconditionally where the
-    gigabytes a materialized column set costs are worth weighing. DuckDB re-reads a file
-    that has been rewritten, so an artifact replaced under an open corpus is read as it
-    stands.
+    gigabytes a materialized column set costs are weighed against a budget. DuckDB
+    re-reads a file that has been rewritten, so an artifact replaced under an open
+    corpus is read as it stands.
 
     Set globally rather than on this connection: a search runs on its own cursor, which
     is its own session, and a session-scoped setting would leave every search paying the

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -856,6 +856,42 @@ def test_the_footer_cache_reaches_the_cursor_a_search_runs_on(corpus):
     assert setting == (True,)
 
 
+def test_a_rewritten_artifact_is_not_answered_from_its_cached_footer(
+    corpus_dir, tmp_path
+):
+    # Holding the footers means holding something the file can go on to contradict. The
+    # rewrite lands in the same second as the read that cached it, which is the case a
+    # cache keyed on a coarse timestamp would answer stale. Nothing is materialized, so
+    # both searches reach the Parquet files rather than the second one reading a table
+    # the first one built.
+    root = _copy_corpus(corpus_dir, tmp_path)
+    request = query.Query.model_validate(
+        {
+            "where": _exists(
+                {
+                    "op": "eq",
+                    "path": "reaction_role",
+                    "value": {"literal": "SOLVENT"},
+                }
+            )
+        }
+    )
+    with execute.Corpus(
+        str(root / "projections" / "*.parquet"),
+        str(root / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        narrow_budget_bytes=0,
+    ) as value:
+        assert _reactions(value.search(request)) == {"ord-aa01"}
+        projected = root / "projections" / "ord_dataset-aa.parquet"
+        table = pq.read_table(projected)
+        kept = table.filter(
+            pa.compute.not_equal(table.column("reaction_id"), "ord-aa01")
+        )
+        pq.write_table(kept, projected)
+        assert _reactions(value.search(request)) == set()
+
+
 def test_concurrent_searches_return_their_own_answers(corpus_dir):
     # Distinct queries with distinct answers, run at once against one corpus: each
     # thread has to come back with the reactions its own query selected. Sharing one

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -842,6 +842,20 @@ def test_a_search_runs_on_a_cursor_rather_than_the_shared_connection(corpus_dir)
         assert counter.cursors == taken + 1
 
 
+def test_the_footer_cache_reaches_the_cursor_a_search_runs_on(corpus):
+    # A cursor is its own session, and a session-scoped setting would leave the parse
+    # charged to every search while the corpus's own connection -- which runs no
+    # queries -- reported the cache as on.
+    cursor = corpus._connection.cursor()
+    try:
+        setting = cursor.execute(
+            "SELECT current_setting('parquet_metadata_cache')"
+        ).fetchone()
+    finally:
+        cursor.close()
+    assert setting == (True,)
+
+
 def test_concurrent_searches_return_their_own_answers(corpus_dir):
     # Distinct queries with distinct answers, run at once against one corpus: each
     # thread has to come back with the reactions its own query selected. Sharing one


### PR DESCRIPTION
## Summary

Most of what a projection query costs is not reading columns — it is re-parsing the Parquet footers. A 442-leaf schema over 53 files has large footers, and DuckDB re-parses them on every scan however few leaves the query then reads. DuckDB will hold them parsed instead; this turns that on at `Corpus` open.

The cache is bounded by the files rather than by what is asked of them — about 200 MB over the whole corpus, once — which is why it is spent unconditionally where the gigabytes a materialized column set costs are weighed against a budget.

## Changes

- `_cache_footers` sets `parquet_metadata_cache` globally, so the per-search cursors (each its own session) see it too.
- Corrected the README's column-set numbers, which were measured before the footers were held, and the refusal warning, which claimed a magnitude that is now only true for pivots.

## Testing

- `pytest ord_schema/search -n auto` → 252 passed.
- New `test_the_footer_cache_reaches_the_cursor_a_search_runs_on`, which is the part that would silently regress: a session-scoped `SET` leaves the corpus connection reporting the cache as on while every search pays the parse.
- Measured over the full corpus (2,428,291 reactions, 53 files, warm) through a real `Corpus`, identical row counts on both routes:

| query | footers reparsed | footers held | held as a column set |
| --- | --- | --- | --- |
| temperature filter | 0.759s | 0.096s | 0.032s |
| group-by on stirring type | 0.728s | 0.055s | 0.003s |
| temperature and city | 0.712s | 0.029s | 0.002s |
| substring of a safety note | 0.713s | 0.026s | 0.001s |

- Checked that a rewritten file is not served from the cache, including a rewrite within the same second.

## Notes

The third column is the open question this raises rather than settles: materialized column sets were worth an order of magnitude before the footers were held and are worth tens of milliseconds after, for gigabytes apiece. What still justifies the shared budget is the pivots, which are worth seconds. Whether the column-set path should stay is a follow-up, and needs one more measurement — a query pairing a structure clause with a projection one, with pivots in play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR enables DuckDB’s global Parquet metadata cache when opening a corpus and updates the search documentation with revised performance and memory measurements.
- Adds global footer caching shared by per-search cursors.
- Adds tests for cursor visibility and replacement of an open Parquet artifact.
- Revises cache, pivot, and deployment sizing documentation.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/search/execute.py | Enables the global Parquet metadata cache during corpus initialization and updates related documentation and warning text. |
| ord_schema/search/execute_test.py | Adds coverage for cache-setting visibility and rewritten Parquet artifacts. |
| ord_schema/search/README.md | Updates performance measurements, memory sizing, and explanations of footer, column-set, and pivot caching. |

</details>

<sub>Reviews (6): Last reviewed commit: ["Say what the occurrence index actually c..."](https://github.com/open-reaction-database/ord-schema/commit/85ee79f78aeaf14bd1bd0ee2495c99ad0723d4da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53712266)</sub>

<!-- /greptile_comment -->