### PR TITLE
Compare compounds rather than spellings

### DIFF
--- a/ord_schema/artifacts/base.py
+++ b/ord_schema/artifacts/base.py
@@ -209,7 +209,35 @@ def load_stamps(path: str | os.PathLike[str]) -> Stamps:
     )
 
 
-def is_current(path: str | os.PathLike[str], artifact: str, source_md5: str) -> bool:
+def missing_columns(path: str | os.PathLike[str], schema: pa.Schema) -> list[str]:
+    """Returns the columns ``schema`` declares that ``path`` does not carry.
+
+    Stamps say nothing about a file's columns, so this is what sees a column added to
+    an artifact's definition: a file written before it stamps exactly as a file written
+    after it, and the difference shows up only in the schema.
+
+    Args:
+        path: Path to check. Need not exist.
+        schema: The columns this library's version of the artifact carries.
+
+    Returns:
+        The declared names the file lacks, in declaration order. A file that cannot be
+        read at all lacks all of them.
+    """
+    try:
+        with pq.ParquetFile(path) as parquet_file:
+            names = set(parquet_file.schema_arrow.names)
+    except (OSError, ValueError, pa.ArrowInvalid):
+        return list(schema.names)
+    return [name for name in schema.names if name not in names]
+
+
+def is_current(
+    path: str | os.PathLike[str],
+    artifact: str,
+    source_md5: str,
+    schema: pa.Schema | None = None,
+) -> bool:
     """Returns whether ``path`` holds ``artifact`` derived from ``source_md5`` by us.
 
     All of the source content, the library version, the artifact version, and the RDKit
@@ -220,6 +248,9 @@ def is_current(path: str | os.PathLike[str], artifact: str, source_md5: str) -> 
         path: Path to check. Need not exist.
         artifact: Artifact name the file is expected to hold.
         source_md5: Hash the file is expected to restate.
+        schema: The columns the artifact carries, when the caller has them. Given, a
+            file lacking one is not current, which is what makes a column added
+            without a version bump derive again instead of being skipped.
 
     Returns:
         Whether the file is one this library would write today.
@@ -229,6 +260,8 @@ def is_current(path: str | os.PathLike[str], artifact: str, source_md5: str) -> 
     except (OSError, ValueError):
         # Broad on purpose: every way of failing to read stamps -- absent, truncated,
         # not Parquet at all -- answers "derive it again", which is safe.
+        return False
+    if schema is not None and missing_columns(path, schema):
         return False
     return value.source_md5 == source_md5 and stamps_are_current(value, artifact)
 
@@ -441,6 +474,7 @@ def derive_tree(
     *,
     artifact: str,
     write: ArtifactWriter,
+    schema: pa.Schema | None = None,
     force: bool = False,
     parent_artifact: str | None = None,
 ) -> tuple[int, int, int]:
@@ -457,6 +491,8 @@ def derive_tree(
         artifact: Artifact name, used for the staleness check and the footer stamp.
         write: Writer taking ``(parent, output, source_md5=..., source_dataset_id=...)``
             and returning rows.
+        schema: The columns ``write`` produces, when the caller has them. Given, an
+            artifact lacking one is derived again rather than skipped.
         force: Rewrite artifacts that are already current.
         parent_artifact: Artifact the parents hold, for a derivation that reads another
             artifact rather than a source dataset. None means the parents are source
@@ -508,7 +544,7 @@ def derive_tree(
         source_md5, source_dataset_id = _parent_provenance(
             source, parent_artifact, parent_stamps[source]
         )
-        if not force and is_current(destination, artifact, source_md5):
+        if not force and is_current(destination, artifact, source_md5, schema):
             logger.info("%s is current; skipping", destination)
             skipped += 1
             continue

--- a/ord_schema/artifacts/scripts/derive_projection.py
+++ b/ord_schema/artifacts/scripts/derive_projection.py
@@ -71,6 +71,7 @@ def main(args: argparse.Namespace) -> None:
         args.output_dir,
         artifact=projection.ARTIFACT,
         write=projection.write_projection,
+        schema=projection.SCHEMA,
         force=args.force,
     )
     if not written and not skipped:

--- a/ord_schema/artifacts/scripts/derive_structures.py
+++ b/ord_schema/artifacts/scripts/derive_structures.py
@@ -78,6 +78,7 @@ def main(args: argparse.Namespace) -> None:
         args.output_dir,
         artifact=structures.ARTIFACT,
         write=structures.write_structures,
+        schema=structures.SCHEMA,
         force=args.force,
         parent_artifact=projection.ARTIFACT,
     )

--- a/ord_schema/artifacts/structures.py
+++ b/ord_schema/artifacts/structures.py
@@ -47,19 +47,24 @@ verification at all: Tanimoto is defined on the Morgan fingerprint, so the scree
 the answer, and ``morgan_popcount`` bounds it (``popcount(B)`` must lie within ``[t *
 popcount(A), popcount(A) / t]`` for Tanimoto ``>= t``).
 
-Beside the SMILES the projection derived, a row carries a ``mol_hash``: an
-identity for the molecule that ignores how it was drawn. Equality on the stored
-spelling is exact and answers the wrong question surprisingly often -- acetic acid and
-acetate, an amine and its ammonium, a 2-pyridone and its 2-hydroxypyridine tautomer are
-each one reagent written two ways, and each compares unequal. The hash is taken of the
-uncharged molecule, so protonation states collapse, and it is RDKit's het-atom tautomer
-hash, so tautomers collapse with them.
+Beside the SMILES the projection derived, a row carries a ``mol_hash``: an identity
+for the molecule that ignores how it was drawn. Equality on the stored spelling is
+exact and answers the wrong question surprisingly often -- acetic acid and acetate, an
+amine and its ammonium, a 2-pyridone and its 2-hydroxypyridine tautomer are each one
+reagent written two ways, and each compares unequal.
 
-It is a hash rather than a standardized SMILES because canonicalizing a tautomer costs
-what the corpus does not have: measured over ORD's own molecules, RDKit's tautomer
-enumerator runs at ~500 structures a second against ~19,000 for the hash, which is an
-hour against two minutes over the two million distinct structures here. The stored
-SMILES beside it is what a reader looks at; the hash is only ever compared.
+It is RDKit's registration hash, taken of the uncharged molecule. Uncharging is what
+makes the scheme insensitive to protonation as well as to tautomer: one of its layers
+is the molecular formula, and a formula states the charge. Registration is the right
+API rather than a bare tautomer hash because it normalizes what a bare hash does not --
+atom-map labels, unnecessary explicit hydrogens, enhanced stereo, S-group data -- so a
+compound written with atom maps is the same compound. It is a hash rather than a
+canonical tautomer because canonicalizing one costs what the corpus does not have:
+measured over ORD's own molecules, RDKit's tautomer enumerator runs at ~500 structures
+a second against ~2,600 for this hash, which is an hour against thirteen minutes over
+the two million distinct structures here, before the per-file parallelism the build
+already has. The stored SMILES beside it is what a reader looks at; the hash is only
+ever compared.
 
 Fragments are left alone, so sodium acetate stays distinct from acetic acid. That is a
 narrower claim than "the same reagent" on purpose -- every salt-stripping rule measured
@@ -84,7 +89,7 @@ from typing import Any
 import pyarrow as pa
 import pyarrow.parquet as pq
 from rdkit import Chem, DataStructs
-from rdkit.Chem import rdFingerprintGenerator, rdMolHash
+from rdkit.Chem import RegistrationHash, rdFingerprintGenerator
 from rdkit.Chem.MolStandardize import rdMolStandardize
 
 from ord_schema import atomic_io
@@ -305,17 +310,23 @@ def _collect(source: str | os.PathLike[str]) -> list[str]:
 # Built once: constructing an uncharger per molecule dominates the work it does, and
 # it carries no per-molecule state.
 _UNCHARGER = rdMolStandardize.Uncharger()
-# Version 2 of the het-atom tautomer hash. Version 1 leaves a keto/enol pair apart,
-# which is the tautomer a chemist is most likely to have drawn either way.
-_TAUTOMER_HASH = rdMolHash.HashFunction.HetAtomTautomerv2
+# The registration hash's tautomer-insensitive scheme drops the two layers that spell a
+# structure exactly and keeps the formula, the tautomer hash, and the S-group data.
+_SCHEME = RegistrationHash.HashScheme.TAUTOMER_INSENSITIVE_LAYERS
 
 
 def mol_hash(structure: Chem.Mol | str) -> str | None:
     """Returns an identity for a molecule that ignores tautomer and protonation state.
 
     Two drawings of one reagent hash the same: acetic acid and acetate, an amine and
