### PR TITLE
Refuse a corpus whose pivots are not all there

### DIFF
--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -821,7 +821,9 @@ class Corpus:
                 level, rather than building the missing ones in memory on the query
                 that first wants one. Needs a ``pivots_dir``. What it costs is a footer
                 read per artifact at startup; what it buys is that no query pays for an
-                unnest nobody meant to run.
+                unnest nobody meant to run. It leaves ``pivot_budget_bytes`` with
+                nothing to govern -- every level is read rather than built -- so the two
+                together are a contradiction rather than a belt and braces.
             derive_pivots: Write the artifact for a level that has none, rather than
                 building the level in memory. Needs a writable ``pivots_dir``. The pass
                 costs what building in memory costs, and once, since the next process
@@ -846,7 +848,9 @@ class Corpus:
             PairingError: If either pattern matches nothing, a file on one side has no
                 partner on the other, a pair's stamps disagree about the source
                 dataset, or -- with ``require_current`` -- any artifact is stale.
-            ValueError: If ``pivot_budget_bytes`` is negative, which no amount of
+            ValueError: If ``require_pivots`` is set beside a ``pivot_budget_bytes``,
+                which budgets for a build it rules out. If ``pivot_budget_bytes`` is
+                negative, which no amount of
                 memory is; zero is allowed, and materializes nothing; or if
                 ``derive_pivots`` or ``require_pivots`` is set without a
                 ``pivots_dir``.
@@ -857,17 +861,31 @@ class Corpus:
                 f"pivot_budget_bytes is {pivot_budget_bytes}, which is not an amount "
                 "of memory; pass zero to materialize nothing"
             )
+        if require_pivots and pivot_budget_bytes is not None:
+            raise ValueError(
+                "require_pivots leaves no pivot to build in memory, so a "
+                "pivot_budget_bytes beside it budgets for something that cannot "
+                "happen; pass one or the other"
+            )
+        # Zero where every level is read: nothing reaches the builder to be budgeted.
         self._pivot_budget = (
-            pivot_budget_bytes
-            if pivot_budget_bytes is not None
-            else _PIVOT_BUDGET_BYTES
+            0
+            if require_pivots
+            else (
+                pivot_budget_bytes
+                if pivot_budget_bytes is not None
+                else _PIVOT_BUDGET_BYTES
+            )
         )
         # Said at open because the alternative is saying it nowhere: a process killed
         # for holding too much leaves no log of its own, and what it thought it was
         # allowed to hold is the first thing worth knowing afterwards.
-        logger.info(
-            "pivots built in process may hold %s", _format_bytes(self._pivot_budget)
-        )
+        if require_pivots:
+            logger.info("every pivot is read from %s, and none is built", pivots_dir)
+        else:
+            logger.info(
+                "pivots built in process may hold %s", _format_bytes(self._pivot_budget)
+            )
         self._threads = threads
         # Built on first substructure query; see _library. The library holds one entry
         # per distinct molecule, and _members with _starts map an entry back to the

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -779,6 +779,7 @@ class Corpus:
         pivot_budget_bytes: int | None = None,
         pivots_dir: str | None = None,
         derive_pivots: bool = False,
+        require_pivots: bool = False,
         memory_limit: str | None = None,
     ) -> None:
         """Pairs the artifacts, checks their stamps, and prepares the relations.
@@ -816,6 +817,11 @@ class Corpus:
                 milliseconds of the built ones. A level with no subdirectory is still
                 built in process, so a partial set of artifacts is a partial speedup
                 rather than a missing answer.
+            require_pivots: Refuse a corpus whose ``pivots_dir`` does not hold every
+                level, rather than building the missing ones in memory on the query
+                that first wants one. Needs a ``pivots_dir``. What it costs is a footer
+                read per artifact at startup; what it buys is that no query pays for an
+                unnest nobody meant to run.
             derive_pivots: Write the artifact for a level that has none, rather than
                 building the level in memory. Needs a writable ``pivots_dir``. The pass
                 costs what building in memory costs, and once, since the next process
@@ -842,7 +848,8 @@ class Corpus:
                 dataset, or -- with ``require_current`` -- any artifact is stale.
             ValueError: If ``pivot_budget_bytes`` is negative, which no amount of
                 memory is; zero is allowed, and materializes nothing; or if
-                ``derive_pivots`` is set without a ``pivots_dir`` to derive into.
+                ``derive_pivots`` or ``require_pivots`` is set without a
+                ``pivots_dir``.
         """
         self._resolver = resolver if resolver is not None else _resolve_with_resolvers
         if pivot_budget_bytes is not None and pivot_budget_bytes < 0:
@@ -903,6 +910,11 @@ class Corpus:
                 "derive_pivots was set without a pivots_dir, so there is nowhere to "
                 "write what it would derive"
             )
+        if require_pivots and pivots_dir is None:
+            raise ValueError(
+                "require_pivots was set without a pivots_dir, so there is nowhere to "
+                "look for what it would require"
+            )
         pairs, self._fingerprint = _pair(
             projection_pattern, structures_pattern, require_current
         )
@@ -925,6 +937,8 @@ class Corpus:
             _cache_footers(self._connection)
             _warn_when_the_cap_leaves_no_headroom(self._connection)
             self._total, self._searchable = self._prepare(pairs)
+            if require_pivots:
+                self._require_every_pivot()
         except Exception:
             # Nothing else holds the connection yet, and the caller has no object to
             # close one from if __init__ does not return.
@@ -1024,6 +1038,29 @@ class Corpus:
         not.
         """
         return self._fingerprint
+
+    def _require_every_pivot(self) -> None:
+        """Refuses a corpus whose pivots_dir does not hold every level, current.
+
+        ``check_pivots`` reports what is held; this insists. A level with no artifacts
+        is otherwise built in process on the query that first wants it, which is
+        minutes of unnesting charged to whoever asked and no error anywhere -- the
+        failure a caller naming a pivots_dir is least likely to be expecting, since
+        naming one says the artifacts are meant to answer.
+
+        Raises:
+            PairingError: If any level has no artifacts. Wrong provenance, a level
+                filed under another, and staleness are raised by the publishing itself.
+        """
+        missing = [
+            path for path in sorted(pivot.LEVELS) if self._pivot_view(path) is None
+        ]
+        if missing:
+            raise PairingError(
+                f"{self._pivots_dir} holds no pivot artifacts for {missing}, which "
+                "this corpus was opened requiring; derive them first with "
+                "ord_schema.artifacts.scripts.derive_pivots"
+            )
 
     def check_pivots(self) -> dict[str, int]:
         """Publishes every pivot artifact this corpus can read, and returns the counts.

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -3264,6 +3264,22 @@ def test_requiring_pivots_without_a_directory_says_so(wide_root):
         )
 
 
