### PR TITLE
Use a forall example that quantifies over something

### DIFF
--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -128,7 +128,7 @@ in what they read. Worked examples, with the route each clause takes:
 | pyridine as the solvent | `exists inputs.components` | occurrence index |
 | pyridine as the solvent, yield above 50% | `exists inputs.components` | occurrence index |
 | | `exists outcomes.products.measurements` | pivot |
-| every product is desired | `forall outcomes.products` | pivot — the index shows which elements match, never that all of them do |
+| solvent-free: no component is a solvent | `forall inputs.components` | pivot — the index shows which elements match, never that all of them do |
 | pyridine **and** a boronic acid in one component | `exists inputs.components` | pivot — two structure predicates is one more than an occurrence row can carry |
 | a desired product with a yield above 50% | `exists outcomes.products`, nested `exists measurements` | both levels' pivots, joined on the ordinal prefix |
 


### PR DESCRIPTION
Summary
-------
The search README's worked-example table used "every product is desired" to illustrate a `forall`. It is a query nobody would ask: reactions carry 1.10 products on average, so the quantifier almost always ranges over one element, and `is_desired_product` is recorded on 173,048 of 2,673,037 products — what it mostly separates is which depositors set the flag, not chemistry.

Changes
-------
Replaced the row with solvent-free (`forall inputs.components`, `reaction_role <> SOLVENT`), which takes the same route over a level that has real multiplicity.

Testing
-------
Route read off the compiler, unchanged from the row it replaces — pivot on `inputs.components`, falling back to the elements when none is available:

```sql
SELECT reaction_id FROM reactions WHERE NOT EXISTS (
  SELECT 1 FROM pivot_inputs_components AS x0
  WHERE x0.reaction_id = reactions.reaction_id AND NOT (x0.element.reaction_role <> 'SOLVENT'))
```

Counted over the local projections (2,428,291 reactions): 4.92 components per reaction, `reaction_role` recorded on all but 2,116 of 11.9M components, no reaction with zero components so the `forall` is never vacuous, and 885,972 reactions match.

Notes
-----
The logbook entry benchmarks the old query by name and keeps its measured latencies. Those numbers are what was measured and stay as they are, but they are a `forall` over 1.10 elements per reaction — close to the cheapest one available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the search README’s `forall` worked example to quantify over the higher-multiplicity `inputs.components` level.
- Replaces “every product is desired” with a solvent-free query.
- Documents the pivot route for checking that every component has a non-solvent reaction role.
</details>

<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge.

The new example is consistent with the schema and compiler behavior, and no concrete incorrect or misleading documentation remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/search/README.md | The revised example accurately reflects the compiler’s `forall` semantics, pivot selection, and documented fallback behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Use a forall example that quantifies ove..."](https://github.com/open-reaction-database/ord-schema/commit/0c0961e5297a93bd2d68758529769f6709bd7350) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53845470)</sub>

<!-- /greptile_comment -->