### PR TITLE
Draw the routes a query takes, and give two packages a README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Excellent! There are a few steps you'll need to follow to get ready to submit ch
    ### GitHub
 
     1. Create a fork of `ord-schema` by clicking the "Fork" button at the top-right of this page.
-       Note that you only need to do this once---all of your changes can use the same fork.
+       You only need to do this once---all of your changes can use the same fork.
     1. Follow
        the [GitHub flow](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/github-flow)
        to make changes and send a pull request to the official repository. While you are making
@@ -70,7 +70,9 @@ Excellent! There are a few steps you'll need to follow to get ready to submit ch
        npx --yes markdownlint-cli2@0.23.1 "**/*.md"
        ```
 
-    1. Create a new branch and make your changes.
+    1. Create a new branch and make your changes. If you edit `proto/*.proto`,
+       [install](https://grpc.io/docs/protoc-installation/) `protoc` and run
+       `./compile_proto_wrappers.sh` to rebuild the generated wrappers, and commit those too.
     1. Test your changes by syncing the environment and running the test suite, for example:
        `uv sync --extra tests` then `uv run pytest` (or `pytest` after activating the `.venv` that `uv` creates).
        CI runs the same checks when you open a pull request, but running them locally first saves time.

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,0 +1,24 @@
+# Data conventions
+
+Guidance for depositors on how to record something the schema can hold in more than one
+shape. A convention is not enforced by
+[`ord_schema.validations`](ord_schema/validations.py) — the schema accepts any of the
+shapes, and this is the one to prefer so that data from different depositors answers the
+same query.
+
+Each entry records when it was agreed and what it was agreed in, so a reader can tell a
+settled convention from a stale one. Propose a new one, or a change to an existing one,
+by opening an issue.
+
+## Compound stoichiometry
+
+*Created 2023-07-04. Last updated 2023-07-04.*
+
+Record stoichiometry in the `features` map of `Compound` or `ProductCompound`:
+
+- the key is `stoichiometric_coefficient` or `stoichiometric_ratio`;
+- the value is a `Data` message whose `float_value` carries the coefficient or ratio.
+
+Discussion:
+[#683](https://github.com/open-reaction-database/ord-schema/issues/683),
+[#684](https://github.com/open-reaction-database/ord-schema/pull/684).

--- a/README.md
+++ b/README.md
@@ -218,20 +218,6 @@ The `tests` extra pulls in the feature extras (`huggingface`, `orm`) it needs to
 
 ## Conventions
 
-### 1. convention: compound stoichiometry
-
-#### Created: 2023.07.04
-
-#### Last updated: 2023.07.04
-
-#### Description
-
-1. The preferred field for compound stoichiometry is the map `Compound.features` or `ProductCompound.features`.
-2. The key should be "stoichiometric_coefficient" or "stoichiometric_ratio".
-3. The value should be a `Data` message with its `float_value` representing the compound's stoichiometric
-coefficient or ratio.
-
-#### Related links
-
-[#683](https://github.com/open-reaction-database/ord-schema/issues/683)
-[#684](https://github.com/open-reaction-database/ord-schema/pull/684)
+Some things the schema can hold in more than one shape have an agreed shape to prefer, so
+that data from different depositors answers the same query. These are guidance rather than
+validation rules; see [CONVENTIONS.md](CONVENTIONS.md).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This installs the core schema and helpers (building, parsing, validation, and me
 
 | Extra | Enables | Install |
 | ------- | --------- | --------- |
+| `search` | `ord_schema.search`: query derived Parquet artifacts with a validated query grammar (DuckDB) | `pip install "ord-schema[search]"` |
 | `huggingface` | `ord_schema.huggingface.fetch_dataset`: download datasets from the Hugging Face [ord-data](https://huggingface.co/datasets/open-reaction-database/ord-data) mirror | `pip install "ord-schema[huggingface]"` |
 | `orm` | `ord_schema.orm`: map the schema into a relational (SQLAlchemy + PostgreSQL) database | `pip install "ord-schema[orm]"` |
 | `examples` | running the notebooks under `examples/` (see below) | `pip install "ord-schema[examples]"` |
@@ -198,6 +199,10 @@ $ pip install "ord-schema[examples]"
 
 Click here to run the examples with Binder:
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/open-reaction-database/ord-schema/HEAD?labpath=examples)
+
+## Package layout
+
+[`ord_schema/README.md`](ord_schema/README.md) maps the package: which module builds a message, which stores a dataset, and which of the two query paths answers which kind of question. The subsystems document themselves — [`artifacts/`](ord_schema/artifacts/README.md) for the derived Parquet and its staleness stamps, [`search/`](ord_schema/search/README.md) for the query grammar and its compiler, [`orm/`](ord_schema/orm/README.md) for the relational mapping.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Click here to run the examples with Binder:
 
 ## Development
 
-To install in editable/development mode (recommended: [uv](https://docs.astral.sh/uv/)):
+Editable install, with [uv](https://docs.astral.sh/uv/) or with pip (`pip install -e ".[tests]"`):
 
 ```shell
 $ git clone https://github.com/open-reaction-database/ord-schema.git
@@ -214,15 +214,7 @@ $ cd ord-schema
 $ uv sync --extra tests
 ```
 
-The `tests` extra pulls in the feature extras (`huggingface`, `orm`) it needs to exercise their code paths, so this is enough to run the full suite. Add `--extra examples` as well to run the notebooks (heavier deps):
-
-```shell
-$ uv sync --extra examples --extra tests
-```
-
-You can still use pip if you prefer: `pip install -e ".[tests]"`.
-
-If you make changes to the protocol buffer definitions, [install](https://grpc.io/docs/protoc-installation/) `protoc` and run `./compile_proto_wrappers.sh` to rebuild the wrappers.
+The `tests` extra pulls in the feature extras (`huggingface`, `orm`) it needs to exercise their code paths, so this is enough to run the full suite; add `--extra examples` for the notebooks. [CONTRIBUTING.md](CONTRIBUTING.md) covers the rest: pre-commit hooks, running the same checks by hand, rebuilding the proto wrappers, and how a release is cut.
 
 ## Conventions
 

--- a/ord_schema/README.md
+++ b/ord_schema/README.md
@@ -6,8 +6,8 @@ definitions themselves, and everything that builds, validates, stores, and queri
 The serialized protos in
 [ord-data](https://github.com/open-reaction-database/ord-data) are the
 [source of truth](https://en.wikipedia.org/wiki/Single_source_of_truth). Every other
-representation here is derived from them and is expected to be reproducible from them —
-which is what lets a derived form be rebuilt rather than reconciled when it disagrees.
+representation here is derived from them and reproducible from them, which is what lets a
+derived form be rebuilt rather than reconciled when it disagrees.
 
 ```mermaid
 flowchart TB
@@ -62,20 +62,22 @@ query paths below exist for.
 
 ## Querying at scale
 
-Two independent paths, neither of which replaces the protos:
+Two independent paths, neither of which replaces the protos. **Derived Parquet**, read
+by a query engine:
 
-- [`artifacts/`](artifacts/) — derived Parquet restating the same reactions in shapes a
-  query engine can read: a **projection** carrying every field as nested columns, a
-  **structures** artifact carrying fingerprints for chemical search, and **pivots** over
-  the repeated levels. Footer stamps make an artifact's staleness detectable without
-  reading column data. See [artifacts/README.md](artifacts/README.md).
-- [`search/`](search/) — the query layer over those artifacts, for callers that should
-  not be writing SQL. A model emits a validated `Query`, and the library compiles it to
-  one DuckDB statement whose worst case is one pass and a sort. See
-  [search/README.md](search/README.md).
-- [`orm/`](orm/) — SQLAlchemy mappers loading the protos into PostgreSQL, one table per
-  message type, for field-level queries against a live database. See
-  [orm/README.md](orm/README.md).
+- [`artifacts/`](artifacts/) restates the same reactions in shapes that can be read
+  cheaply — a **projection** carrying every field as nested columns, a **structures**
+  artifact carrying fingerprints for chemical search, and **pivots** over the repeated
+  levels. Footer stamps make staleness detectable without reading column data.
+  ([README](artifacts/README.md))
+- [`search/`](search/) is the query layer over them, for callers who should not be
+  writing SQL. A model emits a validated `Query`, and the library compiles it to one
+  DuckDB statement whose worst case is one pass and a sort. ([README](search/README.md))
+
+Or a **relational database**, for field-level queries against a live server:
+
+- [`orm/`](orm/) maps the protos into PostgreSQL through SQLAlchemy, one table per
+  message type. ([README](orm/README.md))
 
 ## Command-line entry points
 

--- a/ord_schema/README.md
+++ b/ord_schema/README.md
@@ -36,7 +36,7 @@ flowchart TB
 
 | module | what it is for |
 | --- | --- |
-| [`proto/`](proto/) | generated `dataset_pb2` / `reaction_pb2` and their type stubs; regenerate with `./compile_proto_wrappers.sh` after touching `proto/*.proto` |
+| [`proto/`](proto/) | generated `dataset_pb2` / `reaction_pb2` and their type stubs, rebuilt from `proto/*.proto` |
 | [`message_helpers.py`](message_helpers.py) | the general-purpose toolkit: building messages, single-message I/O, and the canonical SMILES a compound resolves to |
 | [`macros/`](macros/) | shorthand for the shapes people write repeatedly — solutions, workup steps |
 | [`units.py`](units.py) | parses `"1.25 mmol"` into the united message that means it |
@@ -94,10 +94,5 @@ Deriving the query artifacts is separate, and runs in dependency order — proje
 first, then structures and pivots from it; see
 [artifacts/README.md](artifacts/README.md).
 
-## Testing
-
-```bash
-uv run pytest -n auto
-```
-
-The ORM tests start a real PostgreSQL, so `initdb` has to be on `PATH`.
+Installing, running the tests, and rebuilding the proto wrappers are in the
+[repository README](../README.md).

--- a/ord_schema/README.md
+++ b/ord_schema/README.md
@@ -83,12 +83,18 @@ Or a **relational database**, for field-level queries against a live server:
 
 ```bash
 python -m ord_schema.scripts.validate_dataset --input_pattern='data/*/*.pb.gz'
