### PR TITLE
Answer from the pivots, and stop holding column sets

### DIFF
--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -203,30 +203,29 @@ of milliseconds of the same pivot held in memory** — which is the whole argume
 deriving them, since the artifact costs no budget at all.
 
 Building one in process unnests the projection down to its level, and is charged against
-the same `narrow_budget_bytes` as a materialized column set and evicted by the same LRU.
-What it costs, measured one build per process so eviction cannot corrupt the reading,
-beside the top-level column a query would otherwise materialize:
+`pivot_budget_bytes` and evicted least-recently-used. What it costs, measured one build
+per process so eviction cannot corrupt the reading:
 
-| level | unnests | held | build | as an artifact | column | held | build |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `workups` | 1 | 4.18 GiB | 42s | 149 MB | `workups` | 5.20 GiB | 3.3s |
-| `outcomes.products` | 2 | 0.39 GiB | 461s | 104 MB | `outcomes` | 3.23 GiB | 4.1s |
-| `inputs.components` | 2 | 2.64 GiB | 626s | 224 MB | `inputs` | 4.05 GiB | 2.5s |
-| `outcomes.products.measurements` | 3 | 1.34 GiB | 854s | 37 MB | `outcomes` | 3.23 GiB | 4.1s |
+| level | unnests | held | build | as an artifact |
+| --- | --- | --- | --- | --- |
+| `workups` | 1 | 4.18 GiB | 42s | 149 MB |
+| `outcomes.products` | 2 | 0.39 GiB | 461s | 104 MB |
+| `inputs.components` | 2 | 2.64 GiB | 626s | 224 MB |
+| `outcomes.products.measurements` | 3 | 1.34 GiB | 854s | 37 MB |
 
 Three things fall out. **Build cost is depth**: one unnest is 42 seconds, and each
-further repeated level costs roughly an order of magnitude, where materializing a column
-is 2.5–4.1s whatever it holds. **Size saving is width**: how much of its column an
-element still carries once the repeated fields are pruned away. And **the two are
-anti-correlated** — `workups` is the cheapest to build and the worst to hold, at 4.18 GiB
-against a 4 GB default that refuses it.
+further repeated level costs roughly an order of magnitude. **Size saving is width**: how
+much of its column an element still carries once the repeated fields are pruned away. And
+**the two are anti-correlated** — `workups` is the cheapest to build and the worst to
+hold, at 4.18 GiB against a 4 GB default that refuses it.
 
 The third is what makes the artifact the answer rather than a further prune. All four
 levels are **514 MB on disk against 9.21 GiB held**, because Parquet charges for data
 where an in-memory column charges for shape: `workups` carries 40 leaves, most of them
 NULL in most rows, which encode to almost nothing and occupy a full-width vector and a
-validity mask apiece. Publishing all four as views takes 0.9s and no memory, against
-32 minutes and 9.21 GiB to build them in process.
+validity mask apiece. The projection itself expands the same way, 1.53 GB of Parquet to
+**18.46 GB in memory**, which is why nothing here holds it. Publishing all four levels as
+views takes 0.9s and no memory, against 32 minutes and 9.21 GiB to build them in process.
 
 That is what `scripts/derive_pivots.py` is for — one subdirectory per level, one file per
 projection within it, stamped like any other derived artifact and read by
@@ -254,67 +253,46 @@ leaves the query goes on to read. DuckDB will **hold the parsed footers** betwee
 queries, which the corpus turns on at open, and over ORD that is most of the cost of a
 projection query:
 
-| query | footers reparsed | footers held | held as a column set |
-| --- | --- | --- | --- |
-| temperature filter | 0.759s | 0.096s | 0.032s |
-| group-by on stirring type | 0.728s | 0.055s | 0.003s |
-| temperature and city | 0.712s | 0.029s | 0.002s |
-| substring of a safety note | 0.713s | 0.026s | 0.001s |
+| query | footers reparsed | footers held |
+| --- | --- | --- |
+| temperature filter | 0.759s | 0.096s |
+| group-by on stirring type | 0.728s | 0.055s |
+| temperature and city | 0.712s | 0.029s |
+| substring of a safety note | 0.713s | 0.026s |
 
 The footers cost about **200 MB** over the whole corpus, once, and are bounded by the
 files rather than by what is asked of them — which is why they are held unconditionally
-where the gigabytes a column set costs are weighed against a budget.
+where the gigabytes a pivot costs are weighed against a budget. With them held, a scalar
+query over the projection lands in hundredths of a second, so there is nothing left for a
+cache of the columns themselves to buy.
 
-The third column is a **materialized column set** holding only the top-level columns a
-query names. Sets were worth an order of magnitude before the footers were held and are
-worth tens of milliseconds after; what still justifies the budget is the pivots, which
-share it and are worth seconds. The columns are read back off the compiled SQL and the
-query is then compiled again against the table, so a column it names and the table lacks
-is a catalog error rather than a wrong answer, and no SQL text is edited. Sets are held
-to a memory budget and evicted least-recently-used, skipping any a search is still
-reading; one too large to keep is not kept, the projection answers directly, and that is
-remembered rather than rediscovered by building it again. Only builds wait on builds: a
-search whose columns are already materialized is answered while another is being built.
-The rows are the same rows either way, in an order neither relation promises — a query
-wanting one has to say so.
+Pivots are held to that memory budget and evicted least-recently-used, skipping any a
+search is still reading; one too large to keep is not kept, the quantifier compiles over
+the elements, and that is remembered rather than rediscovered by building it again. Only
+builds wait on builds: a search over a level already materialized is answered while
+another is being built.
 
-**The budget is the cliff, and it says so.** A refused entry logs a **warning** on every
-query that wants it, giving what it costs, what the budget is, and the argument that
-changes them — so a query that suddenly takes seconds explains itself in the log rather
-than by profiling:
+**The budget is the cliff, and it says so.** A refused level logs a **warning** on every
+query over it, giving what it costs, what the budget is, and what changes them — so a
+query that suddenly takes seconds explains itself in the log rather than by profiling:
 
 ```text
-WARNING materializing the pivot over outcomes.products.measurements takes 1.6 GB, over
-this corpus's budget of 1.0 GB, so every query wanting it reads the Parquet files
-instead. Open the Corpus with a larger narrow_budget_bytes if the machine has the memory
-to spare.
+WARNING the pivot over outcomes.products.measurements takes 1.6 GB, over this corpus's
+budget of 1.0 GB, so every query over that level unnests the projection instead. Derive
+the pivot as an artifact, or open the Corpus with a larger pivot_budget_bytes if the
+machine has the memory to spare.
 ```
 
-The projection is **18.46 GB in memory**, from 1.53 GB of Parquet — a twelvefold
-expansion, and more than any default should claim:
-
-| column | in memory | | column | in memory |
-| --- | --- | --- | --- | --- |
-| `workups` | 5.08 GB | | `notes` | 1.33 GB |
-| `inputs` | 3.93 GB | | `smiles` | 0.89 GB |
-| `outcomes` | 3.04 GB | | `setup` | 0.59 GB |
-| `provenance` | 1.65 GB | | `observations` | 0.13 GB |
-| `conditions` | 1.61 GB | | `identifiers`, `reaction_id` | 0.21 GB |
-
-So every budget is a partial cache and the only question is which columns fit. The
-default is a fixed **4 GB**, which holds any single one of the large columns — what a
-query pairing a structure clause with a projection one needs — and
-`Corpus(narrow_budget_bytes=...)` states otherwise on a machine with room to spare.
-Building a set costs its size whether or not it is kept, so the peak is the budget plus
-the largest set, not the budget alone — `narrow_budget_bytes=0` is the one figure that
-avoids the build entirely, and so the one that bounds a small machine. This is also the
-second thing the index buys: a query whose structure clause becomes a semi-join never
-names `inputs` at all, so what has to be resident is far smaller than for the same
-question answered from the elements.
+The default is a fixed **4 GB**, which holds any single one of the pivots worth the most,
+and `Corpus(pivot_budget_bytes=...)` states otherwise on a machine with room to spare.
+Building one costs its size whether or not it is kept, so the peak is the budget plus the
+largest pivot, not the budget alone — `pivot_budget_bytes=0` is the one figure that
+avoids the build entirely, and so the one that bounds a small machine. A deployment with
+derived artifacts spends none of it: those are views over Parquet, not tables.
 
 **Sizing a deployment.** Measured as process resident size, since that is what a memory
 limit is applied to, building each part in the order a first substructure query would,
