### PR TITLE
Let a deployment bound what DuckDB holds

### DIFF
--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -311,8 +311,9 @@ derived artifacts spends none of it: those are views over Parquet, not tables.
 Budget **about 8 GiB of resident memory** for a corpus serving substructure search over
 ORD: 1.1 GiB to open, 2.2 GiB for the `SubstructLibrary`, 1.19 GiB for the occurrence
 index, and DuckDB's own caches on top, which fill whatever `memory_limit` allows. `Corpus`
-sets no limit, so DuckDB takes its default share of the machine it finds. The step-by-step
-breakdown is in [the logbook entry][cache-entry], finding 16.
+takes that limit as an argument; left unset, DuckDB claims about 80% of the machine — or
+of the container's cap, which it does read. The step-by-step breakdown is in
+[the logbook entry][cache-entry], finding 16.
 
 None of that is optional for substructure search, since the screen and verify are RDKit in
 this process rather than SQL in an engine. Everything above it is latency: a container
@@ -321,7 +322,7 @@ the projection, in seconds rather than the tens of milliseconds a pivot takes. T
 no managed service to move this to — Athena and its kin can scan the Parquet, but the
 chemistry is not SQL.
 
-**The index build has a floor, and it is not a soft one.** Over ORD it wants about **5 GB**
+**The index build has a floor, and it is not a soft one.** Over ORD it wants **5–6.5 GB**
 of DuckDB memory, and below that it raises `OutOfMemoryException` rather than running
 slowly — a block it cannot pin is not one it can spill, so a `temp_directory` does not
 rescue it. Near the floor it also wants 16–25 GiB of scratch disk, which a container may