+
 python -m ord_schema.scripts.build_dataset --input_pattern='reactions/*.pbtxt' \
     --name=... --description=... --output=dataset.pb.gz
+
 python -m ord_schema.scripts.enumerate_dataset --template=... --spreadsheet=... \
-    --output=dataset.pb.gz
+    --name=... --description=... --output=dataset.pb.gz
+
 python -m ord_schema.scripts.pb_to_parquet_dataset data/*/*.pb.gz --output=dataset.parquet
 ```
+
+Every option shown is required; each script takes optional ones too, so ask it for
+`--help` rather than reading this as the whole interface.
 
 `parse_uspto.py` converts CML from the NRD and is not part of the normal path.
 

--- a/ord_schema/README.md
+++ b/ord_schema/README.md
@@ -1,0 +1,103 @@
+# `ord_schema`
+
+The reference implementation of the Open Reaction Database schema: the protocol buffer
+definitions themselves, and everything that builds, validates, stores, and queries them.
+
+The serialized protos in
+[ord-data](https://github.com/open-reaction-database/ord-data) are the
+[source of truth](https://en.wikipedia.org/wiki/Single_source_of_truth). Every other
+representation here is derived from them and is expected to be reproducible from them —
+which is what lets a derived form be rebuilt rather than reconciled when it disagrees.
+
+```mermaid
+flowchart TB
+    subgraph author["authoring"]
+        M["message_helpers<br/>macros, units, templating"]
+        V["validations<br/>updates, resolvers"]
+    end
+    P["proto/<br/>Reaction, Dataset"]
+    subgraph store["serialization"]
+        PQ["parquet<br/>datasets, huggingface"]
+    end
+    subgraph read["reading at scale"]
+        A["artifacts/<br/>projection, structures, pivot"]
+        S["search/<br/>a grammar, a compiler, an executor"]
+        O["orm/<br/>PostgreSQL mappers"]
+    end
+    M --> P
+    V --> P
+    P --> PQ
+    PQ --> A
+    A --> S
+    PQ --> O
+```
+
+## Building and checking a message
+
+| module | what it is for |
+| --- | --- |
+| [`proto/`](proto/) | generated `dataset_pb2` / `reaction_pb2` and their type stubs; regenerate with `./compile_proto_wrappers.sh` after touching `proto/*.proto` |
+| [`message_helpers.py`](message_helpers.py) | the general-purpose toolkit: building messages, single-message I/O, and the canonical SMILES a compound resolves to |
+| [`macros/`](macros/) | shorthand for the shapes people write repeatedly — solutions, workup steps |
+| [`units.py`](units.py) | parses `"1.25 mmol"` into the united message that means it |
+| [`templating.py`](templating.py) | enumerates a Dataset from one template reaction and a spreadsheet |
+| [`resolvers.py`](resolvers.py) | turns a name or an identifier string into a structured message; calls external services |
+| [`validations.py`](validations.py) | what a message must satisfy to be publishable |
+| [`updates.py`](updates.py) | automated edits applied to a `Reaction` before it is stored |
+
+## Storing a dataset
+
+| module | what it is for |
+| --- | --- |
+| [`datasets.py`](datasets.py) | the entry point for whole-dataset I/O, dispatching on filename suffix |
+| [`parquet.py`](parquet.py) | the Parquet serialization of a `Dataset`, and `DatasetView`, which streams a file rather than materializing it |
+| [`huggingface.py`](huggingface.py) | fetches published datasets from the ord-data mirror; needs the `huggingface` extra |
+| [`atomic_io.py`](atomic_io.py) | write-then-rename helpers, so a failure partway leaves the previous file intact |
+
+A Parquet dataset is one row per `Reaction` — `reaction_id` plus the wire-format
+`reaction` bytes — with the `Dataset` scalar fields in the footer under `ord.*` keys.
+Random access by row group and streaming iteration both fall out of that; **field-level
+questions do not**, since the reaction is still opaque bytes. That is what the two
+query paths below exist for.
+
+## Querying at scale
+
+Two independent paths, neither of which replaces the protos:
+
+- [`artifacts/`](artifacts/) — derived Parquet restating the same reactions in shapes a
+  query engine can read: a **projection** carrying every field as nested columns, a
+  **structures** artifact carrying fingerprints for chemical search, and **pivots** over
+  the repeated levels. Footer stamps make an artifact's staleness detectable without
+  reading column data. See [artifacts/README.md](artifacts/README.md).
+- [`search/`](search/) — the query layer over those artifacts, for callers that should
+  not be writing SQL. A model emits a validated `Query`, and the library compiles it to
+  one DuckDB statement whose worst case is one pass and a sort. See
+  [search/README.md](search/README.md).
+- [`orm/`](orm/) — SQLAlchemy mappers loading the protos into PostgreSQL, one table per
+  message type, for field-level queries against a live database. See
+  [orm/README.md](orm/README.md).
+
+## Command-line entry points
+
+```bash
+python -m ord_schema.scripts.validate_dataset --input_pattern='data/*/*.pb.gz'
+python -m ord_schema.scripts.build_dataset --input_pattern='reactions/*.pbtxt' \
+    --name=... --description=... --output=dataset.pb.gz
+python -m ord_schema.scripts.enumerate_dataset --template=... --spreadsheet=... \
+    --output=dataset.pb.gz
+python -m ord_schema.scripts.pb_to_parquet_dataset data/*/*.pb.gz --output=dataset.parquet
+```
+
+`parse_uspto.py` converts CML from the NRD and is not part of the normal path.
+
+Deriving the query artifacts is separate, and runs in dependency order — projection
+first, then structures and pivots from it; see
+[artifacts/README.md](artifacts/README.md).
+
+## Testing
+
+```bash
+uv run pytest -n auto
+```
+
+The ORM tests start a real PostgreSQL, so `initdb` has to be on `PATH`.

--- a/ord_schema/artifacts/README.md
+++ b/ord_schema/artifacts/README.md
@@ -1,0 +1,144 @@
+# Derived artifacts
+
+A source dataset in [ord-data](https://github.com/open-reaction-database/ord-data) stores
+reactions as opaque wire-format bytes, so any question about them costs a full
+deserialization. A **derived artifact** restates those same reactions in a shape some
+consumer can read cheaply. It adds no information, which is the whole discipline here: an
+artifact is *wrong* if it disagrees with its source, and *stale* if its source has moved
+on. Both have to be detectable without reading a single column of data.
+
+Three artifacts, derived in a chain:
+
+```mermaid
+flowchart LR
+    D["source dataset<br/>ord-data, wire-format bytes"] --> P["<b>projection</b><br/>every field, as nested Parquet"]
+    P --> S["<b>structures</b><br/>one row per distinct molecule<br/>fingerprints + serialized mol"]
+    P --> V["<b>pivot</b><br/>one row per element of<br/>one repeated level"]
+    S -.->|"paired by source dataset"| C["ord_schema.search.Corpus"]
+    P -.-> C
+    V -.-> C
+```
+
+| artifact | one file per | holds | read by |
+| --- | --- | --- | --- |
+| [`projection`](projection.py) | source dataset | every field of every message reachable from `Reaction`, as `STRUCT` / `LIST` / `MAP` | any query engine; the compiler in [`ord_schema.search`](../search/) |
+| [`structures`](structures.py) | projection | one row per distinct structure: `pattern_fp`, `morgan_fp`, `morgan_popcount`, `mol_binary`, keyed by `structure_id` | the screen and verify steps of substructure search |
+| [`pivot`](pivot.py) | projection × repeated level | one row per element, carrying `reaction_id`, the ordinal of every enclosing level, and the element's own non-repeated fields | quantifiers, as a semi-join |
+
+The projection leaves **no field out** — a field left out is a question nobody can ask,
+and the point is to serve questions nobody enumerated in advance. Its schema is generated
+from the proto descriptors rather than written by hand, so a field added upstream appears
+without anyone deciding it is worth carrying. Only two normalizations are applied, both
+because the un-normalized form is a trap rather than because it is inconvenient: united
+`{value, precision, units}` triples become columns named for their unit
+(`setpoint_kelvin`), so `WHERE temperature > 350` cannot silently miss the rows recorded
+in Celsius; and the structural identifiers collapse to one `smiles`, so "what is this
+molecule" has one answer. Everything else stays in the source `reaction` column, which
+remains authoritative for byte-exact round-tripping.
+
+## Stamps
+
+Every artifact carries five footer keys in the `ord.` namespace, and
+[`base.is_current`](base.py) requires all of them to match before a file counts as
+current:
+
+| key | why it can invalidate |
+| --- | --- |
+| `ord.artifact` | tells one artifact from another without inspecting the schema |
+| `ord.artifact_version` | one version across **all** artifacts, so two artifacts of one dataset cannot disagree while both look current |
+| `ord.source_md5` | the content of the source dataset this restates |
+| `ord.ord_schema_version` | what derived it |
+| `ord.rdkit_version` | RDKit releases have changed both canonicalization and pattern fingerprints, either of which silently breaks a file whose consumers run the newer one |
+
+A sixth, `ord.source_dataset_id`, is written only when the source records one, and is the
+only key not required to read stamps back.
+
+An artifact derived from another artifact **passes `source_md5` through** rather than
+hashing its parent. So every artifact names the dataset it reflects however many
+derivations away it sits, and one comparison answers "is this current for that dataset?"
+A chain is invisible to a consumer checking currency.
+
+The version is deliberately shared rather than per-artifact. A derivation change usually
+touches shared helpers, and a reader comparing two artifacts to each other needs to know
+they were built by the same definition.
+
+## Deriving a tree
+
+[`base.derive_tree`](base.py) is the driver every script uses. It walks a glob and, for
+each match:
+
+- mirrors the input's directory layout beneath `output_dir`, rooted at the leading
+  components of the pattern that hold no wildcard;
+- **skips** anything whose footer already records the current source and versions, so
+  re-running is cheap and an interrupted run resumes rather than restarts;
+- **ignores** a match that is not the kind of parent this derivation reads — a source
+  dataset where a projection was wanted, or an artifact from an earlier run — so
+  `output_dir` may sit inside a recursive pattern's reach;
+- **refuses** to write over any of its inputs, checked across every destination against
+  every source rather than each against its own, because an `output_dir` nested in the
+  source tree maps one dataset onto a *different* one, which a per-source check passes
+  while destroying a source the run has not reached yet.
+
+Three scripts wrap it, in dependency order:
+
+```bash
+python -m ord_schema.artifacts.scripts.derive_projection \
+    --input_pattern='data/*/*.parquet' --output_dir=projections
+
+python -m ord_schema.artifacts.scripts.derive_structures \
+    --input_pattern='projections/*/*.parquet' --output_dir=structures
+
+python -m ord_schema.artifacts.scripts.derive_pivots \
+    --input_pattern='projections/*/*.parquet' --output_dir=pivots \
+    --levels outcomes.products outcomes.products.measurements
+```
+
+Each takes `--force` to rewrite what is already current. `derive_pivots` defaults to all
+39 repeated levels, which is far more than a deployment answers questions over; naming
+the levels it does is the cheaper run.
+
+## What pairs with what
+
+`structure_id` is assigned by `write_projection` in first-seen order and is **local to
+one dataset**. The projection and its structures artifact are two statements of one
+derivation and are meaningful only together:
+
+- IDs are not stable across builds, so nothing outside the artifacts should record them.
+  The column is marked internal and stays out of what a model is told it may query.
+- A projection rewritten in place needs its structures artifact rederived with it. The
+  stamps name the *source dataset* rather than the projection file, so the skip check
+  cannot see that the pairing changed — which is why
+  [`Corpus`](../search/execute.py) additionally refuses a structures artifact too short
+  to hold every `structure_id` its projection carries.
+- Pairing is by source dataset rather than by filename, so the two trees need not share a
+  layout.
+
+A pivot names its reactions by ID, so one derived from another corpus resolves against
+rows this one does not hold — confidently and wrongly. `Corpus` refuses pivot artifacts
+whose source datasets are not its projections'.
+
+## Querying a projection
+
+Use list lambdas over repeated levels, never `UNNEST` in a `FROM` clause. Measured in
+DuckDB it is 27–200× slower where it finishes at all, and over the full corpus 0.9
+seconds against no result in four minutes. It also emits one row per matching identifier
+rather than one per reaction, so the two spellings need a `DISTINCT` to even count alike:
+
+```sql
+-- fast
+SELECT reaction_id FROM p
+WHERE len(list_filter(
+        flatten(list_transform(map_values(inputs), i -> i.components)),
+        c -> len(list_filter(c.identifiers,
+                             x -> x.type = 'NAME' AND x.value = 'THF')) > 0)) > 0
+
+-- same answer, does not finish
+SELECT DISTINCT reaction_id
+FROM p, UNNEST(map_values(inputs)) t(i), UNNEST(i.components) u(c),
+        UNNEST(c.identifiers) v(x)
+WHERE x.type = 'NAME' AND x.value = 'THF'
+```
+
+Writing that by hand is what [`ord_schema.search`](../search/) exists to avoid: it
+compiles a validated `Query` to the fast spelling, and routes quantifiers to the pivots
+and to a structure index rather than to the projection where it can.

--- a/ord_schema/artifacts/README.md
+++ b/ord_schema/artifacts/README.md
@@ -25,16 +25,15 @@ flowchart LR
 | [`structures`](structures.py) | projection | one row per distinct structure: `pattern_fp`, `morgan_fp`, `morgan_popcount`, `mol_binary`, keyed by `structure_id` | the screen and verify steps of substructure search |
 | [`pivot`](pivot.py) | projection × repeated level | one row per element, carrying `reaction_id`, the ordinal of every enclosing level, and the element's own non-repeated fields | quantifiers, as a semi-join |
 
-The projection leaves **no field out** — a field left out is a question nobody can ask,
-and the point is to serve questions nobody enumerated in advance. Its schema is generated
-from the proto descriptors rather than written by hand, so a field added upstream appears
-without anyone deciding it is worth carrying. Only two normalizations are applied, both
-because the un-normalized form is a trap rather than because it is inconvenient: united
-`{value, precision, units}` triples become columns named for their unit
-(`setpoint_kelvin`), so `WHERE temperature > 350` cannot silently miss the rows recorded
-in Celsius; and the structural identifiers collapse to one `smiles`, so "what is this
-molecule" has one answer. Everything else stays in the source `reaction` column, which
-remains authoritative for byte-exact round-tripping.
+The projection leaves **no field out** — a field left out is a question nobody can ask.
+Its schema is generated from the proto descriptors, so a field added upstream appears
+without anyone deciding it is worth carrying. Two normalizations are applied, both
+because the un-normalized form is a trap: united `{value, precision, units}` triples
+become columns named for their unit (`setpoint_kelvin`), so `WHERE temperature > 350`
+cannot silently miss the rows recorded in Celsius; and the structural identifiers
+collapse to one `smiles`, so "what is this molecule" has one answer. Everything else
+stays in the source `reaction` column, which remains authoritative for byte-exact
+round-tripping.
 
 ## Stamps
 
@@ -54,11 +53,11 @@ A sixth, `ord.source_dataset_id`, is written only when the source records one, a
 only key not required to read stamps back.
 
 An artifact derived from another artifact **passes `source_md5` through** rather than
-hashing its parent. So every artifact names the dataset it reflects however many
+hashing its parent, so every artifact names the dataset it reflects however many
 derivations away it sits, and one comparison answers "is this current for that dataset?"
 A chain is invisible to a consumer checking currency.
 
-The version is deliberately shared rather than per-artifact. A derivation change usually
+The version is shared rather than per-artifact because a derivation change usually
 touches shared helpers, and a reader comparing two artifacts to each other needs to know
 they were built by the same definition.
 

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -2,7 +2,7 @@
 
 The serialized protocol buffers in [ord-data](https://github.com/open-reaction-database/ord-data)
 are the [source of truth](https://en.wikipedia.org/wiki/Single_source_of_truth), and the
-[projection](../projection.py) restates them as nested Parquet so a query engine can read one
+[projection](../artifacts/projection.py) restates them as nested Parquet so a query engine can read one
 leaf without deserializing the rest. This package is how a language model reaches that
 projection: what the model is told it may query, what it is allowed to emit, and how that
 becomes SQL.
@@ -88,10 +88,58 @@ is a compile error rather than a wrong answer:
   those are real graph atoms in a stored molecule and the query already works;
   28,297 ORD reactions have an `[H][H]` component.
 
+## How a query is answered
+
+One `Query` becomes one SQL statement. The chemistry and the compound names are lifted
+out of it and bound as parameters, so what DuckDB runs is a filter over the projection
+and nothing else:
+
+```mermaid
+flowchart TB
+    Q["Query, as JSON"] --> V["validate against projection.SCHEMA<br/>paths, leaf types, quantifiers"]
+    V --> C["compile to one SQL statement<br/>one relation, no join, no recursion"]
+    C --> N["compound names<br/>resolvers → SMILES"]
+    C --> S["structure predicates<br/>RDKit screen → verify → bitmap"]
+    C --> X["run on this search's own cursor"]
+    N -- "bound parameters" --> X
+    S -- "bound parameters" --> X
+    X --> O["reaction_id, or the group<br/>and measure columns"]
+```
+
+Three relations can answer a quantifier, and the compiler chooses **per quantifier**
+rather than per query — so one statement can spend the occurrence index on one clause
+and a pivot on the next:
+
+```mermaid
+flowchart TB
+    A["exists / forall over a repeated level"] --> B{"an exists whose body is one structure<br/>predicate on the element's own smiles,<br/>at most a reaction_role beside it?"}
+    B -- yes --> I["<b>occurrence index</b><br/>reaction_id IN (SELECT … FROM occurrences …)"]
+    B -- no --> P{"does the body resolve against<br/>the pivot's pruned element,<br/>and does a pivot fit?"}
+    P -- yes --> V["<b>a pivot</b><br/>EXISTS (SELECT 1 FROM pivot_… AS x0 …)"]
+    P -- no --> E["<b>the elements</b><br/>list_filter over the nested column"]
+```
+
+The three answer identically — that is what the differential tests pin — and differ only
+in what they read. Worked examples, with the route each clause takes:
+
+| query | clause | route |
+| --- | --- | --- |
+| above 350 K | `conditions.temperature.setpoint_kelvin > 350` | no quantifier: the projection |
+| pyridine as the solvent | `exists inputs.components` | occurrence index |
+| pyridine as the solvent, yield above 50% | `exists inputs.components` | occurrence index |
+| | `exists outcomes.products.measurements` | pivot |
+| every product is desired | `forall outcomes.products` | pivot — the index shows which elements match, never that all of them do |
+| pyridine **and** a boronic acid in one component | `exists inputs.components` | pivot — two structure predicates is one more than an occurrence row can carry |
+| a desired product with a yield above 50% | `exists outcomes.products`, nested `exists measurements` | both levels' pivots, joined on the ordinal prefix |
+
+Every pivot row above falls to the elements when no pivot is available — a level the
+budget refused, or one with neither an artifact nor room to build. The answer does not
+change; the query gets slower, and the log says which route it took.
+
 ## Structure search
 
 A structure predicate compiles to a bitmap test, not to chemistry. The chemistry runs
-in [`execute.Corpus`](execute.py) against the [structures artifact](../structures.py).
+in [`execute.Corpus`](execute.py) against the [structures artifact](../artifacts/structures.py).
 Substructure runs through an RDKit `SubstructLibrary` built over the corpus: a
 fingerprint **screen** — complete but not exact — over every distinct molecule in the
 corpus, then exact subgraph **verification** of the survivors. It runs on RDKit's own
@@ -181,6 +229,23 @@ clauses hold of *different* elements: "a desired product with a yield above 50%"
 wrong, silently. ORD is effectively single-outcome, so dropping the *outcome* ordinal
 changes nothing at all, which is exactly why the product-level error looks correct until
 it is checked.
+
+A reaction with the shape of those 942 — one outcome, two products, and the high yield on
+the one nobody wanted — is two rows in each pivot:
+
+```text
+pivot over outcomes.products                pivot over outcomes.products.measurements
+reaction  outcome product  is_desired       reaction  outcome product  meas  type   value
+ord-wd07  1       1        true             ord-wd07  1       1        1     YIELD  10
+ord-wd07  1       2        false            ord-wd07  1       2        1     YIELD  90
+          └───────┴──── the outer clause selects this product ────┘
+                          ...and the inner clause selects the other product's measurement
+```
+
+The outer clause holds of `(1, 1)` and the inner of `(1, 2, 1)`. Joined on the reaction
+alone — or on `(reaction, outcome)`, which over ORD is the same join — the desired product
+pairs with its sibling's 90% and the reaction answers yes. Joined on the whole prefix it
+does not: product 1's only measurement is 10%.
 
 Over the whole corpus, warm, against the same queries answered from the elements — the
 pivots read as artifacts, and the same pivots built in process:

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -631,3 +631,14 @@ Execution has no sandbox. `enable_external_access=false` cannot be combined with
 view — only a materialized table survives it — so running against the full corpus needs
 DuckDB's `allowed_directories` or a separate process. Compiling from an IR removes the reasons
 to fear the *query*; it does not remove the reasons to contain the *process*.
+
+**Text search is deferred, not approximated.** `contains`, `starts_with`, and `ends_with`
+compile and run against any of the projection's 234 string leaves, including the 72 that hold
+free prose, and searching a short string field — a `type`, a `vendor`, a compound's name — is
+squarely in scope. What is out of scope is *tuning for* the prose ones: nothing here is
+indexed, cached, or budgeted on their behalf, and where a measurement on this page involves a
+substring it is reported rather than optimized against. Searching unstructured text properly
+wants an inverted index over the prose columns, which is a different shape from a scan of a
+nested projection, and building toward it inside this design would make the eventual thing
+harder rather than nearer. Compound names have a route that is not string matching anyway: a
+`{"compound": ...}` value resolves to SMILES and becomes a structure predicate.

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -165,24 +165,16 @@ that is the RDKit screen and verify, which the index does not touch: pyridine's 
 alone is about 1.4s of its 1.46s. What the index cut is the reaction lookup, from roughly
 3.5s to 0.2s.
 
-The index answers one *quantifier* at a time, not one query: an `exists` whose body asks
-for one structure and at most one role becomes `reaction_id IN (...)`, and the rest of
-the query compiles as if the index did not exist. So "reactions with yield > 50% where
-pyridine is the solvent" spends the index on its pyridine clause and answers the yield
-clause from the pivot over `outcomes.products.measurements`, in one query — and
-aggregates, orderings, limits, negations, disjunctions, and second structure predicates
-all compose the same way. A quantifier the index cannot carry — one binding another
-element field, holding no structure predicate or two, or any `forall`, which needs every
-element rather than some — falls to the pivot, and to the elements only if no pivot holds
-the level either. Either way it is one compiled query, screened
-and verified identically; the log line says whether the index took a clause. A level the
-source never recorded — most reactions have no workups and no authentic standards — is a
-level with no elements: nothing satisfies an `exists` there and nothing contradicts a
-`forall`, so "reactions **without** pyridine in the workup" includes every reaction that
-has no workup at all, whichever way the clause was answered. The index
-is built on the first query that spends it, one pass over the projections per indexed
-path, so a server that wants its first real query to be fast should issue a throwaway
-structure query at startup.
+Whichever route a clause takes, aggregates, orderings, limits, negations, disjunctions,
+and a second structure predicate compose around it, and the screening and verification
+are identical. A level the source never recorded — most reactions have no workups and no
+authentic standards — is a level with no elements: nothing satisfies an `exists` there
+and nothing contradicts a `forall`, so "reactions **without** pyridine in the workup"
+includes every reaction that has no workup at all.
+
+The index is built by the first query that spends it, one pass over the projections per
+indexed path, so a server wanting its first real query to be fast should issue a
+throwaway structure query at startup.
 
 ## Pivoted levels
 
@@ -195,21 +187,20 @@ AND …)`, and a `forall` the same with `NOT EXISTS` and the body negated.
 
 Two properties do the work. The pivot is **complete** — every element gets a row,
 including one whose fields are all NULL — which is what lets it answer `forall`, where