-with `narrow_budget_bytes=0` and the pivots read as artifacts:
+with `pivot_budget_bytes=0` and the pivots read as artifacts:
 
 | after | resident |
 | --- | --- |
@@ -326,10 +304,10 @@ with `narrow_budget_bytes=0` and the pivots read as artifacts:
 
 None of it is optional for substructure search, since the screen and verify are RDKit in
 this process rather than SQL in an engine. Everything above it is latency: a container
-held to `narrow_budget_bytes=0` answers every query from Parquet in hundredths of a
-second, and one given room to hold `outcomes` answers the same query in thousandths.
-There is no managed service to move this to — Athena and its kin can scan the Parquet,
-but the chemistry is not SQL.
+held to `pivot_budget_bytes=0` and given no artifacts answers a quantifier by unnesting
+the projection, in seconds rather than the tens of milliseconds a pivot takes. There is
+no managed service to move this to — Athena and its kin can scan the Parquet, but the
+chemistry is not SQL.
 
 The last row is mostly not the index. The table is 1.19 GiB; the rest is DuckDB's own
 caches, which are bounded by `memory_limit` and fill what they are given — 752 MB at a

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -84,7 +84,6 @@ import contextlib
 import dataclasses
 import glob
 import math
-import re
 import threading
 import time
 from collections.abc import Callable, Iterable, Iterator, Sequence
@@ -112,25 +111,18 @@ _BUILD_BATCH = 50_000
 # seconds.
 _CACHED_MATCHES = 16
 
-# How much memory the materialized column sets and pivots may hold between them, when
-# the caller states no budget. The whole projection is 18.46 GB in memory at ORD's scale
-# and no default holds it, so every budget is a partial cache and the question is only
-# what fits. This holds any single one of the large entries -- the workups column is
-# 5.08 GB, inputs 3.93 GB, outcomes 3.04 GB, and the pivots worth the most are 0.39 to
-# 4.18 GB. A corpus asked for more says so on every query it costs, naming this
+# How much memory the pivots built in process may hold between them, when the caller
+# states no budget. The ones worth the most are 0.39 to 4.18 GB at ORD's scale, so this
+# holds any single one of them and every budget is a partial cache; the question is only
+# which fit. A corpus asked for more says so on every query it costs, naming this
 # argument; see _warn_refused. A pivot read from an artifact costs nothing here, and
-# answers within tens of milliseconds of one held, so a deployment holding much of this
+# answers within tens of milliseconds of one built, so a deployment holding much of this
 # is one that has not derived them.
 #
-# Held to after an entry is built rather than before, since what one costs is known only
-# once it exists: the peak is this plus the largest single entry, and building one costs
+# Held to after a pivot is built rather than before, since what one costs is known only
+# once it exists: the peak is this plus the largest single pivot, and building one costs
 # its size whether or not it is kept.
-_NARROW_BUDGET_BYTES = 4 * 1024**3
-
-# Top-level projection columns, which is the granularity a compiled query names them at.
-# A narrower table holding only the ones a query mentions answers it identically, so the
-# query is compiled against it as written.
-_TOP_LEVEL = tuple(projection.SCHEMA.names)
+_PIVOT_BUDGET_BYTES = 4 * 1024**3
 
 
 # What a structure predicate's answer depends on: the operation, whether the string
@@ -424,38 +416,6 @@ def _group(entry_of: array.array, count: int) -> tuple[array.array, array.array]
     return members, starts
 
 
-def _mentioned(sql: str) -> frozenset[str]:
-    """Returns the top-level projection columns a compiled query names.
-
-    Read back off the SQL rather than walked from the query, because the SQL is
-    what has to resolve: a column named there and missing from the table is a
-    catalog error, and one named only in the query is nothing at all.
-
-    Matched as a word outside a string literal and not behind a dot. A top-level
-    column is always where a path starts, while a field reached through one is
-    always qualified -- an element's ``e0.smiles`` and a reaction's own ``smiles``
-    are different columns spelled alike, and matching the qualified form would
-    materialize the reaction-level column for a query that reads only the element's.
-    Literals are stripped for the same reason: the semi-joins carry path literals
-    like ``'inputs.components'``, and a name inside one is never a column reference.
-
-    Args:
-        sql: The compiled query.
-
-    Returns:
-        The columns the query mentions, always including ``reaction_id``.
-    """
-    # An escaped quote inside a literal is two quotes, so this eats those too.
-    outside = re.sub(r"'(?:[^']|'')*'", "''", sql)
-    mentioned = {
-        column
-        for column in _TOP_LEVEL
-        if re.search(rf"(?<![.\w]){re.escape(column)}\b", outside)
-    }
-    mentioned.add("reaction_id")
-    return frozenset(mentioned)
-
-
 def _memory_bytes(cursor: duckdb.DuckDBPyConnection) -> int:
     """Returns the bytes DuckDB holds in its in-memory tables.
 
@@ -488,9 +448,9 @@ def _cache_footers(connection: duckdb.DuckDBPyConnection) -> None:
 
     Roughly 200 MB across the whole corpus, and bounded by the files rather than by what
     is asked of them, which is what makes it worth spending unconditionally where the
-    gigabytes a materialized column set costs are weighed against a budget. DuckDB
-    re-reads a file that has been rewritten, so an artifact replaced under an open
-    corpus is read as it stands.
+    gigabytes a materialized pivot costs are weighed against a budget. DuckDB re-reads a
+    file that has been rewritten, so an artifact replaced under an open corpus is read
+    as it stands.
 
     Set globally rather than on this connection: a search runs on its own cursor, which
     is its own session, and a session-scoped setting would leave every search paying the
@@ -547,33 +507,14 @@ def _run_with_timeout(
             running = False
 
 
-@dataclasses.dataclass(frozen=True)
-class _Held:
-    """Something worth keeping in memory, and the statement that builds it.
-
-    One cache and one budget cover both kinds, so eviction can weigh a column set
-    against a pivot rather than each starving the other in its own pool.
-
-    Attributes:
-        key: Identity in the cache. Carries the kind, so a pivot over a path and a
-            column set naming it cannot collide.
-        select: The query ``CREATE TABLE`` wraps.
-        description: How the entry is named in a log line or a warning.
-    """
-
-    key: tuple[str, ...]
-    select: str
-    description: str
-
-
 @dataclasses.dataclass
-class _Narrow:
-    """A materialized table holding some of the projection's top-level columns.
+class _Pivot:
+    """A pivot over one repeated level, materialized in memory.
 
     Attributes:
         name: The table's name in the catalog.
         held: What it costs to keep, in bytes.
-        readers: Searches currently reading it. An entry with any is passed over by
+        readers: Searches currently reading it. A pivot with any is passed over by
             eviction, since a search holds only the name until it runs.
     """
 
@@ -597,7 +538,7 @@ class Corpus:
         resolver: Callable[[str], str] | None = None,
         threads: int = -1,
         require_current: bool = True,