-    its ammonium, a 2-pyridone and its 2-hydroxypyridine tautomer. Fragments are left
-    alone, so sodium acetate hashes differently from acetic acid.
+    its ammonium, a 2-pyridone and its 2-hydroxypyridine tautomer, a compound written
+    with atom-map labels and the same compound without them. Fragments are left alone,
+    so sodium acetate hashes differently from acetic acid, and so is stereochemistry,
+    so enantiomers stay apart.
+
+    The molecule is uncharged before it is hashed, which is what makes the scheme
+    insensitive to protonation as well: one of its layers is the molecular formula, and
+    a formula states the charge.
 
     Args:
         structure: A parsed molecule, or SMILES to read one from.
@@ -330,8 +341,16 @@ def mol_hash(structure: Chem.Mol | str) -> str | None:
     if molecule is None:
         return None
     try:
-        return rdMolHash.MolHash(_UNCHARGER.uncharge(molecule), _TAUTOMER_HASH)
-    except (Chem.AtomValenceException, Chem.KekulizeException, RuntimeError):
+        layers = RegistrationHash.GetMolLayers(
+            _UNCHARGER.uncharge(molecule), enable_tautomer_hash_v2=True
+        )
+        return RegistrationHash.GetMolHash(layers, _SCHEME)
+    except (
+        Chem.AtomValenceException,
+        Chem.KekulizeException,
+        RuntimeError,
+        ValueError,
+    ):
         return None
 
 

--- a/ord_schema/artifacts/structures.py
+++ b/ord_schema/artifacts/structures.py
@@ -47,6 +47,31 @@ verification at all: Tanimoto is defined on the Morgan fingerprint, so the scree
 the answer, and ``morgan_popcount`` bounds it (``popcount(B)`` must lie within ``[t *
 popcount(A), popcount(A) / t]`` for Tanimoto ``>= t``).
 
+Beside the SMILES the projection derived, a row carries a ``mol_hash``: an
+identity for the molecule that ignores how it was drawn. Equality on the stored
+spelling is exact and answers the wrong question surprisingly often -- acetic acid and
+acetate, an amine and its ammonium, a 2-pyridone and its 2-hydroxypyridine tautomer are
+each one reagent written two ways, and each compares unequal. The hash is taken of the
+uncharged molecule, so protonation states collapse, and it is RDKit's het-atom tautomer
+hash, so tautomers collapse with them.
+
+It is a hash rather than a standardized SMILES because canonicalizing a tautomer costs
+what the corpus does not have: measured over ORD's own molecules, RDKit's tautomer
+enumerator runs at ~500 structures a second against ~19,000 for the hash, which is an
+hour against two minutes over the two million distinct structures here. The stored
+SMILES beside it is what a reader looks at; the hash is only ever compared.
+
+Fragments are left alone, so sodium acetate stays distinct from acetic acid. That is a
+narrower claim than "the same reagent" on purpose -- every salt-stripping rule measured
+here trades one class of wrong answer for another, turning Pd(OAc)2 into acetic acid or
+NaH into hydrogen -- and a corpus-wide column is the wrong place to guess. Salt
+insensitivity is a second question and would be a second column.
+
+The hash is RDKit's and moves with it, which is why ``base`` stamps the RDKit version
+and ``is_current`` refuses an artifact built by another one. Without that stamp an
+RDKit upgrade would silently change what a stored column means while every query kept
+running.
+
 A structure whose SMILES RDKit cannot parse keeps its row -- the ID space must stay
 dense -- with every derived column null. It can never match a structure query, and the
 count of such rows is logged per dataset.
@@ -59,7 +84,8 @@ from typing import Any
 import pyarrow as pa
 import pyarrow.parquet as pq
 from rdkit import Chem, DataStructs
-from rdkit.Chem import rdFingerprintGenerator
+from rdkit.Chem import rdFingerprintGenerator, rdMolHash
+from rdkit.Chem.MolStandardize import rdMolStandardize
 
 from ord_schema import atomic_io
 from ord_schema.artifacts import base, projection