-the occurrence index cannot, since that one holds only elements carrying a structure.
-And struct nesting is **kept**, so `percentage.value` is `x.element.percentage.value`
-here and `e0.percentage.value` over the elements: the same path by the same spelling,
-which is what makes the two routes comparable. Removing only the repeated fields is
-where the size goes; the cost was never struct access but the reconstruction of lists of
-structs, and a scalar pulled out of a deep struct across the whole corpus is seconds.
+the occurrence index cannot, holding as it does only elements carrying a structure. And
+struct nesting is **kept**, so `percentage.value` is `x.element.percentage.value` here
+and `e0.percentage.value` over the elements: the same path by the same spelling, which is
+what makes the two routes comparable. Removing only the repeated fields is where the size
+goes; the cost was never struct access but the reconstruction of lists of structs.
 
 That also decides coverage without a list anybody maintains. A body reaching a field the
 pivot dropped fails to resolve against the pruned element type, so the quantifier falls
-back to the elements. What a pivot does carry is `structure_id`, so a structure
-predicate inside a pivoted quantifier works too, reading `structure_offset` from the
-enclosing reaction. A quantifier's path need not name a level either: descending from
-one through singular struct fields reaches one value per element rather than a list of
-its own — an authentic standard is one compound per measurement — so the level it ranges
-over is the nearest repeated ancestor, whose pivot already carries the struct.
+back to the elements. A pivot does carry `structure_id`, so a structure predicate inside
+a pivoted quantifier works too, reading `structure_offset` from the enclosing reaction.
+A quantifier's path need not name a level either: descending through singular struct
+fields reaches one value per element rather than a list of its own — an authentic
+standard is one compound per measurement — so the level it ranges over is the nearest
+repeated ancestor, whose pivot already carries the struct.
 
 The ordinals are what a flat row needs to say *which* element it was, and a **nested**
 quantifier is where they are spent: an `exists` inside a pivoted one becomes a semi-join