-        narrow_budget_bytes: int | None = None,
+        pivot_budget_bytes: int | None = None,
         pivots_dir: str | None = None,
     ) -> None:
         """Pairs the artifacts, checks their stamps, and prepares the relations.
@@ -617,15 +558,15 @@ class Corpus:
                 artifact, and RDKit versions. The screen's completeness guarantee
                 assumes the query and the artifact fingerprint identically, so turning
                 this off is only for reading a corpus known to match anyway.
-            narrow_budget_bytes: How much memory the materialized column sets and
-                pivots may hold between them; 4 GB by default. Worth stating on a
-                machine that can spend more, since what the budget refuses is read from
-                the Parquet files on every query that wants it -- tens of milliseconds
-                for a column set, seconds for a pivot. The whole projection is 18.46 GB
-                in memory, so a corpus asked about most of it wants most of that. Zero
-                materializes nothing at all, which is what bounds a small machine: an
-                entry is measured by building it, so any other figure has a peak of
-                itself plus the largest entry a query wants, kept or not.
+            pivot_budget_bytes: How much memory the pivots built in process may hold
+                between them; 4 GB by default. Worth stating on a machine that can spend
+                more, since a quantifier over a level the budget refuses is answered by
+                unnesting the projection, which is seconds rather than milliseconds. The
+                four levels that answer the most cost 9.21 GB built, so a corpus asked
+                about all of them and given no artifacts wants most of that. Zero
+                materializes nothing at all, which is what bounds a small machine: a
+                pivot is measured by building it, so any other figure has a peak of
+                itself plus the largest pivot a query wants, kept or not.
             pivots_dir: Directory holding derived pivot artifacts, one subdirectory per
                 repeated level. Given one, a quantifier over a level reads the artifact
                 instead of unnesting the projection to build it, which is minutes per
@@ -640,25 +581,25 @@ class Corpus:
             PairingError: If either pattern matches nothing, a file on one side has no
                 partner on the other, a pair's stamps disagree about the source
                 dataset, or -- with ``require_current`` -- any artifact is stale.
-            ValueError: If ``narrow_budget_bytes`` is negative, which no amount of
+            ValueError: If ``pivot_budget_bytes`` is negative, which no amount of
                 memory is; zero is allowed, and materializes nothing.
         """
         self._resolver = resolver if resolver is not None else _resolve_with_resolvers
-        if narrow_budget_bytes is not None and narrow_budget_bytes < 0:
+        if pivot_budget_bytes is not None and pivot_budget_bytes < 0:
             raise ValueError(
-                f"narrow_budget_bytes is {narrow_budget_bytes}, which is not an amount "
+                f"pivot_budget_bytes is {pivot_budget_bytes}, which is not an amount "
                 "of memory; pass zero to materialize nothing"
             )
