### PR TITLE
Keep every question, and the query it became

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ node_modules/
 
 # Claude/working planning docs (local only)
 *_PLAN.md
+# Sphinx reads only .rst, so Markdown under docs/ is a working draft, not a page.
+docs/*.md

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -492,6 +492,86 @@ The ~15k-token prefix — these rules plus `describe()` plus the grammar — is 
 is most of what a query costs. `answer.query` is the query that ran, so a caller can show
 what was searched and offer to run it again.
 
+### Keep the questions
+
+```python
+from ord_schema.search import nl, nl_log
+
+sink = nl_log.JsonlSink("nl-log/today.jsonl")          # or S3Sink(boto3.client("s3"), bucket=...)
+answer = nl.ask(question, corpus, sink=sink, session_id=session_id)
+...
+nl_log.write(sink, nl_log.thumb(answer.record_id, "down", comment="wrong solvent"))
+```
+
+Recording is off until a caller opts in. `ask()` without a `sink` records nothing, and
+nothing here builds an `S3Sink` -- a deployment hands one its own client and bucket, so
+no bucket name lives in this package. `nl_log.write()` is the single path each event
+takes, so an unreachable sink costs the record rather than the answer whether the event
+is the ask this package writes or the thumb a caller builds.
+
+The questions people ask are the only material that can refine a translator, so they are
+recorded rather than discarded. The log is an **append-only stream of events**, not a
+table: an `ask` written by the library, a `thumb` a reader leaves, and a `label` a
+maintainer applies all share a `record_id`, because they are three assertions by three
+parties at three times and one mutable row would lose which was which. Each carries its
+own `event_id` as well, which is what an object store keys on — a key built from the
+shared `record_id` would have the thumb overwrite the question it judges.
+
+Every ending is recorded, not only the one where everything worked. `nl_log.Outcome` is
+`ANSWERED`, `EMPTY`, `DECLINED`, `MALFORMED`, or the rest of the error taxonomy — and the
+first three self-label: a question that translated and matched nothing, or that the model
+declined, is a failure that needs no human to recognize it. Grouped by `session_id`, a
+rephrasing reads as the reader's own correction of the question before it. The caller
+mints that identifier and decides what it spans.
+
+`source` names the surface a question arrived from — `web`, `eval`, `api`. One prefix
+holds all of them, and nothing else in a record separates a person rephrasing from a
+harness working through a case file.
+
+Results are **not** stored; `translation` plus `corpus_fingerprint` reproduce them.
+`prompt_fingerprint` names the translator that wrote a record, and moves exactly when the
+cached prefix does.
+
+A record is a typed envelope around an opaque payload: identifiers, outcome, usage, and
+timings are fields, while the question and the whole `attempts` list — not only the query
+inside it — are strings. They stay strings because a `Query` is recursive and differently
+shaped record to record, and because a month in which everything compiled writes
+`"error": null` throughout and infers that field as JSON where a month holding one
+rejection infers it as text. Either way DuckDB would be inferring a struct from whichever
+shapes a month happened to hold, and whether two months read back together would depend
+on what it can coerce. As strings they reconcile by construction.
+
+Identifiers are minted as hex rather than as dashed UUIDs for the same reason: a source
+whose `session_id`s are all dashed UUIDs infers `UUID` and one holding opaque tokens
+infers `VARCHAR`, and a read spanning both would refuse to union them. `read()` casts
+them anyway, which is what covers a client that minted its own.
+
+Read it with `nl_log.read()`, which folds the verdicts onto their asks and derives
+`translation` and `repaired` from the attempts:
+
+```python
+nl_log.read("nl-log/parquet/*.parquet", "nl-log/raw/dt=*/*.json",
+            statement="SELECT question, outcome, usage.input FROM log WHERE thumb = 'down'")
+```
+
+JSON and Parquet mix freely, so `nl_log.compact()` can fold a stretch into one file
+whenever volume asks for it rather than as a migration. It leaves what it folded in
+place, and `read()` counts an event once however many sources carry it, so a compacted
+month and the raw days inside it can be read together until whoever owns the prefix
+decides the days can go. `compact(redact=True)`, off by default, empties every
+free-text column — the question, the answer, the thumb's comment, the label's note —
+rather than dropping them, so a file written either way keeps one schema and a query
+spanning both binds.
+
+A thumb and a label are spelled from `nl_log.Thumb` and `nl_log.Verdict` rather than
+free strings: the log is append-only, so a verdict typed `"Down"` can be superseded but
+never corrected, and it is invisible to the query above.
+
+Writes are best-effort: an unreachable bucket costs the record, never the answer, and so
+does an artifact that has gone unreadable when the record's fingerprint is taken. The
+eval harness records too — `nl_eval --log run.jsonl` — which is why the log has to be
+writable from a laptop.
+
 ### Measure how good a translation is
 
 ```bash

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -84,6 +84,7 @@ import contextlib
 import dataclasses
 import functools
 import glob
+import hashlib
 import math
 import pathlib
 import threading
@@ -225,7 +226,7 @@ def _canonical(smiles: str) -> str:
     return Chem.MolToSmiles(molecule) if molecule is not None else smiles
 
 
-def _sql_string(value: str) -> str:
+def sql_string(value: str) -> str:
     """Returns ``value`` as a SQL string literal, single quotes escaped."""
     escaped = value.replace("'", "''")
     return f"'{escaped}'"
@@ -233,7 +234,7 @@ def _sql_string(value: str) -> str:
 
 def _sql_strings(values: Iterable[str]) -> str:
     """Returns ``values`` as a SQL list literal, single quotes escaped."""
-    return "[" + ", ".join(_sql_string(value) for value in values) + "]"
+    return "[" + ", ".join(sql_string(value) for value in values) + "]"
 
 
 def _max_structure_id(path: str) -> int | None:
@@ -268,7 +269,7 @@ def _max_structure_id(path: str) -> int | None:
 
 def _index(
     pattern: str, artifact: str, schema: pa.Schema, require_current: bool
-) -> dict[str, str]:
+) -> dict[str, tuple[str, base.Stamps]]:
     """Returns the artifacts matching ``pattern``, keyed by source dataset.
 
     Keyed by the source hash rather than the filename because that is what an
@@ -283,14 +284,16 @@ def _index(
         require_current: Refuse artifacts not written by the current versions.
 
     Returns:
-        A mapping from source dataset hash to path.
+        A mapping from source dataset hash to the path and the stamps read off it. The
+        stamps come back rather than being dropped because reading them opens a footer,
+        and the corpus fingerprint wants exactly the same ones.
 
     Raises:
         PairingError: If a match holds another artifact, lacks a column this library
             reads, is stale under ``require_current``, or restates a dataset another
             match already did.
     """
-    index: dict[str, str] = {}
+    index: dict[str, tuple[str, base.Stamps]] = {}
     for path in sorted(glob.glob(pattern, recursive=True)):
         stamps = base.load_stamps(path)
         if stamps.artifact != artifact:
@@ -310,17 +313,40 @@ def _index(
             raise PairingError(f"{path} is stale; derive it again first")
         if stamps.source_md5 in index:
             raise PairingError(
-                f"{path} and {index[stamps.source_md5]} are both {artifact} "
+                f"{path} and {index[stamps.source_md5][0]} are both {artifact} "
                 "artifacts of the same source dataset; which one answers a query "
                 "would be arbitrary"
             )
-        index[stamps.source_md5] = path
+        index[stamps.source_md5] = (path, stamps)
     return index
+
+
+def _fingerprint(stamps: Iterable[base.Stamps]) -> str:
+    """Returns a short digest naming the artifacts a corpus opened.
+
+    Args:
+        stamps: The stamps of every artifact in the corpus, in any order. Both halves
+            of each pair belong here: the structures artifact answers every structure
+            predicate and is derived separately, so a corpus whose structures were
+            rebuilt can answer differently with its projections untouched.
+
+    Returns:
+        Sixteen hex characters, sorted so the same corpus opened through a different
+        glob digests the same. The whole stamp goes in rather than the source hash
+        alone, because two artifacts built from identical sources by different library
+        versions can disagree too.
+    """
+    digest = hashlib.sha256()
+    # Sorted as text rather than as tuples: a stamp field is optional, and comparing
+    # None against a string to order two artifacts raises.
+    for value in sorted(repr(dataclasses.astuple(one)) for one in stamps):
+        digest.update(value.encode())
+    return digest.hexdigest()[:16]
 
 
 def _pair(
     projection_pattern: str, structures_pattern: str, require_current: bool
-) -> list[tuple[str, str]]:
+) -> tuple[list[tuple[str, str]], str]:
     """Returns (projection, structures) path pairs, verified by their stamps.
 
     Args:
@@ -329,7 +355,8 @@ def _pair(
         require_current: Refuse artifacts not written by the current versions.
 
     Returns:
-        One pair per source dataset, ordered by the projection's source hash.
+        One pair per source dataset, ordered by the projection's source hash, and the
+        fingerprint over the stamps this already read to verify them.
 
     Raises:
         PairingError: If no projection matches, if either side lacks a column this
@@ -346,12 +373,20 @@ def _pair(
         raise PairingError(f"no projections matched: {projection_pattern}")
     unpaired = projections.keys() ^ structure_files.keys()
     if unpaired:
-        orphans = sorted((projections | structure_files)[key] for key in unpaired)
+        orphans = sorted((projections | structure_files)[key][0] for key in unpaired)
         raise PairingError(
             "projections and structures artifacts do not pair up; these have no "
             f"counterpart derived from the same source dataset: {orphans}"
         )
-    return [(projections[key], structure_files[key]) for key in sorted(projections)]
+    pairs = [
+        (projections[key][0], structure_files[key][0]) for key in sorted(projections)
+    ]
+    fingerprint = _fingerprint(
+        stamps
+        for index in (projections, structure_files)
+        for _, stamps in index.values()
+    )
+    return pairs, fingerprint
 
 
 # A structure that did not parse still gets a library entry, so every structure ID
@@ -446,12 +481,12 @@ def _index_condition(
     if path not in INDEXED_PATHS or set(fields) - {_INDEXED_FIELD}:
         return None
     conditions = [
-        f"occurrence.path = {_sql_string(path)}",
+        f"occurrence.path = {sql_string(path)}",
         f"get_bit(CAST(${allocate()} AS BITSTRING), occurrence.global_id::INTEGER) = 1",
     ]
     role = fields.get(_INDEXED_FIELD)
     if role is not None:
-        conditions.append(f"occurrence.{_INDEXED_FIELD} = {_sql_string(role)}")
+        conditions.append(f"occurrence.{_INDEXED_FIELD} = {sql_string(role)}")
     # S608: every fragment is a schema-derived path, a compiler-issued parameter
     # name, or an escaped literal. The inner relation is aliased so that the outer
     # reaction_id and the inner one cannot be confused for each other.
@@ -868,7 +903,9 @@ class Corpus:
                 "derive_pivots was set without a pivots_dir, so there is nowhere to "
                 "write what it would derive"
             )
-        pairs = _pair(projection_pattern, structures_pattern, require_current)
+        pairs, self._fingerprint = _pair(
+            projection_pattern, structures_pattern, require_current
+        )
         self._pivots_dir = pivots_dir
         self._derive_pivots = derive_pivots
         self._require_current = require_current
@@ -976,6 +1013,17 @@ class Corpus:
                 "to their offsets; a path did not survive read_parquet"
             )
         return total, searchable
+
+    @property
+    def fingerprint(self) -> str:
+        """Returns a short digest naming the artifacts this corpus opened.
+
+        A question log records this beside the query rather than the rows the query
+        returned, so an old record stays reproducible: the same query against the same
+        fingerprint answers the same way, and a different fingerprint says why it does
+        not.
+        """
+        return self._fingerprint
 
     def check_pivots(self) -> dict[str, int]:
         """Publishes every pivot artifact this corpus can read, and returns the counts.