@@ -234,18 +225,16 @@ A reaction with the shape of those 942 — one outcome, two products, and the hi
 the one nobody wanted — is two rows in each pivot:
 
 ```text
-pivot over outcomes.products                pivot over outcomes.products.measurements
-reaction  outcome product  is_desired       reaction  outcome product  meas  type   value
-ord-wd07  1       1        true             ord-wd07  1       1        1     YIELD  10
-ord-wd07  1       2        false            ord-wd07  1       2        1     YIELD  90
-          └───────┴──── the outer clause selects this product ────┘
-                          ...and the inner clause selects the other product's measurement
+pivot over outcomes.products              pivot over outcomes.products.measurements
+reaction  outcome product  is_desired     reaction  outcome product  meas  type   value
+ord-wd07  1       1        true      <--  ord-wd07  1       1        1     YIELD  10
+ord-wd07  1       2        false          ord-wd07  1       2        1     YIELD  90
+          the outer clause holds here     and the inner clause holds here  -----^
 ```
 
-The outer clause holds of `(1, 1)` and the inner of `(1, 2, 1)`. Joined on the reaction
-alone — or on `(reaction, outcome)`, which over ORD is the same join — the desired product
-pairs with its sibling's 90% and the reaction answers yes. Joined on the whole prefix it
-does not: product 1's only measurement is 10%.
+Joined on the reaction alone — or on `(reaction, outcome)`, which over ORD is the same
+join — the desired product pairs with its sibling's 90% and the reaction answers yes.
+Joined on the whole prefix it does not: product 1's only measurement is 10%.
 
 Over the whole corpus, warm, against the same queries answered from the elements — the
 pivots read as artifacts, and the same pivots built in process:
@@ -267,9 +256,8 @@ else is 6–27× against the elements, and **a pivot read from Parquet is within
 of milliseconds of the same pivot held in memory** — which is the whole argument for
 deriving them, since the artifact costs no budget at all.
 
-Building one in process unnests the projection down to its level, and is charged against
-`pivot_budget_bytes` and evicted least-recently-used. What it costs, measured one build
-per process so eviction cannot corrupt the reading:
+Building one in process unnests the projection down to its level. What that costs,
+measured one build per process so eviction cannot corrupt the reading:
 
 | level | unnests | held | build | as an artifact |
 | --- | --- | --- | --- | --- |
@@ -309,16 +297,7 @@ and `check_pivots()` never triggers it: that call reaches all 39 levels, and der
 there would unnest the projection 39 times at startup for a deployment that asks about
 two.
 
-What remains is the chemistry itself, and two things cut it. Structures are deduplicated
-per dataset, so the library holds one entry per **distinct** molecule — 1,435,426 of the
-corpus's 2,016,224 rows, so 29% of the matching disappears — and maps each entry back to
-every structure ID sharing it. And a match set depends on the query molecule, the
-operation, and the threshold, so recent ones are **cached**: pyridine costs 1.05s the
-first time and 0.02s the next. A compound is keyed by what it resolved to rather than by
-its name, and by which parser reads it — the same text is one molecule as SMILES and
-another as SMARTS. A predicate asked
-again while the first pass is still running waits for that pass, so a burst of identical
-requests costs one match; unrelated searches still overlap.
+## What a projection query costs
 
 Queries the index declines read the projection, and most of what that costs is not the
 reading. A scan re-parses the footer of every file it touches, and a 442-leaf projection