-        self._narrow_budget = (
-            narrow_budget_bytes
-            if narrow_budget_bytes is not None
-            else _NARROW_BUDGET_BYTES
+        self._pivot_budget = (
+            pivot_budget_bytes
+            if pivot_budget_bytes is not None
+            else _PIVOT_BUDGET_BYTES
         )
         # Said at open because the alternative is saying it nowhere: a process killed
         # for holding too much leaves no log of its own, and what it thought it was
         # allowed to hold is the first thing worth knowing afterwards.
         logger.info(
-            "materialized column sets may hold %s", _format_bytes(self._narrow_budget)
+            "pivots built in process may hold %s", _format_bytes(self._pivot_budget)
         )
         self._threads = threads
         # Built on first substructure query; see _library. The library holds one entry
@@ -682,23 +623,21 @@ class Corpus:
         # runs wait for that answer instead of repeating it; see _matches.
         self._matching: dict[_MatchKey, threading.Event] = {}
         self._matches_lock = threading.Lock()
-        # Materialized column sets, most recently used last; see _narrowed_table. The
+        # Pivots built in process, most recently used last; see _pivoted_table. The
         # serial names them, and never repeats, so a build that fails partway leaves no
         # name for the next one to collide with.
-        self._narrowed: collections.OrderedDict[tuple[str, ...], _Narrow] = (
-            collections.OrderedDict()
-        )
-        # Column sets that came out larger than the whole budget, and what each cost.
+        self._pivoted: collections.OrderedDict[str, _Pivot] = collections.OrderedDict()
+        # Levels whose pivot came out larger than the whole budget, and what each cost.
         # Kept because the projection they are built from does not change while this
         # object is open, so building one again costs a pass over the corpus to reach
-        # the same refusal -- and because every query naming one is slow for a reason
+        # the same refusal -- and because every query over one is slow for a reason
         # worth restating; see _warn_refused.
-        self._narrow_refused: dict[tuple[str, ...], int] = {}
-        self._narrow_serial = 0
-        self._narrow_lock = threading.Lock()
+        self._too_large: dict[str, int] = {}
+        self._pivot_serial = 0
+        self._pivots_lock = threading.Lock()
         # Held across a materialization, so the two memory readings bracket one table
         # and no search waits on a build to be told what the cache already holds.
-        self._narrow_build_lock = threading.Lock()
+        self._build_lock = threading.Lock()
         pairs = _pair(projection_pattern, structures_pattern, require_current)
         self._pivots_dir = pivots_dir
         self._require_current = require_current
@@ -706,7 +645,7 @@ class Corpus:
         # already published over the artifacts that were; see _pivot_view.
         self._projections = [pair[0] for pair in pairs]
         self._pivot_views: dict[str, str | None] = {}
-        self._pivot_lock = threading.Lock()
+        self._views_lock = threading.Lock()
         self._connection = duckdb.connect()
         try:
             _cache_footers(self._connection)
@@ -1117,7 +1056,7 @@ class Corpus:
                 # the next query repeats rather than one that collides with itself
                 # forever. S608: the fragments are this module's own schema walk and
                 # the compiler's traversals, not anything a query supplies.
-                with self._narrow_build_lock:
+                with self._build_lock:
                     cursor.execute(f"CREATE OR REPLACE TABLE occurrences AS {selects}")
                 counts = dict(
                     cursor.execute(
@@ -1231,115 +1170,118 @@ class Corpus:
             bits[global_id] = ord("1")
         return bits.decode()
 
-    def _materialize(self, held: _Held) -> _Narrow | None:
-        """Returns the table ``held`` describes, building it if the cache lacks one.
+    def _materialize(self, path: str, select: str) -> _Pivot | None:
+        """Returns the pivot over ``path``, building it if the cache lacks one.
 
         The caller owns a read on whatever comes back and has to release it, which
-        ``_narrowed_table`` does; an entry with a reader is never evicted.
+        ``_pivoted_table`` does; a pivot with a reader is never evicted.
 
         What the cache holds is read under the short lock the bookkeeping takes, and
-        only a build waits on another build. A search whose columns are already
-        materialized is answered while one is running, which is the common case on a
-        corpus serving several questions at once.
+        only a build waits on another build. A search over a level already materialized
+        is answered while one is running, which is the common case on a corpus serving
+        several questions at once.
 
         Args:
-            held: What to keep, and the statement that builds it.
+            path: The repeated level, as the query grammar names it.
+            select: The query ``CREATE TABLE`` wraps.
 
         Returns:
-            The entry, or None when the budget is zero or this costs more than the
-            cache may hold in total. Nothing is kept either way and the projection
-            answers directly; something refused as too large is remembered, so the next
+            The pivot, or None when the budget is zero or this costs more than the cache
+            may hold in total. Nothing is kept either way and the quantifier compiles
+            over the elements; a level refused as too large is remembered, so the next
             query wanting it does not build it again to throw it away again.
         """
-        if not self._narrow_budget:
-            # The one budget that can be settled without building, since what a set
+        if not self._pivot_budget:
+            # The one budget that can be settled without building, since what a pivot
             # costs is known only once it exists. A small container spends nothing and
             # answers from Parquet.
             return None
-        with self._narrow_lock:
-            settled, entry, refused = self._cached(held.key)
+        with self._pivots_lock:
+            settled, entry, refused = self._cached(path)
         if settled:
             # Warned outside the lock: it is the one every search takes to read the
             # cache, and a log handler is not something to hold it through.
             if refused is not None:
-                self._warn_refused(held, refused)
+                self._warn_refused(path, refused)
             return entry
-        with self._narrow_build_lock:
+        with self._build_lock:
             # Asked again under the build lock: whoever held it may have been building
             # exactly this, and a second table of it would be memory held twice for one
             # answer.
-            with self._narrow_lock:
-                settled, entry, refused = self._cached(held.key)
+            with self._pivots_lock:
+                settled, entry, refused = self._cached(path)
             if settled:
                 if refused is not None:
-                    self._warn_refused(held, refused)
+                    self._warn_refused(path, refused)
                 return entry
-            return self._build(held)
+            return self._build(path, select)
 
-    def _cached(self, key: tuple[str, ...]) -> tuple[bool, _Narrow | None, int | None]:
-        """Returns whether the cache settles ``key``, and how.
+    def _cached(self, path: str) -> tuple[bool, _Pivot | None, int | None]:
+        """Returns whether the cache settles ``path``, and how.
 
-        Called with ``_narrow_lock`` held. A hit takes the read on the caller's behalf,
-        since an entry released back to the cache between the lookup and the read could
+        Called with ``_pivots_lock`` held. A hit takes the read on the caller's behalf,
+        since a pivot released back to the cache between the lookup and the read could
         be evicted in between.
 
         Args:
-            key: Identity of the entry, as ``_Held.key`` gives it.
+            path: The repeated level, as the query grammar names it.
 
         Returns:
-            Whether the cache settles the question, the entry for a hit, and what it
+            Whether the cache settles the question, the pivot for a hit, and what it
             cost where it was refused as too large -- which the caller says out loud
             once it is no longer holding the lock.
         """
-        cached = self._narrowed.get(key)
+        cached = self._pivoted.get(path)
         if cached is not None:
-            self._narrowed.move_to_end(key)
+            self._pivoted.move_to_end(path)
             cached.readers += 1
             return True, cached, None
-        refused = self._narrow_refused.get(key)
+        refused = self._too_large.get(path)
         if refused is not None:
             return True, None, refused
         return False, None, None
 
-    def _warn_refused(self, held: _Held, cost: int) -> None:
+    def _warn_refused(self, path: str, cost: int) -> None:
         """Says that a query is about to be answered the slow way, and what to change.
 
-        Warned on every query that wants the entry rather than once when it was first
-        refused, because the query is slow every time and whoever is asking why is
-        reading the log now, not the one line printed when the corpus opened.
+        Warned on every query over the level rather than once when it was first refused,
+        because the query is slow every time and whoever is asking why is reading the
+        log now, not the one line printed when the corpus opened.
 
         Args:
-            held: What was refused, and how to name it.
+            path: The level whose pivot was refused.
             cost: What building it took when it was measured.
         """
         logger.warning(
-            "materializing %s takes %s, over this corpus's budget of %s, so every "
-            "query wanting it reads the Parquet files instead. Open the Corpus with a "
-            "larger narrow_budget_bytes if the machine has the memory to spare.",
-            held.description,
+            "the pivot over %s takes %s, over this corpus's budget of %s, so every "
+            "query over that level unnests the projection instead. Derive the pivot as "
+            "an artifact, or open the Corpus with a larger pivot_budget_bytes if the "
+            "machine has the memory to spare.",
+            path,
             _format_bytes(cost),
-            _format_bytes(self._narrow_budget),
+            _format_bytes(self._pivot_budget),
         )
 
-    def _build(self, held: _Held) -> _Narrow | None:
-        """Materializes ``held``, recording its cost or that it costs too much.
+    def _build(self, path: str, select: str) -> _Pivot | None:
+        """Materializes the pivot over ``path``, or records that it costs too much.
 
-        Called with ``_narrow_build_lock`` held and ``_narrow_lock`` free, so the two
-        memory readings bracket this table and nothing else: every other statement that
-        puts a table in this database -- another materialization, or the index build --
-        takes the same lock.
+        Called with ``_build_lock`` held and ``_pivots_lock`` free, so the two memory
+        readings bracket this table and nothing else: every other statement that puts a
+        table in this database -- another materialization, or the index build -- takes
+        the same lock.
 
         Args:
-            held: What to keep, and the statement that builds it.
+            path: The repeated level, as the query grammar names it.
+            select: The query ``CREATE TABLE`` wraps.
 
         Returns:
-            The entry, held once for the caller, or None if it exceeds the budget.
+            The pivot, held once for the caller, or None if it exceeds the budget.
         """
-        with self._narrow_lock:
+        with self._pivots_lock:
             # Never reused, so a build that fails between the CREATE and the entry
             # cannot leave a name the next attempt collides with.
-            self._narrow_serial += 1
-            name = f"narrow_{self._narrow_serial}"
+            self._pivot_serial += 1
+            name = f"pivoted_{self._pivot_serial}"
         start = time.perf_counter()
         # Its own cursor, for the same reason the index build takes one: searches
         # are in flight, and the shared connection holds their results.
@@ -1348,18 +1290,18 @@ class Corpus:
             # Said before the pass rather than after it, because the pass is what
             # takes the time and whoever is watching a query hang wants to know what it
             # is waiting for while it waits.
-            logger.info("building %s", held.description)
+            logger.info("building the pivot over %s", path)
             before = _memory_bytes(cursor)
-            # The select was assembled by whoever built the _Held, which is where
-            # its fragments are accounted for.
-            cursor.execute(f"CREATE TABLE {name} AS {held.select}")
+            # The select comes from ord_schema.artifacts.pivot, which is where its
+            # fragments are accounted for.
+            cursor.execute(f"CREATE TABLE {name} AS {select}")
             cost = max(_memory_bytes(cursor) - before, 0)
-            if cost > self._narrow_budget:
+            if cost > self._pivot_budget:
                 # Too big to keep, and keeping it is the only reason to build it.
                 cursor.execute(f"DROP TABLE {name}")
-                with self._narrow_lock:
-                    self._narrow_refused[held.key] = cost
-                self._warn_refused(held, cost)
+                with self._pivots_lock:
+                    self._too_large[path] = cost
+                self._warn_refused(path, cost)
                 return None
         except Exception:
             # A table nobody tracks is memory nobody frees, and the failure the
@@ -1375,35 +1317,35 @@ class Corpus:
         finally:
             cursor.close()
         logger.info(
-            "materialized %s as %s, %s in %.1fs",
-            held.description,
+            "materialized the pivot over %s as %s, %s in %.1fs",
+            path,
             name,
             _format_bytes(cost),
             time.perf_counter() - start,
         )
-        entry = _Narrow(name=name, held=cost, readers=1)
-        with self._narrow_lock:
-            self._narrowed[held.key] = entry
+        entry = _Pivot(name=name, held=cost, readers=1)
+        with self._pivots_lock:
+            self._pivoted[path] = entry
             self._evict()
         return entry
 
     def _evict(self) -> None:
-        """Drops materialized tables, least recently used first, down to the budget.
+        """Drops materialized pivots, least recently used first, down to the budget.
 
-        Called with ``_narrow_lock`` held. An entry a search is reading is passed over
+        Called with ``_pivots_lock`` held. A pivot a search is reading is passed over
         rather than dropped: the search bound the table's name into its SQL and reads it
         only after resolving names and matching structures, so dropping it there would
         fail a query that had already been answered correctly. Passing over every
         candidate leaves the cache above its budget until a reader finishes, which is
         the direction that keeps answers right.
         """
-        for key in list(self._narrowed):
+        for path in list(self._pivoted):
             if (
-                sum(entry.held for entry in self._narrowed.values())
-                <= self._narrow_budget
+                sum(entry.held for entry in self._pivoted.values())
+                <= self._pivot_budget
             ):
                 return
-            entry = self._narrowed[key]
+            entry = self._pivoted[path]
             if entry.readers:
                 continue
             cursor = self._connection.cursor()
@@ -1416,50 +1358,8 @@ class Corpus:
                 logger.exception("could not drop the materialized %s", entry.name)
             finally:
                 cursor.close()
-            del self._narrowed[key]
-            logger.info("evicted the materialized %s", entry.name)
-
-    @contextlib.contextmanager
-    def _narrowed_table(self, columns: frozenset[str]) -> Iterator[str | None]:
-        """Yields a table holding only ``columns``, held against eviction while read.
-
-        Reading a handful of columns out of a 442-leaf projection spread over 53 files
-        costs mostly per-file overhead, which is the same whatever the query asks for.
-        Paying it once and answering from memory afterwards is worth a materialization
-        for the columns a corpus is actually asked about: a temperature filter falls
-        from 1.24s to 0.21s, a group-by on stirring type from 0.75s to 0.003s.
-
-        The rows are the same rows; their order is not. Neither relation orders anything
-        a query did not ask to be ordered, and they do not agree on the accident, so a
-        caller wanting a particular order has to say so -- and a caller wanting a
-        particular *subset*, which is what a ``limit`` with no ordering asks for, is
-        asking a question neither relation answers the same way twice.
-
-        Args:
-            columns: Top-level projection columns the query names.
-
-        Yields:
-            The table's name, or None when nothing is materialized -- a budget of zero,
-            or a set costing more memory than the whole cache is allowed -- in which
-            case the projection answers directly.
-        """
-        selected = ", ".join([*sorted(columns), query.STRUCTURE_OFFSET])
-        entry = self._materialize(
-            _Held(
-                key=("columns", *sorted(columns)),
-                # S608: the names come from the projection schema and this module.
-                select=f"SELECT {selected} FROM {query.TABLE}",  # noqa: S608
-                description=str(sorted(columns)),
-            )
-        )
-        if entry is None:
-            yield None
-            return
-        try:
-            yield entry.name
-        finally:
-            with self._narrow_lock:
-                entry.readers -= 1
+            del self._pivoted[path]
+            logger.info("evicted the pivot over %s, held as %s", path, entry.name)
 
     def _pivot_view(self, path: str) -> str | None:
         """Returns a view over the pivot artifacts for ``path``, or None if none exist.
@@ -1482,7 +1382,7 @@ class Corpus:
         """
         if self._pivots_dir is None:
             return None
-        with self._pivot_lock:
+        with self._views_lock:
             if path in self._pivot_views:
                 return self._pivot_views[path]
             # Recursive, because a pivot tree mirrors the projections it was derived
@@ -1581,20 +1481,14 @@ class Corpus:
             # there is no reader to take and no budget to spend.
             yield published
             return
-        entry = self._materialize(
-            _Held(
-                key=("pivot", path),
-                select=pivot.select(level, query.TABLE),
-                description=f"the pivot over {path}",
-            )
-        )
+        entry = self._materialize(path, pivot.select(level, query.TABLE))
         if entry is None:
             yield None
             return
         try:
             yield entry.name
         finally:
-            with self._narrow_lock:
+            with self._pivots_lock:
                 entry.readers -= 1
 
     def _matches(
@@ -1698,8 +1592,8 @@ class Corpus:
         Runs on its own cursor, so concurrent searches sharing this corpus do not read
         each other's results. Two searches wait on each other at the one-time library
         and index builds, at a structure predicate one of them is already matching, and
-        at a materialization, which is one lock for all column sets: the cost of a table
-        is read as the difference two memory readings make, and two builds interleaved
+        at a materialization, which is one lock for all pivots: the cost of a table is
+        read as the difference two memory readings make, and two builds interleaved
         would each be charged the other's.
 
         A quantifier the occurrence index can answer becomes a condition on the row
@@ -1710,11 +1604,9 @@ class Corpus:
         holding a match. Which happened is logged, because it is the one thing about a
         search that the result does not show.
 
-        A query whose named columns fit the cache's budget is compiled a second time
-        against a table holding only those columns, which for an indexed structure
-        query is little more than the reaction ID. The narrow table is held for the
-        life of the search, since the query names it seconds before it reads it and
-        eviction would otherwise drop it in between.
+        A pivot the query routes a quantifier to is held for the life of the search,
+        since the SQL names it seconds before it reads it and eviction would otherwise
+        drop it in between.
 
         Args:
             request: The query to run.
@@ -1762,8 +1654,8 @@ class Corpus:
             def pivot_table(path: str) -> str | None:
                 # Built while compiling rather than after, because the budget decides
                 # whether the table exists at all and the SQL names it either way. The
-                # answer is remembered so the second compilation, against the narrow
-                # relation, cannot route a quantifier differently from the first.
+                # answer is remembered so a level two quantifiers range over is one
+                # build and one read, held once for the whole search.
                 if path not in pivoted:
                     pivoted[path] = reading.enter_context(self._pivoted_table(path))
                 return pivoted[path]
@@ -1778,16 +1670,6 @@ class Corpus:
                 logger.info("the occurrence index answers part of this query")
             else:
                 logger.info("the projection answers this query")
-            # Read off the compiled SQL, so the second compilation is the same query
-            # against a different relation -- no rewriting of SQL text, which a query
-            # whose own string literal named the relation would otherwise corrupt.
-            narrow = reading.enter_context(
-                self._narrowed_table(_mentioned(compiled.sql))
-            )
-            if narrow is not None:
-                compiled = query.compile_query(
-                    request, table=narrow, index=index, pivot=pivot_table
-                )
             cursor = self._connection.cursor()
             try:
                 parameters: dict[str, Any] = {

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -880,7 +880,7 @@ def test_a_rewritten_artifact_is_not_answered_from_its_cached_footer(
         str(root / "projections" / "*.parquet"),
         str(root / "structures" / "*.parquet"),
         resolver={}.__getitem__,
-        narrow_budget_bytes=0,
+        pivot_budget_bytes=0,
     ) as value:
         assert _reactions(value.search(request)) == {"ord-aa01"}
         projected = root / "projections" / "ord_dataset-aa.parquet"
@@ -2098,108 +2098,18 @@ def test_the_cache_stays_bounded(corpus_dir, monkeypatch):
         assert [key[2] for key in value._matched] == ["c1ccccc1", "[Pt]"]
 
 
-def _columns_key(columns: frozenset[str]) -> tuple[str, ...]:
-    """Returns the cache key a materialized column set is held under."""
-    return ("columns", *sorted(columns))
+def _over_products(where):
+    return {"op": "exists", "path": "outcomes.products", "where": where}
 
 
-@contextlib.contextmanager
-def _no_narrow_table(self, columns: frozenset[str]) -> Iterator[str | None]:
-    """Stands in for _narrowed_table so a search reads the projection directly."""
-    del self, columns  # Unused.
-    yield None
+_WHITE_PRODUCT = _over_products(
+    {"op": "eq", "path": "isolated_color", "value": {"literal": "white"}}
+)
 
 
-def test_a_narrow_table_answers_what_the_projection_would(corpus_dir):
-    # Materializing the columns a query names is a second relation to answer from, so
-    # what makes it safe is that it answers identically. Each of these is run against
-    # the narrow table and against the projection, and compared as multisets: a query
-    # with no ordering has none, and the two relations really do return the same rows
-    # in different orders at corpus scale. What must never differ is which rows.
-    requests = {
-        "a scalar leaf": {
-            "where": {
-                "op": "not_null",
-                "path": "conditions.temperature.setpoint_kelvin",
-            }
-        },
-        "a nested quantifier": {
-            "where": _exists(
-                {"op": "eq", "path": "smiles", "value": {"literal": "CCO"}}
-            )
-        },
-        "an aggregate": {
-            "where": None,
-            "aggregate": {
-                "group_by": ["conditions.stirring.type"],
-                "measures": [{"fn": "count", "name": "n"}],
-            },
-        },
-        "an ordering and a limit": {
-            "where": None,
-            "order_by": [{"key": "reaction_id"}],
-            "limit": 2,
-        },
-        "a structure predicate the index declines": {
-            "where": {
-                "op": "and",
-                "clauses": [
-                    _exists(
-                        {"op": "substructure", "path": "smiles", "smarts": "[OX2H]"}
-                    ),
-                    {"op": "not_null", "path": "reaction_id"},
-                ],
-            }
-        },
-    }
-    with execute.Corpus(
-        str(corpus_dir / "projections" / "*.parquet"),
-        str(corpus_dir / "structures" / "*.parquet"),
-        resolver={}.__getitem__,
-    ) as value:
-        for label, body in requests.items():
-            request = query.Query.model_validate(body)
-            narrowed = value.search(request).to_pylist()
-            # The same request with the materialization turned off.
-            with pytest.MonkeyPatch.context() as patcher:
-                patcher.setattr(execute.Corpus, "_narrowed_table", _no_narrow_table)
-                direct = value.search(request).to_pylist()
-            if request.order_by:
-                # An ordered query is the one case where the order is the answer, so
-                # this is the one comparison that may not sort first.
-                assert list(map(repr, narrowed)) == list(map(repr, direct)), label
-            else:
-                assert sorted(map(repr, narrowed)) == sorted(map(repr, direct)), label
-
-
-def test_the_columns_a_query_names_are_the_ones_materialized(corpus_dir):
-    # Too few and the query fails to resolve; too many and the corpus holds columns
-    # nobody asked about. A name inside a string literal costs a column, nothing more.
-    assert execute._mentioned(
-        "SELECT reaction_id FROM reactions WHERE conditions.temperature.x > 1"
-    ) == frozenset({"reaction_id", "conditions"})
-    assert "provenance" in execute._mentioned("SELECT provenance.doi FROM reactions")
-    # reaction_id comes along whether or not the query said so.
-    assert "reaction_id" in execute._mentioned("SELECT 1 FROM reactions")
-    # A substring of a real column is not that column.
-    assert "conditions" not in execute._mentioned(
-        "SELECT reaction_id FROM reactions WHERE notes.preconditions_x = 'a'"
-    )
-    # An element's field is not the reaction's column of the same name: a query
-    # filtering components by their SMILES reads no reaction-level smiles column, and
-    # materializing one costs the largest column in the projection.
-    assert "smiles" not in execute._mentioned(
-        "SELECT reaction_id FROM reactions WHERE len(list_filter("
-        "flatten(list_transform(map_values(inputs), x -> x.components)), "
-        "e0 -> e0.smiles = 'CCO')) > 0"
-    )
-    # Where a path starts is where a top-level column is named.
-    assert "smiles" in execute._mentioned("SELECT smiles FROM reactions")
-
-
-def test_a_materialized_column_set_is_reused(corpus_dir):
+def test_a_materialized_pivot_is_reused(corpus_dir):
     request = query.Query.model_validate(
-        {"where": {"op": "not_null", "path": "conditions.temperature.setpoint_kelvin"}}
+        {"where": _exists({"op": "eq", "path": "smiles", "value": {"literal": "CCO"}})}
     )
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
@@ -2207,17 +2117,13 @@ def test_a_materialized_column_set_is_reused(corpus_dir):
         resolver={}.__getitem__,
     ) as value:
         value.search(request)
-        assert len(value._narrowed) == 1
-        built = dict(value._narrowed)
+        assert list(value._pivoted) == ["inputs.components"]
+        built = dict(value._pivoted)
         value.search(request)
-        assert dict(value._narrowed) == built  # Reused, not rebuilt under a new name.
-        # A query naming other columns is a different set, materialized separately.
-        value.search(
-            query.Query.model_validate(
-                {"where": {"op": "not_null", "path": "provenance.doi"}}
-            )
-        )
-        assert len(value._narrowed) == 2
+        assert dict(value._pivoted) == built  # Reused, not rebuilt under a new name.
+        # A quantifier over another level is another pivot, materialized separately.
+        value.search(query.Query.model_validate({"where": _WHITE_PRODUCT}))
+        assert list(value._pivoted) == ["inputs.components", "outcomes.products"]
 
 
 def _stated_bytes(*readings):
@@ -2241,32 +2147,28 @@ def _tables(value) -> set[str]:
 
 
 def test_a_budget_no_memory_could_answer_to_is_refused(corpus_dir):
-    # Negative is not an amount of memory, and taken as one it makes every set too
+    # Negative is not an amount of memory, and taken as one it makes every pivot too
     # large and every eviction immediate, which reads as a corpus that cannot cache.
     with pytest.raises(ValueError, match="not an amount of memory"):
         execute.Corpus(
             str(corpus_dir / "projections" / "*.parquet"),
             str(corpus_dir / "structures" / "*.parquet"),
             resolver={}.__getitem__,
-            narrow_budget_bytes=-1,
+            pivot_budget_bytes=-1,
         )
     # Zero is an amount of memory, and a caller asking to materialize nothing means it
-    # -- including the build that would otherwise measure a set before dropping it,
+    # -- including the build that would otherwise measure a pivot before dropping it,
     # which is the peak a machine has to have room for.
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
-        narrow_budget_bytes=0,
+        pivot_budget_bytes=0,
     ) as value:
-        value.search(
-            query.Query.model_validate(
-                {"where": {"op": "not_null", "path": "provenance.doi"}}
-            )
-        )
-        assert not value._narrowed
-        assert value._narrow_serial == 0  # No table was built to find that out.
-        assert not [name for name in _tables(value) if name.startswith("narrow_")]
+        value.search(query.Query.model_validate({"where": _WHITE_PRODUCT}))
+        assert not value._pivoted
+        assert value._pivot_serial == 0  # No table was built to find that out.
+        assert not [name for name in _tables(value) if name.startswith("pivoted_")]
 
 
 def test_a_materialization_is_measured_in_bytes(corpus_dir):
@@ -2278,19 +2180,15 @@ def test_a_materialization_is_measured_in_bytes(corpus_dir):
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
     ) as value:
-        value.search(
-            query.Query.model_validate(
-                {"where": {"op": "not_null", "path": "provenance.doi"}}
-            )
-        )
-        (entry,) = value._narrowed.values()
+        value.search(query.Query.model_validate({"where": _WHITE_PRODUCT}))
+        (entry,) = value._pivoted.values()
         assert entry.held > 1024
 
 
 def test_the_cache_evicts_the_least_recently_used_and_drops_its_table(
     corpus_dir, monkeypatch
 ):
-    # An unevicted cache is one table per column set a server is ever asked for, none of
+    # An unevicted cache is one table per level a server is ever asked about, none of
     # them ever freed. Sizes are stated here rather than measured so the budget admits
     # exactly one table whatever DuckDB's allocator does with three rows.
     budget = 150
@@ -2298,19 +2196,17 @@ def test_the_cache_evicts_the_least_recently_used_and_drops_its_table(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
-        narrow_budget_bytes=budget,
+        pivot_budget_bytes=budget,
     ) as value:
         monkeypatch.setattr(
             execute, "_memory_bytes", _stated_bytes(0, 100, 0, 100, 0, 100)
         )
-        first = frozenset({"reaction_id", "provenance"})
-        second = frozenset({"reaction_id", "conditions"})
-        with value._narrowed_table(first) as name:
+        with value._pivoted_table("inputs.components") as name:
             dropped = name
         assert dropped in _tables(value)
-        with value._narrowed_table(second) as name:
+        with value._pivoted_table("outcomes.products") as name:
             kept = name
-        assert list(value._narrowed) == [_columns_key(second)]
+        assert list(value._pivoted) == ["outcomes.products"]
         assert dropped not in _tables(value)  # Dropped, not merely forgotten.
         assert kept in _tables(value)
 
@@ -2325,27 +2221,22 @@ def test_a_table_a_search_is_reading_is_not_evicted(corpus_dir, monkeypatch):
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
-        narrow_budget_bytes=budget,
+        pivot_budget_bytes=budget,
     ) as value:
         monkeypatch.setattr(
             execute, "_memory_bytes", _stated_bytes(0, 100, 0, 100, 0, 100)
         )
-        first = frozenset({"reaction_id", "provenance"})
-        second = frozenset({"reaction_id", "conditions"})
-        with value._narrowed_table(first) as reading:
-            with value._narrowed_table(second):
+        with value._pivoted_table("inputs.components") as reading:
+            with value._pivoted_table("outcomes.products"):
                 pass
             # Over budget, and the only candidate is being read: it stays, and the
             # cache stays over its budget until the reader is done.
             assert reading in _tables(value)
-            assert list(value._narrowed) == [
-                _columns_key(first),
-                _columns_key(second),
-            ]
+            assert list(value._pivoted) == ["inputs.components", "outcomes.products"]
         # Released, so the next materialization can take it.
-        with value._narrowed_table(frozenset({"reaction_id", "notes"})):
+        with value._pivoted_table("identifiers"):
             pass
-        assert first not in value._narrowed
+        assert "inputs.components" not in value._pivoted
         assert reading not in _tables(value)
 
 
@@ -2375,7 +2266,7 @@ def _stalled_build(value, monkeypatch) -> Iterator[threading.Event]:
 
     def build() -> None:
         try:
-            with value._narrowed_table(frozenset({"reaction_id", "conditions"})):
+            with value._pivoted_table("outcomes.products"):
                 pass
         except BaseException as error:  # noqa: BLE001 - reported below, not handled.
             stalled.append(error)
@@ -2404,21 +2295,20 @@ def test_a_materialized_table_is_handed_out_while_another_is_being_built(
     corpus_dir, monkeypatch
 ):
     # A build is a pass over the corpus, and a Corpus is shared between searches. A
-    # search whose columns are already materialized has nothing to wait for, and making
-    # it wait turns one slow first query into a stall for everyone. Asked from a thread
+    # search over a level already materialized has nothing to wait for, and making it
+    # wait turns one slow first query into a stall for everyone. Asked from a thread
     # rather than here, so a hit that does wait fails this test rather than hanging it.
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
     ) as value:
-        cached = frozenset({"reaction_id", "provenance"})
-        with value._narrowed_table(cached):
+        with value._pivoted_table("inputs.components"):
             pass
         with _stalled_build(value, monkeypatch):
 
             def read() -> str | None:
-                with value._narrowed_table(cached) as name:
+                with value._pivoted_table("inputs.components") as name:
                     return name
 
             reader, answered = _in_a_thread(read)
@@ -2428,33 +2318,30 @@ def test_a_materialized_table_is_handed_out_while_another_is_being_built(
         assert not reader.is_alive()
 
 
-def test_one_column_set_is_built_once_however_many_searches_want_it(
-    corpus_dir, monkeypatch
-):
-    # Two searches naming the same columns arrive together on a cold cache. Building
-    # twice costs two passes over the corpus and leaves two tables of one column set,
-    # of which only the last is remembered -- the other is memory nothing will free.
+def test_one_pivot_is_built_once_however_many_searches_want_it(corpus_dir, monkeypatch):
+    # Two searches over the same level arrive together on a cold cache. Building twice
+    # costs two passes over the corpus and leaves two tables of one level, of which only
+    # the last is remembered -- the other is memory nothing will free.
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
     ) as value:
-        wanted = frozenset({"reaction_id", "conditions"})
         with _stalled_build(value, monkeypatch):
 
             def read() -> str | None:
-                with value._narrowed_table(wanted) as name:
+                # The stalled build is materializing this very level.
+                with value._pivoted_table("outcomes.products") as name:
                     return name
 
-            # The stalled build is materializing these very columns.
             second, answered = _in_a_thread(read)
             second.join(timeout=1)
             assert not answered, "the second ask did not wait for the build in flight"
         second.join(timeout=30)
         assert answered, "the second ask never got its table"
         assert answered[0] is not None
-        assert value._narrow_serial == 1  # One name taken, so one table built.
-        assert [name for name in _tables(value) if name.startswith("narrow_")] == [
+        assert value._pivot_serial == 1  # One name taken, so one table built.
+        assert [name for name in _tables(value) if name.startswith("pivoted_")] == [
             answered[0]
         ]
 
@@ -2471,18 +2358,17 @@ def test_a_table_a_second_search_took_from_the_cache_is_not_evicted(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
-        narrow_budget_bytes=budget,
+        pivot_budget_bytes=budget,
     ) as value:
         monkeypatch.setattr(
             execute, "_memory_bytes", _stated_bytes(0, 100, 0, 100, 0, 100)
         )
-        first = frozenset({"reaction_id", "provenance"})
-        with value._narrowed_table(first) as built:
+        with value._pivoted_table("inputs.components") as built:
             pass
         # Taken from the cache this time, and read while the budget forces an eviction.
-        with value._narrowed_table(first) as reading:
+        with value._pivoted_table("inputs.components") as reading:
             assert reading == built
-            with value._narrowed_table(frozenset({"reaction_id", "conditions"})):
+            with value._pivoted_table("outcomes.products"):
                 pass
             assert reading in _tables(value)
 
@@ -2490,9 +2376,7 @@ def test_a_table_a_second_search_took_from_the_cache_is_not_evicted(
 def test_a_failed_materialization_leaves_nothing_behind(corpus_dir, monkeypatch):
     # A table nobody tracks is memory nobody frees, and under a name a later attempt
     # would collide with. The failure is raised after the CREATE, which is the window.
-    request = query.Query.model_validate(
-        {"where": {"op": "not_null", "path": "provenance.doi"}}
-    )
+    request = query.Query.model_validate({"where": _WHITE_PRODUCT})
     failing = True
     original = execute._memory_bytes
     reads = 0
@@ -2514,64 +2398,22 @@ def test_a_failed_materialization_leaves_nothing_behind(corpus_dir, monkeypatch)
     ) as value:
         with pytest.raises(duckdb.Error, match="no memory accounting"):
             value.search(request)
-        assert not value._narrowed
-        assert not [name for name in _tables(value) if name.startswith("narrow_")]
+        assert not value._pivoted
+        assert not [name for name in _tables(value) if name.startswith("pivoted_")]
         failing = False
-        # The column set is still materializable, under a name of its own.
+        # The level is still materializable, under a name of its own.
         value.search(request)
-        assert len(value._narrowed) == 1
+        assert len(value._pivoted) == 1
 
 
-def test_a_literal_naming_the_relation_is_not_a_rewrite(tmp_path):
-    # The columns are read off the compiled SQL, which carries string literals inline --
-    # so a query searching for the text "FROM reactions" puts that text in the SQL. The
-    # narrow table is reached by compiling again against it, not by editing that SQL: an
-    # edit would rewrite the literal too, and this reaction would stop being findable by
-    # what its own notes say.
-    note = "distilled FROM reactions overnight"
-    reaction = _reaction("ord-dd01", components=[("CCO", _ROLE.REACTANT)])
-    reaction.notes.procedure_details = note
-    source = tmp_path / "data" / "ord_dataset-dd.parquet"
-    source.parent.mkdir(parents=True, exist_ok=True)
-    parquet.save_dataset(
-        dataset_pb2.Dataset(
-            dataset_id="ord_dataset-dd",
-            name="test",
-            description="test",
-            reactions=[reaction],
-        ),
-        str(source),
-    )
-    projected = tmp_path / "projections" / source.name
-    projected.parent.mkdir(parents=True, exist_ok=True)
-    projection.write_projection(source, projected)
-    structured = tmp_path / "structures" / source.name
-    structured.parent.mkdir(parents=True, exist_ok=True)
-    structures.write_structures(projected, structured)
-    request = query.Query.model_validate(
-        {
-            "where": {
-                "op": "eq",
-                "path": "notes.procedure_details",
-                "value": {"literal": note},
-            }
-        }
-    )
-    with execute.Corpus(
-        str(projected), str(structured), resolver={}.__getitem__
-    ) as value:
-        assert _reactions(value.search(request)) == {"ord-dd01"}
-        assert len(value._narrowed) == 1
-
-
-def test_a_column_set_too_large_to_keep_is_not_kept(corpus_dir, monkeypatch):
+def test_a_pivot_too_large_to_keep_is_not_kept(corpus_dir, monkeypatch):
     # Materializing is only worth it if the table survives to answer the next query.
     budget = 1
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
-        narrow_budget_bytes=budget,
+        pivot_budget_bytes=budget,
     ) as value:
         matched = value.search(
             query.Query.model_validate(
@@ -2584,20 +2426,16 @@ def test_a_column_set_too_large_to_keep_is_not_kept(corpus_dir, monkeypatch):
         )
         # Answered anyway, straight from the projection.
         assert matched.column("reaction_id").to_pylist() == ["ord-bb01"]
-        assert not value._narrowed
+        assert not value._pivoted
 
 
-def test_a_column_set_too_large_to_keep_says_so_and_says_what_to_change(
-    corpus_dir, caplog
-):
-    # The slowest thing a corpus does is answer from Parquet because a column set did
-    # not fit, and nothing about the answer says that is what happened. Whoever is
-    # asking why a query takes seconds is reading the log, so the log has to name the
-    # columns, the two figures, and the argument that changes it.
+def test_a_pivot_too_large_to_keep_says_so_and_says_what_to_change(corpus_dir, caplog):
+    # The slowest thing a corpus does is unnest the projection because a pivot did not
+    # fit, and nothing about the answer says that is what happened. Whoever is asking
+    # why a query takes seconds is reading the log, so the log has to name the level,
+    # the two figures, and what changes it.
     caplog.set_level(logging.INFO, logger="ord_schema.search.execute")
-    request = query.Query.model_validate(
-        {"where": {"op": "not_null", "path": "provenance.doi"}}
-    )
+    request = query.Query.model_validate({"where": _WHITE_PRODUCT})
 
     def warnings() -> list[str]:
         return [
@@ -2611,14 +2449,14 @@ def test_a_column_set_too_large_to_keep_says_so_and_says_what_to_change(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
-        narrow_budget_bytes=1,
+        pivot_budget_bytes=1,
     ) as value:
         value.search(request)
         assert len(warnings()) == 1
         said = warnings()[0]
-        assert "provenance" in said
-        assert "narrow_budget_bytes" in said
-        assert execute._format_bytes(value._narrow_budget) in said
+        assert "outcomes.products" in said
+        assert "pivot_budget_bytes" in said
+        assert execute._format_bytes(value._pivot_budget) in said
         # Both figures have to be figures. Stated in gigabytes, a fixture costing
         # kilobytes against a budget of one byte reads "0.0 GB over 0.0 GB", which
         # names the problem in units that hide it.
@@ -2630,9 +2468,7 @@ def test_a_column_set_too_large_to_keep_says_so_and_says_what_to_change(
         assert len(warnings()) == 2
 
 
-def test_two_searches_wanting_one_refused_column_set_build_it_once(
-    corpus_dir, monkeypatch
-):
+def test_two_searches_wanting_one_refused_pivot_build_it_once(corpus_dir, monkeypatch):
     # The refusal is settled under the build lock as well as before it, so a search
     # that waited out another's build finds the answer rather than repeating a pass
     # over the corpus to reach the same refusal.
@@ -2640,13 +2476,12 @@ def test_two_searches_wanting_one_refused_column_set_build_it_once(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
-        narrow_budget_bytes=1,
+        pivot_budget_bytes=1,
     ) as value:
-        wanted = frozenset({"reaction_id", "conditions"})
         with _stalled_build(value, monkeypatch):
 
             def read() -> str | None:
-                with value._narrowed_table(wanted) as name:
+                with value._pivoted_table("outcomes.products") as name:
                     return name
 
             second, answered = _in_a_thread(read)
@@ -2654,28 +2489,27 @@ def test_two_searches_wanting_one_refused_column_set_build_it_once(
             assert not answered, "the second ask did not wait for the build in flight"
         second.join(timeout=30)
         assert answered == [None]  # Refused, and told so rather than building again.
-        assert value._narrow_serial == 1
+        assert value._pivot_serial == 1
 
 
-def test_a_column_set_too_large_to_keep_is_not_built_twice(corpus_dir, monkeypatch):
+def test_a_pivot_too_large_to_keep_is_not_built_twice(corpus_dir, monkeypatch):
     # What the refusal costs is a pass over the corpus, and the projection it reads
     # does not change while the corpus is open. Asking again is the common case -- a
     # notebook loop, a server serving one shape of question -- and rebuilding a table
-    # only to drop it again holds the narrow lock against every other search each time.
+    # only to drop it again holds the build lock against every other search each time.
     budget = 1
-    columns = frozenset({"reaction_id", "provenance"})
     with execute.Corpus(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
-        narrow_budget_bytes=budget,
+        pivot_budget_bytes=budget,
     ) as value:
-        with value._narrowed_table(columns) as name:
+        with value._pivoted_table("inputs.components") as name:
             assert name is None
-        built = value._narrow_serial
-        with value._narrowed_table(columns) as name:
+        built = value._pivot_serial
+        with value._pivoted_table("inputs.components") as name:
             assert name is None
-        assert value._narrow_serial == built  # No second CREATE to name.
+        assert value._pivot_serial == built  # No second CREATE to name.
 
 
 def test_a_library_that_lost_a_molecule_is_refused(corpus_dir, monkeypatch):


### PR DESCRIPTION
## Summary

Materializing the top-level columns a query names was worth an order of magnitude before #968 held the parsed Parquet footers. It is worth 25–65 ms after, against 1.5 GB and up of budget apiece, so this deletes the path. The cache, the budget, and the LRU stay — they now hold only the pivots, which are worth seconds and are what the budget was really being spent on.

## Changes

- Delete `_mentioned`, `_TOP_LEVEL`, `_narrowed_table`, and the second `compile_query` pass in `search`.
- Collapse `_Held`/`_Narrow` into `_Pivot` and key the cache on the level's path, since only one kind of entry is left.
- Rename `narrow_budget_bytes` to `pivot_budget_bytes` (and the internals to match), because the budget now bounds exactly one thing.
- The refusal warning names deriving the pivot as an artifact first — that fix costs no memory at all, where raising the budget costs the pivot's size.

## Testing

- `uv run pytest` with `initdb` on PATH: 1172 passed, 2 skipped.
- The cache tests — eviction, readers held against eviction, one build for concurrent askers, refusal remembered, failed build leaves nothing — carry over onto pivots rather than being dropped, so the machinery keeps its coverage. `_pivoted_table` builds over two levels of the fixture corpus, which is what the column sets used to give them.
- Deleted with the path they tested: the narrow-vs-projection differential (`test_a_pivot_answers_what_the_level_answers` is the surviving equivalent), the `_mentioned` column-matching test, and the string-literal rewrite test, which existed because the second compilation had to not be a text edit.

## Notes

- `query.compile_query(table=...)` now has no production caller. Left in place: it is the compiler's own parameterization of the relation it reads, with its own identifier validation and tests, and removing it would be a compiler API change unrelated to this cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes materialized top-level column sets now that cached Parquet footers make them comparatively low value, leaving the memory budget and LRU dedicated to pivots.
- Renames the public and internal narrow-cache budget terminology to pivot-specific terminology.
- Simplifies query execution to compile once and read scalar results directly from the projection.
- Retains pivot caching, refusal tracking, concurrent-build coordination, reader protection, and eviction coverage.
- Updates performance and deployment guidance to describe the pivot-only cache.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The removed compilation and column-set cache path only substituted a materialized subset of the same reaction relation, while pivot routing, cache synchronization, reader protection, refusal tracking, and eviction behavior remain intact and covered by focused tests.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/search/execute.py | Removes column-set materialization and the second compiler pass while specializing the existing synchronized cache machinery for pivots. |
| ord_schema/search/execute_test.py | Deletes obsolete narrow-table tests, updates budget terminology, and retains focused pivot correctness and cache-lifecycle coverage. |
| ord_schema/search/README.md | Revises performance, memory-budget, warning, and deployment documentation for direct projection reads and pivot-only caching. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Q[Search request] --> C[Compile query once]
    C --> P{Quantifier can use pivot?}
    P -->|Artifact exists| V[Read pivot artifact view]
    P -->|No artifact and budget permits| M[Build or reuse in-memory pivot]
    P -->|Budget zero or pivot refused| E[Compile quantifier over projection elements]
    P -->|No pivot needed| R[Read reactions projection]
    V --> X[Execute compiled SQL]
    M --> X
    E --> X
    R --> X
    X --> O[Arrow result]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Answer from the pivots, and stop holding..."](https://github.com/open-reaction-database/ord-schema/commit/1a5ab33f60e5d30a9b28aefa43cf20274d296200) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53832498)</sub>

<!-- /greptile_comment -->