+def test_requiring_pivots_and_budgeting_for_one_is_refused(wide_root, tmp_path):
+    # Requiring every level leaves nothing to build, so a budget beside it is money set
+    # aside for something that cannot happen -- more likely a misunderstanding of one
+    # of the two than a deliberate pairing.
+    pivots = _write_pivots(wide_root, ("outcomes.products",), into=tmp_path / "pivots")
+    with pytest.raises(ValueError, match="pass one or the other"):
+        execute.Corpus(
+            str(wide_root / "projections" / "*.parquet"),
+            str(wide_root / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(pivots),
+            require_pivots=True,
+            pivot_budget_bytes=0,
+        )
+
+
 def test_requiring_pivots_opens_a_corpus_holding_every_level(wide_root, tmp_path):
     # Its own directory: this is the one tree holding every level, and the tests below
     # are about what happens when a level is missing from the shared one.

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -22,7 +22,7 @@ import re
 import shutil
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 
 import duckdb
 import pyarrow as pa
@@ -3155,14 +3155,27 @@ def test_a_pivot_holds_every_element_including_an_empty_one(wide_corpus):
     assert absent == (0,)
 
 
-def _write_pivots(root: pathlib.Path, levels: tuple[str, ...]) -> pathlib.Path:
+def _write_pivots(
+    root: pathlib.Path,
+    levels: Sequence[str],
+    into: pathlib.Path | None = None,
+) -> pathlib.Path:
     """Derives pivot artifacts for ``levels`` from every projection under ``root``.
 
     Written under ``<level>/<shard>/`` rather than directly under the level, because
     that is where ``derive_pivots`` puts them: it mirrors the projections' own layout,
     and a helper that flattened it would test a tree nothing produces.
+
+    Args:
+        root: Holds the projections to derive from.
+        levels: Which repeated levels to write.
+        into: Where to write, defaulting to ``<root>/pivots``. A test wanting a tree
+            nothing else sees passes its own, since ``root`` is shared by the module.
+
+    Returns:
+        The directory written into.
     """
-    pivots = root / "pivots"
+    pivots = into if into is not None else root / "pivots"
     for level in levels:
         for projected in sorted((root / "projections").glob("*.parquet")):
             shard = pivots / level / projected.stem[-2:]
@@ -3225,6 +3238,44 @@ def test_a_pivot_artifact_is_read_rather_than_built(wide_root, caplog):
     messages = [record.message for record in caplog.records]
     assert any("read 1 pivot artifacts" in message for message in messages)
     assert not any("building the pivot" in message for message in messages)
+
+
+def test_requiring_pivots_refuses_a_level_with_no_artifacts(wide_root):
+    # The silent case: a missing level is otherwise unnested in process on the query
+    # that first wants it, minutes charged to whoever asked with no error anywhere.
+    pivots = _write_pivots(wide_root, ("outcomes.products",))
+    with pytest.raises(execute.PairingError, match="holds no pivot artifacts"):
+        execute.Corpus(
+            str(wide_root / "projections" / "*.parquet"),
+            str(wide_root / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(pivots),
+            require_pivots=True,
+        )
+
+
+def test_requiring_pivots_without_a_directory_says_so(wide_root):
+    with pytest.raises(ValueError, match="nowhere to look"):
+        execute.Corpus(
+            str(wide_root / "projections" / "*.parquet"),
+            str(wide_root / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            require_pivots=True,
+        )
+
+
+def test_requiring_pivots_opens_a_corpus_holding_every_level(wide_root, tmp_path):
+    # Its own directory: this is the one tree holding every level, and the tests below
+    # are about what happens when a level is missing from the shared one.
+    pivots = _write_pivots(wide_root, sorted(pivot.LEVELS), into=tmp_path / "pivots")
+    with execute.Corpus(
+        str(wide_root / "projections" / "*.parquet"),
+        str(wide_root / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        pivots_dir=str(pivots),
+        require_pivots=True,
+    ) as corpus:
+        assert _search(corpus, _white("exists"))
 
 
 def test_a_level_without_artifacts_is_still_built(wide_root, caplog):


### PR DESCRIPTION
## Summary

A level with no artifacts under `pivots_dir` is built in process on the query that first wants it. On the full corpus that is minutes of unnesting charged to whoever happened to ask, and no error anywhere — the failure a caller naming a `pivots_dir` is least likely to expect, since naming one says the artifacts are meant to answer. `require_pivots` makes absence refuse at construction instead.

Found while pointing an eval run at a pivots directory: it silently rebuilt `outcomes.products.measurements` for five minutes before I noticed the artifacts were stale.

## Changes

- `Corpus(..., require_pivots=True)` raises `PairingError` naming the levels with no artifacts, and `ValueError` when set without a `pivots_dir`.
- It leaves `pivot_budget_bytes` nothing to govern, since every level is read rather than built, so passing both is refused and the log line at open says which arrangement the process is in.
- Wrong provenance, a level filed under another, and staleness were already refused by the publishing itself; this adds the one case that was silent.
- `_write_pivots` in the tests takes an `into` directory, so a test wanting every level does not leave artifacts in the tree the module shares.

## Testing

- `uv run pytest -n auto`: 1401 passed.
- New coverage: a missing level refuses, a directory holding every level opens, `require_pivots` without a `pivots_dir` says so, and a budget beside it is refused.
- Measured against the local 53-dataset corpus: about 0.7s per level at startup, against the multi-minute in-memory build it replaces.

## Notes

- `check_pivots()` stays as it is — it reports what is held, which is what a deployment wanting a partial set needs. This is the stricter question, asked at construction.
- `pivots_dir` stays optional: `check_corpus` opens a corpus without one by design, since pivots are derived from the projections it validates and requiring them would invert that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an opt-in startup check that refuses a corpus unless its pivot directory contains valid artifacts for every repeated level.
- Introduces the `require_pivots` constructor option and validates incompatible or missing configuration.
- Publishes and validates every required pivot during corpus initialization.
- Adds tests for missing, complete, and invalid pivot configurations and isolates test artifact directories.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/execute.py | Adds strict pivot-completeness validation during corpus construction and rejects contradictory configuration. |
| ord_schema/search/execute_test.py | Covers required-pivot success and failure cases while allowing pivot fixtures to use isolated output directories. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Leave the budget nothing to govern"](https://github.com/open-reaction-database/ord-schema/commit/6605245f565979c9d503287dcb3319bfb444323d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57327662)</sub>

<!-- /greptile_comment -->