@@ -337,14 +316,14 @@ projection query:
 The footers cost about **200 MB** over the whole corpus, once, and are bounded by the
 files rather than by what is asked of them — which is why they are held unconditionally
 where the gigabytes a pivot costs are weighed against a budget. With them held, a scalar
-query over the projection lands in hundredths of a second, so there is nothing left for a
-cache of the columns themselves to buy.
+query over the projection lands in hundredths of a second, which leaves a cache of the
+columns themselves nothing to buy.
 
-Pivots are held to that memory budget and evicted least-recently-used, skipping any a
-search is still reading; one too large to keep is not kept, the quantifier compiles over
-the elements, and that is remembered rather than rediscovered by building it again. Only
-builds wait on builds: a search over a level already materialized is answered while
-another is being built.
+A pivot built in process is charged against `pivot_budget_bytes` and evicted
+least-recently-used, skipping any a search is still reading; one too large to keep is not
+kept, the quantifier compiles over the elements, and that is remembered rather than
+rediscovered by building it again. Only builds wait on builds: a search over a level
+already materialized is answered while another is being built.
 
 **The budget is the cliff, and it says so.** A refused level logs a **warning** on every
 query over it, giving what it costs, what the budget is, and what changes them — so a
@@ -364,9 +343,11 @@ largest pivot, not the budget alone — `pivot_budget_bytes=0` is the one figure
 avoids the build entirely, and so the one that bounds a small machine. A deployment with
 derived artifacts spends none of it: those are views over Parquet, not tables.
 