@@ -329,6 +330,14 @@ not have: a Fargate task carries 20 GB of ephemeral storage by default, and `Cor
 no `temp_directory`. Three remedies were measured and none moves the floor; a fourth,
 building per projection file, lowers it to ~2 GB and costs every unconstrained deployment
 68% more time — measured and rejected ([logbook][cache-entry], findings 16–17).
+
+**Under a container cap, state the limit rather than letting DuckDB pick it.** Its default
+is sized from the cgroup and not from the host, which is the right input, but the limit
+bounds DuckDB's buffers rather than the process: the build holds up to 2.8 GB beside them,
+and reaching the cap is a kill — neither an exception nor a log line. An 8 GiB container
+on DuckDB's own 6.3 GiB default was killed 85s in; a 12 GiB container holding DuckDB to
+`6500MiB` finished, peaking at 9.3 GB resident. `Corpus` warns at open when a cap it can
+read leaves less than 4 GB above the limit ([logbook][cache-entry], finding 19).
 
 Which is survivable but should not be discovered by a user. The index is built by the
 first query that can spend it, so a container short of the floor starts cleanly, passes

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -127,6 +127,22 @@ _CACHED_MATCHES = 16
 _PIVOT_BUDGET_BYTES = 4 * 1024**3
 
 
+# What the process holds beside DuckDB's own accounting while the occurrence index
+# builds: about 1.4 GB resident before it starts -- the interpreter, RDKit, the paired
+# footers -- and up to 2.8 GB more during it. A cgroup cap leaving less than this above
+# the memory_limit is one the kernel ends at, and a kill arrives as neither an exception
+# nor a log line. Measured in a container over the full corpus: an 8 GiB cap took
+# DuckDB's default 6.3 GiB limit and was killed 85s in, while the same build under a
+# 6.5 GiB limit and a 12 GiB cap finished, peaking at 9.3 GB resident.
+_PROCESS_HEADROOM_BYTES = 4 * 1024**3
+
+# Where a container states its memory cap, cgroup v2 first. Read at open rather than
+# taken as given, since DuckDB sizes its default limit from the same cap and the two
+# together are what has to fit.
+_CGROUP_V2_MEMORY_MAX = pathlib.Path("/sys/fs/cgroup/memory.max")
+_CGROUP_V1_MEMORY_LIMIT = pathlib.Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+
+
 # What a structure predicate's answer depends on: the operation, whether the string
 # is read as SMARTS or as SMILES, the string, and the similarity threshold.
 _MatchKey = tuple[str, bool, str, float | None]
@@ -464,6 +480,83 @@ def _cache_footers(connection: duckdb.DuckDBPyConnection) -> None:
     connection.execute("SET GLOBAL parquet_metadata_cache=true")
 
 
+def _container_cap_bytes() -> int | None:
+    """Returns the memory this process's container may hold, in bytes.
+
+    Returns:
+        The cgroup's cap, or None where there is none to read -- a machine outside a
+        container, a cgroup that states no limit, or any platform without cgroups.
+        Values at the top of the range are how both cgroup versions spell "unlimited".
+    """
+    for path in (_CGROUP_V2_MEMORY_MAX, _CGROUP_V1_MEMORY_LIMIT):
+        try:
+            text = path.read_text().strip()
+        except OSError:
+            continue
+        if text == "max":
+            return None
+        try:
+            cap = int(text)
+        except ValueError:
+            continue
+        return None if cap >= 2**60 else cap
+    return None
+
+
+def _setting_bytes(value: str) -> int | None:
+    """Returns a DuckDB size setting in bytes.
+
+    Args:
+        value: A setting as DuckDB prints it, e.g. ``6.3 GiB``.
+
+    Returns:
+        The figure in bytes, or None if it does not read as a size, which is what
+        ``memory_limit`` says when nothing bounds it.
+    """
+    scales = {"B": 1, "KiB": 1024, "MiB": 1024**2, "GiB": 1024**3, "TiB": 1024**4}
+    number, _, unit = value.strip().partition(" ")
+    scale = scales.get(unit)
+    if scale is None:
+        return None
+    try:
+        return int(float(number) * scale)
+    except ValueError:
+        return None
+
+
+def _warn_when_the_cap_leaves_no_headroom(
+    connection: duckdb.DuckDBPyConnection,
+) -> None:
+    """Warns when DuckDB's limit leaves the rest of the process too little to run in.
+
+    DuckDB reads the cgroup, so a container gets a limit sized to its own cap rather
+    than to the host -- but that limit bounds DuckDB's buffers, not the process, and
+    the default takes about 80% of the cap for them. What the corpus holds beside them
+    is what the kernel kills for.
+
+    Args:
+        connection: The corpus connection.
+    """
+    cap = _container_cap_bytes()
+    if cap is None:
+        return
+    setting = connection.execute("SELECT current_setting('memory_limit')").fetchone()
+    limit = _setting_bytes(setting[0]) if setting is not None else None
+    if limit is None or cap - limit >= _PROCESS_HEADROOM_BYTES:
+        return
+    logger.warning(
+        "this container may hold %s and DuckDB's memory_limit is %s, leaving %s for "
+        "everything else the process holds, which building the occurrence index has "
+        "been measured to want %s of. Reaching the cap is a kill rather than an "
+        "exception, so open the Corpus with a memory_limit that leaves that much, or "
+        "give the container more.",
+        _format_bytes(cap),
+        _format_bytes(limit),
+        _format_bytes(cap - limit),
+        _format_bytes(_PROCESS_HEADROOM_BYTES),
+    )
+
+
 def _run_with_timeout(
     cursor: duckdb.DuckDBPyConnection,
     sql: str,
@@ -543,6 +636,7 @@ class Corpus:
         pivot_budget_bytes: int | None = None,
         pivots_dir: str | None = None,
         derive_pivots: bool = False,
+        memory_limit: str | None = None,
     ) -> None:
         """Pairs the artifacts, checks their stamps, and prepares the relations.
 
@@ -588,6 +682,16 @@ class Corpus:
                 artifacts someone else derives should not start writing them because a
                 directory was mistyped, and a corpus-scale derivation belongs in
                 ``ord_schema.artifacts.scripts.derive_pivots``.
+            memory_limit: What DuckDB may hold, spelled as it spells sizes: ``6500MiB``,
+                ``8GB``. Left unset, DuckDB takes about 80% of the machine, or of the
+                container's cap, which it does read. That default suits a process that
+                is mostly DuckDB, and this one is not: RDKit, the interpreter, and the
+                index build's own allocations sit outside that accounting, and together
+                have been measured at up to 2.8 GB during a build. Exceeding a cap is a
+                kill rather than an exception, so a container wants this set low enough
+                to leave that much. Over ORD, ``6500MiB`` under a 12 GiB cap builds the
+                occurrence index, where DuckDB's own default under an 8 GiB cap is
+                killed partway.
 
         Raises:
             PairingError: If either pattern matches nothing, a file on one side has no
@@ -669,9 +773,12 @@ class Corpus:
         self._projections = [pair[0] for pair in pairs]
         self._pivot_views: dict[str, str | None] = {}
         self._views_lock = threading.Lock()
-        self._connection = duckdb.connect()
+        self._connection = duckdb.connect(
+            config={"memory_limit": memory_limit} if memory_limit is not None else {}
+        )
         try:
             _cache_footers(self._connection)
+            _warn_when_the_cap_leaves_no_headroom(self._connection)
             self._total, self._searchable = self._prepare(pairs)
         except Exception:
             # Nothing else holds the connection yet, and the caller has no object to
@@ -812,10 +919,18 @@ class Corpus:
         otherwise built by the first query that can spend it, so a corpus it refuses --
         a reaction stated twice, a structure no indexed path reaches -- fails that query
         rather than the deployment. It also has a memory floor, and meeting that one the
-        other way is worse still. Over ORD the build wants about 5 GB of DuckDB memory
-        and writes 16-25 GB of temporary files getting there; below that it raises
+        other way is worse still. Over ORD the build wants 5-6.5 GB of DuckDB memory and
+        writes 16-25 GB of temporary files getting there; below that it raises
         ``duckdb.OutOfMemoryException`` rather than running slowly, since a block it
         cannot pin is not one it can spill.
+
+        That exception is the good outcome, and under a cgroup cap it is only reached
+        with room to spare above ``memory_limit``: the build holds up to 2.8 GB outside
+        DuckDB's accounting, and reaching the cap is a kill, which arrives as neither an
+        exception nor a log line. DuckDB's default limit is about 80% of the cap, which
+        does not leave it -- an 8 GiB container is killed 85s in, where a 12 GiB one
+        holding DuckDB to 6500MiB finishes at 9.3 GB resident. ``Corpus`` warns at open
+        when a cap it can read leaves too little.
 
         Opt-in rather than done at open, because the cost is real and a corpus asked
         only for scalar or similarity queries never pays it: about a minute, and 1.19 GB

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -138,9 +138,13 @@ _PROCESS_HEADROOM_BYTES = 4 * 1024**3
 
 # Where a container states its memory cap, cgroup v2 first. Read at open rather than
 # taken as given, since DuckDB sizes its default limit from the same cap and the two
-# together are what has to fit.
-_CGROUP_V2_MEMORY_MAX = pathlib.Path("/sys/fs/cgroup/memory.max")
-_CGROUP_V1_MEMORY_LIMIT = pathlib.Path("/sys/fs/cgroup/memory/memory.limit_in_bytes")
+# together are what has to fit. A cap can be stated at any level from the process's own
+# cgroup up to the mount root, and a container in a systemd slice sits under several, so
+# the path this process occupies is read from /proc rather than assumed to be the root,
+# and every level of it is consulted.
+_CGROUP_V2_ROOT = pathlib.Path("/sys/fs/cgroup")
+_CGROUP_V1_MEMORY_ROOT = pathlib.Path("/sys/fs/cgroup/memory")
+_PROC_SELF_CGROUP = pathlib.Path("/proc/self/cgroup")
 
 
 # What a structure predicate's answer depends on: the operation, whether the string
@@ -480,27 +484,83 @@ def _cache_footers(connection: duckdb.DuckDBPyConnection) -> None:
     connection.execute("SET GLOBAL parquet_metadata_cache=true")
 
 
-def _container_cap_bytes() -> int | None:
-    """Returns the memory this process's container may hold, in bytes.
+def _cgroup_relative_path(controller: str) -> str:
+    """Returns the cgroup this process occupies, relative to that hierarchy's mount.
+
+    Args:
+        controller: A cgroup v1 controller name, or the empty string for the v2
+            hierarchy, whose ``/proc/self/cgroup`` line names no controller.
 
     Returns:
-        The cgroup's cap, or None where there is none to read -- a machine outside a
-        container, a cgroup that states no limit, or any platform without cgroups.
-        Values at the top of the range are how both cgroup versions spell "unlimited".
+        The path with no leading slash, empty where /proc says nothing about this
+        hierarchy -- which includes every platform without cgroups.
     """
-    for path in (_CGROUP_V2_MEMORY_MAX, _CGROUP_V1_MEMORY_LIMIT):
-        try:
-            text = path.read_text().strip()
-        except OSError:
-            continue
-        if text == "max":
-            return None
-        try:
-            cap = int(text)
-        except ValueError:
-            continue
-        return None if cap >= 2**60 else cap
-    return None
+    try:
+        text = _PROC_SELF_CGROUP.read_text()
+    except OSError:
+        return ""
+    for line in text.splitlines():
+        # Lines read "hierarchy:controllers:path", with controllers empty under v2.
+        _, _, rest = line.partition(":")
+        controllers, _, path = rest.partition(":")
+        named = controllers.split(",") if controllers else []
+        matched = controller in named if named else not controller
+        if matched:
+            return path.lstrip("/")
+    return ""
+
+
+def _stated_cap_bytes(path: pathlib.Path) -> int | None:
+    """Returns the cap one cgroup file states, or None where it states none.
+
+    Args:
+        path: A ``memory.max`` or ``memory.limit_in_bytes`` file, which need not exist.
+
+    Returns:
+        The figure in bytes. None covers an unreadable file, ``max``, and the
+        top-of-range number that is how cgroup v1 spells the same thing.
+    """
+    try:
+        text = path.read_text().strip()
+    except OSError:
+        return None
+    if text == "max":
+        return None
+    try:
+        cap = int(text)
+    except ValueError:
+        return None
+    return None if cap >= 2**60 else cap
+
+
+def _container_cap_bytes() -> int | None:
+    """Returns the memory this process may hold before the kernel intervenes, in bytes.
+
+    A cap can be stated at any level between the process's own cgroup and the mount
+    root, and the one that ends the process is the smallest of them, so every level is
+    read rather than the root alone.
+
+    Returns:
+        The smallest cap that applies, or None where none does -- a machine outside a
+        container, a cgroup hierarchy that states no limit anywhere above this process,
+        or any platform without cgroups.
+    """
+    caps = []
+    for root, filename, controller in (
+        (_CGROUP_V2_ROOT, "memory.max", ""),
+        (_CGROUP_V1_MEMORY_ROOT, "memory.limit_in_bytes", "memory"),
+    ):
+        directory = root
+        directories = [root]
+        for part in pathlib.PurePosixPath(_cgroup_relative_path(controller)).parts:
+            directory = directory / part
+            directories.append(directory)
+        caps.extend(
+            cap
+            for cap in (_stated_cap_bytes(d / filename) for d in directories)
+            if cap is not None
+        )
+    return min(caps) if caps else None
 
 
 def _setting_bytes(value: str) -> int | None:

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -382,6 +382,91 @@ def test_nothing_matched_is_refused(tmp_path):
         )
 
 
+def _capped(monkeypatch, tmp_path, cap: str) -> None:
+    """Points the cgroup readers at a file stating ``cap``, and at no v1 file."""
+    path = tmp_path / "memory.max"
+    path.write_text(cap)
+    monkeypatch.setattr(execute, "_CGROUP_V2_MEMORY_MAX", path)
+    monkeypatch.setattr(execute, "_CGROUP_V1_MEMORY_LIMIT", tmp_path / "absent")
+
+
+def _open(corpus_dir, **kwargs) -> execute.Corpus:
+    return execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        **kwargs,
+    )
+
+
+def test_a_memory_limit_is_given_to_duckdb(corpus_dir):
+    with _open(corpus_dir, memory_limit="512MiB") as corpus:
+        setting = corpus._connection.execute(
+            "SELECT current_setting('memory_limit')"
+        ).fetchone()
+    assert setting is not None
+    assert execute._setting_bytes(setting[0]) == 512 * 1024**2
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("512.0 MiB", 512 * 1024**2),
+        ("6.3 GiB", int(6.3 * 1024**3)),
+        ("1024 B", 1024),
+        # What the setting says when nothing bounds it.
+        ("-1", None),
+    ],
+)
+def test_a_size_setting_reads_as_bytes(value, expected):
+    assert execute._setting_bytes(value) == expected
+
+
+@pytest.mark.parametrize("cap", ["max", str(2**63 - 4096)])
+def test_an_unbounded_cgroup_is_no_cap(monkeypatch, tmp_path, cap):
+    # Both versions spell "unlimited" as something readable, so a corpus on a machine
+    # with cgroups but no limit must not warn about the room it has.
+    _capped(monkeypatch, tmp_path, cap)
+    assert execute._container_cap_bytes() is None
+
+
+def test_a_cap_leaving_the_process_nothing_is_warned_about(
+    corpus_dir, tmp_path, monkeypatch, caplog
+):
+    _capped(monkeypatch, tmp_path, str(2 * 1024**3))
+    caplog.set_level(logging.WARNING, logger="ord_schema.search.execute")
+    caplog.clear()
+    with _open(corpus_dir, memory_limit="1GiB"):
+        pass
+    assert [
+        record for record in caplog.records if "1.0 GB for everything" in record.message
+    ]
+
+
+def test_a_cap_leaving_the_process_room_is_not_warned_about(
+    corpus_dir, tmp_path, monkeypatch, caplog
+):
+    _capped(monkeypatch, tmp_path, str(12 * 1024**3))
+    caplog.set_level(logging.WARNING, logger="ord_schema.search.execute")
+    caplog.clear()
+    with _open(corpus_dir, memory_limit="1GiB"):
+        pass
+    assert not [
+        record for record in caplog.records if "for everything" in record.message
+    ]
+
+
+def test_no_cap_to_read_is_not_warned_about(corpus_dir, tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr(execute, "_CGROUP_V2_MEMORY_MAX", tmp_path / "absent")
+    monkeypatch.setattr(execute, "_CGROUP_V1_MEMORY_LIMIT", tmp_path / "absent")
+    caplog.set_level(logging.WARNING, logger="ord_schema.search.execute")
+    caplog.clear()
+    with _open(corpus_dir, memory_limit="1GiB"):
+        pass
+    assert not [
+        record for record in caplog.records if "for everything" in record.message
+    ]
+
+
 def _copy_corpus(corpus_dir, tmp_path) -> pathlib.Path:
     """Copies the built corpus so a test can damage one artifact in isolation."""
     for name in ("projections", "structures"):

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -382,12 +382,30 @@ def test_nothing_matched_is_refused(tmp_path):
         )
 
 
-def _capped(monkeypatch, tmp_path, cap: str) -> None:
-    """Points the cgroup readers at a file stating ``cap``, and at no v1 file."""
-    path = tmp_path / "memory.max"
-    path.write_text(cap)
-    monkeypatch.setattr(execute, "_CGROUP_V2_MEMORY_MAX", path)
-    monkeypatch.setattr(execute, "_CGROUP_V1_MEMORY_LIMIT", tmp_path / "absent")
+def _capped(monkeypatch, tmp_path, *caps: str, relative: str = "") -> None:
+    """Builds a cgroup v2 tree this process sits at the bottom of.
+
+    Args:
+        monkeypatch: The fixture, which points the readers at the tree.
+        tmp_path: Where to build it.
+        caps: What each level states, root first, one per level of ``relative`` plus the
+            root itself. A level with no cap given states none at all.
+        relative: The cgroup this process occupies, relative to the mount.
+    """
+    root = tmp_path / "cgroup"
+    directories = [root]
+    for part in relative.split("/") if relative else []:
+        directories.append(directories[-1] / part)
+    for directory, cap in zip(directories, caps, strict=False):
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "memory.max").write_text(cap)
+    directories[-1].mkdir(parents=True, exist_ok=True)
+
+    proc = tmp_path / "cgroup.proc"
+    proc.write_text(f"0::/{relative}\n")
+    monkeypatch.setattr(execute, "_CGROUP_V2_ROOT", root)
+    monkeypatch.setattr(execute, "_CGROUP_V1_MEMORY_ROOT", tmp_path / "absent")
+    monkeypatch.setattr(execute, "_PROC_SELF_CGROUP", proc)
 
 
 def _open(corpus_dir, **kwargs) -> execute.Corpus:
@@ -429,6 +447,52 @@ def test_an_unbounded_cgroup_is_no_cap(monkeypatch, tmp_path, cap):
     assert execute._container_cap_bytes() is None
 
 
+def test_a_cap_above_this_process_is_found(monkeypatch, tmp_path):
+    # A container inside a slice sits several levels below the mount, and the level
+    # holding the cap is not the one it occupies: reading only the root finds nothing
+    # here, and only the leaf finds the wrong thing.
+    _capped(
+        monkeypatch,
+        tmp_path,
+        "max",
+        str(8 * 1024**3),
+        "max",
+        relative="system.slice/docker-abc.scope",
+    )
+    assert execute._container_cap_bytes() == 8 * 1024**3
+
+
+def test_the_smallest_cap_that_applies_is_the_one_that_counts(monkeypatch, tmp_path):
+    # Every level's cap binds, so the process reaches the smallest of them first --
+    # which is not always the innermost.
+    _capped(
+        monkeypatch,
+        tmp_path,
+        str(4 * 1024**3),
+        str(12 * 1024**3),
+        relative="nested",
+    )
+    assert execute._container_cap_bytes() == 4 * 1024**3
+
+
+def test_a_cgroup_line_for_another_controller_is_not_read_as_this_one(
+    monkeypatch, tmp_path
+):
+    # A v1 line names its controllers where the v2 line names none, so matching by
+    # position rather than by name would read one hierarchy's path against the other's
+    # mount.
+    root = tmp_path / "cgroup"
+    (root / "leaf").mkdir(parents=True)
+    (root / "memory.max").write_text("max")
+    (root / "leaf" / "memory.max").write_text(str(2 * 1024**3))
+    proc = tmp_path / "cgroup.proc"
+    proc.write_text("5:memory:/other\n0::/leaf\n")
+    monkeypatch.setattr(execute, "_CGROUP_V2_ROOT", root)
+    monkeypatch.setattr(execute, "_CGROUP_V1_MEMORY_ROOT", tmp_path / "absent")
+    monkeypatch.setattr(execute, "_PROC_SELF_CGROUP", proc)
+    assert execute._container_cap_bytes() == 2 * 1024**3
+
+
 def test_a_cap_leaving_the_process_nothing_is_warned_about(
     corpus_dir, tmp_path, monkeypatch, caplog
 ):
@@ -456,8 +520,9 @@ def test_a_cap_leaving_the_process_room_is_not_warned_about(
 
 
 def test_no_cap_to_read_is_not_warned_about(corpus_dir, tmp_path, monkeypatch, caplog):
-    monkeypatch.setattr(execute, "_CGROUP_V2_MEMORY_MAX", tmp_path / "absent")
-    monkeypatch.setattr(execute, "_CGROUP_V1_MEMORY_LIMIT", tmp_path / "absent")
+    monkeypatch.setattr(execute, "_CGROUP_V2_ROOT", tmp_path / "absent")
+    monkeypatch.setattr(execute, "_CGROUP_V1_MEMORY_ROOT", tmp_path / "absent")
+    monkeypatch.setattr(execute, "_PROC_SELF_CGROUP", tmp_path / "absent")
     caplog.set_level(logging.WARNING, logger="ord_schema.search.execute")
     caplog.clear()
     with _open(corpus_dir, memory_limit="1GiB"):


### PR DESCRIPTION
Summary
-------
`Corpus` created its DuckDB connection with no configuration, so a caller could not set `memory_limit` without reaching into `_connection`. In a container that is not a small gap: DuckDB reads the cgroup, so it sizes its default limit from the container's own cap rather than the host's — but that limit bounds DuckDB's buffers, not the process, and the default claims about 80% of the cap for them. The occurrence index build holds up to 2.8 GB beside that accounting, so the default is over the cap by construction, and reaching a cap is a kill: no exception, no log line, exit 137.

Measured in a container over the full corpus (2,428,291 reactions), calling `check_index()`:

| cap | `memory_limit` | outcome |
| --- | --- | --- |
| 4 GiB | 3.1 GiB (DuckDB's default) | OOM-killed, exit 137 |
| 4 GiB | 2 GiB | OOM-killed, exit 137 |
| 4 GiB | 1 GiB | `OutOfMemoryException` at 195s, peak RSS 3.91 GiB |
| 8 GiB | 6.3 GiB (DuckDB's default) | OOM-killed at 85s |
| 12 GiB | 5 GiB | `OutOfMemoryException` at 194s, peak RSS 8.65 GiB |
| 12 GiB | 6500MiB | 18,847,978 occurrences, peak RSS 9.29 GiB |

The catchable exception `check_index()` documents only arrives when the limit leaves room; the docstring promised it unconditionally.

Changes
-------
- `Corpus(..., memory_limit=...)` passes the setting to `duckdb.connect`.
- `_warn_when_the_cap_leaves_no_headroom` reads the cgroup at open (v2, then v1, treating `max` and the top-of-range sentinel as no cap) and warns when it leaves less than 4 GB above the limit.
- `check_index` and the README's deployment section say what a cap has to leave, and the floor reads 5–6.5 GB rather than 5 GB — 5 GiB raised where 6500MiB finished.

Testing
-------
`uv run pytest -n auto` — 1189 passed, 2 skipped.

Eleven new tests cover the setting reaching DuckDB, the size parser, `max` and the v1 sentinel reading as no cap, and the warning firing on a cap with no headroom while staying quiet on one with headroom and on a machine with no cgroup to read.

End to end in an 8 GiB container, the configuration that was killed above:

```
WARNING execute.py:547: this container may hold 8.0 GB and DuckDB's memory_limit is 6.3 GB,
leaving 1.7 GB for everything else the process holds, which building the occurrence index
has been measured to want 4.0 GB of. Reaching the cap is a kill rather than an exception,
so open the Corpus with a memory_limit that leaves that much, or give the container more.
```

Notes
-----
The default is unchanged: no `memory_limit` means DuckDB decides, as before. The warning is the only new behavior on that path, and it fires only where a cgroup cap is readable.

Wall-clock figures above are inflated — the container read the artifacts and spilled through a bind mount. Resident sizes, which are what the change is about, are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR lets callers configure DuckDB's memory limit and adds deployment guidance for budgeting memory under container caps.
- Passes an optional `memory_limit` through `Corpus` to DuckDB.
- Detects effective caps across ancestor cgroups and warns when insufficient process headroom remains.
- Adds focused parsing, cap-detection, warning, and configuration tests.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ord_schema/search/execute.py | Adds configurable DuckDB memory limits, cgroup-cap detection, and a headroom warning during Corpus initialization. |
| ord_schema/search/execute_test.py | Adds unit coverage for memory-limit propagation, setting parsing, ancestor cap selection, and warning behavior. |
| ord_schema/search/README.md | Documents measured memory requirements and recommended container memory-limit configuration. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Read the cgroup this process is in, not ..."](https://github.com/open-reaction-database/ord-schema/commit/3f1f39d8efeb9800a489d193e260159daab1ff35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54185828)</sub>

<!-- /greptile_comment -->