### PR TITLE
Let a query order by a value under a repeated level

### DIFF
--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -55,9 +55,11 @@ Value      = { literal: <scalar> } | { compound: <name> }
 
 Aggregate  = { group_by: [Path],
                measures: [{ fn: "count"|"count_distinct"|"sum"|"avg"|"min"|"max",
-                            path?: Path, name: string }] }
+                            path?: Path | Reduction, name: string }] }
 
-Order      = { key: string, descending?: bool }
+Reduction  = { reduce: "min"|"max"|"avg"|"sum"|"count", path: Path }
+
+Order      = { key: string | Reduction, descending?: bool }
 ```
 
 A `Path` is a dotted column path such as `conditions.temperature.setpoint_kelvin`. Inside an
@@ -76,6 +78,10 @@ is a compile error rather than a wrong answer:
 - Operators must suit the leaf type — `contains` is text-only, ordering is numeric-only.
 - `group_by` paths must be scalar, so the number of groups is bounded by the values a column
   holds rather than by an explosion over a repeated level.
+- A `Reduction` is the one place a repeated path is read without a quantifier: it reduces
+  that reaction's own elements to a single value, so `max` over `outcomes.products.measurements.percentage.value`
+  is the reaction's best yield rather than the corpus's. Its path must cross a repeated level;
+  a scalar one is refused, since it would give the same query two spellings.
 - A `{"compound": ...}` value is resolved through [`ord_schema.resolvers`](../resolvers.py) and
   **bound as a parameter**, so the model names compounds and never spells structures.
 - A `substructure`/`similarity` path must name a compound's `smiles`, inside a
@@ -131,6 +137,7 @@ in what they read. Worked examples, with the route each clause takes:
 | solvent-free: no component is a solvent | `forall inputs.components` | pivot — the index shows which elements match, never that all of them do |
 | pyridine **and** a boronic acid in one component | `exists inputs.components` | pivot — two structure predicates is one more than an occurrence row can carry |
 | a desired product with a yield above 50% | `exists outcomes.products`, nested `exists measurements` | both levels' pivots, joined on the ordinal prefix |
+| the ten highest-yielding reactions | `order_by` a `reduce` over `outcomes.products.measurements` | no quantifier: a list aggregate over the projection |
 
 Every pivot row above falls to the elements when no pivot is available — a level the
 budget refused, or one with neither an artifact nor room to build. The answer does not

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -82,6 +82,9 @@ is a compile error rather than a wrong answer:
   that reaction's own elements to a single value, so `max` over `outcomes.products.measurements.percentage.value`
   is the reaction's best yield rather than the corpus's. Its path must cross a repeated level;
   a scalar one is refused, since it would give the same query two spellings.
+- `min`, `max`, `avg`, and `sum` need a numeric column, whether they reduce a repeated path
+  or aggregate a scalar one; `count` takes any. Arithmetic over text is refused where the
+  query is compiled rather than left to fail where it runs.
 - A `{"compound": ...}` value is resolved through [`ord_schema.resolvers`](../resolvers.py) and
   **bound as a parameter**, so the model names compounds and never spells structures.
 - A `substructure`/`similarity` path must name a compound's `smiles`, inside a

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -468,6 +468,11 @@ _REDUCERS = {
     "count": "len(list_filter({expression}, value -> value IS NOT NULL))",
 }
 
+# Reducers and aggregates that arithmetic has to carry. The grammar already holds
+# ordered comparisons to numbers, and a sum over text is a DuckDB error rather than an
+# answer, so both are refused where the query is compiled rather than where it runs.
+_ARITHMETIC = frozenset({"min", "max", "avg", "sum"})
+
 
 class Reduction(BaseModel):
     """One value per reaction, reduced from a path that crosses a repeated level.
@@ -1009,12 +1014,27 @@ def _predicate(
     return _leaf(node, resolved, compounds)
 
 
-def _scalar(path: str, schema: pa.Schema, what: str) -> str:
-    """Returns the expression for a path that has to be scalar."""
+def _scalar(path: str, schema: pa.Schema, what: str) -> _Resolved:
+    """Returns where a path that has to be scalar landed."""
     resolved = resolve(path, schema=schema)
     if resolved.repeated:
         raise QueryError(f"{path}: {what} needs a scalar column, not a repeated level")
-    return resolved.expression
+    return resolved
+
+
+def _check_numeric(path: str, leaf: pa.DataType, what: str) -> None:
+    """Raises unless a leaf holds numbers.
+
+    Args:
+        path: The path, named in the message.
+        leaf: The type that path reaches.
+        what: The reducer or aggregate asking, named in the message.
+
+    Raises:
+        QueryError: If the leaf is neither an integer nor a floating-point type.
+    """
+    if not (pa.types.is_integer(leaf) or pa.types.is_floating(leaf)):
+        raise QueryError(f"{path}: {what} needs a numeric column, not {leaf}")
 
 
 def _reduced(reduction: Reduction, schema: pa.Schema) -> str:
@@ -1029,8 +1049,9 @@ def _reduced(reduction: Reduction, schema: pa.Schema) -> str:
         holds no elements under that path at all.
 
     Raises:
-        QueryError: If the path is already scalar, which needs no reduction; accepting
-            one would give the same query two spellings.
+        QueryError: If the path is already scalar, which needs no reduction (accepting
+            one would give the same query two spellings), or if an arithmetic reducer
+            reaches a leaf that does not hold numbers.
     """
     resolved = resolve(reduction.path, schema=schema)
     if not resolved.repeated:
@@ -1038,7 +1059,36 @@ def _reduced(reduction: Reduction, schema: pa.Schema) -> str:
             f"{reduction.path}: {reduction.reduce} reduces a repeated level, and this "
             f"path is already scalar; order by the path itself"
         )
+    if reduction.reduce in _ARITHMETIC:
+        _check_numeric(reduction.path, resolved.type, reduction.reduce)
     return _REDUCERS[reduction.reduce].format(expression=resolved.expression)
+
+
+def _measure_argument(measure: Measure, schema: pa.Schema) -> str:
+    """Returns the expression a measure aggregates over.
+
+    Args:
+        measure: The measure being compiled.
+        schema: Schema its path resolves against.
+
+    Returns:
+        ``*`` for a bare count, a reduced expression where the path crosses a repeated
+        level, and the resolved column otherwise, prefixed with ``DISTINCT`` for
+        ``count_distinct``.
+
+    Raises:
+        QueryError: If the path cannot be meant as this measure's argument.
+    """
+    if measure.path is None:
+        return "*"
+    if isinstance(measure.path, Reduction):
+        argument = _reduced(measure.path, schema)
+    else:
+        resolved = _scalar(measure.path, schema, measure.fn)
+        if measure.fn in _ARITHMETIC:
+            _check_numeric(measure.path, resolved.type, measure.fn)
+        argument = resolved.expression
+    return f"DISTINCT {argument}" if measure.fn == "count_distinct" else argument
 
 
 def compile_query(
@@ -1080,20 +1130,12 @@ def compile_query(
     structures: list[StructureParameter] = []
     if query.aggregate:
         groups = [
-            _scalar(path, schema, "group_by") for path in query.aggregate.group_by
+            _scalar(path, schema, "group_by").expression
+            for path in query.aggregate.group_by
         ]
         selected = list(groups)
         for measure in query.aggregate.measures:
-            if measure.path is None:
-                argument = "*"
-            elif isinstance(measure.path, Reduction):
-                argument = _reduced(measure.path, schema)
-                if measure.fn == "count_distinct":
-                    argument = f"DISTINCT {argument}"
-            else:
-                argument = _scalar(measure.path, schema, measure.fn)
-                if measure.fn == "count_distinct":
-                    argument = f"DISTINCT {argument}"
+            argument = _measure_argument(measure, schema)
             selected.append(f"{_AGGREGATES[measure.fn]}({argument}) AS {measure.name}")
         names = {measure.name for measure in query.aggregate.measures}
         orderable = names | set(query.aggregate.group_by)
@@ -1138,10 +1180,12 @@ def compile_query(
                     )
                 key = _reduced(order.key, schema)
             elif orderable is None:
-                key = _scalar(order.key, schema, "order_by")
+                key = _scalar(order.key, schema, "order_by").expression
             elif order.key in orderable:
                 key = (
-                    order.key if order.key in names else _scalar(order.key, schema, "")
+                    order.key
+                    if order.key in names
+                    else _scalar(order.key, schema, "").expression
                 )
             else:
                 raise QueryError(

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -28,8 +28,10 @@ nothing here.
 Two things the compiler settles that SQL leaves to whoever writes it:
 
 * **Quantifiers are stated, never assumed.** A path crossing a repeated level is
-  refused unless an ``exists`` or ``forall`` binds it. The same intent in SQL is spelled
-  ``UNNEST``, which silently means "any" *and* multiplies the row count.
+  refused in a predicate unless an ``exists`` or ``forall`` binds it. The same intent in
+  SQL is spelled ``UNNEST``, which silently means "any" *and* multiplies the row count.
+  A ``Reduction`` is the one reading that needs no quantifier, because it names what to
+  do with the elements instead of asking which of them match.
 * **Repeated levels compile to list lambdas**, never to ``UNNEST`` in a ``FROM`` clause
   -- measured at 27-200x the cost for identical answers, and the idiom every SQL
   tutorial teaches. A compiler cannot reach for the wrong one.

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -1045,8 +1045,9 @@ def _reduced(reduction: Reduction, schema: pa.Schema) -> str:
         schema: Schema the path resolves against.
 
     Returns:
-        A DuckDB expression yielding one scalar per reaction, NULL where the reaction
-        holds no elements under that path at all.
+        A DuckDB expression yielding one scalar per reaction. An arithmetic reducer
+        yields NULL for a reaction holding no elements under that path; ``count``
+        yields zero there, and NULL only where the repeated level itself is absent.
 
     Raises:
         QueryError: If the path is already scalar, which needs no reduction (accepting

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -458,11 +458,40 @@ Not.model_rebuild()
 Quantifier.model_rebuild()
 
 
+# DuckDB's list aggregates, which ignore the nulls a list may hold. `count` filters
+# rather than taking len(), which would count them.
+_REDUCERS = {
+    "min": "list_min({expression})",
+    "max": "list_max({expression})",
+    "avg": "list_avg({expression})",
+    "sum": "list_sum({expression})",
+    "count": "len(list_filter({expression}, value -> value IS NOT NULL))",
+}
+
+
+class Reduction(BaseModel):
+    """One value per reaction, reduced from a path that crosses a repeated level.
+
+    An ordering key and an aggregate's argument both have to be scalar, which leaves
+    "the highest-yielding reactions" unwritable: a yield lives under outcomes, products,
+    and measurements, so the path resolves to a list rather than a number. This reduces
+    that list to the one value the reaction is judged by, leaving the aggregate to
+    combine those across reactions.
+
+    Attributes:
+        reduce: How to reduce the list. ``count`` counts the values that are present.
+        path: A dotted path crossing at least one repeated level.
+    """
+
+    reduce: Literal["min", "max", "avg", "sum", "count"]
+    path: str
+
+
 class Measure(BaseModel):
     """One aggregate over the matching rows."""
 
     fn: Literal["count", "count_distinct", "sum", "avg", "min", "max"]
-    path: str | None = None
+    path: str | Reduction | None = None
     name: str
 
     @model_validator(mode="after")
@@ -488,7 +517,7 @@ class Aggregate(BaseModel):
 class Order(BaseModel):
     """How to sort the result."""
 
-    key: str
+    key: str | Reduction
     descending: bool = False
 
 
@@ -988,6 +1017,30 @@ def _scalar(path: str, schema: pa.Schema, what: str) -> str:
     return resolved.expression
 
 
+def _reduced(reduction: Reduction, schema: pa.Schema) -> str:
+    """Returns the expression reducing a repeated path to one value per reaction.
+
+    Args:
+        reduction: What to reduce, and how.
+        schema: Schema the path resolves against.
+
+    Returns:
+        A DuckDB expression yielding one scalar per reaction, NULL where the reaction
+        holds no elements under that path at all.
+
+    Raises:
+        QueryError: If the path is already scalar, which needs no reduction; accepting
+            one would give the same query two spellings.
+    """
+    resolved = resolve(reduction.path, schema=schema)
+    if not resolved.repeated:
+        raise QueryError(
+            f"{reduction.path}: {reduction.reduce} reduces a repeated level, and this "
+            f"path is already scalar; order by the path itself"
+        )
+    return _REDUCERS[reduction.reduce].format(expression=resolved.expression)
+
+
 def compile_query(
     query: Query,
     *,
@@ -1033,6 +1086,10 @@ def compile_query(
         for measure in query.aggregate.measures:
             if measure.path is None:
                 argument = "*"
+            elif isinstance(measure.path, Reduction):
+                argument = _reduced(measure.path, schema)
+                if measure.fn == "count_distinct":
+                    argument = f"DISTINCT {argument}"
             else:
                 argument = _scalar(measure.path, schema, measure.fn)
                 if measure.fn == "count_distinct":
@@ -1071,7 +1128,16 @@ def compile_query(
     if query.order_by:
         keys = []
         for order in query.order_by:
-            if orderable is None:
+            if isinstance(order.key, Reduction):
+                if orderable is not None:
+                    # After grouping there is no reaction left to reduce over: the
+                    # reduction is one input to a measure, not a key beside it.
+                    raise QueryError(
+                        "an aggregated query orders by a measure name or a group_by "
+                        "path; reduce inside a measure instead"
+                    )
+                key = _reduced(order.key, schema)
+            elif orderable is None:
                 key = _scalar(order.key, schema, "order_by")
             elif order.key in orderable:
                 key = (

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -393,6 +393,154 @@ def test_rejected_before_compilation(payload):
         query.Query.model_validate(payload)
 
 
+# Reductions over a repeated level
+
+
+def test_ordering_by_a_reduction_over_a_repeated_path():
+    # A yield lives under outcomes, products, and measurements, so ordering by it needs
+    # the list reduced to the one number the reaction is judged by.
+    compiled = _compile(
+        {
+            "order_by": [
+                {
+                    "key": {
+                        "reduce": "max",
+                        "path": "outcomes.products.measurements.percentage.value",
+                    },
+                    "descending": True,
+                }
+            ],
+            "limit": 10,
+        }
+    )
+    assert "list_max(" in compiled.sql
+    assert compiled.sql.endswith("DESC LIMIT 10")
+
+
+def test_a_reduction_reaches_the_same_rows_the_elements_do():
+    # The reduction is over the reaction's own elements, so it agrees with the list the
+    # projection holds rather than with a corpus-wide aggregate.
+    compiled = _compile(
+        {
+            "order_by": [
+                {
+                    "key": {
+                        "reduce": "max",
+                        "path": "outcomes.products.measurements.percentage.value",
+                    }
+                }
+            ]
+        }
+    )
+    resolved = query.resolve("outcomes.products.measurements.percentage.value")
+    assert resolved.expression in compiled.sql
+
+
+def test_a_measure_may_reduce_a_repeated_path():
+    compiled = _compile(
+        {
+            "aggregate": {
+                "group_by": ["conditions.temperature.setpoint_kelvin"],
+                "measures": [
+                    {
+                        "fn": "avg",
+                        "path": {
+                            "reduce": "max",
+                            "path": "outcomes.products.measurements.percentage.value",
+                        },
+                        "name": "best_yield",
+                    }
+                ],
+            }
+        }
+    )
+    assert "avg(list_max(" in compiled.sql
+
+
+@pytest.mark.parametrize(
+    ("reducer", "expected"),
+    [
+        ("min", "list_min("),
+        ("max", "list_max("),
+        ("avg", "list_avg("),
+        ("sum", "list_sum("),
+        # Counting what is there means filtering the nulls a list may hold, since len()
+        # would count them.
+        ("count", "len(list_filter("),
+    ],
+)
+def test_each_reducer_compiles_to_its_list_aggregate(reducer, expected):
+    compiled = _compile(
+        {
+            "order_by": [
+                {
+                    "key": {
+                        "reduce": reducer,
+                        "path": "outcomes.products.measurements.percentage.value",
+                    }
+                }
+            ]
+        }
+    )
+    assert expected in compiled.sql
+
+
+def test_a_reduction_over_a_scalar_path_is_refused():
+    # A scalar needs no reducing, and accepting one would give the same query two
+    # spellings, one of which wraps a value in a single-element list.
+    with pytest.raises(query.QueryError, match="already scalar"):
+        _compile(
+            {
+                "order_by": [
+                    {
+                        "key": {
+                            "reduce": "max",
+                            "path": "conditions.temperature.setpoint_kelvin",
+                        }
+                    }
+                ]
+            }
+        )
+
+
+def test_an_aggregated_query_cannot_order_by_a_reduction():
+    # After grouping there is no reaction left to reduce over; the reduction belongs
+    # inside a measure, where it is one input to the aggregate.
+    with pytest.raises(query.QueryError, match="reduce inside a measure"):
+        _compile(
+            {
+                "aggregate": {"measures": [{"fn": "count", "name": "n"}]},
+                "order_by": [
+                    {
+                        "key": {
+                            "reduce": "max",
+                            "path": "outcomes.products.measurements.percentage.value",
+                        }
+                    }
+                ],
+            }
+        )
+
+
+def test_a_reduction_runs():
+    # The expression has to be DuckDB the planner accepts, not merely a string.
+    compiled = _compile(
+        {
+            "order_by": [
+                {
+                    "key": {
+                        "reduce": "max",
+                        "path": "outcomes.products.measurements.percentage.value",
+                    },
+                    "descending": True,
+                }
+            ],
+            "limit": 5,
+        }
+    )
+    assert _run(compiled) == []
+
+
 # The whole point
 
 

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -503,6 +503,57 @@ def test_a_reduction_over_a_scalar_path_is_refused():
         )
 
 
+@pytest.mark.parametrize("reducer", ["min", "max", "avg", "sum"])
+def test_an_arithmetic_reduction_over_text_is_refused(reducer):
+    # Summing a list of strings is a DuckDB error rather than an answer, and a query
+    # that cannot mean anything is worth refusing where it is compiled.
+    with pytest.raises(query.QueryError, match="needs a numeric column"):
+        _compile(
+            {
+                "order_by": [
+                    {
+                        "key": {
+                            "reduce": reducer,
+                            "path": "outcomes.products.identifiers.value",
+                        }
+                    }
+                ]
+            }
+        )
+
+
+def test_counting_a_repeated_text_path_is_allowed():
+    # How many identifiers a reaction's products carry is a number, whatever the
+    # identifiers themselves hold.
+    compiled = _compile(
+        {
+            "order_by": [
+                {
+                    "key": {
+                        "reduce": "count",
+                        "path": "outcomes.products.identifiers.value",
+                    }
+                }
+            ]
+        }
+    )
+    assert "len(list_filter(" in compiled.sql
+
+
+def test_an_arithmetic_measure_over_text_is_refused():
+    # The same rule reaches a measure that names a scalar column directly.
+    with pytest.raises(query.QueryError, match="needs a numeric column"):
+        _compile(
+            {
+                "aggregate": {
+                    "measures": [
+                        {"fn": "avg", "path": "reaction_id", "name": "mean_id"}
+                    ]
+                }
+            }
+        )
+
+
 def test_an_aggregated_query_cannot_order_by_a_reduction():
     # After grouping there is no reaction left to reduce over; the reduction belongs
     # inside a measure, where it is one input to the aggregate.


### PR DESCRIPTION
Summary
-------
`Order.key` and `Measure.path` both required a scalar path, so a value under a repeated level could not be ordered or aggregated by:

```text
outcomes.products.measurements.percentage.value: max needs a scalar column, not a repeated level
```

That makes "the ten highest-yielding reactions" unwritable. It surfaced while measuring natural-language translation: **both Haiku 4.5 and Opus 5 reached for it independently**, and it was Opus's only failure across ten questions — unrepairable, because nothing they could have written would have worked. See [ord-logbook#45](https://github.com/open-reaction-database/ord-logbook/pull/45), finding 7.

Changes
-------
- `Reduction` — `{"reduce": "min"|"max"|"avg"|"sum"|"count", "path": ...}` — names how to reduce a repeated path to one value per reaction. `Order.key` and `Measure.path` now accept one.
- `resolve()` already returns a *list* expression for a repeated path, so this compiles to a single DuckDB list aggregate around what the resolver produces. `count` filters nulls rather than using `len`, which would count them.
- Refused two ways: over a scalar path (which needs no reduction, and accepting it would give the same query two spellings), and as an aggregated query's ordering key (after grouping there is no reaction left to reduce over — the reduction belongs inside a measure).
- `min`, `max`, `avg`, and `sum` need a numeric leaf, whether they reduce a repeated path or aggregate a scalar one; `count` takes any. Arithmetic over text used to reach DuckDB and fail there, on the new reduction path and on the pre-existing scalar-measure path alike, so the check covers both and the measure branch moves into `_measure_argument`.
- README: the grammar block, the two rules, and a worked-example row.

Testing
-------
`uv run pytest -n auto` — 1216 passed. Sixteen new tests: each reducer's expression, all three refusals, a measure reducing, `count` still taking a text path, agreement with what `resolve()` produces, and one that executes the SQL.

Against the full corpus (2,428,291 reactions) the previously-unwritable query now runs:

```
10 rows in 2.82s
```

And it is *right*, not merely runnable — the compiled SQL returns the same ten reactions in the same order as a hand-written reference query:

```
compiled : ord-50b993b6..., ord-aaba6e4b..., ord-09fe18d4..., ord-4951e7a3..., ord-c889cb5c...
reference: ord-50b993b6..., ord-aaba6e4b..., ord-09fe18d4..., ord-4951e7a3..., ord-c889cb5c...
same set : True
```

Notes
-----
Worth knowing separately from this change: the top yields in ORD are junk — the highest is `9.02e+19` percent. The query is correct; the corpus has percentage values that are not percentages. That is a data-quality question for another day, but anything that ranks by yield will surface it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds per-reaction reductions over repeated paths so they can be used as ordering keys or measure inputs.
- Adds typed `Reduction` support for ordering and aggregation.
- Compiles reductions to DuckDB list aggregates, with null-aware counting.
- Validates repeated-path usage and numeric requirements during compilation.
- Documents the new query grammar and adds compilation and execution tests.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/query.py | Adds reduction models, numeric validation, list-aggregate compilation, and restrictions for scalar and grouped-query contexts; the previously reported leaf-type validation gap is fixed. |
| ord_schema/search/query_test.py | Covers all reducers, invalid scalar and text paths, measure reductions, grouped ordering rejection, resolver agreement, and executable SQL. |
| ord_schema/search/README.md | Updates the query grammar, reduction constraints, numeric requirements, and worked examples. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Q[Query Reduction] --> R[Resolve repeated path]
    R --> V{Arithmetic reducer?}
    V -->|Yes| N[Validate numeric leaf]
    V -->|No: count| L[Filter null elements]
    N --> A[DuckDB list aggregate]
    L --> C[Count remaining elements]
    A --> S[Scalar per reaction]
    C --> S
    S --> O[Order key or measure input]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Name the reading a quantifier does not b..."](https://github.com/open-reaction-database/ord-schema/commit/7a7baa21128be00bc9f65cf5327a8109def3863e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54205803)</sub>

<!-- /greptile_comment -->