-**Sizing a deployment.** Measured as process resident size, since that is what a memory
-limit is applied to, building each part in the order a first substructure query would,
-with `pivot_budget_bytes=0` and the pivots read as artifacts:
+## Sizing a deployment
+
+Measured as process resident size, since that is what a memory limit is applied to,
+building each part in the order a first substructure query would, with
+`pivot_budget_bytes=0` and the pivots read as artifacts:
 
 | after | resident |
 | --- | --- |
@@ -417,8 +398,7 @@ never needs to spend.
 Over the whole corpus (2,428,291 reactions, 53 files, the default budget, pivots read as
 artifacts, warm), a mixed set of queries pairing an indexed structure clause with one the
 index cannot carry. The second column refuses the index, so the pivots take every
-quantifier — which is what a corpus without an index now falls to, rather than to the
-elements:
+quantifier — which is where a corpus without an index lands:
 
 | query | index | pivots alone |
 | --- | --- | --- |
@@ -438,6 +418,18 @@ other clause is cheap — a scalar path or a substring — because there the who
 the structure clause. Where the other clause is itself a quantifier the pivot answers, the
 two routes converge.
 
+## The screen and the match set
+
+Two things cut the chemistry. Structures are deduplicated per dataset, so the library
+holds one entry per **distinct** molecule — 1,435,426 of the corpus's 2,016,224 rows, so
+29% of the matching disappears — and maps each entry back to every structure ID sharing
+it. And a match set depends on the query molecule, the operation, and the threshold, so
+recent ones are **cached**: pyridine costs 1.05s the first time and 0.02s the next. A
+compound is keyed by what it resolved to rather than by its name, and by which parser
+reads it — the same text is one molecule as SMILES and another as SMARTS. A predicate
+asked again while the first pass is still running waits for that pass, so a burst of
+identical requests costs one match; unrelated searches still overlap.
+
 The screen itself is not a lever. It is the same `PatternFingerprint` the RDKit
 PostgreSQL cartridge screens with (`rdkit.sss_fp_size`, via `makeMolSignature`), and for
 a small common query it admits most of the corpus — 80% for pyridine, of which 73% then