@@ -106,6 +132,9 @@ SCHEMA = pa.schema(
         # carries one, and rows here are numbered 0..n-1 in the same first-seen order.
         pa.field("structure_id", pa.uint32(), nullable=False),
         pa.field("smiles", pa.string(), nullable=False),
+        # What an equality compares when the question is "the same compound" rather
+        # than "the same drawing of one"; see the module docstring.
+        pa.field("mol_hash", pa.string()),
         pa.field(
             "pattern_fp",
             pa.binary(),
@@ -273,6 +302,39 @@ def _collect(source: str | os.PathLike[str]) -> list[str]:
     return [smiles_by_id[structure_id] for structure_id in range(len(smiles_by_id))]
 
 
+# Built once: constructing an uncharger per molecule dominates the work it does, and
+# it carries no per-molecule state.
+_UNCHARGER = rdMolStandardize.Uncharger()
+# Version 2 of the het-atom tautomer hash. Version 1 leaves a keto/enol pair apart,
+# which is the tautomer a chemist is most likely to have drawn either way.
+_TAUTOMER_HASH = rdMolHash.HashFunction.HetAtomTautomerv2
+
+
+def mol_hash(structure: Chem.Mol | str) -> str | None:
+    """Returns an identity for a molecule that ignores tautomer and protonation state.
+
+    Two drawings of one reagent hash the same: acetic acid and acetate, an amine and
+    its ammonium, a 2-pyridone and its 2-hydroxypyridine tautomer. Fragments are left
+    alone, so sodium acetate hashes differently from acetic acid.
+
+    Args:
+        structure: A parsed molecule, or SMILES to read one from.
+
+    Returns:
+        The hash, or None where RDKit cannot read or hash the structure, which leaves
+        the column null rather than storing a value the query side would not reproduce.
+    """
+    molecule = (
+        Chem.MolFromSmiles(structure) if isinstance(structure, str) else structure
+    )
+    if molecule is None:
+        return None
+    try:
+        return rdMolHash.MolHash(_UNCHARGER.uncharge(molecule), _TAUTOMER_HASH)
+    except (Chem.AtomValenceException, Chem.KekulizeException, RuntimeError):
+        return None
+
+
 def _row(structure_id: int, smiles: str) -> dict[str, Any]:
     """Featurizes one structure into a row matching ``SCHEMA``.
 
@@ -287,6 +349,7 @@ def _row(structure_id: int, smiles: str) -> dict[str, Any]:
     row: dict[str, Any] = {
         "structure_id": structure_id,
         "smiles": smiles,
+        "mol_hash": None,
         "pattern_fp": None,
         "morgan_fp": None,
         "morgan_popcount": None,
@@ -295,6 +358,7 @@ def _row(structure_id: int, smiles: str) -> dict[str, Any]:
     mol = Chem.MolFromSmiles(smiles)
     if mol is None:
         return row
+    row["mol_hash"] = mol_hash(mol)
     morgan = morgan_fingerprint(mol)
     row["pattern_fp"] = DataStructs.BitVectToBinaryText(
         Chem.PatternFingerprint(mol, fpSize=PATTERN_FP_SIZE)

--- a/ord_schema/artifacts/structures_test.py
+++ b/ord_schema/artifacts/structures_test.py
@@ -407,3 +407,22 @@ def test_the_artifact_carries_a_hash_beside_every_readable_structure(tmp_path):
     acetate = next(row for row in rows if "[O-]" in row["smiles"])
     assert acetate["mol_hash"] == structures.mol_hash("CC(=O)O")
     assert all(row["mol_hash"] for row in rows)
+
+
+def test_an_artifact_lacking_a_column_is_not_current(tmp_path):
+    # The stamps say nothing about columns, so without the schema an artifact written
+    # before one was added skips derivation and then fails wherever it is read.
+    source = _project(tmp_path)
+    output = tmp_path / "structures.parquet"
+    structures.write_structures(source, output)
+    stamps = base.load_stamps(output)
+    assert structures.is_current(output, stamps.source_md5)
+    table = pq.read_table(output)
+    pq.write_table(
+        table.drop_columns(["mol_hash"]).replace_schema_metadata(table.schema.metadata),
+        output,
+    )
+    assert base.missing_columns(output, structures.SCHEMA) == ["mol_hash"]
+    assert not base.is_current(
+        output, structures.ARTIFACT, stamps.source_md5, structures.SCHEMA
+    )

--- a/ord_schema/artifacts/structures_test.py
+++ b/ord_schema/artifacts/structures_test.py
@@ -160,7 +160,13 @@ def test_an_unparseable_structure_keeps_its_row_with_null_columns():
     row = structures._row(7, "not-a-smiles")
     assert row["structure_id"] == 7
     assert row["smiles"] == "not-a-smiles"
-    for column in ("pattern_fp", "morgan_fp", "morgan_popcount", "mol_binary"):
+    for column in (
+        "mol_hash",
+        "pattern_fp",
+        "morgan_fp",
+        "morgan_popcount",
+        "mol_binary",
+    ):
         assert row[column] is None, column
 
 
@@ -290,7 +296,13 @@ def test_an_unparseable_structure_survives_the_write_path(tmp_path):
     rows = pq.read_table(output).to_pylist()
     bad = next(r for r in rows if r["smiles"] == "not-a-smiles")
     assert bad["structure_id"] == ids["c1ccccc1"]
-    for column in ("pattern_fp", "morgan_fp", "morgan_popcount", "mol_binary"):
+    for column in (
+        "mol_hash",
+        "pattern_fp",
+        "morgan_fp",
+        "morgan_popcount",
+        "mol_binary",
+    ):
         assert bad[column] is None, column
     good = next(r for r in rows if r["smiles"] != "not-a-smiles")
     assert good["mol_binary"] is not None
@@ -336,3 +348,55 @@ def test_a_stale_projection_is_refused(tmp_path):
     pq.write_table(pa.Table.from_pylist([], schema=schema), path)
     with pytest.raises(ValueError, match="stale"):
         structures.write_structures(path, tmp_path / "structures.parquet")
+
+
+@pytest.mark.parametrize(
+    ("label", "left", "right"),
+    [
+        ("protonation", "CC(=O)O", "CC(=O)[O-]"),
+        ("ammonium", "CCN", "CC[NH3+]"),
+        ("keto-enol", "CC(=O)C", "CC(O)=C"),
+        ("amide-imidic acid", "CC(=O)N", "CC(O)=N"),
+        ("lactam-lactim", "O=c1cccc[nH]1", "Oc1ccccn1"),
+        ("kekule", "C1=CC=NC=C1", "c1ccncc1"),
+    ],
+)
+def test_one_compound_drawn_two_ways_hashes_the_same(label, left, right):
+    del label
+    assert structures.mol_hash(left) == structures.mol_hash(right)
+
+
+@pytest.mark.parametrize(
+    ("label", "left", "right"),
+    [
+        ("different molecules", "CCO", "CC(=O)O"),
+        ("different heteroatom", "c1ccncc1", "c1ccccc1"),
+        # A salt is a different reagent rather than a different drawing of one, and
+        # every rule that collapses the two mangles something else: keeping the largest
+        # fragment turns Pd(OAc)2 into acetic acid, and stripping recognized
+        # counterions turns NaH into hydrogen.
+        ("salt", "CC(=O)O", "CC(=O)[O-].[Na+]"),
+        ("cocrystal", "c1ccccc1", "c1ccccc1.Cc1ccccc1"),
+    ],
+)
+def test_different_compounds_hash_differently(label, left, right):
+    del label
+    assert structures.mol_hash(left) != structures.mol_hash(right)
+
+
+def test_an_unhashable_smiles_is_none_rather_than_a_guess():
+    # A column holding a spelling the query side would not reproduce is worse than a
+    # null one, which simply never matches.
+    assert structures.mol_hash("not a molecule") is None
+
+
+def test_the_artifact_carries_a_hash_beside_every_readable_structure(tmp_path):
+    source = _project(tmp_path, [_reaction(input_smiles="CC(=O)[O-]")])
+    output = tmp_path / "structures.parquet"
+    structures.write_structures(source, output)
+    rows = pq.read_table(output).to_pylist()
+    # The acetate is stored as drawn and hashes to what acetic acid hashes to, which is
+    # the whole point: the corpus keeps its own spelling and still answers for it.
+    acetate = next(row for row in rows if "[O-]" in row["smiles"])
+    assert acetate["mol_hash"] == structures.mol_hash("CC(=O)O")
+    assert all(row["mol_hash"] for row in rows)

--- a/ord_schema/artifacts/structures_test.py
+++ b/ord_schema/artifacts/structures_test.py
@@ -359,6 +359,10 @@ def test_a_stale_projection_is_refused(tmp_path):
         ("amide-imidic acid", "CC(=O)N", "CC(O)=N"),
         ("lactam-lactim", "O=c1cccc[nH]1", "Oc1ccccn1"),
         ("kekule", "C1=CC=NC=C1", "c1ccncc1"),
+        # Registration strips atom-map labels, which a bare tautomer hash keeps: the
+        # same reagent written for a mapped reaction is the same reagent.
+        ("atom maps", "[CH3:1][C:2](=[O:3])[OH:4]", "CC(=O)O"),
+        ("explicit hydrogens", "[H]OC", "CO"),
     ],
 )
 def test_one_compound_drawn_two_ways_hashes_the_same(label, left, right):
@@ -377,6 +381,9 @@ def test_one_compound_drawn_two_ways_hashes_the_same(label, left, right):
         # counterions turns NaH into hydrogen.
         ("salt", "CC(=O)O", "CC(=O)[O-].[Na+]"),
         ("cocrystal", "c1ccccc1", "c1ccccc1.Cc1ccccc1"),
+        # Stereochemistry is not a way of drawing one compound.
+        ("enantiomers", "C[C@H](N)C(=O)O", "C[C@@H](N)C(=O)O"),
+        ("isotopes", "[2H]OC", "CO"),
     ],
 )
 def test_different_compounds_hash_differently(label, left, right):

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -93,10 +93,11 @@ is a compile error rather than a wrong answer:
 - `same_compound` asks "the same compound, however either was drawn"; an `eq` on a `smiles`
   asks "the same spelling". Acetic acid and acetate, an amine and its ammonium, a 2-pyridone
   and its 2-hydroxypyridine tautomer are each one reagent written two ways, and each compares
-  unequal under `eq`. It matches on the `mol_hash` the structures artifact derives, so
-  protonation state and tautomer are ignored — and fragments are not, so sodium acetate is
-  still a different reagent from acetic acid. Prefer it to `eq` whenever the question names a
-  compound rather than a string.
+  unequal under `eq`. It matches on the `mol_hash` the structures artifact derives — RDKit's
+  registration hash of the uncharged molecule — so protonation state, tautomer, and atom-map
+  labels are ignored. Fragments and stereochemistry are not: sodium acetate is still a
+  different reagent from acetic acid, and enantiomers are still different compounds. Prefer
+  it to `eq` whenever the question names a compound rather than a string.
 - A SMARTS naming a hydrogen the corpus stores implicitly is rewritten, with a warning,
   rather than run as written: stored molecules come from SMILES, so `[H]OC` matches no
   methanol and would return empty without saying why. `MergeQueryHs` folds it to

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -50,6 +50,7 @@ Predicate  = { op: "and" | "or", clauses: [Predicate] }
            | { op: "substructure", path: Path, smarts?: string, compound?: <name> }
            | { op: "similarity", path: Path, smiles?: string, compound?: <name>,
                threshold: float }
+           | { op: "same_compound", path: Path, smiles?: string, compound?: <name> }
 
 Value      = { literal: <scalar> } | { compound: <name> }
 
@@ -87,8 +88,15 @@ is a compile error rather than a wrong answer:
   query is compiled rather than left to fail where it runs.
 - A `{"compound": ...}` value is resolved through [`ord_schema.resolvers`](../resolvers.py) and
   **bound as a parameter**, so the model names compounds and never spells structures.
-- A `substructure`/`similarity` path must name a compound's `smiles`, inside a
-  quantifier like any other element predicate.
+- A `substructure`/`similarity`/`same_compound` path must name a compound's `smiles`,
+  inside a quantifier like any other element predicate.
+- `same_compound` asks "the same compound, however either was drawn"; an `eq` on a `smiles`
+  asks "the same spelling". Acetic acid and acetate, an amine and its ammonium, a 2-pyridone
+  and its 2-hydroxypyridine tautomer are each one reagent written two ways, and each compares
+  unequal under `eq`. It matches on the `mol_hash` the structures artifact derives, so
+  protonation state and tautomer are ignored — and fragments are not, so sodium acetate is
+  still a different reagent from acetic acid. Prefer it to `eq` whenever the question names a
+  compound rather than a string.
 - A SMARTS naming a hydrogen the corpus stores implicitly is rewritten, with a warning,
   rather than run as written: stored molecules come from SMILES, so `[H]OC` matches no
   methanol and would return empty without saying why. `MergeQueryHs` folds it to

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -258,7 +258,9 @@ def _max_structure_id(path: str) -> int | None:
     return largest
 
 
-def _index(pattern: str, artifact: str, require_current: bool) -> dict[str, str]:
+def _index(
+    pattern: str, artifact: str, schema: pa.Schema, require_current: bool
+) -> dict[str, str]:
     """Returns the artifacts matching ``pattern``, keyed by source dataset.
 
     Keyed by the source hash rather than the filename because that is what an
@@ -269,20 +271,35 @@ def _index(pattern: str, artifact: str, require_current: bool) -> dict[str, str]
     Args:
         pattern: Glob matching the artifact files.
         artifact: Artifact name every match must hold.
+        schema: The columns this library's version of the artifact carries.
         require_current: Refuse artifacts not written by the current versions.
 
     Returns:
         A mapping from source dataset hash to path.
 
     Raises:
-        PairingError: If a match holds another artifact, is stale under
-            ``require_current``, or restates a dataset another match already did.
+        PairingError: If a match holds another artifact, lacks a column this library
+            reads, is stale under ``require_current``, or restates a dataset another
+            match already did.
     """
     index: dict[str, str] = {}
     for path in sorted(glob.glob(pattern, recursive=True)):
+        with pq.ParquetFile(path) as parquet_file:
+            columns = set(parquet_file.schema_arrow.names)
         stamps = base.load_stamps(path)
         if stamps.artifact != artifact:
             raise PairingError(f"{path} is a {stamps.artifact}, not a {artifact}")
+        missing = [name for name in schema.names if name not in columns]
+        if missing:
+            # The stamps say nothing about a file's columns, so this is the only check
+            # that sees a schema change. Without it a file predating a column is read
+            # as a corpus member and fails deep in DuckDB -- as a binder error on the
+            # query that wants the column, or, where some files have it and some do
+            # not, as a schema mismatch that takes down every structure query.
+            raise PairingError(
+                f"{path} is a {artifact} artifact without {missing}, which this "
+                "library reads; derive it again first"
+            )
         if require_current and not base.stamps_are_current(stamps, artifact):
             raise PairingError(f"{path} is stale; derive it again first")
         if stamps.source_md5 in index:
@@ -309,12 +326,16 @@ def _pair(
         One pair per source dataset, ordered by the projection's source hash.
 
     Raises:
-        PairingError: If no projection matches, or if either side states a dataset the
-            other does not, since a projection's IDs index its own partner's molecules
-            and nobody else's.
+        PairingError: If no projection matches, if either side lacks a column this
+            library reads, or if either side states a dataset the other does not, since
+            a projection's IDs index its own partner's molecules and nobody else's.
     """
-    projections = _index(projection_pattern, projection.ARTIFACT, require_current)
-    structure_files = _index(structures_pattern, structures.ARTIFACT, require_current)
+    projections = _index(
+        projection_pattern, projection.ARTIFACT, projection.SCHEMA, require_current
+    )
+    structure_files = _index(
+        structures_pattern, structures.ARTIFACT, structures.SCHEMA, require_current
+    )
     if not projections:
         raise PairingError(f"no projections matched: {projection_pattern}")
     unpaired = projections.keys() ^ structure_files.keys()
@@ -1849,7 +1870,7 @@ class Corpus:
         that hit it rather than with everyone queued behind.
 
         Args:
-            cursor: The cursor a similarity screen runs on.
+            cursor: The cursor a similarity screen or a hash match runs on.
             parameter: The predicate to evaluate.
             resolve: Maps a compound name to SMILES.
 
@@ -1857,8 +1878,9 @@ class Corpus:
             The bitmap over corpus-wide structure IDs.
 
         Raises:
-            ValueError: If the predicate names neither a pattern nor a compound, or if
-                a resolved compound's SMILES does not parse.
+            ValueError: If the predicate names neither a pattern nor a compound, if a
+                resolved compound's SMILES does not parse, or if RDKit refuses to hash
+                the query molecule of a ``same_compound`` predicate.
             PairingError: If the library does not come out one entry per distinct
                 molecule over an unbroken run of IDs.
         """

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -284,12 +284,10 @@ def _index(
     """
     index: dict[str, str] = {}
     for path in sorted(glob.glob(pattern, recursive=True)):
-        with pq.ParquetFile(path) as parquet_file:
-            columns = set(parquet_file.schema_arrow.names)
         stamps = base.load_stamps(path)
         if stamps.artifact != artifact:
             raise PairingError(f"{path} is a {stamps.artifact}, not a {artifact}")
-        missing = [name for name in schema.names if name not in columns]
+        missing = base.missing_columns(path, schema)
         if missing:
             # The stamps say nothing about a file's columns, so this is the only check
             # that sees a schema change. Without it a file predating a column is read

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -1386,6 +1386,44 @@ class Corpus:
         ).fetchall()
         return [row[0] for row in rows]
 
+    def _same_compound_ids(
+        self,
+        cursor: duckdb.DuckDBPyConnection,
+        parameter: query.StructureParameter,
+        resolve: Callable[[str], str],
+    ) -> list[int]:
+        """Matches on the compound hash; returns global IDs.
+
+        The artifact already holds every structure's hash, so the whole answer is one
+        equality against a column -- no screen, no verification, and no chemistry
+        beyond hashing the query molecule the way the artifact hashed its own.
+
+        Args:
+            cursor: The cursor the match runs on.
+            parameter: The predicate to match.
+            resolve: Maps a compound name to SMILES.
+
+        Returns:
+            The corpus-wide structure IDs sharing the query molecule's hash.
+
+        Raises:
+            ValueError: If a resolved compound's SMILES does not parse, or if RDKit
+                refuses to hash the query molecule -- either leaves the question
+                unaskable rather than quietly unanswerable.
+        """
+        molecule = self._query_molecule(parameter, resolve)
+        hashed = structures.mol_hash(molecule)
+        if hashed is None:
+            raise ValueError(
+                f"could not hash the query molecule for {parameter.name!r}; the corpus "
+                "compares compounds by hash, so there is nothing to compare it to"
+            )
+        rows = cursor.execute(
+            "SELECT global_id FROM corpus_structures WHERE mol_hash = $h",
+            {"h": hashed},
+        ).fetchall()
+        return [row[0] for row in rows]
+
     def _bitmap(self, matched: Sequence[int]) -> str:
         """Returns the match set as a bitmap over the corpus-wide ID space."""
         bits = bytearray(b"0" * max(self._total, 1))
@@ -1858,6 +1896,8 @@ class Corpus:
         try:
             if parameter.op == "substructure":
                 matched = self._substructure_ids(parameter, resolve)
+            elif parameter.op == "same_compound":
+                matched = self._same_compound_ids(cursor, parameter, resolve)
             else:
                 matched = self._similarity_ids(cursor, parameter, resolve)
             logger.info(

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -18,6 +18,7 @@ import contextlib
 import logging
 import pathlib
 import re
+import shutil
 import threading
 import time
 from collections.abc import Iterator
@@ -30,7 +31,7 @@ from rdkit import Chem
 from rdkit.Chem import rdSubstructLibrary
 
 from ord_schema import parquet
-from ord_schema.artifacts import pivot, projection, structures
+from ord_schema.artifacts import base, pivot, projection, structures
 from ord_schema.proto import dataset_pb2, reaction_pb2
 from ord_schema.search import execute, query
 
@@ -1262,6 +1263,11 @@ _ROUTABLE = {
     "a compound name": {
         "where": _exists(
             {"op": "substructure", "path": "smiles", "compound": "pyridine"}
+        )
+    },
+    "same compound": {
+        "where": _exists(
+            {"op": "same_compound", "path": "smiles", "smiles": "c1ccncc1"}
         )
     },
     "products rather than inputs": {
@@ -3684,3 +3690,52 @@ def test_a_compound_name_resolves_to_a_same_compound_query(drawn_two_ways):
         drawn_two_ways,
         _exists({"op": "same_compound", "path": "smiles", "compound": "acetic_acid"}),
     ) == {"ord-dd01"}
+
+
+def _without_mol_hash(corpus_dir, tmp_path, *, files: int) -> pathlib.Path:
+    """Copies a corpus and drops ``mol_hash`` from some of its structures artifacts.
+
+    The stamps are carried over untouched, which is the whole point: they say nothing
+    about a file's columns, so a file predating one still reads as current.
+
+    Args:
+        corpus_dir: The corpus to copy.
+        tmp_path: Where to put the copy.
+        files: How many structures artifacts to drop the column from.
+
+    Returns:
+        The copy's root.
+    """
+    root = tmp_path / "aged"
+    shutil.copytree(corpus_dir, root)
+    for path in sorted((root / "structures").glob("*.parquet"))[:files]:
+        table = pq.read_table(path)
+        pq.write_table(
+            table.drop_columns(["mol_hash"]).replace_schema_metadata(
+                table.schema.metadata
+            ),
+            path,
+        )
+    return root
+
+
+def test_a_structures_artifact_without_mol_hash_is_refused(corpus_dir, tmp_path):
+    # Stale is not what this is: the stamps still match, so nothing rebuilds the file
+    # and nothing else would notice until DuckDB failed to bind the column.
+    root = _without_mol_hash(corpus_dir, tmp_path, files=2)
+    assert structures.is_current(
+        next((root / "structures").glob("*.parquet")),
+        base.load_stamps(next((root / "structures").glob("*.parquet"))).source_md5,
+    )
+    with pytest.raises(execute.PairingError, match="mol_hash"):
+        _open(root)
+
+
+def test_one_aged_structures_artifact_is_refused_with_the_others_current(
+    corpus_dir, tmp_path
+):
+    # The likelier state, and the worse one: DuckDB reads a glob of mismatched schemas
+    # as an error on every structure query rather than on the one that wants the column.
+    root = _without_mol_hash(corpus_dir, tmp_path, files=1)
+    with pytest.raises(execute.PairingError, match="derive it again"):
+        _open(root)

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -3595,3 +3595,92 @@ def test_a_nested_correlation_binds_the_measurement_to_its_own_product(wide_corp
     )
     # ord-wd07 keeps both in one outcome, so only the product ordinal separates them.
     assert found == {"ord-wd02"}
+
+
+@pytest.fixture(scope="module")
+def drawn_two_ways(tmp_path_factory) -> Iterator[execute.Corpus]:
+    """A corpus storing acetate, an enol, and a salt, none spelled the query's way."""
+    acetate = reaction_pb2.Reaction(reaction_id="ord-dd01")
+    _component(acetate.inputs["in"], "CC(=O)[O-]", _ROLE.REAGENT)
+    enol = reaction_pb2.Reaction(reaction_id="ord-dd02")
+    _component(enol.inputs["in"], "CC(O)=C", _ROLE.REACTANT)
+    salt = reaction_pb2.Reaction(reaction_id="ord-dd03")
+    _component(salt.inputs["in"], "CC(=O)[O-].[Na+]", _ROLE.REAGENT)
+    other = reaction_pb2.Reaction(reaction_id="ord-dd04")
+    _component(other.inputs["in"], "CCO", _ROLE.SOLVENT)
+    root = tmp_path_factory.mktemp("drawn")
+    source = root / "data" / "ord_dataset-dd.parquet"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    parquet.save_dataset(
+        dataset_pb2.Dataset(
+            dataset_id="ord_dataset-dd",
+            name="test",
+            description="test",
+            reactions=[acetate, enol, salt, other],
+        ),
+        str(source),
+    )
+    projected = root / "projections" / source.name
+    projected.parent.mkdir(parents=True, exist_ok=True)
+    projection.write_projection(source, projected)
+    structured = root / "structures" / source.name
+    structured.parent.mkdir(parents=True, exist_ok=True)
+    structures.write_structures(projected, structured)
+    with execute.Corpus(
+        str(projected),
+        str(structured),
+        resolver={"acetic_acid": "CC(=O)O"}.__getitem__,
+    ) as value:
+        yield value
+
+
+def test_same_compound_matches_another_protonation_state(drawn_two_ways):
+    # The corpus stores the acetate; an eq on the spelling answers nothing and says so
+    # by returning no rows, which is the worst way for a query to be wrong.
+    assert (
+        _search(
+            drawn_two_ways,
+            _exists(
+                {"op": "eq", "path": "smiles", "value": {"literal": "CC(=O)O"}},
+            ),
+        )
+        == set()
+    )
+    assert _search(
+        drawn_two_ways,
+        _exists({"op": "same_compound", "path": "smiles", "smiles": "CC(=O)O"}),
+    ) == {"ord-dd01"}
+
+
+def test_same_compound_matches_another_tautomer(drawn_two_ways):
+    assert _search(
+        drawn_two_ways,
+        _exists({"op": "same_compound", "path": "smiles", "smiles": "CC(=O)C"}),
+    ) == {"ord-dd02"}
+
+
+def test_same_compound_does_not_reach_a_salt(drawn_two_ways):
+    # Sodium acetate is a different reagent from acetic acid rather than a different
+    # drawing of it, and dd03 is the reaction that would come back if it were not.
+    matched = _search(
+        drawn_two_ways,
+        _exists({"op": "same_compound", "path": "smiles", "smiles": "CC(=O)O"}),
+    )
+    assert "ord-dd03" not in matched
+
+
+def test_same_compound_does_not_match_a_different_molecule(drawn_two_ways):
+    assert (
+        _search(
+            drawn_two_ways,
+            _exists({"op": "same_compound", "path": "smiles", "smiles": "c1ccccc1"}),
+        )
+        == set()
+    )
+
+
+def test_a_compound_name_resolves_to_a_same_compound_query(drawn_two_ways):
+    assert _search(
+        drawn_two_ways,
+        _exists({"op": "same_compound", "path": "smiles", "compound": "acetic_acid"}),
+    ) == {"ord-dd01"}

--- a/ord_schema/search/nl_prompt.md
+++ b/ord_schema/search/nl_prompt.md
@@ -36,6 +36,10 @@ Rules that keep a query answerable:
 - Name compounds rather than spelling structures: `{"compound": "pyridine"}` resolves to
   SMILES. Reach for `substructure` with a SMARTS only when the user describes a pattern
   or a scaffold rather than a molecule.
+- Ask for a compound with `same_compound`, not with `eq` on a `smiles`. An `eq` compares
+  spellings, so it misses the same reagent recorded as another protonation state or
+  tautomer — acetate where the question said acetic acid. Use `eq` on a `smiles` only when
+  the user gives you an exact string and wants exactly it.
 - To rank or aggregate by a value under a repeated level, reduce it:
   `{"reduce": "max", "path": "outcomes.products.measurements.percentage.value"}` is a
   reaction's best yield. A plain path there is refused.

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -449,8 +449,52 @@ class Similarity(BaseModel):
         return self
 
 
+class SameCompound(BaseModel):
+    """The element's structure is the same compound, however either was drawn.
+
+    An ``eq`` on a ``smiles`` compares spellings, and two drawings of one reagent are
+    unequal: acetic acid and acetate, an amine and its ammonium, a 2-pyridone and its
+    2-hydroxypyridine tautomer. This compares the ``mol_hash`` the structures
+    artifact derives, which ignores protonation state and tautomer, so those match.
+    Fragments are not ignored: sodium acetate stays distinct from acetic acid.
+
+    ``path`` names a compound's ``smiles``. The query is a SMILES, or a compound name
+    resolved at execution; exactly one is given.
+    """
+
+    op: Literal["same_compound"]
+    path: str
+    smiles: str | None = None
+    compound: str | None = None
+
+    @model_validator(mode="after")
+    def _check(self) -> "SameCompound":
+        if (self.smiles is None) == (self.compound is None):
+            raise ValueError("a compound query is a smiles or a compound, not both")
+        if self.compound is not None and not _NAME.match(self.compound):
+            raise ValueError(f"compound name is not an identifier: {self.compound!r}")
+        if self.smiles is not None:
+            molecule = Chem.MolFromSmiles(self.smiles)
+            if molecule is None:
+                raise ValueError(f"SMILES does not parse: {self.smiles!r}")
+            if not molecule.GetNumAtoms():
+                # It hashes to the empty molecule's hash, which nothing in a corpus of
+                # real structures carries: a guaranteed-empty answer that still costs a
+                # pass over every structure.
+                raise ValueError(f"SMILES has no atoms: {self.smiles!r}")
+        return self
+
+
 Predicate = Annotated[
-    And | Or | Not | Quantifier | Comparison | NullCheck | Substructure | Similarity,
+    And
+    | Or
+    | Not
+    | Quantifier
+    | Comparison
+    | NullCheck
+    | Substructure
+    | Similarity
+    | SameCompound,
     Field(discriminator="op"),
 ]
 
@@ -598,7 +642,8 @@ def _leaf(node: Any, resolved: _Resolved, compounds: list[str]) -> str:
 
 
 def _structure_parameter(
-    node: "Substructure | Similarity", structures: list[StructureParameter]
+    node: "Substructure | Similarity | SameCompound",
+    structures: list[StructureParameter],
 ) -> str:
     """Returns the parameter name for a structure predicate, reusing an equal one.
 
@@ -634,7 +679,7 @@ def _structure_parameter(
 
 
 def _structure(
-    node: "Substructure | Similarity",
+    node: "Substructure | Similarity | SameCompound",
     scope: str | None,
     schema: Any,
     structures: list[StructureParameter],
@@ -1005,7 +1050,7 @@ def _predicate(
         return f"(NOT {inner})"
     if isinstance(node, Quantifier):
         return _quantifier(node, scope, schema, compounds, structures, depth, routing)
-    if isinstance(node, Substructure | Similarity):
+    if isinstance(node, Substructure | Similarity | SameCompound):
         return _structure(node, scope, schema, structures)
     resolved = resolve(node.path, schema=schema, root=scope)
     if resolved.repeated:

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -454,9 +454,10 @@ class SameCompound(BaseModel):
 
     An ``eq`` on a ``smiles`` compares spellings, and two drawings of one reagent are
     unequal: acetic acid and acetate, an amine and its ammonium, a 2-pyridone and its
-    2-hydroxypyridine tautomer. This compares the ``mol_hash`` the structures
-    artifact derives, which ignores protonation state and tautomer, so those match.
-    Fragments are not ignored: sodium acetate stays distinct from acetic acid.
+    2-hydroxypyridine tautomer. This compares the ``mol_hash`` the structures artifact
+    derives, which ignores protonation state, tautomer, and atom-map labels, so those
+    match. Fragments and stereochemistry are not ignored: sodium acetate stays distinct
+    from acetic acid, and enantiomers from each other.
 
     ``path`` names a compound's ``smiles``. The query is a SMILES, or a compound name
     resolved at execution; exactly one is given.

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -734,7 +734,7 @@ def _structure(
 
 def _element_terms(
     node: "Quantifier",
-) -> "tuple[Substructure | Similarity, dict[str, str]] | None":
+) -> "tuple[Substructure | Similarity | SameCompound, dict[str, str]] | None":
     """Returns what an ``exists`` body asks of one element, or None if it asks more.
 
     The shape an element index can answer, stated without knowing what any index holds:
@@ -754,10 +754,10 @@ def _element_terms(
     if node.op != "exists":
         return None
     clauses = node.where.clauses if isinstance(node.where, And) else [node.where]
-    structure: Substructure | Similarity | None = None
+    structure: Substructure | Similarity | SameCompound | None = None
     fields: dict[str, str] = {}
     for clause in clauses:
-        if isinstance(clause, Substructure | Similarity):
+        if isinstance(clause, Substructure | Similarity | SameCompound):
             if structure is not None or clause.path != "smiles":
                 return None
             structure = clause

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -1137,3 +1137,83 @@ def test_a_singular_struct_routes_to_its_ancestor_level_s_pivot():
     )
     assert "FROM pivot_outcomes_products_measurements AS x0" in sql
     assert "x0.element.authentic_standard.smiles" in sql
+
+
+# Comparing compounds rather than spellings
+
+
+def test_same_compound_compiles_to_a_bitmap_test():
+    compiled = _compile(
+        {
+            "where": {
+                "op": "exists",
+                "path": "inputs.components",
+                "where": {
+                    "op": "same_compound",
+                    "path": "smiles",
+                    "smiles": "CC(=O)O",
+                },
+            }
+        }
+    )
+    assert "get_bit" in compiled.sql
+    assert [(p.op, p.pattern) for p in compiled.structures] == [
+        ("same_compound", "CC(=O)O")
+    ]
+
+
+def test_same_compound_by_name_is_bound_rather_than_spelled():
+    compiled = _compile(
+        {
+            "where": {
+                "op": "exists",
+                "path": "inputs.components",
+                "where": {
+                    "op": "same_compound",
+                    "path": "smiles",
+                    "compound": "pyridine",
+                },
+            }
+        }
+    )
+    assert [(p.op, p.compound) for p in compiled.structures] == [
+        ("same_compound", "pyridine")
+    ]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # Neither a smiles nor a compound, or both at once.
+        {"op": "same_compound", "path": "smiles"},
+        {
+            "op": "same_compound",
+            "path": "smiles",
+            "smiles": "CC(=O)O",
+            "compound": "pyridine",
+        },
+        {"op": "same_compound", "path": "smiles", "smiles": "not a molecule"},
+        # An empty molecule matches nothing and still costs a pass over the corpus.
+        {"op": "same_compound", "path": "smiles", "smiles": ""},
+        {"op": "same_compound", "path": "smiles", "compound": "not an identifier"},
+    ],
+)
+def test_a_malformed_same_compound_is_refused_before_compilation(payload):
+    with pytest.raises(ValidationError):
+        query.Query.model_validate(
+            {"where": {"op": "exists", "path": "inputs.components", "where": payload}}
+        )
+
+
+def test_same_compound_needs_a_compound_smiles_column():
+    # The hash lives beside a structure, and reaction_id has none.
+    with pytest.raises(query.QueryError, match="applies to a compound"):
+        _compile(
+            {
+                "where": {
+                    "op": "same_compound",
+                    "path": "reaction_id",
+                    "smiles": "CC(=O)O",
+                }
+            }
+        )


### PR DESCRIPTION
Summary
-------
An `eq` on a `smiles` compares **strings**, so the same reagent recorded another way answers zero — the pyridine bug's family, of which canonicalizing the resolver's answer ([#980](https://github.com/open-reaction-database/ord-schema/pull/980)) fixed only the aromatic/Kekulé half.

```python
{"op": "eq", "path": "smiles", "value": {"literal": "CC(=O)O"}}          # 0 rows; the corpus holds CC(=O)[O-]
{"op": "same_compound", "path": "smiles", "smiles": "CC(=O)O"}          # matches it
```

The structures artifact gains a `mol_hash` beside every readable structure, and `same_compound` matches on it through the bitmap path `substructure` and `similarity` already use. The whole answer is one equality against a column: no screen, no verification, no chemistry beyond hashing the query molecule the way the artifact hashed its own.

Three decisions, each measured
------------------------------
**A hash, not a canonical tautomer.** Over ORD's own molecules — not toy ones — RDKit's tautomer enumerator runs at **504 structures/second** against **2,600** for the hash. Across the 2,016,224 distinct structures in the corpus that is **~67 minutes against ~13**, before the per-file parallelism the build already has. Both pass the same chemistry pairs; only one is affordable. The `smiles` column sits beside it for anyone who wants to read what matched.

**`RegistrationHash`, uncharged, with `enable_tautomer_hash_v2`.** Two things have to be right for it to work. Its tautomer-insensitive scheme carries a `FORMULA` layer and a formula states the charge, so hashing the molecule as recorded never collapses a protonation state — **uncharging first** is what fixes that. And its default tautomer layer is the v1 function, which leaves keto/enol apart; `enable_tautomer_hash_v2=True` closes it. With both, 11/11 on the chemistry pairs.

Registration rather than a bare `rdMolHash` call because it normalizes what a bare hash does not: **atom-map labels**, unnecessary explicit hydrogens, enhanced stereo, and S-group data. A compound written for a mapped reaction is the same compound — `[CH3:1][C:2](=[O:3])[OH:4]` and `CC(=O)O` hash alike under registration and differently under `rdMolHash`. Only 20 structures in the corpus carry atom maps today, so the count is not what decides it; the layered scheme is the maintained API for asking what a structure *is*, and a stereo-insensitive question later becomes a scheme rather than a rewrite.

**Fragments are not stripped.** Sodium acetate stays distinct from acetic acid. Every stripping rule measured here trades one class of wrong answer for another:

| rule | Pd(OAc)₂ becomes | NaH becomes | K₂CO₃ becomes |
| --- | --- | --- | --- |
| largest fragment | **acetic acid** | `[Na+]` | carbonic acid |
| strip recognized counterions | `[Pd+2]` | **hydrogen** | carbonic acid |
| ...only if carbon survives | Pd(OAc)₂ | NaH | **carbonic acid** |

A corpus-wide column is the wrong place to guess, and each of those is silent when wrong. 4.8% of distinct structures are multi-fragment, so salt insensitivity is worth measuring — as a *second* column and a second operator, since "the same parent" is a different question from "the same compound".

Two fixes found by reviewing the above
--------------------------------------
**A stale artifact was accepted, then failed deep in DuckDB.** The currency stamps say nothing about a file's columns, and this change moves neither the package version, the artifact version, nor RDKit's — so a structures artifact built before `mol_hash` still reads as current. Reproduced with the stamps left byte-identical: `is_current` returns `True`, `derive` skips the file, and the first `same_compound` query fails as a binder error. Where some files carry the column and some do not, `read_parquet` refuses the glob and *every* structure query dies with it.

Rather than bumping `ARTIFACT_VERSION` — which this repo defers until the artifacts first ship — the failure is now loud and early on both sides. `base.missing_columns` is the one place that sees a column added to a definition: `_index` raises `PairingError` at `Corpus` construction naming the file and what it lacks, and `is_current` takes the schema so a plain re-derive rebuilds the file instead of skipping it. Verified end to end through `derive_structures` with no `--force`. Being schema-driven rather than a hardcoded list, it covers the next column addition too.

**`same_compound` was missing from `_element_terms`.** Every other dispatch site was extended for the new predicate, but not the one the occurrence index consults, so an `exists` over `same_compound` fell to a per-element scan. Results were correct; the query just never took the fast path its siblings get. It is now in the existing `_ROUTABLE` harness, which asserts the indexed answer matches what the projection alone returns — a correctness check, not only a speed one.

Changes
-------
- `structures.py` — `mol_hash`, taking a molecule or a SMILES, and the column beside `smiles`. Null where RDKit cannot read or hash the structure, which never matches rather than storing something the query side would not reproduce.
- `query.py` — `same_compound`, validated like `similarity` and compiled like every structure predicate.
- `execute.py` — `_same_compound_ids`, one equality against `mol_hash`, sharing the match-set cache the other structure predicates use.
- `README.md`, `nl_prompt.md` — the grammar block, the rule, and the instruction to prefer `same_compound` to `eq` whenever the question names a compound rather than a string.

Testing
-------
`uv run pytest -n auto` — **1295 passed**. The chemistry is pinned both ways: eight pairs that must hash the same (protonation, ammonium, keto/enol, amide/imidic acid, lactam/lactim, Kekulé, atom maps, explicit hydrogens) and six that must not (different molecules, different heteroatom, salt, cocrystal, enantiomers, isotopes). End to end, a corpus storing acetate, an enol, and sodium acetate answers `eq` with nothing and `same_compound` with the right reaction, and does not reach the salt.

Notes
-----
`ARTIFACT_VERSION` is untouched. `is_current` already requires the ord-schema *and* RDKit versions to match, so existing artifacts go stale on their own — which is the containment this needs, since the hash is RDKit's and moves with it. An RDKit upgrade would otherwise change what a stored column means while every query kept running.

Enantiomers and isotopes hash differently, so this is not stereo-insensitive; that is a third question, and the registration scheme already carries a `STEREO_INSENSITIVE_LAYERS` answer to it if it is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds compound-identity matching based on RDKit registration hashes and completes the stale-artifact fix discussed in the previous review.
- Adds `mol_hash` to structures artifacts and a validated `same_compound` query operator.
- Routes compound matches through the existing structure bitmap and match-cache path.
- Makes artifact derivation schema-aware so files lacking newly declared columns are rebuilt rather than skipped.
- Rejects schema-incompatible projection or structures files during corpus construction.
- Adds chemistry, query compilation, execution, mixed-artifact, and re-derivation coverage.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; schema-aware derivation now rebuilds artifacts missing newly declared columns, while corpus construction independently rejects incompatible files before queries run.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/artifacts/base.py | Adds reusable schema-column checks and integrates them into artifact currentness so normal derivation rebuilds incompatible files. |
| ord_schema/artifacts/scripts/derive_structures.py | Supplies the complete structures schema to bulk derivation, resolving the previously reported skip of artifacts lacking `mol_hash`. |
| ord_schema/artifacts/structures.py | Adds registration-hash generation and stores nullable compound hashes while preserving dense structure IDs. |
| ord_schema/search/query.py | Adds and validates the `same_compound` predicate and integrates it with structure routing and compilation. |
| ord_schema/search/execute.py | Validates complete artifact schemas at corpus startup and executes compound-hash equality through the existing bitmap path. |
| ord_schema/artifacts/structures_test.py | Covers hash equivalence boundaries, unhashable structures, artifact output, and schema-aware currentness. |
| ord_schema/search/execute_test.py | Covers end-to-end compound matching and early refusal of uniformly old and mixed-schema structures artifacts. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    P[Projection artifact] --> D[Derive structures]
    D --> C{Declared schema present?}
    C -->|No| R[Rebuild structures artifact]
    C -->|Yes| S[Reuse current artifact]
    R --> H[Store mol_hash per structure]
    S --> O[Corpus construction]
    H --> O
    O --> V{All declared columns present?}
    V -->|No| E[Raise PairingError]
    V -->|Yes| Q[same_compound query]
    Q --> M[Hash query molecule]
    M --> B[Match mol_hash and build bitmap]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Derive again what a schema check would r..."](https://github.com/open-reaction-database/ord-schema/commit/07bc22394679430f7f96252bd8aea69fdc603c4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55870132)</sub>

<!-- /greptile_comment -->