@@ -1267,7 +1315,7 @@ class Corpus:
             # offset comes from the row's own file, which the reactions view carries.
             selects = "\nUNION ALL\n".join(
                 f"""
-                SELECT reaction_id, {_sql_string(path)} AS path,
+                SELECT reaction_id, {sql_string(path)} AS path,
                        (element.structure_id + {query.STRUCTURE_OFFSET})::UINTEGER
                            AS global_id,
                        element.{_INDEXED_FIELD} AS {_INDEXED_FIELD}

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -15,6 +15,7 @@
 """Tests for ord_schema.search.execute."""
 
 import contextlib
+import dataclasses
 import logging
 import pathlib
 import re
@@ -3761,3 +3762,76 @@ def test_one_aged_structures_artifact_is_refused_with_the_others_current(
     root = _without_mol_hash(corpus_dir, tmp_path, files=1)
     with pytest.raises(execute.PairingError, match="derive it again"):
         _open(root)
+
+
+def test_a_corpus_reads_each_artifacts_stamps_once(corpus_dir, monkeypatch):
+    # Pairing opens a footer per artifact to verify it, and the fingerprint is taken
+    # from those stamps. Reading them a second time costs 0.65 seconds on the real
+    # corpus for values already in hand.
+    opened: list[str] = []
+    real = base.load_stamps
+
+    def counting(path):
+        opened.append(str(path))
+        return real(path)
+
+    monkeypatch.setattr(base, "load_stamps", counting)
+    projections = str(corpus_dir / "projections" / "*.parquet")
+    structures_glob = str(corpus_dir / "structures" / "*.parquet")
+    with execute.Corpus(projections, structures_glob) as value:
+        assert value.fingerprint
+        assert value.fingerprint  # A second read opens nothing either.
+    assert len(opened) == len(set(opened))
+
+
+def test_a_corpus_fingerprint_names_the_artifacts_it_opened(corpus_dir):
+    # The fingerprint travels in a question log so an old record can be reproduced, so
+    # it has to be the same for two openings of one corpus and different for a corpus
+    # holding different artifacts.
+    both = str(corpus_dir / "projections" / "*.parquet")
+    one = str(corpus_dir / "projections" / "ord_dataset-aa.parquet")
+    structures_glob = str(corpus_dir / "structures" / "*.parquet")
+    with (
+        execute.Corpus(both, structures_glob) as first,
+        execute.Corpus(both, structures_glob) as second,
+        execute.Corpus(
+            one, str(corpus_dir / "structures" / "ord_dataset-aa.parquet")
+        ) as subset,
+    ):
+        assert first.fingerprint == second.fingerprint
+        assert first.fingerprint != subset.fingerprint
+
+
+def test_a_corpus_fingerprint_moves_when_only_the_structures_are_rebuilt(
+    corpus_dir, tmp_path
+):
+    # Structures answer every structure predicate and are derived separately from the
+    # projections they pair with, so a corpus can be rebuilt with its projections
+    # untouched and still answer differently. A fingerprint blind to them says two
+    # corpora agree when they do not, and a question log promising to reproduce an old
+    # query from one would quietly be wrong. The stamp changed here is one currency
+    # does not check, so the pair still opens.
+    root = tmp_path / "restructured"
+    shutil.copytree(corpus_dir, root)
+    for path in (root / "structures").glob("*.parquet"):
+        table = pq.read_table(path)
+        stamps = base.load_stamps(path)
+        pq.write_table(
+            table.replace_schema_metadata(
+                base.to_metadata(
+                    dataclasses.replace(stamps, source_dataset_id="ord_dataset-other")
+                )
+            ),
+            path,
+        )
+    with (
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+        ) as before,
+        execute.Corpus(
+            str(root / "projections" / "*.parquet"),
+            str(root / "structures" / "*.parquet"),
+        ) as after,
+    ):
+        assert before.fingerprint != after.fingerprint

--- a/ord_schema/search/nl.py
+++ b/ord_schema/search/nl.py
@@ -35,8 +35,13 @@ natural-language layer over the search grammar".
 """
 
 import dataclasses
+import functools
+import hashlib
 import json
 import os
+import time
+from collections.abc import Sequence
+from datetime import UTC, datetime
 from importlib import resources
 from typing import Any
 
@@ -51,7 +56,7 @@ from anthropic.types import (
 )
 
 from ord_schema.logging import get_logger
-from ord_schema.search import execute, query, schema
+from ord_schema.search import execute, nl_log, query, schema
 
 logger = get_logger(__name__)
 
@@ -114,8 +119,62 @@ _ANSWER_SYSTEM = (
 )
 
 
+@functools.cache
+def prompt_fingerprint() -> str:
+    """Returns a short digest of the cached prefix.
+
+    Two things at once, which is why it is worth recording on every question. It names
+    the translator a record was written by, so a query from months ago is not read as
+    evidence about today's prompt. And because the prefix is exactly what the cache
+    keys on, the fingerprint changes when and only when a cache read would have missed
+    -- so a run where it moves unexpectedly is money already spent.
+
+    Cached: the prompt and the tools are module constants built at import, so a served
+    process would otherwise digest the whole prefix again on every question it records.
+    Anything that replaces one of them has to call ``cache_clear``.
+
+    Returns:
+        Twelve hex characters over the system prompt and both tool definitions.
+    """
+    digest = hashlib.sha256(SYSTEM_PROMPT.encode())
+    for tool in (TOOL, REFUSAL_TOOL):
+        digest.update(json.dumps(tool, sort_keys=True).encode())
+    return digest.hexdigest()[:12]
+
+
 class NLQueryError(Exception):
-    """A question could not be answered."""
+    """A question could not be answered.
+
+    Carries what the failed attempt spent, because a record is most worth having
+    exactly when the translation did not work -- and an exception has no return value
+    to put it in.
+
+    Attributes:
+        attempts: Every ``build_query`` call made before giving up, in order.
+        usage: What the whole failed translation cost, including turns that produced no
+            attempt.
+        elapsed_ms: Wall time spent before the failure.
+    """
+
+    def __init__(
+        self,
+        *args: object,
+        attempts: Sequence[nl_log.Attempt] = (),
+        usage: nl_log.Usage | None = None,
+        elapsed_ms: float = 0.0,
+    ) -> None:
+        """Initializes the error.
+
+        Args:
+            *args: Passed to ``Exception``.
+            attempts: The queries built before giving up.
+            usage: What those turns cost.
+            elapsed_ms: Wall time spent.
+        """
+        super().__init__(*args)
+        self.attempts = tuple(attempts)
+        self.usage = usage if usage is not None else nl_log.Usage()
+        self.elapsed_ms = elapsed_ms
 
 
 class ModelUnavailableError(NLQueryError):
@@ -137,24 +196,52 @@ class UnanswerableError(NLQueryError):
     retrying will not help. Comparing two columns is the standard case -- a value is a
     literal or a compound, never another column -- and a layer without a way to say so
     answers with a plausible query that means something else.
-
-    Attributes:
-        attempted: Whether a query came first and failed to compile. A caller is served
-            either way, so this changes nothing about the answer; a measurement wants
-            it, because recognizing an inexpressible question is not the same as
-            backing into it after the compiler refused a guess.
     """
 
-    def __init__(self, reason: str, *, attempted: bool = False) -> None:
-        """Initializes the error.
+    @property
+    def attempted(self) -> bool:
+        """Returns whether a query came first and failed to compile.
 
-        Args:
-            reason: What the question asks for that the grammar lacks, in the model's
-                own words.
-            attempted: Whether the model built a query before declining.
+        A caller is served either way, so this changes nothing about the answer; a
+        measurement wants it, because recognizing an inexpressible question is not the
+        same as backing into it after the compiler refused a guess.
         """
-        super().__init__(reason)
-        self.attempted = attempted
+        return bool(self.attempts)
+
+
+@dataclasses.dataclass(frozen=True)
+class Translation:
+    """A question turned into a query, and what that took.
+
+    Attributes:
+        query: The query, validated and compiled.
+        attempts: Every ``build_query`` call, in order, each with the compiler's verdict
+            and what the turn cost. The rejected query and the error rejecting it are
+            what prompt work runs on, and what pricing a repair turn needs.
+        usage: What the whole translation cost.
+        elapsed_ms: Wall time spent translating.
+    """
+
+    query: query.Query
+    attempts: tuple[nl_log.Attempt, ...]
+    usage: nl_log.Usage
+    elapsed_ms: float
+
+
+@dataclasses.dataclass(frozen=True)
+class Description:
+    """A sentence about a result, and what writing it cost.
+
+    Attributes:
+        text: The prose.
+        usage: What the call cost. The prose is a second model call, so a question's
+            price is not the translation's.
+        elapsed_ms: Wall time spent.
+    """
+
+    text: str
+    usage: nl_log.Usage
+    elapsed_ms: float
 
 
 @dataclasses.dataclass(frozen=True)
@@ -167,12 +254,16 @@ class Answer:
             running it again unchanged.
         table: What the search returned.
         text: A sentence or two describing that result.
+        record_id: What this question was logged as. A caller hands it to the reader so
+            a thumb has something to reference; without it the log records feedback
+            nobody can attach to a question.
     """
 
     question: str
     query: query.Query
     table: pa.Table
     text: str
+    record_id: str = ""
 
 
 def get_client() -> anthropic.Anthropic:
@@ -212,11 +303,11 @@ def _coerce(value: Any) -> Any:
     return value
 
 
-def _validated(raw: Any) -> query.Query:
+def _validated(coerced: Any) -> query.Query:
     """Returns the query a tool call carries, proven to compile.
 
     Args:
-        raw: The tool call's input.
+        coerced: The tool call's input, already run through ``_coerce``.
 
     Returns:
         The parsed query.
@@ -225,7 +316,7 @@ def _validated(raw: Any) -> query.Query:
         ValueError: If it does not validate against the grammar, or if it asks nothing.
         QueryError: If it validates but does not compile against the schema.
     """
-    parsed = query.Query.model_validate(_coerce(raw))
+    parsed = query.Query.model_validate(coerced)
     if parsed.where is None and parsed.aggregate is None and parsed.limit is None:
         # A query with no predicate, no aggregate, and no limit compiles and returns
         # the whole corpus, which is never the answer to a question. It reads as a
@@ -240,10 +331,29 @@ def _validated(raw: Any) -> query.Query:
     return parsed
 
 
+def _spent(response: Any) -> nl_log.Usage:
+    """Returns what one response cost.
+
+    Args:
+        response: A Messages API response.
+
+    Returns:
+        Its usage. The cache fields are read defensively because the API omits them on
+        some responses, and a missing one is zero rather than a failed record.
+    """
+    usage = response.usage
+    return nl_log.Usage(
+        input=usage.input_tokens,
+        output=usage.output_tokens,
+        cache_read=getattr(usage, "cache_read_input_tokens", 0) or 0,
+        cache_creation=getattr(usage, "cache_creation_input_tokens", 0) or 0,
+    )
+
+
 def _call(
     client: anthropic.Anthropic, model: str, messages: list[MessageParam]
-) -> ToolUseBlock:
-    """Returns the tool_use block from one forced call.
+) -> tuple[ToolUseBlock, nl_log.Usage]:
+    """Returns the tool_use block from one forced call, and what it cost.
 
     Args:
         client: Anthropic client.
@@ -251,7 +361,7 @@ def _call(
         messages: The conversation so far.
 
     Returns:
-        The ``tool_use`` content block.
+        The ``tool_use`` content block and the call's usage.
 
     Raises:
         UnanswerableError: If the model calls ``cannot_answer`` instead.
@@ -274,15 +384,16 @@ def _call(
         raise ModelRateLimitedError(str(error)) from error
     except (anthropic.APIConnectionError, anthropic.APIStatusError) as error:
         raise ModelUnavailableError(str(error)) from error
+    spent = _spent(response)
     for block in response.content:
         if isinstance(block, ToolUseBlock):
             if block.name == REFUSAL_TOOL["name"]:
                 reason = "no reason given"
                 if isinstance(block.input, dict):
                     reason = str(block.input.get("reason", reason))
-                raise UnanswerableError(reason)
-            return block
-    raise MalformedQueryError("the model returned no query")
+                raise UnanswerableError(reason, usage=spent)
+            return block, spent
+    raise MalformedQueryError("the model returned no query", usage=spent)
 
 
 def translate(
@@ -291,7 +402,7 @@ def translate(
     client: anthropic.Anthropic | None = None,
     model: str = DEFAULT_MODEL,
     repair: bool = True,
-) -> query.Query:
+) -> "Translation":
     """Returns the query a question asks for.
 
     Args:
@@ -302,24 +413,54 @@ def translate(
             measure how often a model is right without help.
 
     Returns:
-        A query that validates and compiles against the projection schema.
+        The query, every ``build_query`` call that led to it, and what they cost.
 
     Raises:
         MalformedQueryError: If the query does not compile, after the repair turn where
             one was allowed.
         UnanswerableError: If the model says the grammar cannot express the question.
         ModelRateLimitedError: If the caller is over its rate limit.
-        ModelUnavailableError: If the model cannot be reached.
+        ModelUnavailableError: If the model cannot be reached. Every one of these
+            carries the attempts and the usage spent reaching it, because a failed
+            translation is a record worth keeping and an exception has no return value.
     """
     client = client if client is not None else get_client()
+    started = time.monotonic()
+    attempts: list[nl_log.Attempt] = []
+    spent = nl_log.Usage()
+
+    def elapsed() -> float:
+        return (time.monotonic() - started) * 1000
+
+    def failed(error: NLQueryError) -> NLQueryError:
+        """Returns the error with what this translation spent attached to it.
+
+        The error's own usage is added rather than replaced: a turn that declined or
+        returned no tool call carries what it cost and produced no attempt to hold it,
+        so dropping it would leave a refusal looking free.
+        """
+        error.attempts = tuple(attempts)
+        error.usage = spent + error.usage
+        error.elapsed_ms = elapsed()
+        return error
+
     messages: list[MessageParam] = [{"role": "user", "content": question}]
-    block = _call(client, model, messages)
     try:
-        return _validated(block.input)
+        block, usage = _call(client, model, messages)
+    except NLQueryError as error:
+        raise failed(error) from error
+    spent += usage
+    coerced = _coerce(block.input)
+    try:
+        parsed = _validated(coerced)
     except (ValueError, query.QueryError) as error:
+        attempts.append(nl_log.Attempt(coerced, str(error), usage))
         if not repair:
-            raise MalformedQueryError(str(error)) from error
+            raise failed(MalformedQueryError(str(error))) from error
         first = error
+    else:
+        attempts.append(nl_log.Attempt(coerced, None, usage))
+        return Translation(parsed, tuple(attempts), spent, elapsed())
     logger.info("repairing a query that did not compile: %s", first)
     messages += [
         {
@@ -349,19 +490,23 @@ def translate(
         },
     ]
     try:
-        retry = _call(client, model, messages)
-    except UnanswerableError as error:
+        retry, usage = _call(client, model, messages)
+    except NLQueryError as error:
         # Declining on the second turn is still the right answer, and the caller gets
-        # the same one. It is worth marking because the model reached it by way of a
-        # query the compiler refused rather than by reading the question.
-        error.attempted = True
-        raise
+        # the same one. The attempt already recorded is what says the model reached it
+        # by way of a query the compiler refused rather than by reading the question.
+        raise failed(error) from error
+    spent += usage
+    coerced = _coerce(retry.input)
     try:
-        return _validated(retry.input)
+        parsed = _validated(coerced)
     except (ValueError, query.QueryError) as error:
         # One repair, never a loop: a model that missed twice with the compiler's own
         # suggestion in hand is not going to find it on the third paid attempt.
-        raise MalformedQueryError(str(error)) from error
+        attempts.append(nl_log.Attempt(coerced, str(error), usage))
+        raise failed(MalformedQueryError(str(error))) from error
+    attempts.append(nl_log.Attempt(coerced, None, usage))
+    return Translation(parsed, tuple(attempts), spent, elapsed())
 
 
 def summarize(table: pa.Table, *, rows: int = 5) -> str:
@@ -389,7 +534,7 @@ def answer(
     *,
     client: anthropic.Anthropic | None = None,
     model: str = DEFAULT_MODEL,
-) -> str:
+) -> Description:
     """Returns a sentence or two saying what a result shows.
 
     Args:
@@ -399,14 +544,15 @@ def answer(
         model: Which model writes the prose.
 
     Returns:
-        Plain text. The model sees ``summarize(table)`` rather than the rows, so it can
-        describe only what the summary states.
+        The prose and what it cost. The model sees ``summarize(table)`` rather than the
+        rows, so it can describe only what the summary states.
 
     Raises:
         ModelRateLimitedError: If the caller is over its rate limit.
         ModelUnavailableError: If the model cannot be reached.
     """
     client = client if client is not None else get_client()
+    started = time.monotonic()
     try:
         response = client.messages.create(
             model=model,
@@ -423,9 +569,65 @@ def answer(
         raise ModelRateLimitedError(str(error)) from error
     except (anthropic.APIConnectionError, anthropic.APIStatusError) as error:
         raise ModelUnavailableError(str(error)) from error
-    return "".join(
-        block.text for block in response.content if isinstance(block, TextBlock)
+    return Description(
+        text="".join(
+            block.text for block in response.content if isinstance(block, TextBlock)
+        ),
+        usage=_spent(response),
+        elapsed_ms=(time.monotonic() - started) * 1000,
     )
+
+
+_OUTCOMES: tuple[tuple[type[BaseException], nl_log.Outcome], ...] = (
+    (UnanswerableError, nl_log.Outcome.DECLINED),
+    (MalformedQueryError, nl_log.Outcome.MALFORMED),
+    (ModelRateLimitedError, nl_log.Outcome.RATE_LIMITED),
+    (ModelUnavailableError, nl_log.Outcome.UNAVAILABLE),
+    (TimeoutError, nl_log.Outcome.TIMEOUT),
+    (query.QueryError, nl_log.Outcome.SEARCH_FAILED),
+    # Before the ValueError below, which it inherits from. An unresolvable compound is
+    # the question's fault and a corpus whose artifacts disagree is the deployment's,
+    # and the whole point of the taxonomy is that a reader can tell them apart.
+    (execute.PairingError, nl_log.Outcome.SEARCH_FAILED),
+    # Last, because a resolver failure is a ValueError and so are several others; by
+    # here the more specific kinds have already matched.
+    (ValueError, nl_log.Outcome.UNRESOLVED_COMPOUND),
+)
+
+
+def outcome_of(error: BaseException) -> nl_log.Outcome:
+    """Returns the outcome a failure is recorded as.
+
+    Args:
+        error: What ended the ask.
+
+    Returns:
+        The matching ``nl_log.Outcome``, or ``SEARCH_FAILED`` for anything the search
+        raised that has no more specific name.
+    """
+    for kind, outcome in _OUTCOMES:
+        if isinstance(error, kind):
+            return outcome
+    return nl_log.Outcome.SEARCH_FAILED
+
+
+def _stamps(corpus: execute.Corpus) -> tuple[str, str]:
+    """Returns the fingerprints naming what answered a question.
+
+    Args:
+        corpus: What the query will run against.
+
+    Returns:
+        The corpus fingerprint and the prompt fingerprint, both empty where they could
+        not be read. A record is an optimization and never a dependency, so an artifact
+        that has gone unreadable costs the fingerprint rather than the answer somebody
+        is waiting on.
+    """
+    try:
+        return corpus.fingerprint, prompt_fingerprint()
+    except Exception as error:  # noqa: BLE001
+        logger.warning("cannot fingerprint what answered this question: %s", error)
+        return "", ""
 
 
 def ask(
@@ -435,13 +637,20 @@ def ask(
     client: anthropic.Anthropic | None = None,
     model: str = DEFAULT_MODEL,
     timeout_seconds: float = 60.0,
+    sink: nl_log.Sink | None = None,
+    source: str | None = None,
+    session_id: str | None = None,
 ) -> Answer:
-    """Answers a question against a corpus.
+    """Answers a question against a corpus, and records what happened.
 
     The model's own failures arrive as ``NLQueryError`` subclasses; the search's arrive
     as themselves. Folding both into one taxonomy would cost a caller the distinction
     it answers with -- an unresolvable compound is the question's fault, a corpus whose
     artifacts disagree is the deployment's.
+
+    Every ending is recorded, not only the one where everything worked. A question that
+    matched nothing, one the compiler refused twice, and one the model declined are the
+    records worth reading, and a log written on the success path holds none of them.
 
     Args:
         question: The question, in English.
@@ -449,9 +658,16 @@ def ask(
         client: Anthropic client; one is built from the environment if omitted.
         model: Which model translates and describes.
         timeout_seconds: Passed to the search, so a slow query fails rather than hangs.
+        sink: Where the record goes; nothing is recorded if omitted.
+        source: Which surface this arrived from -- ``"web"``, ``"eval"``, ``"api"``.
+            One prefix holds all of them, and nothing else in the record separates a
+            person rephrasing from a harness working through a case file.
+        session_id: Groups this question with the rest of a visit, which is what makes
+            a rephrasing readable as a correction of the question before it.
 
     Returns:
-        The query that ran, the reactions it found, and a description of them.
+        The query that ran, the reactions it found, a description of them, and the
+        identifier the record was written under.
 
     Raises:
         MalformedQueryError: If translation produces nothing that compiles.
@@ -464,11 +680,89 @@ def ask(
         PairingError: If the corpus and its structures do not line up.
     """
     client = client if client is not None else get_client()
-    translated = translate(question, client=client, model=model)
-    table = corpus.search(translated, timeout_seconds=timeout_seconds)
+    timestamp = datetime.now(UTC).isoformat()
+    # Both only where a record is going somewhere: an id nothing wrote would let a
+    # caller hang a thumb on an ask that does not exist, and reading the stamps opens a
+    # footer per artifact.
+    record_id = nl_log.new_identifier() if sink is not None else ""
+    stamps = _stamps(corpus) if sink is not None else None
+
+    def record(outcome: nl_log.Outcome, **fields: Any) -> None:
+        """Writes one record, filling in what every ending of this ask shares."""
+        if stamps is None:
+            return
+        corpus_fingerprint, translator = stamps
+        nl_log.emit(
+            sink,
+            nl_log.Ask(
+                question=question,
+                model=model,
+                corpus_fingerprint=corpus_fingerprint,
+                prompt_fingerprint=translator,
+                outcome=outcome,
+                source=source,
+                session_id=session_id,
+                record_id=record_id,
+                timestamp=timestamp,
+                **fields,
+            ),
+        )
+
+    try:
+        translated = translate(question, client=client, model=model)
+    except NLQueryError as error:
+        record(
+            outcome_of(error),
+            attempts=error.attempts,
+            declined_reason=(
+                str(error) if isinstance(error, UnanswerableError) else None
+            ),
+            error=str(error),
+            usage=error.usage,
+            translate_ms=error.elapsed_ms,
+        )
+        raise
+    started = time.monotonic()
+    try:
+        table = corpus.search(translated.query, timeout_seconds=timeout_seconds)
+    except Exception as error:
+        record(
+            outcome_of(error),
+            attempts=translated.attempts,
+            error=str(error),
+            usage=translated.usage,
+            translate_ms=translated.elapsed_ms,
+            search_ms=(time.monotonic() - started) * 1000,
+        )
+        raise
+    search_ms = (time.monotonic() - started) * 1000
+    try:
+        described = answer(question, table, client=client, model=model)
+    except NLQueryError as error:
+        record(
+            outcome_of(error),
+            attempts=translated.attempts,
+            row_count=table.num_rows,
+            error=str(error),
+            usage=translated.usage + error.usage,
+            translate_ms=translated.elapsed_ms,
+            search_ms=search_ms,
+        )
+        raise
+    record(
+        nl_log.Outcome.ANSWERED if table.num_rows else nl_log.Outcome.EMPTY,
+        attempts=translated.attempts,
+        row_count=table.num_rows,
+        answer_text=described.text,
+        usage=translated.usage + described.usage,
+        translate_ms=translated.elapsed_ms,
+        search_ms=search_ms,
+        answer_ms=described.elapsed_ms,
+    )
     return Answer(
         question=question,
-        query=translated,
+        query=translated.query,
         table=table,
-        text=answer(question, table, client=client, model=model),
+        text=described.text,
+        record_id=record_id,
     )

--- a/ord_schema/search/nl_eval.py
+++ b/ord_schema/search/nl_eval.py
@@ -37,14 +37,16 @@ import argparse
 import dataclasses
 import json
 import pathlib
+import uuid
 from collections.abc import Sequence
 from typing import Any
 
 import anthropic
+import pyarrow as pa
 from pydantic import BaseModel, model_validator
 
 from ord_schema.logging import get_logger
-from ord_schema.search import execute, nl, query
+from ord_schema.search import execute, nl, nl_log, query
 
 logger = get_logger(__name__)
 
@@ -52,6 +54,10 @@ CASES = pathlib.Path(__file__).parent / "nl_cases.json"
 # Longer than a served query would wait, because a run is unattended and a case whose
 # translation is slow is worth a verdict rather than a stopped harness.
 DEFAULT_TIMEOUT_SECONDS = 300.0
+# What a record written by a run is marked with. A case file marched through end to end
+# is not evidence about what people ask, and the two are indistinguishable in the log
+# without this.
+SOURCE = "eval"
 
 
 class EvalCase(BaseModel):
@@ -147,6 +153,43 @@ def score(
     return CaseResult(case, passed=True, detail=f"{len(right)} reactions")
 
 
+def _score_against_reference(
+    case: EvalCase,
+    corpus: execute.Corpus,
+    table: pa.Table,
+    *,
+    timeout_seconds: float,
+) -> CaseResult:
+    """Returns how the translated query's rows compare with the reference query's.
+
+    Args:
+        case: The case, which carries the reference.
+        corpus: The corpus to run the reference against.
+        table: What the model's query returned.
+        timeout_seconds: Bounds the reference search.
+
+    Returns:
+        The result. A reference query that will not run fails its own case rather than
+        the run: that is the case file being wrong, and the other cases still have
+        something to say.
+    """
+    assert case.reference is not None  # A case that compiles carries one.
+    try:
+        expected = corpus.search(
+            query.Query.model_validate({"where": case.reference}),
+            timeout_seconds=timeout_seconds,
+        )
+    except Exception as error:  # noqa: BLE001
+        return CaseResult(
+            case, passed=False, detail=f"the reference query failed: {error}"
+        )
+    return score(
+        case,
+        table.column("reaction_id").to_pylist(),
+        expected.column("reaction_id").to_pylist(),
+    )
+
+
 def run_case(
     case: EvalCase,
     corpus: execute.Corpus,
@@ -155,6 +198,8 @@ def run_case(
     model: str,
     repair: bool,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    sink: nl_log.Sink | None = None,
+    session_id: str | None = None,
 ) -> CaseResult:
     """Translates one case, runs it, and scores what came back.
 
@@ -166,6 +211,10 @@ def run_case(
         repair: Whether a failure gets the repair turn.
         timeout_seconds: Bounds the search, so a case that translates into something
             slow fails the run rather than stopping it.
+        sink: Where each case's record goes; nothing is recorded if omitted. A run is
+            worth recording for the same reason a served question is: a real question
+            against a real model, priced and timed.
+        session_id: Groups this run's cases, the way a visit groups a reader's.
 
     Returns:
         The result. A case marked ``compiles: false`` passes exactly when the model
@@ -178,13 +227,43 @@ def run_case(
         ModelRateLimitedError: If the caller is over its rate limit.
         ModelUnavailableError: If the model cannot be reached. Neither is scored as a
             failed translation: the measurement did not happen, and calling that a
-            wrong answer would understate the model on the next run.
+            wrong answer would understate the model on the next run. Everything else --
+            a query that names an unresolvable compound, a search past its timeout, a
+            reference query the case file got wrong -- fails its own case and lets the
+            rest of the run finish.
     """
+
+    def record(outcome: nl_log.Outcome, **fields: Any) -> None:
+        """Writes one record for this case."""
+        nl_log.emit(
+            sink,
+            nl_log.Ask(
+                question=case.question,
+                model=model,
+                corpus_fingerprint=corpus.fingerprint,
+                prompt_fingerprint=nl.prompt_fingerprint(),
+                outcome=outcome,
+                source=SOURCE,
+                session_id=session_id,
+                **fields,
+            ),
+        )
+
+    # A rate limit or an unreachable model is deliberately not recorded: the
+    # measurement did not happen, and a record of it would read as a translation that
+    # went wrong.
     try:
         translated = nl.translate(
             case.question, client=client, model=model, repair=repair
         )
     except nl.UnanswerableError as error:
+        record(
+            nl_log.Outcome.DECLINED,
+            attempts=error.attempts,
+            declined_reason=str(error),
+            usage=error.usage,
+            translate_ms=error.elapsed_ms,
+        )
         if error.attempted:
             # The model wrote a query for a question the grammar cannot express and
             # only backed off once the compiler said so. The caller is served, but the
@@ -194,24 +273,47 @@ def run_case(
             )
         return CaseResult(case, passed=not case.compiles, detail=f"declined: {error}")
     except nl.MalformedQueryError as error:
+        record(
+            nl_log.Outcome.MALFORMED,
+            attempts=error.attempts,
+            error=str(error),
+            usage=error.usage,
+            translate_ms=error.elapsed_ms,
+        )
         # Never a pass, whatever the case expects. A model that built a query for an
         # inexpressible question reached the right verdict by the wrong road, and
         # counting that as a refusal would hide the day it starts answering instead.
         return CaseResult(case, passed=False, detail=f"did not compile: {error}")
+    try:
+        table = corpus.search(translated.query, timeout_seconds=timeout_seconds)
+    except Exception as error:  # noqa: BLE001
+        # One case whose query names an unresolvable compound, or runs past the
+        # timeout, is one failed case. Letting it out of here would abort the run and
+        # cost every other case's result along with it.
+        record(
+            nl.outcome_of(error),
+            attempts=translated.attempts,
+            error=str(error),
+            usage=translated.usage,
+            translate_ms=translated.elapsed_ms,
+        )
+        return CaseResult(case, passed=False, detail=f"the search failed: {error}")
+    record(
+        nl_log.Outcome.ANSWERED if table.num_rows else nl_log.Outcome.EMPTY,
+        attempts=translated.attempts,
+        row_count=table.num_rows,
+        usage=translated.usage,
+        translate_ms=translated.elapsed_ms,
+    )
     if not case.compiles:
+        # Recorded before the verdict, because a model answering a question the
+        # grammar supposedly cannot express is the most interesting thing in a run:
+        # either the model is wrong, or the case is, and the query is the evidence.
         return CaseResult(
             case, passed=False, detail="compiled, but the grammar cannot express this"
         )
-    assert case.reference is not None  # A case that compiles carries one.
-    expected = corpus.search(
-        query.Query.model_validate({"where": case.reference}),
-        timeout_seconds=timeout_seconds,
-    )
-    table = corpus.search(translated, timeout_seconds=timeout_seconds)
-    return score(
-        case,
-        table.column("reaction_id").to_pylist(),
-        expected.column("reaction_id").to_pylist(),
+    return _score_against_reference(
+        case, corpus, table, timeout_seconds=timeout_seconds
     )
 
 
@@ -278,9 +380,20 @@ def main(argv: Sequence[str] | None = None) -> None:
         action="store_true",
         help="Refuse artifacts not written by this version of the library",
     )
+    parser.add_argument(
+        "--log",
+        default=None,
+        help=(
+            "Append a record per case to this JSONL file, so a run's questions, "
+            "queries, and token cost outlive the printed report"
+        ),
+    )
     args = parser.parse_args(argv)
     cases = load_cases(args.cases)
     client = nl.get_client()
+    sink = None if args.log is None else nl_log.JsonlSink(args.log)
+    # One run is one session, so its cases group the way a reader's questions do.
+    session_id = str(uuid.uuid4())
     with execute.Corpus(
         args.projections,
         args.structures,
@@ -296,6 +409,8 @@ def main(argv: Sequence[str] | None = None) -> None:
                 model=args.model,
                 repair=not args.no_repair,
                 timeout_seconds=args.timeout_seconds,
+                sink=sink,
+                session_id=session_id,
             )
             for case in cases
         ]

--- a/ord_schema/search/nl_eval_test.py
+++ b/ord_schema/search/nl_eval_test.py
@@ -23,10 +23,11 @@ import json
 import types
 from typing import Any, cast
 
+import pyarrow as pa
 import pytest
 from anthropic.types import ToolUseBlock
 
-from ord_schema.search import execute, nl, nl_eval, query
+from ord_schema.search import execute, nl_eval, nl_log, query
 
 _CASE = nl_eval.EvalCase(
     question="which reactions use pyridine as a solvent?",
@@ -75,54 +76,73 @@ class _StubClient:
         block = ToolUseBlock(
             type="tool_use", id="toolu_stub", name=self._name, input=self._payload
         )
-        return types.SimpleNamespace(content=[block], stop_reason="tool_use")
+        usage = types.SimpleNamespace(
+            input_tokens=1,
+            output_tokens=1,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+        )
+        return types.SimpleNamespace(
+            content=[block], usage=usage, stop_reason="tool_use"
+        )
 
 
-class _RaisingClient:
-    """Raises a canned error instead of answering.
+class _SequenceClient:
+    """Answers each call with the next canned tool call, for a repair turn.
 
     Attributes:
         messages: Itself, so ``client.messages.create`` reaches ``create``.
     """
 
-    def __init__(self, error: Exception) -> None:
+    def __init__(self, *calls: tuple[str, dict]) -> None:
         """Initializes the stub.
 
         Args:
-            error: What every request raises.
+            *calls: ``(tool name, input)`` pairs, returned in order.
         """
-        self._error = error
+        self._calls = list(calls)
         self.messages = self
 
     def create(self, **kwargs: Any) -> Any:
-        """Raises the canned error.
+        """Returns the next canned response.
 
         Args:
             **kwargs: The request, which the stub ignores.
 
-        Raises:
-            Exception: Always, with whatever this stub was built around.
+        Returns:
+            A response carrying one ``tool_use`` block.
         """
         del kwargs
-        raise self._error
+        name, payload = self._calls.pop(0)
+        block = ToolUseBlock(type="tool_use", id="toolu_stub", name=name, input=payload)
+        usage = types.SimpleNamespace(
+            input_tokens=1,
+            output_tokens=1,
+            cache_creation_input_tokens=0,
+            cache_read_input_tokens=0,
+        )
+        return types.SimpleNamespace(
+            content=[block], usage=usage, stop_reason="tool_use"
+        )
 
 
-def _run(case, client) -> nl_eval.CaseResult:
+def _run(case, client, *, repair: bool = False) -> nl_eval.CaseResult:
     """Runs a case whose translation fails before any corpus is reached.
 
     Args:
         case: The case to run.
         client: The stub standing in for the model.
+        repair: Whether a failed query gets handed back once.
 
     Returns:
         What ``run_case`` decided.
     """
     return nl_eval.run_case(
         case,
-        cast(execute.Corpus, None),
+        cast(execute.Corpus, _StubCorpus()),
         client=cast(Any, client),
         model="stub",
-        repair=False,
+        repair=repair,
     )
 
 
@@ -254,8 +274,13 @@ def test_a_query_that_does_not_compile_never_passes():
 def test_a_refusal_reached_only_after_a_failed_query_fails():
     # The caller is served either way, but this case exists to measure whether the
     # model reads the question, not whether it eventually stops.
-    error = nl.UnanswerableError("no column comparison", attempted=True)
-    result = _run(_INEXPRESSIBLE, _RaisingClient(error))
+    # What marks it is the attempt translate recorded before the refusal, so the two
+    # turns have to be run rather than an error handed in.
+    client = _SequenceClient(
+        ("build_query", _BAD_PATH),
+        ("cannot_answer", {"reason": "no column comparison"}),
+    )
+    result = _run(_INEXPRESSIBLE, client, repair=True)
     assert not result.passed
     assert "built a query, then declined" in result.detail
 
@@ -266,3 +291,119 @@ def test_an_expressible_question_that_does_not_compile_fails():
 
 def test_declining_an_expressible_question_fails():
     assert not _run(_CASE, _StubClient("cannot_answer", {"reason": "gave up"})).passed
+
+
+def test_a_run_records_its_cases(tmp_path):
+    # The measurement that exists today runs from a laptop, and recording it is the
+    # reason the log is a file and a bucket rather than a database behind a tunnel.
+    sink = nl_log.JsonlSink(tmp_path / "run.jsonl")
+    nl_eval.run_case(
+        _INEXPRESSIBLE,
+        cast(execute.Corpus, _StubCorpus()),
+        client=cast(Any, _StubClient("cannot_answer", {"reason": "no comparison"})),
+        model="stub",
+        repair=False,
+        sink=sink,
+        session_id="run-1",
+    )
+    (line,) = (tmp_path / "run.jsonl").read_text(encoding="utf-8").splitlines()
+    event = json.loads(line)
+    assert event["outcome"] == nl_log.Outcome.DECLINED
+    assert event["question"] == _INEXPRESSIBLE.question
+    # A run is a session, so one run's cases group the way one visitor's questions do.
+    assert event["session_id"] == "run-1"
+
+
+class _StubCorpus:
+    """Answers every query with one reaction, standing in for a real corpus.
+
+    Attributes:
+        fingerprint: What a record names the corpus by.
+    """
+
+    fingerprint = "stubcorpus"
+
+    def search(self, translated: Any, **kwargs: Any) -> pa.Table:
+        """Returns the canned result.
+
+        Args:
+            translated: The query, which the stub ignores.
+            **kwargs: Bounds the stub ignores.
+
+        Returns:
+            A one-row table.
+        """
+        del translated, kwargs
+        return pa.table({"reaction_id": ["ord-aa"]})
+
+
+class _FailingCorpus(_StubCorpus):
+    """Refuses every query the way a resolver refuses an unobtainable compound."""
+
+    def search(self, translated: Any, **kwargs: Any) -> pa.Table:
+        """Raises.
+
+        Args:
+            translated: The query, which the stub ignores.
+            **kwargs: Bounds the stub ignores.
+
+        Raises:
+            ValueError: Always.
+        """
+        del translated, kwargs
+        raise ValueError("cannot resolve 'unobtainium'")
+
+
+def test_a_case_whose_search_fails_costs_that_case_and_not_the_run(tmp_path):
+    # main runs the cases in a comprehension, so an exception escaping run_case costs
+    # every other case's result along with this one.
+    sink = nl_log.JsonlSink(tmp_path / "run.jsonl")
+    result = nl_eval.run_case(
+        _INEXPRESSIBLE,
+        cast(execute.Corpus, _FailingCorpus()),
+        client=cast(
+            Any,
+            _StubClient("build_query", {"where": {"op": "not_null", "path": "smiles"}}),
+        ),
+        model="stub",
+        repair=False,
+        sink=sink,
+    )
+    assert not result.passed
+    assert "unobtainium" in result.detail
+    (line,) = (tmp_path / "run.jsonl").read_text(encoding="utf-8").splitlines()
+    assert json.loads(line)["outcome"] == nl_log.Outcome.UNRESOLVED_COMPOUND
+
+
+def test_a_query_built_for_an_inexpressible_question_is_recorded(tmp_path):
+    # The case fails, but the record is the point: a model answering a question the
+    # grammar supposedly cannot express means either the model is wrong or the case
+    # is, and the query it wrote is the evidence for deciding which.
+    sink = nl_log.JsonlSink(tmp_path / "run.jsonl")
+    result = nl_eval.run_case(
+        _INEXPRESSIBLE,
+        cast(execute.Corpus, _StubCorpus()),
+        client=cast(
+            Any,
+            _StubClient("build_query", {"where": {"op": "not_null", "path": "smiles"}}),
+        ),
+        model="stub",
+        repair=False,
+        sink=sink,
+    )
+    assert not result.passed
+    assert "cannot express" in result.detail
+    (line,) = (tmp_path / "run.jsonl").read_text(encoding="utf-8").splitlines()
+    event = json.loads(line)
+    assert event["outcome"] == nl_log.Outcome.ANSWERED
+    (attempt,) = json.loads(event["attempts"])
+    assert json.loads(attempt["translation"])["where"]["op"] == "not_null"
+    # A case file marched through end to end is not evidence about what people ask, and
+    # it lands in the same place as the questions that are.
+    assert event["source"] == "eval"
+
+
+def test_a_run_without_a_sink_records_nothing(tmp_path):
+    result = _run(_CASE, _StubClient("build_query", _BAD_PATH))
+    assert not result.passed
+    assert not list(tmp_path.iterdir())

--- a/ord_schema/search/nl_log.py
+++ b/ord_schema/search/nl_log.py
@@ -1,0 +1,650 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A durable record of every question, the query it became, and how that went.
+
+The questions people ask are the only material that can refine a translator, and a
+prompt, a grammar, and an eval set are guesses until real ones land against them. This
+module is where a question goes after it has been answered.
+
+The log is an append-only stream of events rather than a table of rows. Three kinds
+share a ``record_id``: the **ask**, written here; the **thumb** a reader leaves; the
+**label** a maintainer applies. They are three assertions, by three parties, at three
+times, and folding them onto one mutable row would lose which was which on the day a
+label contradicts a thumb.
+
+A record is a *typed envelope around an opaque payload*. Identifiers, outcome, usage,
+timings, and fingerprints are fields; the question and the whole ``attempts`` list are
+strings. They stay strings because a model-authored ``Query`` is recursive and
+differently shaped record to record, and because a month in which everything compiled
+carries ``"error": null`` throughout, where a month holding one rejection carries text.
+Either way, compacting into Parquet would leave DuckDB to infer a struct from whichever
+shapes a month happened to hold, and whether two such months then read back together
+depends on what it can coerce: measured cases lose a field silently -- the rows still
+count in every aggregate while the part worth recording is unreachable -- or refuse the
+read outright. As strings the months reconcile by construction, and no inference is
+involved. The measurements are in the ord-logbook entry "Where the question log lives".
+
+Results are not recorded. A translation and a corpus fingerprint reproduce them, and a
+question that returned a hundred thousand reactions should not cost a hundred thousand
+rows of log.
+"""
+
+import contextlib
+import dataclasses
+import enum
+import json
+import os
+import pathlib
+import sys
+import uuid
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+import duckdb
+
+from ord_schema.logging import get_logger
+from ord_schema.search.execute import sql_string
+
+logger = get_logger(__name__)
+
+
+def new_identifier() -> str:
+    """Returns a fresh identifier, as hex rather than as a dashed UUID.
+
+    DuckDB infers a column of dashed UUIDs as ``UUID`` and one of anything else as
+    ``VARCHAR``, and a read spanning both refuses to union them. Hex is 32 characters
+    of the same randomness that no source can infer as anything but text.
+    """
+    return uuid.uuid4().hex
+
+
+class Thumb(enum.StrEnum):
+    """A reader's verdict on an answer."""
+
+    UP = "up"
+    DOWN = "down"
+
+
+class Verdict(enum.StrEnum):
+    """A maintainer's verdict on a translation."""
+
+    CORRECT = "correct"
+    WRONG = "wrong"
+    UNCLEAR = "unclear"
+
+
+class Outcome(enum.StrEnum):
+    """What became of a question.
+
+    The first two are the ordinary endings and the rest are the error taxonomy ``nl``
+    raises, one outcome each, so a failure is queryable rather than a string someone
+    has to grep. Members are strings, so a record serializes to ordinary JSON and a
+    reader compares against ordinary text.
+    """
+
+    ANSWERED = "answered"
+    EMPTY = "empty"
+    DECLINED = "declined"
+    MALFORMED = "malformed"
+    RATE_LIMITED = "rate_limited"
+    UNAVAILABLE = "unavailable"
+    UNRESOLVED_COMPOUND = "unresolved_compound"
+    TIMEOUT = "timeout"
+    SEARCH_FAILED = "search_failed"
+
+
+@dataclasses.dataclass(frozen=True)
+class Usage:
+    """What one call to the model cost, in tokens.
+
+    Attributes:
+        input: Uncached input tokens.
+        output: Generated tokens.
+        cache_read: Input tokens served from the cached prefix, which is most of a
+            query's input and a fraction of its price.
+        cache_creation: Input tokens written into the cache.
+    """
+
+    input: int = 0
+    output: int = 0
+    cache_read: int = 0
+    cache_creation: int = 0
+
+    def __add__(self, other: "Usage") -> "Usage":
+        """Returns the total of two calls, for summing a repair turn onto its first."""
+        return Usage(
+            input=self.input + other.input,
+            output=self.output + other.output,
+            cache_read=self.cache_read + other.cache_read,
+            cache_creation=self.cache_creation + other.cache_creation,
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class Attempt:
+    """One ``build_query`` call, and what the compiler said about it.
+
+    Attributes:
+        translation: The tool input, coerced but not necessarily valid. It is held as
+            raw JSON rather than as a ``Query`` because the attempt worth recording is
+            usually the one that failed to validate, where there is no ``Query`` to
+            hold.
+        error: Why it was rejected, or None where it was not.
+        usage: What this turn cost.
+    """
+
+    translation: dict[str, Any]
+    error: str | None
+    usage: Usage = dataclasses.field(default_factory=Usage)
+
+
+@dataclasses.dataclass(frozen=True)
+class Ask:
+    """One question, and what answering it did.
+
+    Attributes:
+        question: The question, in English.
+        model: Which model translated.
+        corpus_fingerprint: The corpus the query ran against, so the record stays
+            reproducible without holding the rows.
+        prompt_fingerprint: Which translator wrote this, so a record from months ago
+            can be told apart from one written by today's prompt.
+        outcome: How the question ended.
+        attempts: Every ``build_query`` call, in order. Empty where the model declined
+            without writing a query, which is how "read the question and said no" is
+            told apart from "backed off once the compiler refused a guess".
+        row_count: How many reactions came back, where the search ran.
+        declined_reason: What the model said the grammar lacks.
+        error: The failure, where one ended the ask.
+        answer_text: The prose the reader saw, which is what a thumb is a verdict on.
+        usage: What the whole question cost, every model call included. More than the
+            attempts add up to, because a turn can spend tokens without producing one:
+            declining costs a call, and so does writing the sentence describing the
+            result.
+        translate_ms: Wall time turning the question into a query.
+        search_ms: Wall time running it, or None where it never ran.
+        answer_ms: Wall time writing the prose, or None where none was written. A
+            stage that did not run is None rather than an absent field, so every
+            record carries the same keys whatever became of the question -- which is
+            what compaction infers a Parquet schema from.
+        source: Which surface the question arrived from -- ``"web"``, ``"eval"``,
+            ``"api"``. A served endpoint, an eval run, and a script all write to one
+            prefix, and nothing else in the record tells them apart: a rephrasing after
+            a bad answer and a harness marching through a case file look alike once
+            they are mixed. Low cardinality on purpose, so it groups.
+        session_id: Groups a visit, so a rephrasing reads as a correction of what came
+            before it. Minted by the client, which decides what it spans.
+        record_id: What a thumb and a label reference.
+        timestamp: When the question was asked, in UTC.
+    """
+
+    question: str
+    model: str
+    corpus_fingerprint: str
+    outcome: Outcome
+    prompt_fingerprint: str = ""
+    attempts: Sequence[Attempt] = ()
+    row_count: int | None = None
+    declined_reason: str | None = None
+    error: str | None = None
+    answer_text: str | None = None
+    usage: Usage = dataclasses.field(default_factory=Usage)
+    translate_ms: float | None = None
+    search_ms: float | None = None
+    answer_ms: float | None = None
+    source: str | None = None
+    session_id: str | None = None
+    record_id: str = dataclasses.field(default_factory=new_identifier)
+    timestamp: str = dataclasses.field(
+        default_factory=lambda: datetime.now(UTC).isoformat()
+    )
+
+
+def event(ask: Ask) -> dict[str, Any]:
+    """Returns the JSON-ready ask event.
+
+    Args:
+        ask: What happened.
+
+    Returns:
+        A dict of JSON primitives, the model-authored payloads among them serialized
+        to strings. It holds nothing ``read`` can derive: the translation is the last
+        attempt no error rejected, and a repair fired when there is more than one.
+
+        ``attempts`` is one string rather than a list of structs for the same reason a
+        translation is: a month in which every attempt compiled writes ``"error": null``
+        throughout, and DuckDB infers the field as JSON where a month holding one
+        rejection infers it as text. The two then refuse to read together, and a
+        compacted month has the wrong type baked in for good.
+    """
+    return {
+        "event": "ask",
+        "event_id": new_identifier(),
+        "record_id": ask.record_id,
+        "source": ask.source,
+        "session_id": ask.session_id,
+        "timestamp": ask.timestamp,
+        "question": ask.question,
+        "attempts": json.dumps(
+            [
+                {
+                    "translation": json.dumps(attempt.translation, sort_keys=True),
+                    "error": attempt.error,
+                    "usage": dataclasses.asdict(attempt.usage),
+                }
+                for attempt in ask.attempts
+            ],
+            sort_keys=True,
+        ),
+        "outcome": str(ask.outcome),
+        "row_count": ask.row_count,
+        "declined_reason": ask.declined_reason,
+        "error": ask.error,
+        "answer_text": ask.answer_text,
+        "model": ask.model,
+        "corpus_fingerprint": ask.corpus_fingerprint,
+        "prompt_fingerprint": ask.prompt_fingerprint,
+        "usage": dataclasses.asdict(ask.usage),
+        "translate_ms": ask.translate_ms,
+        "search_ms": ask.search_ms,
+        "answer_ms": ask.answer_ms,
+    }
+
+
+class Sink(Protocol):
+    """Somewhere a record goes."""
+
+    def write(self, event: Mapping[str, Any]) -> None:
+        """Records one event."""
+
+
+class ObjectStore(Protocol):
+    """The one operation an object sink needs, which a boto3 S3 client satisfies.
+
+    Taking the client rather than building one keeps this package free of an AWS
+    dependency: a deployment passes ``boto3.client("s3")``, and a test passes something
+    that records what it was handed.
+    """
+
+    def put_object(self, *, Bucket: str, Key: str, Body: bytes) -> Any:
+        """Stores one object."""
+
+
+class JsonlSink:
+    """Appends records to a local file, one JSON object per line.
+
+    Needs no credentials and no network, so an eval run on a laptop is recorded, and
+    the file reads back through the same query as the bucket.
+    """
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        """Initializes the sink.
+
+        Args:
+            path: File to append to. Its parent directory is created if missing.
+        """
+        self._path = pathlib.Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def write(self, event: Mapping[str, Any]) -> None:
+        """Appends one event."""
+        with self._path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+class StdoutSink:
+    """Writes records to stdout, for a container whose logs already go somewhere."""
+
+    def write(self, event: Mapping[str, Any]) -> None:
+        """Prints one event as a single line."""
+        print(json.dumps(event, sort_keys=True), file=sys.stdout, flush=True)
+
+
+class S3Sink:
+    """Writes one object per record, partitioned by date.
+
+    The caller supplies both the store and the bucket, so this holds no opinion about
+    where a record lands and this package carries no AWS dependency.
+    """
+
+    def __init__(
+        self, store: ObjectStore, *, bucket: str, prefix: str = "nl-log/raw"
+    ) -> None:
+        """Initializes the sink.
+
+        Args:
+            store: Something with boto3's ``put_object``.
+            bucket: Bucket to write into.
+            prefix: Key prefix; the date partition goes under it. Keep it disjoint from
+                where compacted months are written, so a lifecycle rule can expire the
+                raw days without touching the month that folded them.
+        """
+        self._store = store
+        self._bucket = bucket
+        self._prefix = prefix.rstrip("/")
+
+    def write(self, event: Mapping[str, Any]) -> None:
+        """Stores one event under ``<prefix>/dt=<date>/<event_id>.json``.
+
+        Keyed by the event rather than by the question it concerns: an ask, the thumb
+        left on it, and a maintainer's label all carry one ``record_id``, so a key
+        built from that would have each overwrite the last and the question itself
+        would be the one lost.
+
+        The date comes from the event's own timestamp rather than from the clock, so a
+        record lands in the partition it belongs to even when it is written late.
+        """
+        day = str(event["timestamp"])[:10]
+        self._store.put_object(
+            Bucket=self._bucket,
+            Key=f"{self._prefix}/dt={day}/{event['event_id']}.json",
+            Body=json.dumps(event, sort_keys=True).encode("utf-8"),
+        )
+
+
+def write(sink: Sink | None, event: Mapping[str, Any]) -> None:
+    """Records one event, and never lets the log cost the answer.
+
+    Every event goes through here -- the ask this module builds and the thumb or label a
+    caller builds alike. A sink reaches a file or a network, and a reader is waiting on
+    the question rather than on the record of it, so a failure is warned about and
+    dropped: an optimization, never a dependency, which is the contract the search cache
+    holds too.
+
+    Args:
+        sink: Where the record goes; None records nothing.
+        event: The event to record.
+    """
+    if sink is None:
+        return
+    try:
+        sink.write(event)
+    except Exception as error:  # noqa: BLE001
+        logger.warning("dropping a question log record: %s", error)
+
+
+def emit(sink: Sink | None, ask: Ask) -> None:
+    """Records an ask.
+
+    Args:
+        sink: Where the record goes; None records nothing.
+        ask: What happened.
+    """
+    write(sink, event(ask))
+
+
+def thumb(
+    record_id: str,
+    value: Thumb | str,
+    *,
+    comment: str | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    """Returns a reader's verdict on an answer.
+
+    Args:
+        record_id: The ask this judges.
+        value: A ``Thumb``, or the string spelling one.
+        comment: Whatever the reader wanted to add.
+        session_id: The visit it came from.
+
+    Returns:
+        A JSON-ready thumb event.
+
+    Raises:
+        ValueError: If ``value`` is not one of the members. The log is append-only, so
+            a typo can be superseded but never corrected, and a verdict spelled
+            ``"Down"`` is invisible to every query that asks for ``"down"``.
+    """
+    return {
+        "event": "thumb",
+        "event_id": new_identifier(),
+        "record_id": record_id,
+        "session_id": session_id,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "value": str(Thumb(value)),
+        "comment": comment,
+    }
+
+
+def label(
+    record_id: str,
+    verdict: Verdict | str,
+    *,
+    reference: Mapping[str, Any] | None = None,
+    note: str | None = None,
+    promoted: bool = False,
+) -> dict[str, Any]:
+    """Returns a maintainer's verdict on a translation.
+
+    Args:
+        record_id: The ask this judges.
+        verdict: A ``Verdict``, or the string spelling one.
+        reference: A query that answers the question, where the translation did not.
+            This is what an eval case needs and what a thumb cannot supply.
+        note: Why.
+        promoted: Whether this became an eval case.
+
+    Returns:
+        A JSON-ready label event.
+
+    Raises:
+        ValueError: If ``verdict`` is not one of the members; see ``thumb``.
+    """
+    return {
+        "event": "label",
+        "event_id": new_identifier(),
+        "record_id": record_id,
+        "timestamp": datetime.now(UTC).isoformat(),
+        "verdict": str(Verdict(verdict)),
+        "reference": (
+            None if reference is None else json.dumps(reference, sort_keys=True)
+        ),
+        "note": note,
+        "promoted": promoted,
+    }
+
+
+# One ask per row, with the later events folded onto it and the fields the record does
+# not store derived here. A thumb or a label can be left more than once, so these
+# aggregate rather than join, and they aggregate by timestamp: the newest verdict is the
+# one that stands, where the largest would make "up" outrank a later "down" and would
+# let a promotion outlive its retraction.
+#
+# The whole event is carried through one aggregate as a struct rather than each of its
+# fields through its own. arg_max skips a row whose value is NULL, so per-field
+# aggregates answer from different events the moment one of them omits an optional
+# field: a reader who thumbs down without a comment would keep the comment left beside
+# an earlier thumb up, and the row would be a verdict nobody gave.
+#
+# The empty row carrying no rows is what lets this bind against a log nobody has left
+# feedback on yet: the columns a thumb and a label contribute do not exist until one has
+# been written, and a reader that only works once someone has replied is no reader.
+_SKELETON = """
+SELECT
+    NULL::VARCHAR AS event,
+    NULL::VARCHAR AS event_id,
+    NULL::VARCHAR AS record_id,
+    NULL::VARCHAR AS session_id,
+    NULL::VARCHAR AS attempts,
+    NULL::VARCHAR AS question,
+    NULL::VARCHAR AS answer_text,
+    NULL::VARCHAR AS value,
+    NULL::VARCHAR AS comment,
+    NULL::VARCHAR AS verdict,
+    NULL::VARCHAR AS reference,
+    NULL::VARCHAR AS note,
+    NULL::BOOLEAN AS promoted
+WHERE FALSE
+"""
+
+# The identifiers a source can infer a type for. A file whose record_ids are all dashed
+# UUIDs reads as UUID and one holding anything else reads as VARCHAR, and the union of
+# the two refuses. This module mints hex so its own files never diverge; the cast is
+# what covers a client that minted its own session_id as a dashed UUID.
+_TEXT_COLUMNS = ("event_id", "record_id", "session_id")
+
+_LOG = """
+WITH events AS (
+    SELECT * FROM ({sources})
+    -- An event is immutable and carries its own identifier, so one arriving twice is
+    -- the same event twice: a compacted month read beside the raw days it folded, or
+    -- two globs that overlap. Counting it twice silently doubles every aggregate.
+    QUALIFY row_number() OVER (PARTITION BY event_id ORDER BY timestamp) = 1
+),
+asks AS (SELECT * FROM events WHERE event = 'ask'),
+verdicts AS (
+    SELECT
+        record_id,
+        arg_max(
+            {{'value': value, 'comment': comment}}, timestamp
+        ) FILTER (event = 'thumb') AS thumb,
+        arg_max(
+            {{
+                'verdict': verdict,
+                'reference': reference,
+                'note': note,
+                'promoted': promoted
+            }},
+            timestamp
+        ) FILTER (event = 'label') AS label
+    FROM events
+    WHERE event IN ('thumb', 'label')
+    GROUP BY record_id
+)
+SELECT
+    asks.* EXCLUDE (event, value, comment, verdict, reference, note, promoted),
+    coalesce(json_array_length(asks.attempts), 0) > 1 AS repaired,
+    list_last(
+        list_transform(
+            list_filter(
+                from_json(asks.attempts, '["JSON"]'),
+                attempt -> json_extract(attempt, '$.error') = 'null'::JSON
+            ),
+            attempt -> json_extract_string(attempt, '$.translation')
+        )
+    ) AS translation,
+    verdicts.thumb['value'] AS thumb,
+    verdicts.thumb['comment'] AS thumb_comment,
+    verdicts.label['verdict'] AS verdict,
+    verdicts.label['reference'] AS reference,
+    verdicts.label['note'] AS note,
+    coalesce(verdicts.label['promoted'], FALSE) AS promoted
+FROM asks LEFT JOIN verdicts USING (record_id)
+"""
+
+
+def _source(pattern: str) -> str:
+    """Returns the reader clause for one glob, chosen by what the glob names.
+
+    The skeleton is unioned in per source rather than once over all of them, so every
+    column exists whatever that source happens to hold -- which is what lets the
+    identifier casts bind against a file of nothing but thumbs.
+    """
+    reader = "read_parquet" if pattern.endswith(".parquet") else "read_json_auto"
+    casts = ", ".join(f"{name}::VARCHAR AS {name}" for name in _TEXT_COLUMNS)
+    # S608: the reader is one of two constants, the path is quoted as a literal, and
+    # the select list is built from this module's own constants.
+    return (
+        f"SELECT * REPLACE ({casts}) FROM ("  # noqa: S608
+        f"SELECT * FROM {reader}({sql_string(pattern)}, union_by_name=true) "
+        f"UNION ALL BY NAME {_SKELETON})"
+    )
+
+
+def read(
+    *sources: str,
+    statement: str = "SELECT * FROM log",
+    connection: duckdb.DuckDBPyConnection | None = None,
+) -> duckdb.DuckDBPyRelation:
+    """Returns the log as one relation, thumbs and labels folded onto their asks.
+
+    Args:
+        *sources: Globs of JSON or Parquet, mixed freely, so a compacted month and the
+            days written since read as one table.
+        statement: SQL over the ``log`` view this defines.
+        connection: DuckDB connection; an in-process one is opened if omitted.
+
+    Returns:
+        One row per question, carrying ``translation`` and ``repaired`` derived from
+        the attempts, and whatever verdicts were left on it. An event read twice --
+        through overlapping globs, or a compacted month beside the days it folded --
+        counts once.
+
+    Raises:
+        ValueError: If no source was given. A caller splatting a computed list has an
+            empty one to answer for, and the alternative is a parser error naming SQL
+            it never wrote.
+    """
+    if not sources:
+        raise ValueError("read needs at least one glob of JSON or Parquet to read")
+    connection = connection if connection is not None else duckdb.connect()
+    union = "\nUNION ALL BY NAME\n".join(_source(pattern) for pattern in sources)
+    connection.execute(
+        "CREATE OR REPLACE TEMP VIEW log AS " + _LOG.format(sources=union)
+    )
+    return connection.sql(statement)
+
+
+# What ``redact`` empties: every column holding free text. A reader's thumb comment and
+# a maintainer's label note are as free-form as the question is, and a column named on
+# an ask is not the only place text arrives. The translation is deliberately not here:
+# it is what reproduces the rows the log declines to store, and it is bounded and
+# structured where free text is neither.
+_FREE_TEXT = ("question", "answer_text", "comment", "note")
+
+
+def compact(
+    pattern: str, output: str | os.PathLike[str], *, redact: bool = False
+) -> int:
+    """Rewrites a stretch of the log into one Parquet file.
+
+    One object per question keeps writing simple and reading slow: a year of them is
+    tens of thousands of files to open. Folding a month into one is what keeps the log
+    queryable, and it is safe only because every model-authored payload is a string --
+    nested ones would give each month its own inferred struct, and a field of one month
+    would then be unreachable from a read spanning both.
+
+    This writes the folded copy and leaves the objects it read where they are. ``read``
+    counts an event once however many sources carry it, so the two can be read together
+    until whoever owns the prefix decides the raw days can go.
+
+    Args:
+        pattern: Glob of the JSON objects to fold.
+        output: Parquet file to write.
+        redact: Empty the free-text fields, keeping the outcomes, timings, usage, and
+            fingerprints. The columns are emptied rather than dropped, so a redacted
+            month and an unredacted one share one schema and a query spanning both
+            binds.
+
+    Returns:
+        How many events were written.
+    """
+    selected = "*"
+    if redact:
+        emptied = ", ".join(f"NULL::VARCHAR AS {name}" for name in _FREE_TEXT)
+        selected = f"* EXCLUDE ({', '.join(_FREE_TEXT)}), {emptied}"
+    with contextlib.closing(duckdb.connect()) as connection:
+        # S608: a quoted literal around this module's own reader clause, and a select
+        # list built from this module's own constants.
+        connection.execute(
+            f"COPY (SELECT {selected} FROM ({_source(pattern)})) "  # noqa: S608
+            f"TO {sql_string(str(output))} (FORMAT parquet)"
+        )
+        row = connection.execute(
+            f"SELECT count(*) FROM read_parquet({sql_string(str(output))})"  # noqa: S608
+        ).fetchone()
+    return 0 if row is None else int(row[0])

--- a/ord_schema/search/nl_log_test.py
+++ b/ord_schema/search/nl_log_test.py
@@ -1,0 +1,592 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.search.nl_log."""
+
+import dataclasses
+import json
+import uuid
+
+import pytest
+
+from ord_schema.search import nl_log
+
+_QUERY = {"op": "eq", "path": "reaction_id", "value": {"literal": "ord-1"}}
+# Two predicates the grammar really produces, agreeing on no part of their shape: one
+# nests a list of clauses, the other a quantifier over a structure predicate.
+_CONJUNCTION = nl_log.Attempt(
+    translation={
+        "op": "and",
+        "clauses": [{"op": "gt", "path": "y", "value": {"literal": 1}}],
+    },
+    error=None,
+)
+_QUANTIFIER = nl_log.Attempt(
+    translation={
+        "op": "exists",
+        "path": "inputs.components",
+        "where": {"op": "similarity", "smiles": "c1ccccc1", "threshold": 0.4},
+    },
+    error=None,
+)
+_ANSWERED = nl_log.Ask(
+    question="which reactions use pyridine as a solvent?",
+    model="claude-haiku-4-5",
+    corpus_fingerprint="b42f19ac",
+    outcome=nl_log.Outcome.ANSWERED,
+    attempts=(nl_log.Attempt(translation=_QUERY, error=None),),
+    row_count=3,
+)
+
+
+def _ask(**kwargs) -> nl_log.Ask:
+    """Returns an answered ask with the fields a test cares about replaced."""
+    return dataclasses.replace(_ANSWERED, **kwargs)
+
+
+def test_every_model_authored_payload_is_written_as_a_string():
+    # Compacting a month of records into Parquet infers a struct from whatever shapes
+    # that month held, and a field of a later month then reads back as missing. That
+    # covers the attempts list as much as the query inside it: a month where everything
+    # compiled has "error": null throughout and infers the field as JSON.
+    event = nl_log.event(_ask())
+    assert isinstance(event["attempts"], str)
+    (attempt,) = json.loads(event["attempts"])
+    assert isinstance(attempt["translation"], str)
+    assert json.loads(attempt["translation"]) == _QUERY
+
+
+def test_each_turn_is_priced_on_its_own_attempt():
+    # Per-attempt usage is what prices the repair turn separately from the first try,
+    # which is the open question about choosing a cheap model and repairing it.
+    event = nl_log.event(
+        _ask(
+            attempts=(
+                nl_log.Attempt(
+                    translation={"op": "eq"},
+                    error="no such path",
+                    usage=nl_log.Usage(input=412, output=233, cache_read=15104),
+                ),
+                nl_log.Attempt(
+                    translation=_QUERY,
+                    error=None,
+                    usage=nl_log.Usage(input=689, output=241, cache_read=15104),
+                ),
+            )
+        )
+    )
+    attempts = json.loads(event["attempts"])
+    assert [attempt["usage"]["input"] for attempt in attempts] == [412, 689]
+
+
+def test_the_total_is_recorded_rather_than_summed_from_the_attempts():
+    # A turn can spend tokens without producing an attempt -- declining costs a call,
+    # and so does writing the sentence -- so the total is stated, not derived.
+    event = nl_log.event(
+        _ask(
+            attempts=(
+                nl_log.Attempt(
+                    translation=_QUERY, error=None, usage=nl_log.Usage(input=10)
+                ),
+            ),
+            usage=nl_log.Usage(input=14, output=30),
+        )
+    )
+    assert event["usage"]["input"] == 14
+    assert event["usage"]["output"] == 30
+
+
+def test_an_outcome_survives_the_round_trip_as_a_plain_string():
+    # The taxonomy is an enumeration so the members and the list of them cannot drift
+    # apart, but what reaches the log has to stay a JSON string: a reader querying it
+    # holds a string, and so does every record written before a member was added.
+    event = nl_log.event(_ask(outcome=nl_log.Outcome.EMPTY))
+    assert json.loads(json.dumps(event))["outcome"] == "empty"
+    assert event["outcome"] == nl_log.Outcome.EMPTY
+
+
+def test_every_outcome_is_reachable_by_iterating_the_enumeration():
+    assert nl_log.Outcome.ANSWERED in list(nl_log.Outcome)
+    assert len(set(nl_log.Outcome)) == len(list(nl_log.Outcome))
+
+
+def test_nothing_derivable_from_the_attempts_is_stored():
+    # A stored copy of what the attempts already say is a second source of truth, and
+    # the reader derives both of these without one.
+    event = nl_log.event(_ask())
+    assert "repaired" not in event
+    assert "translation" not in event
+    assert "declined_attempted" not in event
+
+
+def test_every_outcome_writes_the_same_keys():
+    # The envelope is what compaction infers a Parquet schema from, so a field that
+    # appears only on some outcomes would give two months two schemas -- the failure
+    # the string payload exists to avoid, reintroduced by the envelope.
+    answered = nl_log.event(_ask())
+    failed = nl_log.event(
+        _ask(
+            outcome=nl_log.Outcome.MALFORMED,
+            attempts=(nl_log.Attempt(translation={}, error="no such path"),),
+            row_count=None,
+            error="did not compile",
+            translate_ms=1840.0,
+        )
+    )
+    assert answered.keys() == failed.keys()
+
+
+def test_a_stage_that_never_ran_is_a_null_rather_than_a_missing_key(tmp_path):
+    event = nl_log.event(_ask(outcome=nl_log.Outcome.MALFORMED, translate_ms=12.5))
+    assert event["translate_ms"] == 12.5
+    assert event["search_ms"] is None
+    assert event["answer_ms"] is None
+
+
+def test_a_file_sink_appends_one_line_per_event(tmp_path):
+    path = tmp_path / "log.jsonl"
+    sink = nl_log.JsonlSink(path)
+    sink.write(nl_log.event(_ask(question="first")))
+    sink.write(nl_log.event(_ask(question="second")))
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert [json.loads(line)["question"] for line in lines] == ["first", "second"]
+
+
+def test_an_object_sink_partitions_by_the_events_own_date(fake_store):
+    # The partition comes from the record rather than the clock, so an event written
+    # late still lands in the day it happened.
+    sink = nl_log.S3Sink(fake_store, bucket="ord-internal", prefix="nl-log")
+    written = nl_log.event(
+        _ask(record_id="0f3c", timestamp="2026-08-22T18:04:11+00:00")
+    )
+    sink.write(written)
+    (key,) = fake_store.objects
+    assert key == f"nl-log/dt=2026-08-22/{written['event_id']}.json"
+    assert fake_store.bucket == "ord-internal"
+
+
+def test_a_failing_sink_never_fails_the_question(caplog):
+    # The log is an optimization, never a dependency: an unreachable bucket must cost
+    # the record rather than the answer the reader is waiting for.
+    class _Broken:
+        def write(self, event):
+            raise RuntimeError("bucket unreachable")
+
+    nl_log.emit(_Broken(), _ask())
+    assert "bucket unreachable" in caplog.text
+
+
+def test_emitting_to_no_sink_at_all_is_allowed():
+    assert nl_log.emit(None, _ask()) is None
+
+
+def test_reading_folds_a_thumb_and_a_label_onto_their_ask(tmp_path):
+    sink = nl_log.JsonlSink(tmp_path / "log.jsonl")
+    sink.write(nl_log.event(_ask(record_id="0f3c")))
+    sink.write(nl_log.event(_ask(record_id="7b21", outcome=nl_log.Outcome.EMPTY)))
+    sink.write(nl_log.thumb("0f3c", "down", comment="wrong solvent"))
+    sink.write(nl_log.label("0f3c", "wrong", note="two quantifiers"))
+    found = nl_log.read(
+        str(tmp_path / "*.jsonl"), statement="SELECT record_id FROM log"
+    ).fetchall()
+    # Two asks in, two rows out: a thumb and a label fold onto an ask rather than
+    # arriving as rows of their own.
+    assert {row[0] for row in found} == {"0f3c", "7b21"}
+    verdicts = nl_log.read(
+        str(tmp_path / "*.jsonl"),
+        statement="SELECT thumb, verdict FROM log WHERE record_id = '0f3c'",
+    ).fetchall()
+    assert verdicts == [("down", "wrong")]
+
+
+def test_a_thumb_does_not_overwrite_the_ask_it_judges(fake_store):
+    # Every event on one question shares its record_id, so a key built from that alone
+    # collides: the thumb lands on the ask's object and the question is gone.
+    sink = nl_log.S3Sink(fake_store, bucket="ord-internal")
+    sink.write(nl_log.event(_ask(record_id="0f3c")))
+    sink.write(nl_log.thumb("0f3c", "down"))
+    assert len(fake_store.objects) == 2
+    kinds = {json.loads(body)["event"] for body in fake_store.objects.values()}
+    assert kinds == {"ask", "thumb"}
+
+
+def test_two_thumbs_on_one_question_are_both_kept(fake_store):
+    # An append-only log keeps both and lets the reader decide; overwriting one with
+    # the other loses the history the log exists to hold.
+    sink = nl_log.S3Sink(fake_store, bucket="ord-internal")
+    sink.write(nl_log.thumb("0f3c", "up"))
+    sink.write(nl_log.thumb("0f3c", "down"))
+    assert len(fake_store.objects) == 2
+
+
+def test_the_latest_verdict_wins_rather_than_the_lexically_largest(tmp_path):
+    # "up" sorts after "down", so a reader taking the maximum reports the wrong verdict
+    # whenever someone changes their mind from up to down.
+    sink = nl_log.JsonlSink(tmp_path / "log.jsonl")
+    sink.write(nl_log.event(_ask(record_id="0f3c")))
+    sink.write({**nl_log.thumb("0f3c", "up"), "timestamp": "2026-08-22T09:00:00+00:00"})
+    sink.write(
+        {**nl_log.thumb("0f3c", "down"), "timestamp": "2026-08-22T10:00:00+00:00"}
+    )
+    sink.write(
+        {
+            **nl_log.label("0f3c", "wrong", note="first look", promoted=True),
+            "timestamp": "2026-08-22T09:00:00+00:00",
+        }
+    )
+    sink.write(
+        {
+            **nl_log.label("0f3c", "correct", note="second look"),
+            "timestamp": "2026-08-22T10:00:00+00:00",
+        }
+    )
+    ((thumb, verdict, note, promoted),) = nl_log.read(
+        str(tmp_path / "*.jsonl"),
+        statement="SELECT thumb, verdict, note, promoted FROM log",
+    ).fetchall()
+    assert thumb == "down"
+    assert (verdict, note) == ("correct", "second look")
+    # The retraction has to win too, or a promotion can never be taken back.
+    assert promoted is False
+
+
+def test_a_later_verdict_does_not_inherit_the_field_it_left_empty(tmp_path):
+    # arg_max skips a row whose value is NULL, so per-field aggregates answer from
+    # different events the moment one omits an optional field: the comment left beside
+    # an earlier thumb would outlive the thumb itself, and the row would report a
+    # verdict nobody gave.
+    sink = nl_log.JsonlSink(tmp_path / "log.jsonl")
+    sink.write(nl_log.event(_ask(record_id="0f3c")))
+    sink.write(
+        {
+            **nl_log.thumb("0f3c", "up", comment="exactly right"),
+            "timestamp": "2026-08-22T09:00:00+00:00",
+        }
+    )
+    sink.write(
+        {**nl_log.thumb("0f3c", "down"), "timestamp": "2026-08-22T10:00:00+00:00"}
+    )
+    sink.write(
+        {
+            **nl_log.label("0f3c", "wrong", note="two quantifiers", reference=_QUERY),
+            "timestamp": "2026-08-22T09:00:00+00:00",
+        }
+    )
+    sink.write(
+        {**nl_log.label("0f3c", "correct"), "timestamp": "2026-08-22T10:00:00+00:00"}
+    )
+    ((thumb, comment, verdict, note, reference),) = nl_log.read(
+        str(tmp_path / "*.jsonl"),
+        statement="SELECT thumb, thumb_comment, verdict, note, reference FROM log",
+    ).fetchall()
+    assert (thumb, comment) == ("down", None)
+    assert (verdict, note, reference) == ("correct", None, None)
+
+
+def test_a_month_of_clean_attempts_reads_beside_one_holding_a_rejection(tmp_path):
+    # The whole point of the string payload: a file where every attempt compiled writes
+    # "error": null throughout, and an inferred schema calls that field JSON where a
+    # file holding one rejection calls it text. The two then refuse to union, and a
+    # compacted month has the wrong type in it for good.
+    clean = nl_log.JsonlSink(tmp_path / "clean.jsonl")
+    clean.write(nl_log.event(_ask(record_id="0f3c")))
+    rejected = nl_log.JsonlSink(tmp_path / "rejected.jsonl")
+    rejected.write(
+        nl_log.event(
+            _ask(
+                record_id="7b21",
+                attempts=(
+                    nl_log.Attempt(translation={"op": "eq"}, error="no such path"),
+                    nl_log.Attempt(translation=_QUERY, error=None),
+                ),
+            )
+        )
+    )
+    found = nl_log.read(
+        str(tmp_path / "clean.jsonl"),
+        str(tmp_path / "rejected.jsonl"),
+        statement="SELECT record_id, repaired FROM log ORDER BY record_id",
+    ).fetchall()
+    assert found == [("0f3c", False), ("7b21", True)]
+
+
+def test_a_log_of_uuids_reads_beside_one_of_opaque_tokens(tmp_path):
+    # A client mints its own session_id. All-dashed-UUID infers as UUID and anything
+    # else infers as VARCHAR, and a read spanning both refuses to union them.
+    uuids = nl_log.JsonlSink(tmp_path / "uuids.jsonl")
+    uuids.write(nl_log.event(_ask(session_id=str(uuid.uuid4()))))
+    tokens = nl_log.JsonlSink(tmp_path / "tokens.jsonl")
+    tokens.write(nl_log.event(_ask(session_id="sess-abc123")))
+    sessions = nl_log.read(
+        str(tmp_path / "uuids.jsonl"),
+        str(tmp_path / "tokens.jsonl"),
+        statement="SELECT session_id FROM log",
+    ).fetchall()
+    assert "sess-abc123" in {row[0] for row in sessions}
+
+
+def test_an_event_read_through_two_sources_counts_once(tmp_path):
+    # Compaction leaves the objects it folded in place, so the documented glob pair
+    # reads a compacted month beside the raw days inside it. Counting an ask twice
+    # doubles every rate the log exists to report.
+    raw = tmp_path / "raw"
+    sink = nl_log.JsonlSink(raw / "day.jsonl")
+    sink.write(nl_log.event(_ask(record_id="0f3c")))
+    folded = tmp_path / "2026-08.parquet"
+    assert nl_log.compact(str(raw / "*.jsonl"), folded) == 1
+    rows = nl_log.read(
+        str(folded), str(raw / "*.jsonl"), statement="SELECT record_id FROM log"
+    ).fetchall()
+    assert rows == [("0f3c",)]
+
+
+def test_redaction_empties_what_a_person_typed_not_only_the_question(tmp_path):
+    # A thumb comment and a label note are free text the same way a question is, and
+    # emptying only the columns an ask names would leave both of them.
+    sink = nl_log.JsonlSink(tmp_path / "day.jsonl")
+    sink.write(nl_log.event(_ask(record_id="0f3c")))
+    nl_log.write(sink, nl_log.thumb("0f3c", "down", comment="reader comment text"))
+    nl_log.write(sink, nl_log.label("0f3c", "wrong", note="maintainer note text"))
+    folded = tmp_path / "2026-08.parquet"
+    nl_log.compact(str(tmp_path / "*.jsonl"), folded, redact=True)
+    written = folded.read_bytes()
+    assert b"reader comment text" not in written
+    assert b"maintainer note text" not in written
+    # The outcome and the timings still have to be there, or redaction costs the
+    # measurement it was meant to keep.
+    outcomes = nl_log.read(str(folded), statement="SELECT outcome FROM log").fetchall()
+    assert outcomes == [("answered",)]
+
+
+def test_a_day_holding_only_feedback_still_compacts(tmp_path):
+    # A real partition for a deployment where somebody left a thumb on a day nobody
+    # asked anything, so the ask columns redaction empties are not in it.
+    sink = nl_log.JsonlSink(tmp_path / "day.jsonl")
+    nl_log.write(sink, nl_log.thumb("0f3c", "down", comment="wrong solvent"))
+    folded = tmp_path / "2026-08.parquet"
+    assert nl_log.compact(str(tmp_path / "*.jsonl"), folded, redact=True) == 1
+    assert b"wrong solvent" not in folded.read_bytes()
+
+
+def test_reading_nothing_at_all_says_so(tmp_path):
+    with pytest.raises(ValueError, match="at least one glob"):
+        nl_log.read(statement="SELECT * FROM log")
+
+
+@pytest.mark.parametrize(
+    ("build", "value"),
+    [(nl_log.thumb, "Down"), (nl_log.label, "incorrect")],
+)
+def test_a_verdict_outside_the_vocabulary_is_refused(build, value):
+    # The log is append-only, so a typo can be superseded but never corrected, and a
+    # verdict spelled "Down" is invisible to every query that asks for "down".
+    with pytest.raises(ValueError, match=value):
+        build("0f3c", value)
+
+
+def test_reading_derives_the_translation_and_whether_a_repair_fired(tmp_path):
+    # Neither is stored, so a reader that cannot produce them makes the log unusable
+    # for the question it exists to answer.
+    sink = nl_log.JsonlSink(tmp_path / "log.jsonl")
+    sink.write(
+        nl_log.event(
+            _ask(
+                record_id="0f3c",
+                attempts=(
+                    nl_log.Attempt(translation={"op": "bad"}, error="no such path"),
+                    nl_log.Attempt(translation=_QUERY, error=None),
+                ),
+            )
+        )
+    )
+    sink.write(nl_log.event(_ask(record_id="7b21")))
+    rows = nl_log.read(
+        str(tmp_path / "*.jsonl"),
+        statement="SELECT record_id, repaired, translation FROM log ORDER BY record_id",
+    ).fetchall()
+    assert [(row[0], row[1]) for row in rows] == [("0f3c", True), ("7b21", False)]
+    assert json.loads(rows[0][2]) == _QUERY
+
+
+def test_a_translation_that_never_compiled_reads_as_no_translation(tmp_path):
+    sink = nl_log.JsonlSink(tmp_path / "log.jsonl")
+    sink.write(
+        nl_log.event(
+            _ask(
+                outcome=nl_log.Outcome.MALFORMED,
+                attempts=(
+                    nl_log.Attempt(translation={"op": "bad"}, error="no such path"),
+                ),
+            )
+        )
+    )
+    ((translation,),) = nl_log.read(
+        str(tmp_path / "*.jsonl"), statement="SELECT translation FROM log"
+    ).fetchall()
+    assert translation is None
+
+
+def test_compaction_leaves_a_month_readable_the_same_way(tmp_path):
+    # Two months whose queries have different shapes must still read as one table,
+    # which is what the string payload buys and what a struct would lose.
+    sink = nl_log.JsonlSink(tmp_path / "log.jsonl")
+    sink.write(nl_log.event(_ask(record_id="0f3c")))
+    sink.write(
+        nl_log.event(
+            _ask(
+                record_id="7b21",
+                attempts=(
+                    nl_log.Attempt(
+                        translation={"op": "exists", "where": {"op": "not_null"}},
+                        error=None,
+                    ),
+                ),
+            )
+        )
+    )
+    compacted = tmp_path / "2026-08.parquet"
+    nl_log.compact(str(tmp_path / "*.jsonl"), compacted)
+    rows = nl_log.read(
+        str(compacted),
+        statement="SELECT record_id, translation FROM log ORDER BY record_id",
+    ).fetchall()
+    assert [row[0] for row in rows] == ["0f3c", "7b21"]
+    assert json.loads(rows[1][1])["where"] == {"op": "not_null"}
+
+
+def _month(tmp_path, name, attempt, record_id):
+    """Writes one record, compacts it as a month of its own, and returns the file."""
+    directory = tmp_path / name
+    nl_log.JsonlSink(directory / "log.jsonl").write(
+        nl_log.event(_ask(record_id=record_id, attempts=(attempt,)))
+    )
+    compacted = tmp_path / f"{name}.parquet"
+    nl_log.compact(str(directory / "*.jsonl"), compacted)
+    return compacted
+
+
+def test_two_compacted_months_read_as_one_table(tmp_path):
+    # Each month's Parquet bakes in a schema, and these two predicates share no shape
+    # -- one nests a list of clauses, the other a quantifier over a structure
+    # predicate. As strings the two months reconcile by construction, so every field of
+    # both is reachable. Stored as structs it depends on what DuckDB can coerce, which
+    # is measured rather than guessed: see the ord-logbook entry's probe for shapes
+    # where the read either loses a field or refuses.
+    july = _month(tmp_path, "2026-07", _CONJUNCTION, "0f3c")
+    august = _month(tmp_path, "2026-08", _QUANTIFIER, "7b21")
+    rows = nl_log.read(
+        str(july),
+        str(august),
+        statement="SELECT record_id, translation FROM log ORDER BY record_id",
+    ).fetchall()
+    assert [row[0] for row in rows] == ["0f3c", "7b21"]
+    assert json.loads(rows[0][1])["clauses"][0]["path"] == "y"
+    assert json.loads(rows[1][1])["where"]["threshold"] == 0.4
+
+
+def test_compaction_can_drop_the_free_text_and_keep_everything_else(tmp_path):
+    # The free text goes and everything the analysis runs on stays, so a redacted file
+    # is still worth reading.
+    sink = nl_log.JsonlSink(tmp_path / "log.jsonl")
+    sink.write(
+        nl_log.event(
+            _ask(record_id="0f3c", question="who used pyridine", answer_text="Two.")
+        )
+    )
+    compacted = tmp_path / "2026-08.parquet"
+    nl_log.compact(str(tmp_path / "*.jsonl"), compacted, redact=True)
+    ((question, answer, outcome, row_count, translation),) = nl_log.read(
+        str(compacted),
+        statement=(
+            "SELECT question, answer_text, outcome, row_count, translation FROM log"
+        ),
+    ).fetchall()
+    assert question is None
+    assert answer is None
+    assert outcome == nl_log.Outcome.ANSWERED
+    assert row_count == 3
+    # The translation stays: it is what reproduces the rows the log does not store.
+    assert json.loads(translation) == _QUERY
+    assert "pyridine" not in compacted.read_bytes().decode("utf-8", "replace")
+
+
+def test_a_redacted_month_reads_beside_an_unredacted_one(tmp_path):
+    # Redaction empties the columns rather than dropping them, so the two tiers still
+    # have one schema and a query spanning them binds.
+    sink = nl_log.JsonlSink(tmp_path / "old" / "log.jsonl")
+    sink.write(nl_log.event(_ask(record_id="0f3c", question="an old question")))
+    old = tmp_path / "2026-07.parquet"
+    nl_log.compact(str(tmp_path / "old" / "*.jsonl"), old, redact=True)
+    recent = nl_log.JsonlSink(tmp_path / "new" / "log.jsonl")
+    recent.write(nl_log.event(_ask(record_id="7b21", question="a recent question")))
+    new = tmp_path / "2026-08.parquet"
+    nl_log.compact(str(tmp_path / "new" / "*.jsonl"), new)
+    rows = nl_log.read(
+        str(old),
+        str(new),
+        statement="SELECT record_id, question FROM log ORDER BY record_id",
+    ).fetchall()
+    assert rows == [("0f3c", None), ("7b21", "a recent question")]
+
+
+def test_a_compacted_month_and_a_loose_day_read_as_one_table(tmp_path):
+    # Compaction has to be able to arrive late, so a reader that could see only one
+    # format would force a migration the day it did.
+    compacted = _month(tmp_path, "2026-07", _CONJUNCTION, "0f3c")
+    nl_log.JsonlSink(tmp_path / "today" / "log.jsonl").write(
+        nl_log.event(_ask(record_id="7b21", attempts=(_QUANTIFIER,)))
+    )
+    rows = nl_log.read(
+        str(compacted),
+        str(tmp_path / "today" / "*.jsonl"),
+        statement="SELECT record_id, translation FROM log ORDER BY record_id",
+    ).fetchall()
+    assert [row[0] for row in rows] == ["0f3c", "7b21"]
+    assert json.loads(rows[1][1])["where"]["threshold"] == 0.4
+
+
+@pytest.fixture(name="fake_store")
+def _fake_store():
+    """An object store recording what was put, standing in for a boto3 S3 client."""
+
+    class _Store:
+        def __init__(self):
+            self.objects: dict[str, bytes] = {}
+
+        def put_object(self, *, Bucket: str, Key: str, Body: bytes) -> None:
+            self.bucket = Bucket
+            self.objects[Key] = Body
+
+    return _Store()
+
+
+def test_an_ask_records_which_surface_it_arrived_from():
+    # A served endpoint, an eval run, and a script all write to one prefix, and the
+    # published PubMed log shows what it costs to leave them mixed: hand-typed queries,
+    # bare accession lookups, and tool-generated ones sit side by side there with no
+    # way to tell them apart afterwards.
+    assert nl_log.event(_ask(source="web"))["source"] == "web"
+
+
+def test_a_run_and_a_reader_are_told_apart_by_source(tmp_path):
+    sink = nl_log.JsonlSink(tmp_path / "log.jsonl")
+    sink.write(nl_log.event(_ask(record_id="0f3c", source="web")))
+    sink.write(nl_log.event(_ask(record_id="7b21", source="eval")))
+    # Nothing states it where nothing supplies it, rather than a default that would
+    # read as a claim about where the question came from.
+    sink.write(nl_log.event(_ask(record_id="c40a")))
+    found = nl_log.read(
+        str(tmp_path / "*.jsonl"), statement="SELECT record_id, source FROM log"
+    ).fetchall()
+    assert dict(found) == {"0f3c": "web", "7b21": "eval", "c40a": None}

--- a/ord_schema/search/nl_test.py
+++ b/ord_schema/search/nl_test.py
@@ -32,7 +32,7 @@ from anthropic.types import TextBlock, ToolUseBlock
 from ord_schema import parquet
 from ord_schema.artifacts import projection, structures
 from ord_schema.proto import dataset_pb2, reaction_pb2
-from ord_schema.search import execute, nl
+from ord_schema.search import execute, nl, nl_log
 
 
 @pytest.fixture(scope="module")
@@ -138,10 +138,15 @@ def _stub(*responses) -> Any:
     return _StubClient(*responses)
 
 
-def _where(result) -> Any:
-    """Returns a translated query's predicate, which a caller has to have."""
-    assert result.where is not None
-    return result.where
+def _predicate(translated) -> Any:
+    """Returns a query's predicate, which a caller has to have."""
+    assert translated.where is not None
+    return translated.where
+
+
+def _where(translation) -> Any:
+    """Returns a translation's predicate."""
+    return _predicate(translation.query)
 
 
 def _status_error(status_code: int) -> anthropic.APIStatusError:
@@ -284,9 +289,9 @@ def test_the_summary_says_how_much_it_left_out():
 def test_the_answer_call_sees_the_summary_and_not_the_rows():
     table = pa.table({"reaction_id": [str(value) for value in range(100_000)]})
     client = _stub("A hundred thousand reactions.")
-    text = nl.answer("how many?", table, client=client)
+    described = nl.answer("how many?", table, client=client)
     sent = client.requests[0]["messages"][0]["content"]
-    assert text == "A hundred thousand reactions."
+    assert described.text == "A hundred thousand reactions."
     assert "100000 rows" in sent
     # Only the first few rows travel; a row from the middle would mean the table did.
     assert '"reaction_id": "50000"' not in sent
@@ -297,7 +302,7 @@ def test_ask_returns_the_query_it_ran(corpus):
     client = _stub({"where": _SOLVENT}, "Two reactions, both with pyridine.")
     answer = nl.ask("solvent reactions", corpus, client=client)
     assert answer.question == "solvent reactions"
-    assert _where(answer.query).op == "exists"
+    assert _predicate(answer.query).op == "exists"
     assert answer.table.num_rows == corpus.search(answer.query).num_rows
     assert answer.text == "Two reactions, both with pyridine."
 
@@ -388,4 +393,197 @@ def test_a_query_that_asks_nothing_fails_when_repair_is_off():
 def test_a_bare_limit_is_a_question_someone_asks():
     # "Show me ten reactions" needs no predicate, and the corpus is not what comes back.
     client = _stub({"limit": 10})
-    assert nl.translate("show me ten reactions", client=client).limit == 10
+    assert nl.translate("show me ten reactions", client=client).query.limit == 10
+
+
+class _CollectingSink:
+    """Keeps every record written to it, so a test can read what was logged."""
+
+    def __init__(self):
+        self.events: list[dict] = []
+
+    def write(self, event):
+        self.events.append(event)
+
+
+def test_a_translation_carries_what_it_cost():
+    # Every turn's price rides on the translation, which is what makes the cost of a
+    # question observable and the cheap-model-plus-repair question answerable.
+    client = _stub({"where": _SOLVENT})
+    translation = nl.translate("solvent reactions", client=client)
+    assert _where(translation).op == "exists"
+    assert len(translation.attempts) == 1
+    assert translation.attempts[0].usage.input == 1
+    assert translation.attempts[0].error is None
+
+
+def test_a_repaired_translation_keeps_the_query_the_compiler_refused():
+    # The rejected query and the error rejecting it are what prompt work runs on.
+    client = _stub({"where": _BAD_PATH}, {"where": _SOLVENT})
+    translation = nl.translate("solvent reactions", client=client)
+    assert len(translation.attempts) == 2
+    assert translation.attempts[0].translation == {"where": _BAD_PATH}
+    assert "identifiers" in str(translation.attempts[0].error)
+    assert translation.attempts[1].error is None
+
+
+def test_a_malformed_failure_reports_the_attempts_it_paid_for():
+    # An exception carries no return value, so without this the two turns a failed
+    # translation burned would go unrecorded -- and failures are the records worth
+    # having.
+    client = _stub({"where": _BAD_PATH}, {"where": _BAD_PATH})
+    with pytest.raises(nl.MalformedQueryError) as caught:
+        nl.translate("solvent reactions", client=client)
+    assert len(caught.value.attempts) == 2
+    assert all(attempt.error for attempt in caught.value.attempts)
+
+
+def test_ask_records_the_question_and_what_it_became(corpus):
+    sink = _CollectingSink()
+    client = _stub({"where": _SOLVENT}, "Two reactions, both with pyridine.")
+    answer = nl.ask(
+        "solvent reactions",
+        corpus,
+        client=client,
+        sink=sink,
+        source="web",
+        session_id="a91b",
+    )
+    (event,) = sink.events
+    assert event["question"] == "solvent reactions"
+    assert event["outcome"] == nl_log.Outcome.ANSWERED
+    assert event["source"] == "web"
+    assert event["session_id"] == "a91b"
+    assert event["corpus_fingerprint"] == corpus.fingerprint
+    assert event["row_count"] == answer.table.num_rows
+    # The caller needs the identifier back, or a thumb has nothing to reference.
+    assert event["record_id"] == answer.record_id
+
+
+def test_the_prompt_fingerprint_tracks_the_cached_prefix(monkeypatch):
+    # It answers "which translator wrote this" when an old record is compared against
+    # today's behavior, and it moves exactly when the cached prefix does -- so a run
+    # where it changes unexpectedly is a cache miss already paid for.
+    before = nl.prompt_fingerprint()
+    assert before == nl.prompt_fingerprint()
+    monkeypatch.setattr(nl, "SYSTEM_PROMPT", nl.SYSTEM_PROMPT + " and one more rule")
+    # Cached against the module constants, so anything replacing one has to say so;
+    # a served process digests the whole prefix once rather than once per question.
+    assert nl.prompt_fingerprint() == before
+    nl.prompt_fingerprint.cache_clear()
+    assert nl.prompt_fingerprint() != before
+    nl.prompt_fingerprint.cache_clear()
+
+
+def test_a_corpus_whose_artifacts_disagree_is_not_an_unresolved_compound(corpus):
+    # PairingError is a ValueError, and the catch-all for ValueError is the resolver's.
+    # An unresolvable compound is the question's fault and a corpus that does not pair
+    # is the deployment's, which is the distinction the taxonomy exists to keep.
+    assert (
+        nl.outcome_of(execute.PairingError("projections and structures do not pair up"))
+        is nl_log.Outcome.SEARCH_FAILED
+    )
+    assert (
+        nl.outcome_of(ValueError("cannot resolve 'unobtainium'"))
+        is nl_log.Outcome.UNRESOLVED_COMPOUND
+    )
+
+
+def test_a_question_nobody_logs_never_opens_an_artifact(corpus, monkeypatch):
+    # Reading the stamps opens a footer per artifact, half a second on a real corpus.
+    # A caller that passes no sink is not logging and must not pay for it.
+    def _refuse(self):
+        raise AssertionError("the fingerprint was read for a question nobody logs")
+
+    monkeypatch.setattr(type(corpus), "fingerprint", property(_refuse))
+    answer = nl.ask(
+        "solvent reactions", corpus, client=_stub({"where": _SOLVENT}, "Two.")
+    )
+    # And nothing hands back an id for a record that was never written: a thumb built
+    # against it would reference an ask no row carries, and read() would drop it.
+    assert answer.record_id == ""
+
+
+def test_an_unreadable_artifact_costs_the_record_not_the_answer(
+    corpus, monkeypatch, caplog
+):
+    def _fail(self):
+        raise OSError("artifact footer unreadable")
+
+    monkeypatch.setattr(type(corpus), "fingerprint", property(_fail))
+    sink = _CollectingSink()
+    answer = nl.ask(
+        "solvent reactions",
+        corpus,
+        client=_stub({"where": _SOLVENT}, "Two."),
+        sink=sink,
+    )
+    assert answer.text == "Two."
+    (event,) = sink.events
+    assert event["corpus_fingerprint"] == ""
+    assert "artifact footer unreadable" in caplog.text
+
+
+def test_a_record_names_the_translator_that_wrote_it(corpus):
+    sink = _CollectingSink()
+    client = _stub({"where": _SOLVENT}, "Two reactions.")
+    nl.ask("solvent reactions", corpus, client=client, sink=sink)
+    (event,) = sink.events
+    assert event["prompt_fingerprint"] == nl.prompt_fingerprint()
+
+
+def test_what_a_question_cost_counts_every_call_it_made(corpus):
+    # Three calls answer this one: a translation the compiler refuses, its repair, and
+    # the sentence describing the result. A total summed from the attempts alone would
+    # miss the third, and a decline would go unpriced entirely.
+    sink = _CollectingSink()
+    client = _stub({"where": _BAD_PATH}, {"where": _SOLVENT}, "Two reactions.")
+    nl.ask("solvent reactions", corpus, client=client, sink=sink)
+    (event,) = sink.events
+    assert len(json.loads(event["attempts"])) == 2
+    assert event["usage"]["input"] == 3
+
+
+def test_a_declined_question_is_priced_even_though_it_built_nothing(corpus):
+    sink = _CollectingSink()
+    client = _stub(_Refusal("values are literals, never other columns"))
+    with pytest.raises(nl.UnanswerableError):
+        nl.ask("compare two columns", corpus, client=client, sink=sink)
+    (event,) = sink.events
+    assert json.loads(event["attempts"]) == []
+    assert event["usage"]["input"] == 1
+
+
+def test_a_question_that_matched_nothing_is_recorded_as_empty(corpus):
+    sink = _CollectingSink()
+    where = {"op": "eq", "path": "reaction_id", "value": {"literal": "ord-nope"}}
+    client = _stub({"where": where}, "No reactions matched.")
+    nl.ask("reactions that do not exist", corpus, client=client, sink=sink)
+    (event,) = sink.events
+    assert event["outcome"] == nl_log.Outcome.EMPTY
+    assert event["row_count"] == 0
+
+
+def test_a_failed_ask_is_still_recorded(corpus):
+    # The failures are the records worth having, so the emit cannot sit on the path
+    # that only runs when everything worked.
+    sink = _CollectingSink()
+    client = _stub({"where": _BAD_PATH}, {"where": _BAD_PATH})
+    with pytest.raises(nl.MalformedQueryError):
+        nl.ask("solvent reactions", corpus, client=client, sink=sink)
+    (event,) = sink.events
+    assert event["outcome"] == nl_log.Outcome.MALFORMED
+    assert len(json.loads(event["attempts"])) == 2
+    assert event["row_count"] is None
+
+
+def test_a_declined_question_records_whether_a_query_came_first(corpus):
+    sink = _CollectingSink()
+    client = _stub(_Refusal("values are literals, never other columns"))
+    with pytest.raises(nl.UnanswerableError):
+        nl.ask("compare two columns", corpus, client=client, sink=sink)
+    (event,) = sink.events
+    assert event["outcome"] == nl_log.Outcome.DECLINED
+    assert event["declined_reason"] == "values are literals, never other columns"
+    # No attempt: the model read the question rather than backing off after a refusal.
+    assert json.loads(event["attempts"]) == []


### PR DESCRIPTION
## Summary

`ord_schema.search.nl` answers a question and keeps nothing, so the questions people ask — the only material that can refine the prompt, the grammar, and the eval set — are discarded as fast as they arrive. This records them: an append-only stream of JSON events where an `ask` written by the library, a `thumb` a reader leaves, and a `label` a maintainer applies share a `record_id`, because they are three assertions by three parties at three times and one mutable row would lose which was which.

Results are not stored; a translation plus a corpus fingerprint reproduce them. Every ending is recorded rather than only the successful one — a question that matched nothing, that the compiler refused twice, or that the model declined are the records worth reading, and a log written on the success path holds none of them.

Nothing is recorded until a caller opts in: `ask()` without a sink records nothing, and no bucket name lives in this package — a deployment hands `S3Sink` its own client and bucket, and not passing one is the whole off switch.

The design and the measurement behind the record's shape are in [ord-logbook#46](https://github.com/open-reaction-database/ord-logbook/pull/46).

## Changes

- `nl_log.py`: the record, a one-method `Sink` protocol with file/stdout/object implementations, a reader that folds verdicts onto their asks, and `compact()`. `nl_log.write()` is the single path every event takes, so an unreachable sink costs the record rather than the answer for all three kinds.
- Every model-authored payload is a string — the whole `attempts` list, not only the query inside it — and identifiers are hex rather than dashed UUIDs. Both are so that no source can infer a type another source contradicts: a month where everything compiled carries `"error": null` throughout, and a client's UUID `session_id`s infer `UUID` against another's `VARCHAR`.
- `read()` folds each verdict through one `arg_max` as a whole struct, since `arg_max` skips a NULL and per-field aggregates answer from different events. It counts an event once however many sources carry it, so a compacted month reads beside the raw days inside it.
- `compact()` empties every free-text column under `redact`, and a day holding only feedback compacts rather than failing to bind.
- `translate()` returns a `Translation` carrying every `build_query` call with the compiler's verdict and the tokens that turn spent; `NLQueryError` carries the same, since a record is most worth having when translation failed and an exception has no return value.
- `ask()` takes a `sink` and a `session_id` and returns a `record_id` — empty where nothing was logged, so a thumb can never reference an ask no row carries.
- `Corpus.fingerprint` from the stamps pairing already read to verify the artifacts, and `nl.prompt_fingerprint()` over the cached prefix, digested once per process.
- `execute.PairingError` is a `ValueError`, so it is placed ahead of the resolver's catch-all: an unresolvable compound is the question's fault and a corpus that does not pair is the deployment's.
- `nl_eval` records its cases, with `--log`; one run is one session, and a case whose search fails costs that case rather than the run.
- `UnanswerableError.attempted` reads off the attempts instead of being stored beside them.

## Testing

- `uv run pytest -n auto`: 1397 passed. The `ord_schema/orm` suite needs `initdb` on `PATH` (conda env) or it errors out; with it, everything passes.
- Each schema claim is pinned by a test that reads two sources which would otherwise refuse to union: a month of clean attempts beside one holding a rejection, and a log of UUIDs beside one of opaque tokens.
- Coverage for the parts that are easy to get quietly wrong: every outcome writes the same keys, a stage that never ran is a null rather than a missing key, an event read through two sources counts once, a failing sink never fails the question, a later verdict does not inherit the field it left empty, a question nobody logs opens no artifact, and each artifact's stamps are read once.
- `event()` was written ahead of its tests, so each of its remaining tests was proven by mutating the implementation and confirming the break was caught, rather than assumed green.

## Notes

- Nothing here names a bucket — `S3Sink` takes the object store rather than building one, so no boto3 dependency and no new extra. Provisioning a bucket, a task role, and a lifecycle rule is ord-infrastructure work; this PR is the mechanism only.
- A rate limit or an unreachable model is deliberately not recorded by the eval harness: the measurement did not happen, and a record would read as a translation that went wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds opt-in, append-only logging for natural-language search questions, translations, outcomes, feedback, and labels.

- Adds JSONL, stdout, and object-store sinks plus DuckDB-based reading and compaction.
- Records translation attempts and failure outcomes while preserving normal search behavior when logging fails.
- Adds corpus and prompt fingerprints and integrates logging into the evaluation harness.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/nl_log.py | Adds the event model, best-effort sinks, unique event object keys, atomic latest-verdict folding, mixed-source reading, and compaction. |
| ord_schema/search/nl.py | Carries translation attempts through success and failure paths and optionally emits complete ask records without making logging part of answer availability. |
| ord_schema/search/execute.py | Adds a deterministic corpus fingerprint derived from the stamps already read while pairing artifacts. |
| ord_schema/search/nl_eval.py | Adds optional evaluation-run logging under a shared session identifier. |
| ord_schema/search/nl_log_test.py | Covers event-key uniqueness, latest-event folding, null-field replacement, deduplication, compaction, redaction, and mixed JSON/Parquet reads. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant NL as nl.ask
    participant Corpus
    participant Sink
    participant Reader as nl_log.read
    Caller->>NL: question, optional sink/session_id
    NL->>NL: translate and retain attempts
    NL->>Corpus: execute structured query
    Corpus-->>NL: result or error outcome
    NL-->>Sink: ask event with unique event_id
    NL-->>Caller: answer with record_id
    Caller-->>Sink: thumb/label sharing record_id
    Reader->>Sink: read raw/compacted events
    Reader->>Reader: deduplicate event_id and fold latest verdict
    Reader-->>Caller: one row per ask
```
</details>

<sub>Reviews (10): Last reviewed commit: ["Keep every question, and the query it be..."](https://github.com/open-reaction-database/ord-schema/commit/3e39c314088f14d30e484f37f93bd45ec86e6376) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55906824)</sub>

<!-- /greptile_comment -->