@@ -456,6 +448,10 @@ alternative — intersecting reaction-ID sets — over-returns by 94% on exactly
 query; see [ord-logbook#28](https://github.com/open-reaction-database/ord-logbook/pull/28),
 finding 4. Every corpus-scale figure on this page was measured against that logbook
 entry's snapshot of ORD.
+
+## Usage
+
+### Search a corpus
 
 ```python
 from ord_schema.search import execute, query
@@ -491,8 +487,6 @@ not share a layout. Structure IDs are dataset-local; the executor's relation
 carries a per-file offset column (`structure_offset`), which is why compiled SQL with a
 structure predicate runs only there — validate it against `query.executable_schema()`
 rather than the bare projection schema.
-
-## Usage
 
 ### Tell the model what it may query
 
@@ -621,9 +615,9 @@ human who is not the injection risk and whose slow query costs only their own se
 schema, so it needs no corpus. It refuses anything that is not a single `SELECT`, refuses
 `UNNEST` in a `FROM` clause, and runs on a connection with no filesystem access.
 
-It is a check on the compiler's own output, not the guard it once was — the guard is the
-grammar. It still **does not bound cost**, and says so: a caller running arbitrary SQL against
-a real corpus needs its own statement timeout, row cap, or memory limit.
+It is a check on the compiler's own output; the guard is the grammar. It **does not bound
+cost**, and says so: a caller running arbitrary SQL against a real corpus needs its own
+statement timeout, row cap, or memory limit.
 
 ## Not yet solved
 
@@ -632,13 +626,12 @@ view — only a materialized table survives it — so running against the full c
 DuckDB's `allowed_directories` or a separate process. Compiling from an IR removes the reasons
 to fear the *query*; it does not remove the reasons to contain the *process*.
 
-**Text search is deferred, not approximated.** `contains`, `starts_with`, and `ends_with`
-compile and run against any of the projection's 234 string leaves, including the 72 that hold
-free prose, and searching a short string field — a `type`, a `vendor`, a compound's name — is
-squarely in scope. What is out of scope is *tuning for* the prose ones: nothing here is
-indexed, cached, or budgeted on their behalf, and where a measurement on this page involves a
-substring it is reported rather than optimized against. Searching unstructured text properly
-wants an inverted index over the prose columns, which is a different shape from a scan of a
-nested projection, and building toward it inside this design would make the eventual thing
-harder rather than nearer. Compound names have a route that is not string matching anyway: a
-`{"compound": ...}` value resolves to SMILES and becomes a structure predicate.
+**Text search is deferred, not approximated.** `contains`, `starts_with`, and `ends_with` run
+against any of the projection's 234 string leaves, and searching a short one — a `type`, a
+`vendor`, a compound's name — is in scope. Tuning for the 72 that hold free prose is not:
+nothing here is indexed, cached, or budgeted on their behalf, and a measurement on this page
+involving a substring is reported rather than optimized against. Doing it properly wants an
+inverted index over the prose columns, a different shape from a scan of a nested projection,
+and building toward that inside this design would put it further off rather than nearer.
+Compound names have a route that is not string matching anyway: a `{"compound": ...}` value
+resolves to SMILES and becomes a structure predicate.

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -278,7 +278,7 @@ where an in-memory column charges for shape: `workups` carries 40 leaves, most o
 NULL in most rows, which encode to almost nothing and occupy a full-width vector and a
 validity mask apiece. The projection itself expands the same way, 1.53 GB of Parquet to
 **18.46 GB in memory**, which is why nothing here holds it. Publishing all four levels as
-views takes 0.9s and no memory, against 32 minutes and 9.21 GiB to build them in process.
+views takes 0.9s and no memory, against 32 minutes to build them in process.
 
 That is what `scripts/derive_pivots.py` is for — one subdirectory per level, one file per
 projection within it, stamped like any other derived artifact and read by


### PR DESCRIPTION
## Summary

Documentation only. The search page explains three relations that can answer a quantifier but never shows them together, so which one answers a given clause had to be reassembled from prose several sections apart — two diagrams and a worked-example table now state it directly. The same page had one H2 running three hundred lines over six topics, which is most of why it reads as long. And `ord_schema/` and `ord_schema/artifacts/` had no README at all.

## Changes

- **Search README**: a pipeline diagram and a routing diagram (mermaid, which GitHub renders), plus a table giving the route each clause of six example queries actually takes. Routes were read off the compiler with a probe, not asserted.
- The ordinal-prefix correlation gets rows rather than only SQL — one outcome, two products, the high yield on the one nobody wanted, which is the shape of the 942 reactions a product-blind join over-returned. Rows taken from the real pivots, not invented.
- Four new H2s split the long middle; the chemistry paragraph stranded between the pivot artifacts and the footer cache joins the screen material, and the worked example moves under `Usage`.
- Cut the routing prose the new diagrams restate, stated the budget and eviction rules once instead of three times, and rewrote two sentences that described what the page used to say.
- A note that text search is deferred rather than approximated: substring predicates run on any of the 234 string leaves and searching a short one is in scope, but nothing here is indexed, cached, or budgeted for the 72 that hold free prose.
- **New `ord_schema/README.md`**: a map of the package — building a message, storing a dataset, the two query paths — with a diagram of how they feed each other.
- **New `ord_schema/artifacts/README.md`**: the stamp keys and what each can invalidate, why the artifact version is shared rather than per-artifact, what `derive_tree` skips/ignores/refuses, and the pairing invariants around `structure_id`.
- **Consolidated development setup.** Installing for development was documented twice — the repository README and CONTRIBUTING.md — and CONTRIBUTING's copy was the fuller one. The README keeps the clone-and-sync a reader needs first and points there for hooks, checks, and releases; the proto rebuild moves to CONTRIBUTING beside the other build steps.
- Added the `search` extra to the installation table. It is real in `pyproject.toml` and `search/README.md` opens by telling people to install it, but the table that is supposed to list every extra did not have it.
- The root README gains a **Package layout** section, since a nested README is otherwise found only by browsing into its directory.
- Distill pass over every touched page: fixed the package page claiming "two independent paths" above a three-item list (artifacts and search are one path, the ORM is the other), dropped a repeated `9.21 GiB`, and cut a hedge apiece.
- Fixed two links that still pointed at `../projection.py` and `../structures.py` from before those modules moved under `artifacts/`.

## Testing

- `markdownlint-cli2` clean on all three files; every relative link resolves.
- Every command shown on the two new pages was run against its own `--help`, which caught `pb_to_parquet_dataset` taking positional inputs rather than the `--input_pattern` I had written.
- Prose only — no code changed, so the suite is untouched at 1179 passed, 2 skipped.

## Notes

- The search page is 637 lines against 568 on `main`: the diagrams and the two new sections add more than the distillation cuts. If you want it materially shorter the lever is structural — roughly 250 lines of it are a measured performance report (build costs, resident sizes, the index floor, three benchmark tables) that could move to the logbook or a `PERFORMANCE.md`, leaving grammar, routing, usage, and scope. Say the word and I'll do that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR expands and reorganizes documentation for package structure, derived artifacts, and search-query routing while consolidating contributor setup guidance.
- Adds package-level READMEs for `ord_schema` and its derived-artifact subsystem.
- Documents search routing with Mermaid diagrams and worked examples.
- Adds the `search` installation extra and centralizes data conventions.
- Corrects the `enumerate_dataset` example by supplying all required arguments.
</details>

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge.

No blocking failure remains; the previously incomplete `enumerate_dataset` command now supplies every required CLI argument.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/README.md | Adds a package map and CLI examples; the corrected `enumerate_dataset` invocation now includes all five required options. |
| ord_schema/artifacts/README.md | Documents artifact derivation, provenance stamps, pairing invariants, and query-oriented data shapes. |
| ord_schema/search/README.md | Adds query-routing diagrams and examples while reorganizing and clarifying the existing search documentation. |
| README.md | Adds the search extra and package-layout links while consolidating development instructions. |
| CONTRIBUTING.md | Moves protocol-wrapper rebuild guidance alongside the other contributor build steps. |
| CONVENTIONS.md | Extracts the preferred compound-stoichiometry convention into a dedicated document. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Give the conventions a file, and show ev..."](https://github.com/open-reaction-database/ord-schema/commit/a3592f1b1b4b3c0757473d6b0feb431a08240e7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53838960)</sub>

<!-- /greptile_comment -->