### PR TITLE
Count a level before unnesting it

### DIFF
--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -380,12 +380,15 @@ class FileIdentity(NamedTuple):
     """What tells one version of a file from another, without reading it.
 
     Attributes:
+        device: The filesystem the file sits on, which is what makes the inode mean
+            anything: inode numbers are unique per device, not across them.
         inode: The file's inode, which an atomic replacement changes; atomic_io writes
             a sibling and renames over the destination, so every publication is one.
         size: Size in bytes.
         modified: Modification time in nanoseconds.
     """
 
+    device: int
     inode: int
     size: int
     modified: int
@@ -398,33 +401,33 @@ def file_identity(source: str | os.PathLike[str]) -> FileIdentity:
         source: Path to the file.
 
     Returns:
-        Its inode, size, and modification time.
+        Its device, inode, size, and modification time.
 
     Raises:
         OSError: If ``source`` cannot be stat'ed.
     """
     status = pathlib.Path(source).stat()
-    return FileIdentity(status.st_ino, status.st_size, status.st_mtime_ns)
+    return FileIdentity(
+        status.st_dev, status.st_ino, status.st_size, status.st_mtime_ns
+    )
 
 
 @dataclasses.dataclass(frozen=True)
 class Counts(Mapping[str, int]):
     """How many elements a projection records at each of several levels.
 
-    Carries the identity of the file the counts were read from, which is what lets the
-    build that unnests check that it is unnesting what was counted. A count of zero is
-    the answer nothing downstream can contradict -- it skips the unnest, so the check
-    against the rows produced has nothing to disagree with -- and an empty pivot does
-    not merely lose the matches an ``exists`` would find, it makes every ``forall``
-    over the level vacuously true of every reaction in the corpus.
+    A read-only mapping of level to count, carrying the identity of the file they were
+    read from -- which is what lets the build that unnests check that it is unnesting
+    what was counted. A count of zero is the answer nothing downstream can contradict:
+    it skips the unnest, so the check against the rows produced has nothing to disagree
+    with, and the empty pivot that follows costs what this module's docstring describes.
 
     Handed out whole rather than as a number the caller pairs up itself, because a
     caller holding a bare count and a bare identity can pass an honest count of one
-    level against an honest identity of the file, for a different level entirely.
-
-    A mapping of level to count, taken as read-only through a proxy: one build shares
-    a projection's counts across every level it derives, so a caller writing through
-    one level's handle would be answering for the rest of the run.
+    level against an honest identity of the file, for a different level entirely. Held
+    behind a proxy for the same reason one step on: a build shares a projection's counts
+    across every level it derives, so a write through one level's handle would be
+    answering for the rest of the run.
 
     Attributes:
         identity: The file the counts were read from, as it stood across the read.
@@ -460,6 +463,40 @@ class Counts(Mapping[str, int]):
     def __len__(self) -> int:
         """Returns how many levels these counts cover."""
         return len(self.at)
+
+    def __hash__(self) -> int:
+        """Returns a hash over the file and the counts, which do not change.
+
+        Defined because a frozen dataclass advertises hashability, and the generated
+        one reaches the mapping and raises for it -- naming the mapping's type rather
+        than this one, to a caller who asked about this one.
+        """
+        return hash((self.identity, tuple(self.at.items())))
+
+
+def artifact_paths(
+    pivots_dir: str | os.PathLike[str], level_path: str
+) -> list[pathlib.Path]:
+    """Returns the artifacts a reader finds for one level, in a stable order.
+
+    The one definition of what a level's artifacts are. A build that judges its own
+    output by a wider rule than a reader applies calls a tree healthy that no query can
+    read: the level then has no artifacts as far as the corpus is concerned, and every
+    quantifier over it falls back to unnesting the projection, or is refused.
+
+    Recursive, because a pivot tree mirrors the projections it was derived from: a
+    sharded corpus puts them under ``<level>/<shard>/`` rather than directly under the
+    level. Named rather than stamped, so listing a level costs no reads -- and so a
+    build writing anything else has written something nothing here will find.
+
+    Args:
+        pivots_dir: The directory the levels sit under.
+        level_path: The level, as the query grammar names it.
+
+    Returns:
+        The paths, sorted. Empty if the level has no directory at all.
+    """
+    return sorted(pathlib.Path(pivots_dir).joinpath(level_path).rglob("*.parquet"))
 
 
 def _check_projection(source: str | os.PathLike[str]) -> base.Stamps:

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -371,6 +371,32 @@ def pivot_path(path: str | os.PathLike[str]) -> str | None:
     return value.decode() if value is not None else None
 
 
+def count_expression(level: RepeatedLevel) -> str:
+    """Returns SQL counting the elements a projection records at ``level``.
+
+    Reads list offsets rather than element bodies: ``len`` needs to know how long a
+    list is, not what is in it, so this touches a fraction of what unnesting the level
+    would. Most levels of this schema are never recorded, and discovering that by
+    unnesting costs a full pass over every ancestor.
+
+    Args:
+        level: The level to count.
+
+    Returns:
+        A scalar expression over the reactions relation, zero where nothing is
+        recorded. Flattened at each step, so the count is of elements rather than of
+        the lists holding them.
+    """
+    expression = level.steps[0].expression(None)
+    for depth, step in enumerate(level.steps[1:], start=1):
+        element = f"e{depth}"
+        expression = (
+            f"flatten(list_transform({expression}, "
+            f"{element} -> {step.expression(element)}))"
+        )
+    return f"coalesce(sum(len({expression})), 0)"
+
+
 def write_pivot(
     source: str | os.PathLike[str],
     output: str | os.PathLike[str],
@@ -444,6 +470,20 @@ def write_pivot(
         # Through the relational API rather than a path interpolated into SQL, which a
         # filename holding a quote would otherwise close.
         connection.read_parquet(str(pathlib.Path(source))).create_view("reactions")
+        # S608: the expression is this module's own walk of the projection schema.
+        counted = connection.execute(
+            f"SELECT {count_expression(level)} FROM reactions"  # noqa: S608
+        ).fetchone()
+        if counted is not None and not counted[0]:
+            # Counting read the offsets; unnesting would have walked every ancestor of
+            # a level this projection never records, to arrive at the same nothing.
+            with (
+                atomic_io.atomic_path(output) as temp_path,
+                pq.ParquetWriter(temp_path, target, compression=compression),
+            ):
+                pass
+            logger.info("%s: no elements at %s", source, level_path)
+            return 0
         result = connection.execute(select(level, "reactions"))
         with (
             atomic_io.atomic_path(output) as temp_path,

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -45,7 +45,6 @@ reaction in the corpus. See ``Counts``.
 """
 
 import dataclasses
-import glob
 import os
 import pathlib
 import types
@@ -473,41 +472,6 @@ class Counts(Mapping[str, int]):
         than this one, to a caller who asked about this one.
         """
         return hash((self.identity, frozenset(self.at.items())))
-
-
-def artifact_paths(
-    pivots_dir: str | os.PathLike[str], level_path: str
-) -> list[pathlib.Path]:
-    """Returns the artifacts a reader finds for one level, in a stable order.
-
-    The one definition of what a level's artifacts are. A build that judges its own
-    output by a wider rule than a reader applies calls a tree healthy that no query can
-    read: the level then has no artifacts as far as the corpus is concerned, and every
-    quantifier over it falls back to unnesting the projection, or is refused.
-
-    Recursive, because a pivot tree mirrors the projections it was derived from: a
-    sharded corpus puts them under ``<level>/<shard>/`` rather than directly under the
-    level. Named rather than stamped, so listing a level costs no reads -- and so a
-    build writing anything else has written something nothing here will find.
-
-    Through ``glob``, which descends a symlinked shard directory and passes over a
-    file whose name begins with a dot. Both matter: a deployment is free to put a shard
-    on other storage and link it into place, and the tree may sit on a filesystem whose
-    tools leave dotted siblings of their own. It is also how the projections and
-    structures beside these are found, so one corpus cannot read part of itself.
-
-    Args:
-        pivots_dir: The directory the levels sit under.
-        level_path: The level, as the query grammar names it.
-
-    Returns:
-        The paths, sorted. Empty if the level has no directory at all.
-    """
-    directory = pathlib.Path(pivots_dir) / level_path
-    return sorted(
-        pathlib.Path(found)
-        for found in glob.glob(f"{directory}/**/*.parquet", recursive=True)
-    )
 
 
 def _check_projection(source: str | os.PathLike[str]) -> base.Stamps:

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -45,6 +45,7 @@ reaction in the corpus. See ``Counts``.
 """
 
 import dataclasses
+import glob
 import os
 import pathlib
 import types
@@ -471,7 +472,7 @@ class Counts(Mapping[str, int]):
         one reaches the mapping and raises for it -- naming the mapping's type rather
         than this one, to a caller who asked about this one.
         """
-        return hash((self.identity, tuple(self.at.items())))
+        return hash((self.identity, frozenset(self.at.items())))
 
 
 def artifact_paths(
@@ -489,6 +490,12 @@ def artifact_paths(
     level. Named rather than stamped, so listing a level costs no reads -- and so a
     build writing anything else has written something nothing here will find.
 
+    Through ``glob``, which descends a symlinked shard directory and passes over a
+    file whose name begins with a dot. Both matter: a deployment is free to put a shard
+    on other storage and link it into place, and the tree may sit on a filesystem whose
+    tools leave dotted siblings of their own. It is also how the projections and
+    structures beside these are found, so one corpus cannot read part of itself.
+
     Args:
         pivots_dir: The directory the levels sit under.
         level_path: The level, as the query grammar names it.
@@ -496,7 +503,11 @@ def artifact_paths(
     Returns:
         The paths, sorted. Empty if the level has no directory at all.
     """
-    return sorted(pathlib.Path(pivots_dir).joinpath(level_path).rglob("*.parquet"))
+    directory = pathlib.Path(pivots_dir) / level_path
+    return sorted(
+        pathlib.Path(found)
+        for found in glob.glob(f"{directory}/**/*.parquet", recursive=True)
+    )
 
 
 def _check_projection(source: str | os.PathLike[str]) -> base.Stamps:
@@ -576,7 +587,7 @@ def _count_within(steps: Sequence[Step], source: str | None, depth: int = 0) -> 
     return f"coalesce(list_sum(list_transform({reached}, {element} -> {inner})), 0)"
 
 
-def count_expression(level: RepeatedLevel) -> str:
+def _count_expression(level: RepeatedLevel) -> str:
     """Returns SQL counting the elements a projection records at ``level``.
 
     Cheaper than unnesting the level, because it does not cross-join a row against its
@@ -617,7 +628,7 @@ def _count_view(
     """
     if not level_paths:
         return {}
-    counts = ", ".join(count_expression(LEVELS[path]) for path in level_paths)
+    counts = ", ".join(_count_expression(LEVELS[path]) for path in level_paths)
     # S608: every fragment is this module's own walk of the projection schema, and the
     # view is this module's own name for the relation it just created.
     row = connection.execute(f"SELECT {counts} FROM {view}").fetchone()  # noqa: S608

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -45,7 +45,8 @@ the elements that match something never can.
 import dataclasses
 import os
 import pathlib
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
+from typing import NamedTuple
 
 import duckdb
 import inflection
@@ -372,25 +373,74 @@ def pivot_path(path: str | os.PathLike[str]) -> str | None:
     return value.decode() if value is not None else None
 
 
-def file_identity(source: str | os.PathLike[str]) -> tuple[int, int, int]:
-    """Returns what tells one version of a file from another, cheaply.
+class FileIdentity(NamedTuple):
+    """What tells one version of a file from another, without reading it.
 
-    A count is only the answer for the bytes it was taken over, and a caller that
-    counts and then writes does the two against separate opens. This is what the two
-    ends compare so a file replaced in between is caught -- including by the pivot
-    whose count came out zero, which is otherwise unfalsifiable, since it skips the
-    unnest that would have contradicted it.
+    Attributes:
+        inode: The file's inode, which an atomic replacement changes; atomic_io writes
+            a sibling and renames over the destination, so every publication is one.
+        size: Size in bytes.
+        modified: Modification time in nanoseconds.
+    """
+
+    inode: int
+    size: int
+    modified: int
+
+
+def file_identity(source: str | os.PathLike[str]) -> FileIdentity:
+    """Returns the identity of the file at ``source``.
 
     Args:
         source: Path to the file.
 
     Returns:
-        Inode, size, and modification time in nanoseconds. Not a hash: this is asked
-        once per artifact on the path where a hash would mean reading the file again,
-        and a rewrite that preserves all three is not the accident this guards.
+        Its inode, size, and modification time.
+
+    Raises:
+        OSError: If ``source`` cannot be stat'ed.
     """
     status = pathlib.Path(source).stat()
-    return status.st_ino, status.st_size, status.st_mtime_ns
+    return FileIdentity(status.st_ino, status.st_size, status.st_mtime_ns)
+
+
+@dataclasses.dataclass(frozen=True)
+class Counts:
+    """How many elements a projection records at each of several levels.
+
+    Carries the identity of the file the counts were read from, which is what lets the
+    build that unnests check that it is unnesting what was counted. A count of zero is
+    the answer nothing downstream can contradict -- it skips the unnest, so the check
+    against the rows produced has nothing to disagree with -- and an empty pivot does
+    not merely lose the matches an ``exists`` would find, it makes every ``forall``
+    over the level vacuously true of every reaction in the corpus.
+
+    Handed out whole rather than as a number the caller pairs up itself, because a
+    caller holding a bare count and a bare identity can pass an honest count of one
+    level against an honest identity of the file, for a different level entirely.
+
+    Attributes:
+        identity: The file the counts were read from, as it stood across the read.
+        at: The count per level, in the order asked.
+    """
+
+    identity: FileIdentity
+    at: Mapping[str, int]
+
+    def __getitem__(self, level_path: str) -> int:
+        """Returns the count at ``level_path``.
+
+        Args:
+            level_path: A level these counts were asked for.
+
+        Returns:
+            How many elements the projection records there.
+
+        Raises:
+            KeyError: If these counts do not cover ``level_path``, rather than an
+                answer about some other level.
+        """
+        return self.at[level_path]
 
 
 def _check_projection(source: str | os.PathLike[str]) -> base.Stamps:
@@ -513,14 +563,21 @@ def _count_view(
     row = connection.execute(f"SELECT {counts} FROM {view}").fetchone()  # noqa: S608
     assert row is not None  # An aggregate with no GROUP BY yields exactly one row.
     # The aggregates come back in the order they were selected, which is the order the
-    # levels were asked in; int() is exact because every term is a list length, so the
-    # sum types as an integer and nothing here can arrive fractional and floor.
-    return dict(zip(level_paths, (int(value) for value in row), strict=True))
+    # levels were asked in.
+    counted = {}
+    for level_path, value in zip(level_paths, row, strict=True):
+        if value is None:
+            # Every aggregate is wrapped in coalesce, so this is unreachable by the
+            # expressions this module builds. Named rather than left to int(), whose
+            # TypeError says nothing about which file or which level produced it.
+            raise ValueError(f"counting {level_path} over {view} yielded no answer")
+        # Exact: every term is a list length, so the sum types as an integer and
+        # nothing here arrives fractional to be floored.
+        counted[level_path] = int(value)
+    return counted
 
 
-def count_levels(
-    source: str | os.PathLike[str], level_paths: Iterable[str]
-) -> dict[str, int]:
+def count_levels(source: str | os.PathLike[str], level_paths: Iterable[str]) -> Counts:
     """Returns how many elements a projection records at each of ``level_paths``.
 
     One query carrying one aggregate per level, because the count reads the same
@@ -532,20 +589,31 @@ def count_levels(
         level_paths: The levels to count, as the query grammar names them.
 
     Returns:
-        The count per level, in the order asked.
+        The counts, carrying the identity of the file they were read from. The identity
+        is taken on both sides of the read and must agree, so a projection replaced
+        while it was being counted yields no counts rather than counts of two files.
 
     Raises:
-        ValueError: If ``source`` is not a current projection, or if any path is not a
-            repeated level of the projection schema, or if one is named twice.
+        ValueError: If ``source`` is not a current projection, if any path is not a
+            repeated level of the projection schema, if one is named twice, or if
+            ``source`` was replaced while it was being counted.
+        OSError: If ``source`` cannot be stat'ed.
     """
     wanted = check_levels(level_paths)
     _check_projection(source)
+    before = file_identity(source)
     connection = duckdb.connect()
     try:
         connection.read_parquet(str(pathlib.Path(source))).create_view("reactions")
-        return _count_view(connection, "reactions", wanted)
+        counted = _count_view(connection, "reactions", wanted)
     finally:
         connection.close()
+    if file_identity(source) != before:
+        raise ValueError(
+            f"{source} was replaced while it was being counted; the counts describe "
+            "no one version of it"
+        )
+    return Counts(before, counted)
 
 
 def write_pivot(
@@ -558,8 +626,7 @@ def write_pivot(
     source_dataset_id: str | None = None,
     compression: str = "zstd",
     row_group_size: int = 100_000,
-    element_count: int | None = None,
-    counted_over: tuple[int, int, int] | None = None,
+    counts: Counts | None = None,
 ) -> int:
     """Derives a pivot artifact over one repeated level and writes it.
 
@@ -583,25 +650,24 @@ def write_pivot(
         compression: Parquet codec, any name ``pq.ParquetWriter`` accepts.
         row_group_size: Rows per output row group, which is also how many elements are
             held in memory at a time.
-        element_count: How many elements this level holds, where the caller has already
+        counts: What ``count_levels`` read off ``source``, where the caller has already
             counted. Counted here when omitted. A build deriving every level counts
             them together, since one query answers for all of them at the cost of
-            reading the projection once. Requires ``counted_over``, because a count
-            says nothing without the bytes it was taken over.
-        counted_over: ``file_identity(source)`` as it stood when ``element_count`` was
-            taken, which is checked against ``source`` as it stands now. This is what
-            makes a count of zero falsifiable: a nonzero count is checked against the
-            unnest afterwards, but a zero skips the unnest and would leave nothing to
-            contradict it. Required with ``element_count`` and meaningless without it.
+            reading the projection once. The level's own count is taken from these
+            rather than passed alongside them, and the identity they carry is checked
+            against ``source``: a count of zero skips the unnest, so unlike a nonzero
+            one it is never checked against the rows produced, and this is what stands
+            in place of that check.
 
     Returns:
         Number of rows written: the number of elements at that level.
 
     Raises:
         ValueError: If ``source`` is not a current projection, if the schema has no
-            such repeated level, if ``element_count`` and ``counted_over`` are not
-            passed together, if ``source`` has changed since it was counted, or if the
-            element count and the unnest disagree.
+            such repeated level, if ``source`` has changed since it was counted, or if
+            the element count and the unnest disagree.
+        KeyError: If ``counts`` does not cover ``level_path``.
+        OSError: If ``source`` cannot be stat'ed.
     """
     level = LEVELS.get(level_path)
     if level is None:
@@ -609,18 +675,16 @@ def write_pivot(
             f"{level_path} is not a repeated level of the projection schema; "
             f"a pivot has nothing to hold. Known levels: {sorted(LEVELS)}"
         )
-    if (element_count is None) != (counted_over is None):
-        raise ValueError(
-            "element_count and counted_over go together: a count is only the answer "
-            "for the bytes it was taken over, and the pair is what says so"
-        )
     parent = _check_projection(source)
-    if counted_over is not None and counted_over != file_identity(source):
-        raise ValueError(
-            f"{source} has changed since it was counted; the count of "
-            f"{element_count} at {level_path} is an answer about a file that is no "
-            "longer there. Count it again."
-        )
+    element_count = None
+    if counts is not None:
+        element_count = counts[level_path]
+        if counts.identity != file_identity(source):
+            raise ValueError(
+                f"{source} has changed since it was counted; the count of "
+                f"{element_count} at {level_path} is an answer about a file that is "
+                "no longer there. Count it again."
+            )
     if source_md5 is None:
         source_md5 = parent.source_md5
     if source_dataset_id is None:
@@ -671,9 +735,13 @@ def write_pivot(
                 # over the level vacuously true for every reaction in the corpus.
                 #
                 # This catches any nonzero count the unnest disagrees with, in either
-                # direction. Only zero escapes it, having skipped the unnest that
-                # would have contradicted it; counted_over is what holds that case,
-                # by refusing a count taken over other bytes than these.
+                # direction. Zero escapes it, having skipped the unnest that would
+                # have contradicted it: what stands in its place is that the count
+                # came from Counts, which names the level it answers for and the file
+                # it was read from. A count that is wrong over the right file is
+                # outside both -- that one is held by the tests comparing the count
+                # against the unnest at every level, and by a level that comes out
+                # empty across a whole tree saying so.
                 raise ValueError(
                     f"{source}: counted {element_count} elements at {level_path} and "
                     f"unnested {written}; the count and the pivot disagree"

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -39,13 +39,16 @@ its own, and hoisted it would collide with the row's.
 
 A pivot is unfiltered -- every element gets a row, including one whose fields are all
 NULL. That completeness is what lets it answer ``forall``, which an index holding only
-the elements that match something never can.
+the elements that match something never can -- and what makes an empty one dangerous
+rather than merely useless, since ``forall`` over it is then vacuously true of every
+reaction in the corpus. See ``Counts``.
 """
 
 import dataclasses
 import os
 import pathlib
-from collections.abc import Iterable, Mapping, Sequence
+import types
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from typing import NamedTuple
 
 import duckdb
@@ -63,7 +66,7 @@ logger = get_logger(__name__)
 # holds. One artifact name covers every level, because they are one kind of thing
 # derived one way; the path is what tells them apart.
 ARTIFACT = "pivot"
-_META_PIVOT_PATH = "ord.pivot_path"
+META_PIVOT_PATH = "ord.pivot_path"
 
 # The column the element's own fields sit under, and the row's join key.
 ELEMENT = "element"
@@ -369,7 +372,7 @@ def pivot_path(path: str | os.PathLike[str]) -> str | None:
         pivot artifact.
     """
     metadata = pq.read_schema(path).metadata or {}
-    value = metadata.get(_META_PIVOT_PATH.encode())
+    value = metadata.get(META_PIVOT_PATH.encode())
     return value.decode() if value is not None else None
 
 
@@ -405,7 +408,7 @@ def file_identity(source: str | os.PathLike[str]) -> FileIdentity:
 
 
 @dataclasses.dataclass(frozen=True)
-class Counts:
+class Counts(Mapping[str, int]):
     """How many elements a projection records at each of several levels.
 
     Carries the identity of the file the counts were read from, which is what lets the
@@ -419,6 +422,10 @@ class Counts:
     caller holding a bare count and a bare identity can pass an honest count of one
     level against an honest identity of the file, for a different level entirely.
 
+    A mapping of level to count, taken as read-only through a proxy: one build shares
+    a projection's counts across every level it derives, so a caller writing through
+    one level's handle would be answering for the rest of the run.
+
     Attributes:
         identity: The file the counts were read from, as it stood across the read.
         at: The count per level, in the order asked.
@@ -426,6 +433,10 @@ class Counts:
 
     identity: FileIdentity
     at: Mapping[str, int]
+
+    def __post_init__(self) -> None:
+        """Replaces ``at`` with a read-only view of a copy of what was passed."""
+        object.__setattr__(self, "at", types.MappingProxyType(dict(self.at)))
 
     def __getitem__(self, level_path: str) -> int:
         """Returns the count at ``level_path``.
@@ -441,6 +452,14 @@ class Counts:
                 answer about some other level.
         """
         return self.at[level_path]
+
+    def __iter__(self) -> Iterator[str]:
+        """Yields the levels these counts cover, in the order asked."""
+        return iter(self.at)
+
+    def __len__(self) -> int:
+        """Returns how many levels these counts cover."""
+        return len(self.at)
 
 
 def _check_projection(source: str | os.PathLike[str]) -> base.Stamps:
@@ -543,7 +562,10 @@ def count_expression(level: RepeatedLevel) -> str:
 
 
 def _count_view(
-    connection: duckdb.DuckDBPyConnection, view: str, level_paths: Sequence[str]
+    connection: duckdb.DuckDBPyConnection,
+    view: str,
+    level_paths: Sequence[str],
+    source: str | os.PathLike[str],
 ) -> dict[str, int]:
     """Returns the element count per level over an already-created view.
 
@@ -551,6 +573,7 @@ def _count_view(
         connection: Connection holding the view.
         view: Relation holding the reactions.
         level_paths: The levels to count; checked by the caller.
+        source: The file behind the view, for anything this has to say about it.
 
     Returns:
         The count per level, in the order asked.
@@ -570,7 +593,7 @@ def _count_view(
             # Every aggregate is wrapped in coalesce, so this is unreachable by the
             # expressions this module builds. Named rather than left to int(), whose
             # TypeError says nothing about which file or which level produced it.
-            raise ValueError(f"counting {level_path} over {view} yielded no answer")
+            raise ValueError(f"{source}: counting {level_path} yielded no answer")
         # Exact: every term is a list length, so the sum types as an integer and
         # nothing here arrives fractional to be floored.
         counted[level_path] = int(value)
@@ -605,7 +628,7 @@ def count_levels(source: str | os.PathLike[str], level_paths: Iterable[str]) -> 
     connection = duckdb.connect()
     try:
         connection.read_parquet(str(pathlib.Path(source))).create_view("reactions")
-        counted = _count_view(connection, "reactions", wanted)
+        counted = _count_view(connection, "reactions", wanted, source)
     finally:
         connection.close()
     if file_identity(source) != before:
@@ -667,7 +690,7 @@ def write_pivot(
             such repeated level, if ``source`` has changed since it was counted, or if
             the element count and the unnest disagree.
         KeyError: If ``counts`` does not cover ``level_path``.
-        OSError: If ``source`` cannot be stat'ed.
+        OSError: If ``counts`` is given and ``source`` cannot be stat'ed.
     """
     level = LEVELS.get(level_path)
     if level is None:
@@ -690,7 +713,7 @@ def write_pivot(
     if source_dataset_id is None:
         source_dataset_id = parent.source_dataset_id
     stamps = base.current_stamps(ARTIFACT, source_dataset_id, source_md5)
-    metadata = base.to_metadata(stamps) | {_META_PIVOT_PATH: level_path}
+    metadata = base.to_metadata(stamps) | {META_PIVOT_PATH: level_path}
     target = schema(level).with_metadata(metadata)
     connection = duckdb.connect()
     written = 0
@@ -700,7 +723,7 @@ def write_pivot(
         # the unnest, which read the same nested column.
         connection.read_parquet(str(pathlib.Path(source))).create_view("reactions")
         if element_count is None:
-            element_count = _count_view(connection, "reactions", [level_path])[
+            element_count = _count_view(connection, "reactions", [level_path], source)[
                 level_path
             ]
         with (
@@ -730,18 +753,19 @@ def write_pivot(
                 # Raised inside the atomic write, so the rejected artifact is removed
                 # rather than published: one that reached the destination would be
                 # stamped current, skipped by every later run, and read as the truth
-                # about the level ever after -- where an empty pivot does not merely
-                # lose the matches an exists would have found, it makes every forall
-                # over the level vacuously true for every reaction in the corpus.
+                # about the level ever after, with the consequences this module's
+                # docstring gives.
                 #
                 # This catches any nonzero count the unnest disagrees with, in either
-                # direction. Zero escapes it, having skipped the unnest that would
-                # have contradicted it: what stands in its place is that the count
-                # came from Counts, which names the level it answers for and the file
-                # it was read from. A count that is wrong over the right file is
-                # outside both -- that one is held by the tests comparing the count
-                # against the unnest at every level, and by a level that comes out
-                # empty across a whole tree saying so.
+                # direction. Zero escapes it, having skipped the unnest that would have
+                # contradicted it, and what stands in its place depends on where the
+                # count came from: one taken here read the same view in the same
+                # connection the unnest would have, with no window between them at all,
+                # while one that came in through Counts names the level it answers for
+                # and the file it was read from. A count that is simply wrong over the
+                # right file is outside both -- that one is held by the tests comparing
+                # the count against the unnest at every level, and by a level that
+                # comes out empty across a whole tree saying so.
                 raise ValueError(
                     f"{source}: counted {element_count} elements at {level_path} and "
                     f"unnested {written}; the count and the pivot disagree"

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -509,8 +509,8 @@ def count_levels(
         The count per level, in the order asked.
 
     Raises:
-        ValueError: If ``source`` is not a projection, or if any path is not a
-            repeated level of the projection schema.
+        ValueError: If ``source`` is not a projection, or if any path is not a repeated
+            level of the projection schema, or if one is named twice.
     """
     wanted = check_levels(level_paths)
     _check_projection(source)
@@ -559,7 +559,11 @@ def write_pivot(
         element_count: How many elements this level holds, where the caller has already
             counted. Counted here when omitted. A build deriving every level counts
             them together, since one query answers for all of them at the cost of
-            reading the projection once.
+            reading the projection once. A count that disagrees with the unnest is
+            refused -- but a count of zero skips the unnest, so a caller that answers
+            zero for a level holding elements publishes an empty artifact and gets no
+            error. Pass a count taken over the content at ``source``, not a remembered
+            one; proving a zero costs the full pass this parameter exists to skip.
 
     Returns:
         Number of rows written: the number of elements at that level.

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -372,6 +372,27 @@ def pivot_path(path: str | os.PathLike[str]) -> str | None:
     return value.decode() if value is not None else None
 
 
+def file_identity(source: str | os.PathLike[str]) -> tuple[int, int, int]:
+    """Returns what tells one version of a file from another, cheaply.
+
+    A count is only the answer for the bytes it was taken over, and a caller that
+    counts and then writes does the two against separate opens. This is what the two
+    ends compare so a file replaced in between is caught -- including by the pivot
+    whose count came out zero, which is otherwise unfalsifiable, since it skips the
+    unnest that would have contradicted it.
+
+    Args:
+        source: Path to the file.
+
+    Returns:
+        Inode, size, and modification time in nanoseconds. Not a hash: this is asked
+        once per artifact on the path where a hash would mean reading the file again,
+        and a rewrite that preserves all three is not the accident this guards.
+    """
+    status = pathlib.Path(source).stat()
+    return status.st_ino, status.st_size, status.st_mtime_ns
+
+
 def _check_projection(source: str | os.PathLike[str]) -> base.Stamps:
     """Returns the stamps of a current projection, refusing anything else.
 
@@ -382,11 +403,12 @@ def _check_projection(source: str | os.PathLike[str]) -> base.Stamps:
         Its stamps.
 
     Raises:
-        ValueError: If it holds another artifact, or is a projection the current
-            library did not write. derive_tree refuses stale parents, but the readers
-            here are public and their output inherits the dataset hash: an artifact
-            derived from a stale projection would claim a provenance it does not have
-            and nothing would ever mark it stale again.
+        ValueError: If it carries no artifact stamps at all, if it holds another
+            artifact, or if it is a projection the current library did not write.
+            derive_tree refuses stale parents, but the readers here are public and
+            their output inherits the dataset hash: an artifact derived from a stale
+            projection would claim a provenance it does not have and nothing would
+            ever mark it stale again.
     """
     parent = base.load_stamps(source)
     if parent.artifact != projection.ARTIFACT:
@@ -437,9 +459,8 @@ def _count_within(steps: Sequence[Step], source: str | None, depth: int = 0) -> 
         depth: How far down this is, which names the bound variable.
 
     Returns:
-        An expression summing the lengths at each level rather than building the
-        flattened list and measuring it, so a reaction's elements are never all
-        resident at once.
+        An expression summing the lengths level by level, rather than flattening the
+        levels into one list and measuring that.
     """
     reached = steps[0].expression(source)
     if len(steps) == 1:
@@ -452,19 +473,21 @@ def _count_within(steps: Sequence[Step], source: str | None, depth: int = 0) -> 
 def count_expression(level: RepeatedLevel) -> str:
     """Returns SQL counting the elements a projection records at ``level``.
 
-    Cheaper than unnesting the level, measured at roughly nine times on a populated
-    one, because it does not cross-join a row against its elements -- not because it
-    reads less of the column. Reaching an element to measure its list pulls the whole
-    nested payload off disk either way, and the count scales with the payload's width.
-    What it buys is on the levels a corpus never records, where the answer is nothing
-    and the unnest would still walk every ancestor to say so.
+    Cheaper than unnesting the level, because it does not cross-join a row against its
+    elements -- not because it reads less of the column. Reaching an element to measure
+    its list pulls the whole nested payload off disk either way, and the count scales
+    with the payload's width, so the margin is a property of the corpus and not of this
+    expression: it was roughly nine times on a populated level of an ORD projection
+    holding 8% of the corpus by bytes. What it buys reliably is on the levels a corpus
+    never records, where the answer is nothing and the unnest would still walk every
+    ancestor to say so.
 
     Args:
         level: The level to count.
 
     Returns:
-        An aggregate over the reactions relation, to be selected with no GROUP BY, and
-        zero where nothing is recorded.
+        An aggregate over a relation carrying the projection schema, to be selected
+        with no GROUP BY, and zero where nothing is recorded.
     """
     return f"coalesce(sum({_count_within(level.steps, None)}), 0)"
 
@@ -472,7 +495,7 @@ def count_expression(level: RepeatedLevel) -> str:
 def _count_view(
     connection: duckdb.DuckDBPyConnection, view: str, level_paths: Sequence[str]
 ) -> dict[str, int]:
-    """Returns the element count per level over an already-published view.
+    """Returns the element count per level over an already-created view.
 
     Args:
         connection: Connection holding the view.
@@ -489,6 +512,9 @@ def _count_view(
     # view is this module's own name for the relation it just created.
     row = connection.execute(f"SELECT {counts} FROM {view}").fetchone()  # noqa: S608
     assert row is not None  # An aggregate with no GROUP BY yields exactly one row.
+    # The aggregates come back in the order they were selected, which is the order the
+    # levels were asked in; int() is exact because every term is a list length, so the
+    # sum types as an integer and nothing here can arrive fractional and floor.
     return dict(zip(level_paths, (int(value) for value in row), strict=True))
 
 
@@ -509,8 +535,8 @@ def count_levels(
         The count per level, in the order asked.
 
     Raises:
-        ValueError: If ``source`` is not a projection, or if any path is not a repeated
-            level of the projection schema, or if one is named twice.
+        ValueError: If ``source`` is not a current projection, or if any path is not a
+            repeated level of the projection schema, or if one is named twice.
     """
     wanted = check_levels(level_paths)
     _check_projection(source)
@@ -533,6 +559,7 @@ def write_pivot(
     compression: str = "zstd",
     row_group_size: int = 100_000,
     element_count: int | None = None,
+    counted_over: tuple[int, int, int] | None = None,
 ) -> int:
     """Derives a pivot artifact over one repeated level and writes it.
 
@@ -559,18 +586,22 @@ def write_pivot(
         element_count: How many elements this level holds, where the caller has already
             counted. Counted here when omitted. A build deriving every level counts
             them together, since one query answers for all of them at the cost of
-            reading the projection once. A count that disagrees with the unnest is
-            refused -- but a count of zero skips the unnest, so a caller that answers
-            zero for a level holding elements publishes an empty artifact and gets no
-            error. Pass a count taken over the content at ``source``, not a remembered
-            one; proving a zero costs the full pass this parameter exists to skip.
+            reading the projection once. Requires ``counted_over``, because a count
+            says nothing without the bytes it was taken over.
+        counted_over: ``file_identity(source)`` as it stood when ``element_count`` was
+            taken, which is checked against ``source`` as it stands now. This is what
+            makes a count of zero falsifiable: a nonzero count is checked against the
+            unnest afterwards, but a zero skips the unnest and would leave nothing to
+            contradict it. Required with ``element_count`` and meaningless without it.
 
     Returns:
         Number of rows written: the number of elements at that level.
 
     Raises:
         ValueError: If ``source`` is not a current projection, if the schema has no
-            such repeated level, or if the element count and the unnest disagree.
+            such repeated level, if ``element_count`` and ``counted_over`` are not
+            passed together, if ``source`` has changed since it was counted, or if the
+            element count and the unnest disagree.
     """
     level = LEVELS.get(level_path)
     if level is None:
@@ -578,7 +609,18 @@ def write_pivot(
             f"{level_path} is not a repeated level of the projection schema; "
             f"a pivot has nothing to hold. Known levels: {sorted(LEVELS)}"
         )
+    if (element_count is None) != (counted_over is None):
+        raise ValueError(
+            "element_count and counted_over go together: a count is only the answer "
+            "for the bytes it was taken over, and the pair is what says so"
+        )
     parent = _check_projection(source)
+    if counted_over is not None and counted_over != file_identity(source):
+        raise ValueError(
+            f"{source} has changed since it was counted; the count of "
+            f"{element_count} at {level_path} is an answer about a file that is no "
+            "longer there. Count it again."
+        )
     if source_md5 is None:
         source_md5 = parent.source_md5
     if source_dataset_id is None:
@@ -624,9 +666,14 @@ def write_pivot(
                 # Raised inside the atomic write, so the rejected artifact is removed
                 # rather than published: one that reached the destination would be
                 # stamped current, skipped by every later run, and read as the truth
-                # about the level ever after. This catches a count that came in low; a
-                # count that came in at zero skipped the unnest, so there is nothing
-                # here to disagree with it, and the tests are what hold that case.
+                # about the level ever after -- where an empty pivot does not merely
+                # lose the matches an exists would have found, it makes every forall
+                # over the level vacuously true for every reaction in the corpus.
+                #
+                # This catches any nonzero count the unnest disagrees with, in either
+                # direction. Only zero escapes it, having skipped the unnest that
+                # would have contradicted it; counted_over is what holds that case,
+                # by refusing a count taken over other bytes than these.
                 raise ValueError(
                     f"{source}: counted {element_count} elements at {level_path} and "
                     f"unnested {written}; the count and the pivot disagree"

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -45,7 +45,7 @@ the elements that match something never can.
 import dataclasses
 import os
 import pathlib
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 
 import duckdb
 import inflection
@@ -372,6 +372,83 @@ def pivot_path(path: str | os.PathLike[str]) -> str | None:
     return value.decode() if value is not None else None
 
 
+def _check_projection(source: str | os.PathLike[str]) -> base.Stamps:
+    """Returns the stamps of a current projection, refusing anything else.
+
+    Args:
+        source: Path to the file a pivot would read.
+
+    Returns:
+        Its stamps.
+
+    Raises:
+        ValueError: If it holds another artifact, or is a projection the current
+            library did not write. derive_tree refuses stale parents, but the readers
+            here are public and their output inherits the dataset hash: an artifact
+            derived from a stale projection would claim a provenance it does not have
+            and nothing would ever mark it stale again.
+    """
+    parent = base.load_stamps(source)
+    if parent.artifact != projection.ARTIFACT:
+        raise ValueError(
+            f"{source} is a {parent.artifact}, not a {projection.ARTIFACT}; a pivot "
+            "unnests a projection"
+        )
+    if not base.stamps_are_current(parent, projection.ARTIFACT):
+        raise ValueError(
+            f"{source} is a stale {projection.ARTIFACT}; derive it again first"
+        )
+    return parent
+
+
+def check_levels(level_paths: Iterable[str]) -> list[str]:
+    """Returns ``level_paths`` as a list, refusing any the schema does not have.
+
+    Args:
+        level_paths: The levels to check, as the query grammar names them.
+
+    Returns:
+        The same paths, in order.
+
+    Raises:
+        ValueError: If any path is not a repeated level of the projection schema, or
+            if one is named twice, which would leave a caller fewer answers than it
+            asked for.
+    """
+    wanted = list(level_paths)
+    unknown = sorted(set(wanted) - set(LEVELS))
+    if unknown:
+        raise ValueError(
+            f"not repeated levels of the projection schema: {unknown}; "
+            f"known levels are {sorted(LEVELS)}"
+        )
+    repeated = sorted({path for path in wanted if wanted.count(path) > 1})
+    if repeated:
+        raise ValueError(f"levels named more than once: {repeated}")
+    return wanted
+
+
+def _count_within(steps: Sequence[Step], source: str | None, depth: int = 0) -> str:
+    """Returns an expression counting what ``steps`` reach from one element.
+
+    Args:
+        steps: The steps left to walk, outermost first.
+        source: The variable bound to the element, or None at the row.
+        depth: How far down this is, which names the bound variable.
+
+    Returns:
+        An expression summing the lengths at each level rather than building the
+        flattened list and measuring it, so a reaction's elements are never all
+        resident at once.
+    """
+    reached = steps[0].expression(source)
+    if len(steps) == 1:
+        return f"len({reached})"
+    element = f"e{depth}"
+    inner = _count_within(steps[1:], element, depth + 1)
+    return f"coalesce(list_sum(list_transform({reached}, {element} -> {inner})), 0)"
+
+
 def count_expression(level: RepeatedLevel) -> str:
     """Returns SQL counting the elements a projection records at ``level``.
 
@@ -387,17 +464,32 @@ def count_expression(level: RepeatedLevel) -> str:
 
     Returns:
         An aggregate over the reactions relation, to be selected with no GROUP BY, and
-        zero where nothing is recorded. Flattened at each step, so the count is of
-        elements rather than of the lists holding them.
+        zero where nothing is recorded.
     """
-    expression = level.steps[0].expression(None)
-    for depth, step in enumerate(level.steps[1:], start=1):
-        element = f"e{depth}"
-        expression = (
-            f"flatten(list_transform({expression}, "
-            f"{element} -> {step.expression(element)}))"
-        )
-    return f"coalesce(sum(len({expression})), 0)"
+    return f"coalesce(sum({_count_within(level.steps, None)}), 0)"
+
+
+def _count_view(
+    connection: duckdb.DuckDBPyConnection, view: str, level_paths: Sequence[str]
+) -> dict[str, int]:
+    """Returns the element count per level over an already-published view.
+
+    Args:
+        connection: Connection holding the view.
+        view: Relation holding the reactions.
+        level_paths: The levels to count; checked by the caller.
+
+    Returns:
+        The count per level, in the order asked.
+    """
+    if not level_paths:
+        return {}
+    counts = ", ".join(count_expression(LEVELS[path]) for path in level_paths)
+    # S608: every fragment is this module's own walk of the projection schema, and the
+    # view is this module's own name for the relation it just created.
+    row = connection.execute(f"SELECT {counts} FROM {view}").fetchone()  # noqa: S608
+    assert row is not None  # An aggregate with no GROUP BY yields exactly one row.
+    return dict(zip(level_paths, (int(value) for value in row), strict=True))
 
 
 def count_levels(
@@ -414,30 +506,20 @@ def count_levels(
         level_paths: The levels to count, as the query grammar names them.
 
     Returns:
-        The count per level, in no particular order.
+        The count per level, in the order asked.
 
     Raises:
-        ValueError: If any path is not a repeated level of the projection schema.
+        ValueError: If ``source`` is not a projection, or if any path is not a
+            repeated level of the projection schema.
     """
-    wanted = list(level_paths)
-    unknown = sorted(set(wanted) - set(LEVELS))
-    if unknown:
-        raise ValueError(
-            f"not repeated levels of the projection schema: {unknown}; "
-            f"known levels are {sorted(LEVELS)}"
-        )
-    if not wanted:
-        return {}
+    wanted = check_levels(level_paths)
+    _check_projection(source)
     connection = duckdb.connect()
     try:
         connection.read_parquet(str(pathlib.Path(source))).create_view("reactions")
-        counts = ", ".join(count_expression(LEVELS[path]) for path in wanted)
-        # S608: every fragment is this module's own walk of the projection schema.
-        row = connection.execute(f"SELECT {counts} FROM reactions").fetchone()  # noqa: S608
+        return _count_view(connection, "reactions", wanted)
     finally:
         connection.close()
-    assert row is not None  # An aggregate with no GROUP BY yields exactly one row.
-    return dict(zip(wanted, (int(value) for value in row), strict=True))
 
 
 def write_pivot(
@@ -492,19 +574,7 @@ def write_pivot(
             f"{level_path} is not a repeated level of the projection schema; "
             f"a pivot has nothing to hold. Known levels: {sorted(LEVELS)}"
         )
-    parent = base.load_stamps(source)
-    if parent.artifact != projection.ARTIFACT:
-        raise ValueError(
-            f"{source} is a {parent.artifact}, not a {projection.ARTIFACT}; a pivot "
-            "unnests a projection"
-        )
-    # derive_tree refuses stale parents, but this writer is public and its output
-    # inherits the dataset hash: an artifact derived from a stale projection would
-    # claim a provenance it does not have and nothing would ever mark it stale again.
-    if not base.stamps_are_current(parent, projection.ARTIFACT):
-        raise ValueError(
-            f"{source} is a stale {projection.ARTIFACT}; derive it again first"
-        )
+    parent = _check_projection(source)
     if source_md5 is None:
         source_md5 = parent.source_md5
     if source_dataset_id is None:
@@ -512,50 +582,52 @@ def write_pivot(
     stamps = base.current_stamps(ARTIFACT, source_dataset_id, source_md5)
     metadata = base.to_metadata(stamps) | {_META_PIVOT_PATH: level_path}
     target = schema(level).with_metadata(metadata)
-    if element_count is None:
-        element_count = count_levels(source, [level_path])[level_path]
     connection = duckdb.connect()
     written = 0
     try:
         # Through the relational API rather than a path interpolated into SQL, which a
-        # filename holding a quote would otherwise close.
+        # filename holding a quote would otherwise close. One view serves the count and
+        # the unnest, which read the same nested column.
         connection.read_parquet(str(pathlib.Path(source))).create_view("reactions")
-        # Counting settled it: the unnest would walk every ancestor of a level this
-        # projection never records, to arrive at the same nothing.
-        batches = (
-            iter(())
-            if not element_count
-            else connection.execute(select(level, "reactions")).to_arrow_reader(
-                row_group_size
-            )
-        )
+        if element_count is None:
+            element_count = _count_view(connection, "reactions", [level_path])[
+                level_path
+            ]
         with (
             atomic_io.atomic_path(output) as temp_path,
             pq.ParquetWriter(temp_path, target, compression=compression) as writer,
         ):
-            # A level with no elements writes no batches; the writer's close still
-            # produces a valid zero-row file carrying the schema and stamps, which is
-            # what a reader globs and finds nothing in rather than a file that is
-            # missing. One writer either way, so the two files differ only in rows.
-            for batch in batches:
-                # Cast rather than trust: DuckDB's own widths are its business, and the
-                # artifact's schema is a promise to whoever reads it later.
-                writer.write_table(
-                    pa.Table.from_batches([batch])
-                    .cast(schema(level))
-                    .replace_schema_metadata(metadata)
+            # A level with no elements writes no batches, and the writer's close still
+            # produces a valid zero-row file carrying the schema and stamps -- what a
+            # reader globs and finds nothing in, rather than a file that is missing.
+            # One writer either way, so the two differ only in rows.
+            if element_count:
+                # Counting settled the other case: the unnest would walk every ancestor
+                # of a level this projection never records to reach the same nothing.
+                reader = connection.execute(select(level, "reactions")).to_arrow_reader(
+                    row_group_size
                 )
-                written += batch.num_rows
+                for batch in reader:
+                    # Cast rather than trust: DuckDB's own widths are its business, and
+                    # the artifact's schema is a promise to whoever reads it later.
+                    writer.write_table(
+                        pa.Table.from_batches([batch])
+                        .cast(schema(level))
+                        .replace_schema_metadata(metadata)
+                    )
+                    written += batch.num_rows
+            if written != element_count:
+                # Raised inside the atomic write, so the rejected artifact is removed
+                # rather than published: one that reached the destination would be
+                # stamped current, skipped by every later run, and read as the truth
+                # about the level ever after. This catches a count that came in low; a
+                # count that came in at zero skipped the unnest, so there is nothing
+                # here to disagree with it, and the tests are what hold that case.
+                raise ValueError(
+                    f"{source}: counted {element_count} elements at {level_path} and "
+                    f"unnested {written}; the count and the pivot disagree"
+                )
     finally:
         connection.close()
-    if written != element_count:
-        # The count decides whether the unnest runs at all, so a disagreement is the
-        # one failure that would otherwise be silent: an empty artifact published over
-        # a level that holds rows, which every quantifier over it then reads as no
-        # matches. Loud here, rather than correct-looking forever after.
-        raise ValueError(
-            f"{source}: counted {element_count} elements at {level_path} and unnested "
-            f"{written}; the count and the pivot disagree"
-        )
     logger.info("%s: %d elements at %s", source, written, level_path)
     return written

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -45,6 +45,7 @@ the elements that match something never can.
 import dataclasses
 import os
 import pathlib
+from collections.abc import Iterable
 
 import duckdb
 import inflection
@@ -374,18 +375,20 @@ def pivot_path(path: str | os.PathLike[str]) -> str | None:
 def count_expression(level: RepeatedLevel) -> str:
     """Returns SQL counting the elements a projection records at ``level``.
 
-    Reads list offsets rather than element bodies: ``len`` needs to know how long a
-    list is, not what is in it, so this touches a fraction of what unnesting the level
-    would. Most levels of this schema are never recorded, and discovering that by
-    unnesting costs a full pass over every ancestor.
+    Cheaper than unnesting the level, measured at roughly nine times on a populated
+    one, because it does not cross-join a row against its elements -- not because it
+    reads less of the column. Reaching an element to measure its list pulls the whole
+    nested payload off disk either way, and the count scales with the payload's width.
+    What it buys is on the levels a corpus never records, where the answer is nothing
+    and the unnest would still walk every ancestor to say so.
 
     Args:
         level: The level to count.
 
     Returns:
-        A scalar expression over the reactions relation, zero where nothing is
-        recorded. Flattened at each step, so the count is of elements rather than of
-        the lists holding them.
+        An aggregate over the reactions relation, to be selected with no GROUP BY, and
+        zero where nothing is recorded. Flattened at each step, so the count is of
+        elements rather than of the lists holding them.
     """
     expression = level.steps[0].expression(None)
     for depth, step in enumerate(level.steps[1:], start=1):
@@ -395,6 +398,46 @@ def count_expression(level: RepeatedLevel) -> str:
             f"{element} -> {step.expression(element)}))"
         )
     return f"coalesce(sum(len({expression})), 0)"
+
+
+def count_levels(
+    source: str | os.PathLike[str], level_paths: Iterable[str]
+) -> dict[str, int]:
+    """Returns how many elements a projection records at each of ``level_paths``.
+
+    One query carrying one aggregate per level, because the count reads the same
+    columns for every level sharing a prefix and a query per level reads them again
+    each time.
+
+    Args:
+        source: Path to the projection to count.
+        level_paths: The levels to count, as the query grammar names them.
+
+    Returns:
+        The count per level, in no particular order.
+
+    Raises:
+        ValueError: If any path is not a repeated level of the projection schema.
+    """
+    wanted = list(level_paths)
+    unknown = sorted(set(wanted) - set(LEVELS))
+    if unknown:
+        raise ValueError(
+            f"not repeated levels of the projection schema: {unknown}; "
+            f"known levels are {sorted(LEVELS)}"
+        )
+    if not wanted:
+        return {}
+    connection = duckdb.connect()
+    try:
+        connection.read_parquet(str(pathlib.Path(source))).create_view("reactions")
+        counts = ", ".join(count_expression(LEVELS[path]) for path in wanted)
+        # S608: every fragment is this module's own walk of the projection schema.
+        row = connection.execute(f"SELECT {counts} FROM reactions").fetchone()  # noqa: S608
+    finally:
+        connection.close()
+    assert row is not None  # An aggregate with no GROUP BY yields exactly one row.
+    return dict(zip(wanted, (int(value) for value in row), strict=True))
 
 
 def write_pivot(
@@ -407,6 +450,7 @@ def write_pivot(
     source_dataset_id: str | None = None,
     compression: str = "zstd",
     row_group_size: int = 100_000,
+    element_count: int | None = None,
 ) -> int:
     """Derives a pivot artifact over one repeated level and writes it.
 
@@ -430,13 +474,17 @@ def write_pivot(
         compression: Parquet codec, any name ``pq.ParquetWriter`` accepts.
         row_group_size: Rows per output row group, which is also how many elements are
             held in memory at a time.
+        element_count: How many elements this level holds, where the caller has already
+            counted. Counted here when omitted. A build deriving every level counts
+            them together, since one query answers for all of them at the cost of
+            reading the projection once.
 
     Returns:
         Number of rows written: the number of elements at that level.
 
     Raises:
-        ValueError: If ``source`` is not a current projection, or the schema has no
-            such repeated level.
+        ValueError: If ``source`` is not a current projection, if the schema has no
+            such repeated level, or if the element count and the unnest disagree.
     """
     level = LEVELS.get(level_path)
     if level is None:
@@ -464,36 +512,32 @@ def write_pivot(
     stamps = base.current_stamps(ARTIFACT, source_dataset_id, source_md5)
     metadata = base.to_metadata(stamps) | {_META_PIVOT_PATH: level_path}
     target = schema(level).with_metadata(metadata)
+    if element_count is None:
+        element_count = count_levels(source, [level_path])[level_path]
     connection = duckdb.connect()
     written = 0
     try:
         # Through the relational API rather than a path interpolated into SQL, which a
         # filename holding a quote would otherwise close.
         connection.read_parquet(str(pathlib.Path(source))).create_view("reactions")
-        # S608: the expression is this module's own walk of the projection schema.
-        counted = connection.execute(
-            f"SELECT {count_expression(level)} FROM reactions"  # noqa: S608
-        ).fetchone()
-        if counted is not None and not counted[0]:
-            # Counting read the offsets; unnesting would have walked every ancestor of
-            # a level this projection never records, to arrive at the same nothing.
-            with (
-                atomic_io.atomic_path(output) as temp_path,
-                pq.ParquetWriter(temp_path, target, compression=compression),
-            ):
-                pass
-            logger.info("%s: no elements at %s", source, level_path)
-            return 0
-        result = connection.execute(select(level, "reactions"))
+        # Counting settled it: the unnest would walk every ancestor of a level this
+        # projection never records, to arrive at the same nothing.
+        batches = (
+            iter(())
+            if not element_count
+            else connection.execute(select(level, "reactions")).to_arrow_reader(
+                row_group_size
+            )
+        )
         with (
             atomic_io.atomic_path(output) as temp_path,
             pq.ParquetWriter(temp_path, target, compression=compression) as writer,
         ):
-            # A projection whose reactions record nothing at this level leaves the loop
-            # empty; the writer's close still produces a valid zero-row file carrying
-            # the schema and stamps, which is what a reader globs and finds nothing in
-            # rather than a file that is missing.
-            for batch in result.to_arrow_reader(row_group_size):
+            # A level with no elements writes no batches; the writer's close still
+            # produces a valid zero-row file carrying the schema and stamps, which is
+            # what a reader globs and finds nothing in rather than a file that is
+            # missing. One writer either way, so the two files differ only in rows.
+            for batch in batches:
                 # Cast rather than trust: DuckDB's own widths are its business, and the
                 # artifact's schema is a promise to whoever reads it later.
                 writer.write_table(
@@ -504,5 +548,14 @@ def write_pivot(
                 written += batch.num_rows
     finally:
         connection.close()
+    if written != element_count:
+        # The count decides whether the unnest runs at all, so a disagreement is the
+        # one failure that would otherwise be silent: an empty artifact published over
+        # a level that holds rows, which every quantifier over it then reads as no
+        # matches. Loud here, rather than correct-looking forever after.
+        raise ValueError(
+            f"{source}: counted {element_count} elements at {level_path} and unnested "
+            f"{written}; the count and the pivot disagree"
+        )
     logger.info("%s: %d elements at %s", source, written, level_path)
     return written

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -432,8 +432,9 @@ def test_counting_many_levels_answers_each_one_for_itself(populated):
         "inputs.components.analyses.data",
     ]
     counted = pivot.count_levels(populated, wanted)
-    assert len(set(counted.at.values())) == len(wanted), counted
-    assert counted.at == {path: _unnested(populated, path) for path in wanted}
+    assert len(counted) == len(wanted)
+    assert len(set(counted.values())) == len(wanted), counted
+    assert dict(counted) == {path: _unnested(populated, path) for path in wanted}
 
 
 def test_each_part_of_a_file_identity_catches_a_replacement_the_others_miss(tmp_path):
@@ -704,3 +705,25 @@ def test_reach_declines_a_path_leaving_the_pruned_element():
 def test_reach_declines_a_path_with_no_repeated_ancestor():
     assert pivot.reach("conditions.temperature") is None
     assert pivot.reach("reaction_id") is None
+
+
+def _write_through(mapping, key, value) -> None:
+    """Assigns into ``mapping``, for a mapping that is not supposed to allow it.
+
+    Args:
+        mapping: The mapping to write into.
+        key: The key to assign.
+        value: The value to assign.
+    """
+    mapping[key] = value
+
+
+def test_counts_cannot_be_written_through(populated):
+    # One build shares a projection's counts across every level it derives, so a write
+    # through any level's handle would be answering for the rest of the run.
+    counts = pivot.count_levels(populated, ["workups"])
+    with pytest.raises(TypeError):
+        # Through an unannotated helper: a subscript here is refused statically too,
+        # and what this asserts is that it is refused at runtime.
+        _write_through(counts.at, "workups", 99)
+    assert counts["workups"] == _unnested(populated, "workups")

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -167,7 +167,11 @@ def projected(tmp_path_factory) -> pathlib.Path:
 
 
 def _fill_compound(compound) -> None:
-    """Populates every repeated level a compound carries, several elements per list."""
+    """Populates every repeated level a compound carries, several elements per list.
+
+    Args:
+        compound: The compound to fill.
+    """
     for name in ("ethanol", "ethyl alcohol"):
         compound.identifiers.add(type=reaction_pb2.CompoundIdentifier.NAME, value=name)
     compound.preparations.add(type=reaction_pb2.CompoundPreparation.DRIED)
@@ -194,13 +198,16 @@ def _fill_input(reaction_input, components: int) -> None:
     reaction_input.crude_components.add(reaction_id="ord-pvfull", includes_workup=True)
 
 
-def _second_reaction():
+def _second_reaction() -> reaction_pb2.Reaction:
     """A second reaction recording something at every repeated level.
 
     What separates a total from a per-row maximum, or from the first row's count, is a
     second row recording something at the same level -- not two rows recording
     different numbers, since (1, 1) already sums to more than either. Every level this
     fills is one where taking a maximum falls short.
+
+    Returns:
+        The reaction.
     """
     reaction = reaction_pb2.Reaction(reaction_id="ord-pvsecond")
     reaction.identifiers.add(
@@ -469,19 +476,23 @@ def _miscounted(counts: pivot.Counts, level_path: str, value: int) -> pivot.Coun
     return pivot.Counts(counts.identity, dict(counts.at) | {level_path: value})
 
 
-def test_a_count_that_disagrees_with_the_unnest_is_refused(populated, tmp_path):
-    # A nonzero count is checked against what the unnest produced, in either direction.
-    # A count of zero skips the unnest and has nothing to disagree with; what holds
-    # that case is that the count came from Counts, which names the file it was read
-    # from and the level it answers for -- the two tests below.
+@pytest.mark.parametrize("wrong", [99, 1])
+def test_a_count_that_disagrees_with_the_unnest_is_refused(populated, tmp_path, wrong):
+    # Wrong high and wrong low, since a check comparing one way would let the other
+    # publish a short artifact. A count of zero skips the unnest and has nothing to
+    # disagree with; what holds that case is that the count came from Counts, which
+    # names the file it was read from and the level it answers for --
+    # test_a_count_of_the_bytes_that_are_gone_is_refused and
+    # test_a_count_of_another_level_is_not_an_answer_for_this_one.
     output = tmp_path / "products.parquet"
     counts = pivot.count_levels(populated, ["outcomes.products"])
+    assert counts["outcomes.products"] not in (1, 99), "the miscount must be a miscount"
     with pytest.raises(ValueError, match="disagree"):
         pivot.write_pivot(
             populated,
             output,
             level_path="outcomes.products",
-            counts=_miscounted(counts, "outcomes.products", 99),
+            counts=_miscounted(counts, "outcomes.products", wrong),
         )
     # Nothing published: an artifact that reached the destination would be stamped
     # current, skipped by every later run, and read as the truth about the level.
@@ -499,8 +510,14 @@ def test_a_count_of_the_bytes_that_are_gone_is_refused(populated, tmp_path):
     counts = pivot.count_levels(source, ["outcomes.products"])
     assert counts["outcomes.products"] > 0
     stale = _miscounted(counts, "outcomes.products", 0)
-    # Rewritten in place, at the path already counted.
-    shutil.copy(populated, source)
+    # Republished the way atomic_io does it, a sibling renamed over the destination,
+    # with the timestamp put back the way restoring a backup would: a new inode is the
+    # only thing separating the two, which is the component a same-path rewrite would
+    # otherwise never exercise.
+    replacement = tmp_path / "replacement.parquet"
+    shutil.copy(populated, replacement)
+    os.utime(replacement, ns=(counts.identity.modified, counts.identity.modified))
+    replacement.replace(source)
     output = tmp_path / "products.parquet"
     with pytest.raises(ValueError, match="has changed since it was counted"):
         pivot.write_pivot(source, output, level_path="outcomes.products", counts=stale)
@@ -525,14 +542,20 @@ def test_a_projection_replaced_while_it_is_counted_is_refused(
     populated, tmp_path, monkeypatch
 ):
     # The counts would describe neither version. Caught by the identity being taken on
-    # both sides of the read rather than only before it.
+    # both sides of the read rather than only before it. Republished as atomic_io does
+    # it, timestamp restored, so a new inode is the only difference and no one
+    # component of the identity can carry this on its own.
     source = tmp_path / "projection.parquet"
     shutil.copy(populated, source)
+    before = pivot.file_identity(source)
     original = pivot._count_view
 
     def replace_then_count(*args, **kwargs):
         result = original(*args, **kwargs)
-        shutil.copy(populated, source)
+        replacement = tmp_path / "replacement.parquet"
+        shutil.copy(populated, replacement)
+        os.utime(replacement, ns=(before.modified, before.modified))
+        replacement.replace(source)
         return result
 
     monkeypatch.setattr(pivot, "_count_view", replace_then_count)

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -164,7 +164,7 @@ def projected(tmp_path_factory) -> pathlib.Path:
 
 
 def _fill_compound(compound) -> None:
-    """Populates every repeated level a compound carries, more than one deep."""
+    """Populates every repeated level a compound carries, several elements per list."""
     for name in ("ethanol", "ethyl alcohol"):
         compound.identifiers.add(type=reaction_pb2.CompoundIdentifier.NAME, value=name)
     compound.preparations.add(type=reaction_pb2.CompoundPreparation.DRIED)
@@ -190,17 +190,66 @@ def _fill_input(reaction_input, components: int) -> None:
     reaction_input.crude_components.add(reaction_id="ord-pvfull", includes_workup=True)
 
 
+def _second_reaction():
+    """A reaction recording fewer elements than the first, at the levels that nest.
+
+    A count that took the largest row, or the first, instead of the total agrees with
+    the unnest at every level where one row holds everything. Two rows recording
+    *different* numbers is what separates a sum from a maximum.
+    """
+    reaction = reaction_pb2.Reaction(reaction_id="ord-pvsecond")
+    reaction.identifiers.add(
+        type=reaction_pb2.ReactionIdentifier.REACTION_TYPE, value="reduction"
+    )
+    _fill_input(reaction.inputs["only"], components=1)
+    reaction.setup.vessel.attachments.add(type=reaction_pb2.VesselAttachment.CAP)
+    reaction.setup.vessel.preparations.add(type=reaction_pb2.VesselPreparation.PURGED)
+    reaction.setup.automation_code["other"].string_value = "recorded"
+    reaction.conditions.temperature.measurements.add(
+        type=reaction_pb2.TemperatureConditions.TemperatureMeasurement.THERMOCOUPLE_EXTERNAL
+    )
+    reaction.conditions.pressure.measurements.add(
+        type=reaction_pb2.PressureConditions.PressureMeasurement.CUSTOM,
+        details="recorded",
+    )
+    reaction.conditions.electrochemistry.measurements.add(
+        current={"value": 2.0, "units": "AMPERE"}
+    )
+    reaction.observations.add(comment="also recorded")
+    workup = reaction.workups.add(type=reaction_pb2.ReactionWorkup.FILTRATION)
+    _fill_input(workup.input, components=1)
+    workup.temperature.measurements.add(
+        type=reaction_pb2.TemperatureConditions.TemperatureMeasurement.THERMOCOUPLE_EXTERNAL
+    )
+    outcome = reaction.outcomes.add()
+    outcome_analysis = outcome.analyses["other"]
+    outcome_analysis.type = reaction_pb2.Analysis.GC
+    outcome_analysis.data["datum"].string_value = "recorded"
+    product = outcome.products.add(is_desired_product=True)
+    product.identifiers.add(type=reaction_pb2.CompoundIdentifier.NAME, value="ethanol")
+    product.features["only"].string_value = "recorded"
+    measurement = product.measurements.add(type=reaction_pb2.ProductMeasurement.YIELD)
+    _fill_compound(measurement.authentic_standard)
+    reaction.provenance.record_modified.add(details="also recorded")
+    reaction.provenance.reaction_metadata["other"].string_value = "recorded"
+    return reaction
+
+
 @pytest.fixture(scope="module")
 def populated(tmp_path_factory) -> pathlib.Path:
-    """A projection recording elements at every repeated level, several per parent.
+    """A projection recording elements at every repeated level, over three reactions.
 
     The count decides whether a level is unnested at all, so a wrong count is only
     catchable where the level holds something: against a projection recording nothing
     below the second level, a count that answered zero for everything deeper would
     agree with the unnest on every level there is.
 
-    More than one element per parent, because a count of the lists and a count of the
-    elements inside them are the same number when every list holds one.
+    Three shapes, because three different wrong counts each agree with the unnest on a
+    projection missing one of them. More than one element per parent at the levels that
+    nest, or counting the lists and counting the elements inside them come to the same
+    number. Two rows recording different totals, or a sum and a maximum do. One row
+    recording nothing, so every level is also counted over a chain that is NULL rather
+    than empty.
     """
     root = tmp_path_factory.mktemp("pivot_full")
     reaction = reaction_pb2.Reaction(reaction_id="ord-pvfull")
@@ -254,10 +303,11 @@ def populated(tmp_path_factory) -> pathlib.Path:
             dataset_id="ord_dataset-pvfull",
             name="test",
             description="test",
-            # A reaction recording nothing alongside it, so every level is counted over
-            # a row whose whole chain is NULL: the sum skips those and the traversal
-            # coalesces them, and the two agree only if both do it at every depth.
-            reactions=[reaction, reaction_pb2.Reaction(reaction_id="ord-pvempty")],
+            reactions=[
+                reaction,
+                _second_reaction(),
+                reaction_pb2.Reaction(reaction_id="ord-pvempty"),
+            ],
         ),
         str(source),
     )
@@ -315,7 +365,10 @@ def test_a_level_with_no_elements_still_writes_a_readable_file(projected, tmp_pa
 
 def test_a_level_with_no_elements_is_never_unnested(projected, tmp_path, monkeypatch):
     # The saving: discovering that a level holds nothing by unnesting it costs a full
-    # pass over every ancestor, and most levels of this schema hold nothing.
+    # pass over every ancestor, and this projection records nothing at most levels.
+    # Patched by name, which is the only way to assert that work did *not* happen --
+    # and which stops holding the moment select is called any way but through the
+    # module global.
     def refuse(*args: object, **kwargs: object) -> str:
         raise AssertionError("the level was unnested")
 
@@ -325,38 +378,120 @@ def test_a_level_with_no_elements_is_never_unnested(projected, tmp_path, monkeyp
     assert pq.read_table(output).num_rows == 0
 
 
-@pytest.mark.parametrize("level_path", sorted(pivot.LEVELS))
-def test_counting_a_level_agrees_with_unnesting_it(populated, level_path):
-    # Compared against the unnest itself, never against write_pivot: its row count is
-    # zero *because* the count said zero, so those two agree however wrong the count
-    # is. A count wrongly zero publishes an empty artifact over a level that holds
-    # rows, and every quantifier over it then reads as no matches.
-    counted = pivot.count_levels(populated, [level_path])[level_path]
+def _unnested(source: pathlib.Path, level_path: str) -> int:
+    """Returns the rows unnesting ``level_path`` out of ``source`` produces."""
     connection = duckdb.connect()
     try:
-        connection.read_parquet(str(populated)).create_view("reactions")
-        unnested = (
+        connection.read_parquet(str(source)).create_view("reactions")
+        return (
             connection.execute(pivot.select(pivot.LEVELS[level_path], "reactions"))
             .to_arrow_table()
             .num_rows
         )
     finally:
         connection.close()
-    assert counted == unnested
+
+
+@pytest.mark.parametrize("level_path", sorted(pivot.LEVELS))
+def test_counting_a_level_agrees_with_unnesting_it(populated, level_path):
+    # Compared against the unnest itself, never against write_pivot: its row count is
+    # zero *because* the count said zero, so those two agree however wrong the count
+    # is. A count wrongly zero publishes an empty artifact over a level that holds
+    # rows, and every forall over it is then vacuously true of the whole corpus.
+    counted = pivot.count_levels(populated, [level_path])[level_path]
+    # LEVELS is walked from the schema, so a repeated field added upstream joins this
+    # parametrize on its own -- and would be compared against an unnest of the nothing
+    # the fixture records for it, which proves nothing. Whoever adds the field is the
+    # one who has to populate it.
+    assert counted > 0, f"{level_path} is unpopulated; the comparison proves nothing"
+    assert counted == _unnested(populated, level_path)
+
+
+def test_counting_many_levels_answers_each_one_for_itself(populated):
+    # The aggregates come back as one row and are paired with the levels by position,
+    # so a query built in one order and read in another answers every level with some
+    # other level's count. Levels whose counts are pairwise distinct, or a permutation
+    # would be the identity and there would be nothing here to fail.
+    wanted = [
+        "workups",
+        "inputs.components",
+        "inputs.components.analyses",
+        "inputs.components.analyses.data",
+    ]
+    counted = pivot.count_levels(populated, wanted)
+    assert len(set(counted.values())) == len(wanted), counted
+    assert counted == {path: _unnested(populated, path) for path in wanted}
 
 
 def test_a_count_that_disagrees_with_the_unnest_is_refused(populated, tmp_path):
-    # The count that runs the unnest is checked against what the unnest produced. A
-    # count wrongly zero is a different failure, caught by the agreement test above,
-    # since the unnest it skips has nothing to disagree with.
+    # A nonzero count is checked against what the unnest produced, in either direction.
+    # A count of zero skips the unnest and has nothing to disagree with; counted_over
+    # is what holds that case, in the test below.
     output = tmp_path / "products.parquet"
     with pytest.raises(ValueError, match="disagree"):
         pivot.write_pivot(
-            populated, output, level_path="outcomes.products", element_count=99
+            populated,
+            output,
+            level_path="outcomes.products",
+            element_count=99,
+            counted_over=pivot.file_identity(populated),
         )
     # Nothing published: an artifact that reached the destination would be stamped
     # current, skipped by every later run, and read as the truth about the level.
     assert not output.exists()
+
+
+def test_a_count_taken_over_other_bytes_is_refused(populated, projected, tmp_path):
+    # The case the agreement check cannot reach. Zero is the count that skips the
+    # unnest, so nothing downstream contradicts it and the empty artifact is published
+    # stamped current -- which is why the identity is checked before the count is
+    # believed, rather than the rows checked after.
+    output = tmp_path / "products.parquet"
+    with pytest.raises(ValueError, match="has changed since it was counted"):
+        pivot.write_pivot(
+            populated,
+            output,
+            level_path="outcomes.products",
+            element_count=0,
+            counted_over=pivot.file_identity(projected),
+        )
+    assert not output.exists()
+
+
+def test_a_count_without_what_it_was_counted_over_is_refused(populated, tmp_path):
+    with pytest.raises(ValueError, match="go together"):
+        pivot.write_pivot(
+            populated,
+            tmp_path / "products.parquet",
+            level_path="outcomes.products",
+            element_count=5,
+        )
+    with pytest.raises(ValueError, match="go together"):
+        pivot.write_pivot(
+            populated,
+            tmp_path / "products.parquet",
+            level_path="outcomes.products",
+            counted_over=pivot.file_identity(populated),
+        )
+
+
+def test_a_pivot_larger_than_one_batch_counts_every_batch(populated, tmp_path):
+    # The rows are accumulated across batches and then checked against the count, so a
+    # writer that streams more than one batch is the only shape where the accumulation
+    # can be wrong. Compared against the file, not against the counter it returns.
+    output = tmp_path / "data.parquet"
+    level_path = "inputs.components.analyses.data"
+    counted = pivot.count_levels(populated, [level_path])[level_path]
+    written = pivot.write_pivot(
+        populated,
+        output,
+        level_path=level_path,
+        row_group_size=7,
+        element_count=counted,
+        counted_over=pivot.file_identity(populated),
+    )
+    assert written > 7, "one batch would not exercise the accumulation"
+    assert pq.read_table(output).num_rows == written
 
 
 def test_a_rejected_pivot_leaves_an_existing_artifact_alone(populated, tmp_path):
@@ -369,7 +504,11 @@ def test_a_rejected_pivot_leaves_an_existing_artifact_alone(populated, tmp_path)
     good = pq.read_table(output)
     with pytest.raises(ValueError, match="disagree"):
         pivot.write_pivot(
-            populated, output, level_path="outcomes.products", element_count=99
+            populated,
+            output,
+            level_path="outcomes.products",
+            element_count=99,
+            counted_over=pivot.file_identity(populated),
         )
     assert pq.read_table(output).equals(good)
     assert pivot.pivot_path(output) == "workups"
@@ -382,12 +521,31 @@ def test_counting_a_level_twice_is_refused(populated):
         pivot.count_levels(populated, ["workups", "workups"])
 
 
+def test_counting_a_stale_projection_is_refused(populated, tmp_path, monkeypatch):
+    # An artifact derived from a stale projection inherits the dataset hash and so
+    # claims a provenance it does not have; nothing would mark it stale again.
+    monkeypatch.setattr(base, "ARTIFACT_VERSION", f"{base.ARTIFACT_VERSION}-later")
+    with pytest.raises(ValueError, match="stale projection"):
+        pivot.count_levels(populated, ["workups"])
+    with pytest.raises(ValueError, match="stale projection"):
+        pivot.write_pivot(populated, tmp_path / "workups.parquet", level_path="workups")
+
+
+def test_counting_another_kind_of_artifact_is_refused(populated, tmp_path):
+    # Distinct from a file carrying no stamps at all, which load_stamps refuses one
+    # line earlier; this is the branch that reads the stamps and finds the wrong kind.
+    other = tmp_path / "a-pivot.parquet"
+    pivot.write_pivot(populated, other, level_path="workups")
+    with pytest.raises(ValueError, match="is a pivot, not a projection"):
+        pivot.count_levels(other, ["workups"])
+
+
 def test_counting_something_that_is_not_a_projection_is_refused(tmp_path):
     # Otherwise the failure is a DuckDB binder error naming a view the caller never
     # created, for a file it should have been told is the wrong kind.
     other = tmp_path / "not-a-projection.parquet"
     pq.write_table(pa.table({"x": [1]}), other)
-    with pytest.raises(ValueError, match=r"not a derived artifact|not a projection"):
+    with pytest.raises(ValueError, match="not a derived artifact"):
         pivot.count_levels(other, ["workups"])
 
 

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -501,7 +501,7 @@ def test_two_files_alike_but_for_their_filesystem_are_told_apart(tmp_path, monke
 
 def test_artifact_paths_are_sorted(tmp_path):
     # The order artifacts are read in is the order a view holds their rows, and the
-    # order a report names them. rglob answers in directory order, which is whatever
+    # order a report names them. A glob answers in directory order, which is whatever
     # the filesystem last did.
     directory = tmp_path / "workups"
     for shard in ("cc", "aa", "bb"):

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -14,7 +14,10 @@
 
 """Tests for ord_schema.artifacts.pivot."""
 
+import os
 import pathlib
+import re
+import shutil
 
 import duckdb
 import pyarrow as pa
@@ -168,6 +171,7 @@ def _fill_compound(compound) -> None:
     for name in ("ethanol", "ethyl alcohol"):
         compound.identifiers.add(type=reaction_pb2.CompoundIdentifier.NAME, value=name)
     compound.preparations.add(type=reaction_pb2.CompoundPreparation.DRIED)
+    compound.preparations.add(type=reaction_pb2.CompoundPreparation.SYNTHESIZED)
     compound.features["first"].string_value = "recorded"
     compound.features["second"].string_value = "recorded"
     for key in ("first", "second", "third"):
@@ -191,11 +195,12 @@ def _fill_input(reaction_input, components: int) -> None:
 
 
 def _second_reaction():
-    """A reaction recording fewer elements than the first, at the levels that nest.
+    """A second reaction recording something at every repeated level.
 
-    A count that took the largest row, or the first, instead of the total agrees with
-    the unnest at every level where one row holds everything. Two rows recording
-    *different* numbers is what separates a sum from a maximum.
+    What separates a total from a per-row maximum, or from the first row's count, is a
+    second row recording something at the same level -- not two rows recording
+    different numbers, since (1, 1) already sums to more than either. Every level this
+    fills is one where taking a maximum falls short.
     """
     reaction = reaction_pb2.Reaction(reaction_id="ord-pvsecond")
     reaction.identifiers.add(
@@ -245,11 +250,12 @@ def populated(tmp_path_factory) -> pathlib.Path:
     agree with the unnest on every level there is.
 
     Three shapes, because three different wrong counts each agree with the unnest on a
-    projection missing one of them. More than one element per parent at the levels that
-    nest, or counting the lists and counting the elements inside them come to the same
-    number. Two rows recording different totals, or a sum and a maximum do. One row
-    recording nothing, so every level is also counted over a chain that is NULL rather
-    than empty.
+    projection missing one of them. Lists holding more than one element, at enough
+    levels that counting the lists rather than summing their lengths is caught -- not
+    at every level, since a level whose lists happen to hold one element apiece ties
+    either way. Two reactions recording something at every level, so a maximum or a
+    first-row count falls short of the total everywhere. And a third recording nothing,
+    so every level is also counted over a chain that is NULL rather than empty.
     """
     root = tmp_path_factory.mktemp("pivot_full")
     reaction = reaction_pb2.Reaction(reaction_id="ord-pvfull")
@@ -419,79 +425,135 @@ def test_counting_many_levels_answers_each_one_for_itself(populated):
         "inputs.components.analyses.data",
     ]
     counted = pivot.count_levels(populated, wanted)
-    assert len(set(counted.values())) == len(wanted), counted
-    assert counted == {path: _unnested(populated, path) for path in wanted}
+    assert len(set(counted.at.values())) == len(wanted), counted
+    assert counted.at == {path: _unnested(populated, path) for path in wanted}
+
+
+def test_each_part_of_a_file_identity_catches_a_replacement_the_others_miss(tmp_path):
+    # Three components because each covers what the others let through, and the ways a
+    # file is replaced without appearing to change are ordinary rather than exotic:
+    # restoring timestamps is what rsync --times, tar -p, and a snapshot rollback all
+    # do, and a filesystem with coarse mtime granularity does it by accident.
+    path = tmp_path / "file"
+    path.write_bytes(b"first")
+    identity = pivot.file_identity(path)
+
+    # Replaced by rename, with the timestamp put back: same size, same mtime, and only
+    # the inode says a different file is there.
+    replacement = tmp_path / "replacement"
+    replacement.write_bytes(b"secnd")
+    os.utime(replacement, ns=(identity.modified, identity.modified))
+    replacement.replace(path)
+    renamed = pivot.file_identity(path)
+    assert (renamed.size, renamed.modified) == (identity.size, identity.modified)
+    assert renamed != identity
+
+    # Rewritten in place with the timestamp put back: the inode is unchanged and the
+    # mtime restored, so the size is the only difference left.
+    path.write_bytes(b"longer than before")
+    os.utime(path, ns=(renamed.modified, renamed.modified))
+    resized = pivot.file_identity(path)
+    assert (resized.inode, resized.modified) == (renamed.inode, renamed.modified)
+    assert resized != renamed
+
+    # Rewritten in place at the same length: inode and size both hold, and the
+    # timestamp is what is left to notice.
+    path.write_bytes(b"longer than beforE")
+    retimed = pivot.file_identity(path)
+    assert (retimed.inode, retimed.size) == (resized.inode, resized.size)
+    assert retimed != resized
+
+
+def _miscounted(counts: pivot.Counts, level_path: str, value: int) -> pivot.Counts:
+    """Returns ``counts`` with ``level_path`` answered wrongly, everything else kept."""
+    return pivot.Counts(counts.identity, dict(counts.at) | {level_path: value})
 
 
 def test_a_count_that_disagrees_with_the_unnest_is_refused(populated, tmp_path):
     # A nonzero count is checked against what the unnest produced, in either direction.
-    # A count of zero skips the unnest and has nothing to disagree with; counted_over
-    # is what holds that case, in the test below.
+    # A count of zero skips the unnest and has nothing to disagree with; what holds
+    # that case is that the count came from Counts, which names the file it was read
+    # from and the level it answers for -- the two tests below.
     output = tmp_path / "products.parquet"
+    counts = pivot.count_levels(populated, ["outcomes.products"])
     with pytest.raises(ValueError, match="disagree"):
         pivot.write_pivot(
             populated,
             output,
             level_path="outcomes.products",
-            element_count=99,
-            counted_over=pivot.file_identity(populated),
+            counts=_miscounted(counts, "outcomes.products", 99),
         )
     # Nothing published: an artifact that reached the destination would be stamped
     # current, skipped by every later run, and read as the truth about the level.
     assert not output.exists()
 
 
-def test_a_count_taken_over_other_bytes_is_refused(populated, projected, tmp_path):
-    # The case the agreement check cannot reach. Zero is the count that skips the
-    # unnest, so nothing downstream contradicts it and the empty artifact is published
-    # stamped current -- which is why the identity is checked before the count is
-    # believed, rather than the rows checked after.
+def test_a_count_of_the_bytes_that_are_gone_is_refused(populated, tmp_path):
+    # The case the agreement check cannot reach, at the same path rather than a
+    # different one -- an identity that merely told two paths apart would satisfy a
+    # test using two files, and this is the accident the check exists for. Zero is the
+    # count that skips the unnest, so nothing downstream contradicts it and the empty
+    # artifact is published stamped current.
+    source = tmp_path / "projection.parquet"
+    shutil.copy(populated, source)
+    counts = pivot.count_levels(source, ["outcomes.products"])
+    assert counts["outcomes.products"] > 0
+    stale = _miscounted(counts, "outcomes.products", 0)
+    # Rewritten in place, at the path already counted.
+    shutil.copy(populated, source)
     output = tmp_path / "products.parquet"
     with pytest.raises(ValueError, match="has changed since it was counted"):
+        pivot.write_pivot(source, output, level_path="outcomes.products", counts=stale)
+    assert not output.exists()
+
+
+def test_a_count_of_another_level_is_not_an_answer_for_this_one(populated, tmp_path):
+    # The count is taken from Counts by the level being written rather than passed
+    # beside it, so an honest count of one level cannot be spent on another. Zero is
+    # the one that would go unnoticed: the unnest is skipped and the empty artifact
+    # published.
+    counts = pivot.count_levels(populated, ["observations"])
+    output = tmp_path / "components.parquet"
+    with pytest.raises(KeyError, match=re.escape("inputs.components")):
         pivot.write_pivot(
-            populated,
-            output,
-            level_path="outcomes.products",
-            element_count=0,
-            counted_over=pivot.file_identity(projected),
+            populated, output, level_path="inputs.components", counts=counts
         )
     assert not output.exists()
 
 
-def test_a_count_without_what_it_was_counted_over_is_refused(populated, tmp_path):
-    with pytest.raises(ValueError, match="go together"):
-        pivot.write_pivot(
-            populated,
-            tmp_path / "products.parquet",
-            level_path="outcomes.products",
-            element_count=5,
-        )
-    with pytest.raises(ValueError, match="go together"):
-        pivot.write_pivot(
-            populated,
-            tmp_path / "products.parquet",
-            level_path="outcomes.products",
-            counted_over=pivot.file_identity(populated),
-        )
+def test_a_projection_replaced_while_it_is_counted_is_refused(
+    populated, tmp_path, monkeypatch
+):
+    # The counts would describe neither version. Caught by the identity being taken on
+    # both sides of the read rather than only before it.
+    source = tmp_path / "projection.parquet"
+    shutil.copy(populated, source)
+    original = pivot._count_view
+
+    def replace_then_count(*args, **kwargs):
+        result = original(*args, **kwargs)
+        shutil.copy(populated, source)
+        return result
+
+    monkeypatch.setattr(pivot, "_count_view", replace_then_count)
+    with pytest.raises(ValueError, match="replaced while it was being counted"):
+        pivot.count_levels(source, ["outcomes.products"])
 
 
 def test_a_pivot_larger_than_one_batch_counts_every_batch(populated, tmp_path):
     # The rows are accumulated across batches and then checked against the count, so a
     # writer that streams more than one batch is the only shape where the accumulation
-    # can be wrong. Compared against the file, not against the counter it returns.
+    # can be wrong. One write_table per batch means one row group per batch, so the
+    # file says how many batches there were -- where the row count would only say that
+    # row_group_size was honored, which is DuckDB's business and not this test's.
     output = tmp_path / "data.parquet"
     level_path = "inputs.components.analyses.data"
-    counted = pivot.count_levels(populated, [level_path])[level_path]
+    counts = pivot.count_levels(populated, [level_path])
     written = pivot.write_pivot(
-        populated,
-        output,
-        level_path=level_path,
-        row_group_size=7,
-        element_count=counted,
-        counted_over=pivot.file_identity(populated),
+        populated, output, level_path=level_path, row_group_size=7, counts=counts
     )
-    assert written > 7, "one batch would not exercise the accumulation"
-    assert pq.read_table(output).num_rows == written
+    assert pq.ParquetFile(output).num_row_groups > 1, "one batch proves nothing here"
+    assert pq.read_table(output).num_rows == written == counts[level_path]
 
 
 def test_a_rejected_pivot_leaves_an_existing_artifact_alone(populated, tmp_path):
@@ -507,8 +569,11 @@ def test_a_rejected_pivot_leaves_an_existing_artifact_alone(populated, tmp_path)
             populated,
             output,
             level_path="outcomes.products",
-            element_count=99,
-            counted_over=pivot.file_identity(populated),
+            counts=_miscounted(
+                pivot.count_levels(populated, ["outcomes.products"]),
+                "outcomes.products",
+                99,
+            ),
         )
     assert pq.read_table(output).equals(good)
     assert pivot.pivot_path(output) == "workups"

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -761,20 +761,25 @@ def _write_through(mapping, key, value) -> None:
     mapping[key] = value
 
 
-def test_counts_can_be_hashed(populated):
+def test_counts_of_the_same_levels_hash_alike_whatever_order_they_were_asked_in(
+    populated,
+):
     # A frozen dataclass advertises hashability, and the generated hash would reach the
-    # mapping and raise -- naming the mapping's type, to a caller who asked about this
-    # one. The near miss is next door: the memo keyed on a file identity needs one.
-    counts = pivot.count_levels(populated, ["workups", "outcomes.products"])
-    assert hash(counts) == hash(
-        pivot.count_levels(populated, ["workups", "outcomes.products"])
-    )
-    assert len({counts, counts}) == 1
+    # mapping and raise. Equality does not depend on the order the levels were asked
+    # in, so a hash that did would put equal values in different buckets.
+    wanted = ["workups", "outcomes.products"]
+    counts = pivot.count_levels(populated, wanted)
+    reversed_counts = pivot.count_levels(populated, list(reversed(wanted)))
+    assert counts == reversed_counts
+    assert hash(counts) == hash(reversed_counts)
+    assert len({counts, reversed_counts}) == 1
 
 
-def test_counts_cannot_be_written_through(populated):
+def test_counts_own_their_mapping(populated):
     # One build shares a projection's counts across every level it derives, so a write
-    # through any level's handle would be answering for the rest of the run.
+    # that landed would answer for the rest of the run -- and move the hash under
+    # anything holding one. Refused through the handle, and not reachable through the
+    # mapping the Counts was built from, which a proxy alone would leave open.
     counts = pivot.count_levels(populated, ["workups"])
     with pytest.raises(TypeError):
         # Through an unannotated helper: a subscript here is refused statically too,
@@ -782,14 +787,9 @@ def test_counts_cannot_be_written_through(populated):
         _write_through(counts.at, "workups", 99)
     assert counts["workups"] == _unnested(populated, "workups")
 
-
-def test_counts_do_not_alias_the_mapping_they_were_built_from(populated):
-    # A proxy over the caller's own dict refuses writes through the handle and none
-    # through the dict, which is the half that matters: one build shares a projection's
-    # counts across every level it derives, and the hash would move under them too.
     mutable = {"workups": 7}
-    counts = pivot.Counts(pivot.file_identity(populated), mutable)
-    before = hash(counts)
+    built = pivot.Counts(pivot.file_identity(populated), mutable)
+    before = hash(built)
     mutable["workups"] = 99
-    assert counts["workups"] == 7
-    assert hash(counts) == before
+    assert built["workups"] == 7
+    assert hash(built) == before

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -164,36 +164,51 @@ def projected(tmp_path_factory) -> pathlib.Path:
 
 
 def _fill_compound(compound) -> None:
-    """Populates every repeated level a compound carries."""
-    compound.identifiers.add(type=reaction_pb2.CompoundIdentifier.NAME, value="ethanol")
+    """Populates every repeated level a compound carries, more than one deep."""
+    for name in ("ethanol", "ethyl alcohol"):
+        compound.identifiers.add(type=reaction_pb2.CompoundIdentifier.NAME, value=name)
     compound.preparations.add(type=reaction_pb2.CompoundPreparation.DRIED)
-    compound.features["feature"].string_value = "recorded"
-    analysis = compound.analyses["analysis"]
-    analysis.type = reaction_pb2.Analysis.LC
-    analysis.data["datum"].string_value = "recorded"
+    compound.features["first"].string_value = "recorded"
+    compound.features["second"].string_value = "recorded"
+    for key in ("first", "second", "third"):
+        analysis = compound.analyses[key]
+        analysis.type = reaction_pb2.Analysis.LC
+        analysis.data["datum"].string_value = "recorded"
+        analysis.data["another"].string_value = "recorded"
 
 
-def _fill_input(reaction_input) -> None:
-    """Populates a reaction input, its components, and their levels."""
-    _fill_compound(reaction_input.components.add())
+def _fill_input(reaction_input, components: int) -> None:
+    """Populates a reaction input, its components, and their levels.
+
+    Args:
+        reaction_input: The input to fill.
+        components: How many components to add, which is what makes a count of
+            elements differ from a count of the lists holding them.
+    """
+    for _ in range(components):
+        _fill_compound(reaction_input.components.add())
     reaction_input.crude_components.add(reaction_id="ord-pvfull", includes_workup=True)
 
 
 @pytest.fixture(scope="module")
 def populated(tmp_path_factory) -> pathlib.Path:
-    """A projection recording at least one element at every repeated level.
+    """A projection recording elements at every repeated level, several per parent.
 
     The count decides whether a level is unnested at all, so a wrong count is only
     catchable where the level holds something: against a projection recording nothing
     below the second level, a count that answered zero for everything deeper would
     agree with the unnest on every level there is.
+
+    More than one element per parent, because a count of the lists and a count of the
+    elements inside them are the same number when every list holds one.
     """
     root = tmp_path_factory.mktemp("pivot_full")
     reaction = reaction_pb2.Reaction(reaction_id="ord-pvfull")
     reaction.identifiers.add(
         type=reaction_pb2.ReactionIdentifier.REACTION_TYPE, value="oxidation"
     )
-    _fill_input(reaction.inputs["first"])
+    _fill_input(reaction.inputs["first"], components=3)
+    _fill_input(reaction.inputs["second"], components=2)
     reaction.setup.vessel.attachments.add(type=reaction_pb2.VesselAttachment.SEPTUM)
     reaction.setup.vessel.preparations.add(
         type=reaction_pb2.VesselPreparation.OVEN_DRIED
@@ -209,22 +224,26 @@ def populated(tmp_path_factory) -> pathlib.Path:
         current={"value": 1.0, "units": "AMPERE"}
     )
     reaction.observations.add(comment="recorded")
+    reaction.workups.add(type=reaction_pb2.ReactionWorkup.FILTRATION)
     workup = reaction.workups.add(type=reaction_pb2.ReactionWorkup.EXTRACTION)
-    _fill_input(workup.input)
+    _fill_input(workup.input, components=2)
     workup.temperature.measurements.add(
         type=reaction_pb2.TemperatureConditions.TemperatureMeasurement.THERMOCOUPLE_INTERNAL
     )
+    reaction.outcomes.add()
     outcome = reaction.outcomes.add()
     outcome_analysis = outcome.analyses["analysis"]
     outcome_analysis.type = reaction_pb2.Analysis.LC
     outcome_analysis.data["datum"].string_value = "recorded"
+    outcome.products.add(is_desired_product=False)
     product = outcome.products.add(is_desired_product=True)
-    product.identifiers.add(
-        type=reaction_pb2.CompoundIdentifier.NAME, value="acetaldehyde"
-    )
-    product.features["feature"].string_value = "recorded"
+    for name in ("acetaldehyde", "ethanal"):
+        product.identifiers.add(type=reaction_pb2.CompoundIdentifier.NAME, value=name)
+    product.features["first"].string_value = "recorded"
+    product.features["second"].string_value = "recorded"
+    product.measurements.add(type=reaction_pb2.ProductMeasurement.YIELD)
     measurement = product.measurements.add(
-        type=reaction_pb2.ProductMeasurement.YIELD, analysis_key="analysis"
+        type=reaction_pb2.ProductMeasurement.YIELD, analysis_key="first"
     )
     _fill_compound(measurement.authentic_standard)
     reaction.provenance.record_modified.add(details="recorded")
@@ -327,13 +346,41 @@ def test_a_count_that_disagrees_with_the_unnest_is_refused(populated, tmp_path):
     # The count that runs the unnest is checked against what the unnest produced. A
     # count wrongly zero is a different failure, caught by the agreement test above,
     # since the unnest it skips has nothing to disagree with.
+    output = tmp_path / "products.parquet"
     with pytest.raises(ValueError, match="disagree"):
         pivot.write_pivot(
-            populated,
-            tmp_path / "products.parquet",
-            level_path="outcomes.products",
-            element_count=99,
+            populated, output, level_path="outcomes.products", element_count=99
         )
+    # Nothing published: an artifact that reached the destination would be stamped
+    # current, skipped by every later run, and read as the truth about the level.
+    assert not output.exists()
+
+
+def test_a_rejected_pivot_leaves_an_existing_artifact_alone(populated, tmp_path):
+    output = tmp_path / "products.parquet"
+    pivot.write_pivot(populated, output, level_path="outcomes.products")
+    good = pq.read_table(output)
+    with pytest.raises(ValueError, match="disagree"):
+        pivot.write_pivot(
+            populated, output, level_path="outcomes.products", element_count=99
+        )
+    assert pq.read_table(output).equals(good)
+
+
+def test_counting_a_level_twice_is_refused(populated):
+    # zip would pair both, and the dict would collapse them, leaving the caller one
+    # fewer answer than it asked for and no sign of it.
+    with pytest.raises(ValueError, match="named more than once"):
+        pivot.count_levels(populated, ["workups", "workups"])
+
+
+def test_counting_something_that_is_not_a_projection_is_refused(tmp_path):
+    # Otherwise the failure is a DuckDB binder error naming a view the caller never
+    # created, for a file it should have been told is the wrong kind.
+    other = tmp_path / "not-a-projection.parquet"
+    pq.write_table(pa.table({"x": [1]}), other)
+    with pytest.raises(ValueError, match=r"not a derived artifact|not a projection"):
+        pivot.count_levels(other, ["workups"])
 
 
 def test_a_path_that_is_not_a_level_is_refused(projected, tmp_path):

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -499,22 +499,6 @@ def test_two_files_alike_but_for_their_filesystem_are_told_apart(tmp_path, monke
     assert there != here
 
 
-def test_artifact_paths_are_sorted(tmp_path):
-    # The order artifacts are read in is the order a view holds their rows, and the
-    # order a report names them. A glob answers in directory order, which is whatever
-    # the filesystem last did.
-    directory = tmp_path / "workups"
-    for shard in ("cc", "aa", "bb"):
-        (directory / shard).mkdir(parents=True)
-        (directory / shard / f"ord_dataset-{shard}.parquet").write_bytes(b"")
-    found = pivot.artifact_paths(tmp_path, "workups")
-    assert [path.parent.name for path in found] == ["aa", "bb", "cc"]
-
-
-def test_artifact_paths_finds_nothing_where_there_is_no_level(tmp_path):
-    assert pivot.artifact_paths(tmp_path, "workups") == []
-
-
 def _miscounted(counts: pivot.Counts, level_path: str, value: int) -> pivot.Counts:
     """Returns ``counts`` with ``level_path`` answered wrongly, everything else kept."""
     return pivot.Counts(counts.identity, dict(counts) | {level_path: value})

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -472,6 +472,49 @@ def test_each_part_of_a_file_identity_catches_a_replacement_the_others_miss(tmp_
     assert retimed != resized
 
 
+def test_two_files_alike_but_for_their_filesystem_are_told_apart(tmp_path, monkeypatch):
+    # Inode numbers are unique per filesystem, not across them, so without the device
+    # two projections on different mounts can agree on all three of the rest -- and a
+    # memo keyed on the identity would answer one with the other's counts. Staged
+    # through stat, since a second filesystem is not a thing a test can mount.
+    path = tmp_path / "file"
+    path.write_bytes(b"first")
+    here = pivot.file_identity(path)
+
+    class _Elsewhere:
+        """The same file as stat would report it from another filesystem."""
+
+        st_dev = here.device + 1
+        st_ino = here.inode
+        st_size = here.size
+        st_mtime_ns = here.modified
+
+    monkeypatch.setattr(pathlib.Path, "stat", lambda self, **kwargs: _Elsewhere())
+    there = pivot.file_identity(path)
+    assert (there.inode, there.size, there.modified) == (
+        here.inode,
+        here.size,
+        here.modified,
+    )
+    assert there != here
+
+
+def test_artifact_paths_are_sorted(tmp_path):
+    # The order artifacts are read in is the order a view holds their rows, and the
+    # order a report names them. rglob answers in directory order, which is whatever
+    # the filesystem last did.
+    directory = tmp_path / "workups"
+    for shard in ("cc", "aa", "bb"):
+        (directory / shard).mkdir(parents=True)
+        (directory / shard / f"ord_dataset-{shard}.parquet").write_bytes(b"")
+    found = pivot.artifact_paths(tmp_path, "workups")
+    assert [path.parent.name for path in found] == ["aa", "bb", "cc"]
+
+
+def test_artifact_paths_finds_nothing_where_there_is_no_level(tmp_path):
+    assert pivot.artifact_paths(tmp_path, "workups") == []
+
+
 def _miscounted(counts: pivot.Counts, level_path: str, value: int) -> pivot.Counts:
     """Returns ``counts`` with ``level_path`` answered wrongly, everything else kept."""
     return pivot.Counts(counts.identity, dict(counts) | {level_path: value})
@@ -738,3 +781,15 @@ def test_counts_cannot_be_written_through(populated):
         # and what this asserts is that it is refused at runtime.
         _write_through(counts.at, "workups", 99)
     assert counts["workups"] == _unnested(populated, "workups")
+
+
+def test_counts_do_not_alias_the_mapping_they_were_built_from(populated):
+    # A proxy over the caller's own dict refuses writes through the handle and none
+    # through the dict, which is the half that matters: one build shares a projection's
+    # counts across every level it derives, and the hash would move under them too.
+    mutable = {"workups": 7}
+    counts = pivot.Counts(pivot.file_identity(populated), mutable)
+    before = hash(counts)
+    mutable["workups"] = 99
+    assert counts["workups"] == 7
+    assert hash(counts) == before

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -14,8 +14,10 @@
 
 """Tests for ord_schema.artifacts.pivot."""
 
+import logging
 import pathlib
 
+import duckdb
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
@@ -207,6 +209,39 @@ def test_a_level_with_no_elements_still_writes_a_readable_file(projected, tmp_pa
     assert pivot.write_pivot(projected, output, level_path="workups") == 0
     assert pq.read_table(output).num_rows == 0
     assert pivot.pivot_path(output) == "workups"
+
+
+def test_a_level_with_no_elements_is_never_unnested(projected, tmp_path, caplog):
+    # The saving: discovering that a level holds nothing by unnesting it costs a full
+    # pass over every ancestor, and most levels of this schema hold nothing.
+    with caplog.at_level(logging.INFO, logger="ord_schema.artifacts.pivot"):
+        assert (
+            pivot.write_pivot(projected, tmp_path / "w.parquet", level_path="workups")
+            == 0
+        )
+    assert any("no elements at workups" in record.message for record in caplog.records)
+
+
+@pytest.mark.parametrize("level_path", sorted(pivot.LEVELS))
+def test_counting_a_level_agrees_with_unnesting_it(projected, tmp_path, level_path):
+    # The count decides whether the unnest runs at all, so a count that disagreed with
+    # it would write an empty artifact over a level that holds rows.
+    connection = duckdb.connect()
+    try:
+        connection.read_parquet(str(projected)).create_view("reactions")
+        # S608: the expression comes from the module's own walk of the schema.
+        row = connection.execute(
+            f"SELECT {pivot.count_expression(pivot.LEVELS[level_path])} "  # noqa: S608
+            "FROM reactions"
+        ).fetchone()
+        assert row is not None
+        counted = row[0]
+    finally:
+        connection.close()
+    written = pivot.write_pivot(
+        projected, tmp_path / "level.parquet", level_path=level_path
+    )
+    assert counted == written
 
 
 def test_a_path_that_is_not_a_level_is_refused(projected, tmp_path):

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -254,7 +254,10 @@ def populated(tmp_path_factory) -> pathlib.Path:
             dataset_id="ord_dataset-pvfull",
             name="test",
             description="test",
-            reactions=[reaction],
+            # A reaction recording nothing alongside it, so every level is counted over
+            # a row whose whole chain is NULL: the sum skips those and the traversal
+            # coalesces them, and the two agree only if both do it at every depth.
+            reactions=[reaction, reaction_pb2.Reaction(reaction_id="ord-pvempty")],
         ),
         str(source),
     )
@@ -357,14 +360,19 @@ def test_a_count_that_disagrees_with_the_unnest_is_refused(populated, tmp_path):
 
 
 def test_a_rejected_pivot_leaves_an_existing_artifact_alone(populated, tmp_path):
-    output = tmp_path / "products.parquet"
-    pivot.write_pivot(populated, output, level_path="outcomes.products")
+    # The rejected write is over a *different* level than the one already there. Aimed
+    # at the same level it would unnest the same rows, so a destination overwritten by
+    # the artifact being rejected would hold a file equal to the one it replaced, and
+    # comparing them would pass whether or not anything was published.
+    output = tmp_path / "pivot.parquet"
+    pivot.write_pivot(populated, output, level_path="workups")
     good = pq.read_table(output)
     with pytest.raises(ValueError, match="disagree"):
         pivot.write_pivot(
             populated, output, level_path="outcomes.products", element_count=99
         )
     assert pq.read_table(output).equals(good)
+    assert pivot.pivot_path(output) == "workups"
 
 
 def test_counting_a_level_twice_is_refused(populated):

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -14,7 +14,6 @@
 
 """Tests for ord_schema.artifacts.pivot."""
 
-import logging
 import pathlib
 
 import duckdb
@@ -164,6 +163,87 @@ def projected(tmp_path_factory) -> pathlib.Path:
     return output
 
 
+def _fill_compound(compound) -> None:
+    """Populates every repeated level a compound carries."""
+    compound.identifiers.add(type=reaction_pb2.CompoundIdentifier.NAME, value="ethanol")
+    compound.preparations.add(type=reaction_pb2.CompoundPreparation.DRIED)
+    compound.features["feature"].string_value = "recorded"
+    analysis = compound.analyses["analysis"]
+    analysis.type = reaction_pb2.Analysis.LC
+    analysis.data["datum"].string_value = "recorded"
+
+
+def _fill_input(reaction_input) -> None:
+    """Populates a reaction input, its components, and their levels."""
+    _fill_compound(reaction_input.components.add())
+    reaction_input.crude_components.add(reaction_id="ord-pvfull", includes_workup=True)
+
+
+@pytest.fixture(scope="module")
+def populated(tmp_path_factory) -> pathlib.Path:
+    """A projection recording at least one element at every repeated level.
+
+    The count decides whether a level is unnested at all, so a wrong count is only
+    catchable where the level holds something: against a projection recording nothing
+    below the second level, a count that answered zero for everything deeper would
+    agree with the unnest on every level there is.
+    """
+    root = tmp_path_factory.mktemp("pivot_full")
+    reaction = reaction_pb2.Reaction(reaction_id="ord-pvfull")
+    reaction.identifiers.add(
+        type=reaction_pb2.ReactionIdentifier.REACTION_TYPE, value="oxidation"
+    )
+    _fill_input(reaction.inputs["first"])
+    reaction.setup.vessel.attachments.add(type=reaction_pb2.VesselAttachment.SEPTUM)
+    reaction.setup.vessel.preparations.add(
+        type=reaction_pb2.VesselPreparation.OVEN_DRIED
+    )
+    reaction.setup.automation_code["code"].string_value = "recorded"
+    reaction.conditions.temperature.measurements.add(
+        type=reaction_pb2.TemperatureConditions.TemperatureMeasurement.THERMOCOUPLE_INTERNAL
+    )
+    reaction.conditions.pressure.measurements.add(
+        type=reaction_pb2.PressureConditions.PressureMeasurement.PRESSURE_TRANSDUCER
+    )
+    reaction.conditions.electrochemistry.measurements.add(
+        current={"value": 1.0, "units": "AMPERE"}
+    )
+    reaction.observations.add(comment="recorded")
+    workup = reaction.workups.add(type=reaction_pb2.ReactionWorkup.EXTRACTION)
+    _fill_input(workup.input)
+    workup.temperature.measurements.add(
+        type=reaction_pb2.TemperatureConditions.TemperatureMeasurement.THERMOCOUPLE_INTERNAL
+    )
+    outcome = reaction.outcomes.add()
+    outcome_analysis = outcome.analyses["analysis"]
+    outcome_analysis.type = reaction_pb2.Analysis.LC
+    outcome_analysis.data["datum"].string_value = "recorded"
+    product = outcome.products.add(is_desired_product=True)
+    product.identifiers.add(
+        type=reaction_pb2.CompoundIdentifier.NAME, value="acetaldehyde"
+    )
+    product.features["feature"].string_value = "recorded"
+    measurement = product.measurements.add(
+        type=reaction_pb2.ProductMeasurement.YIELD, analysis_key="analysis"
+    )
+    _fill_compound(measurement.authentic_standard)
+    reaction.provenance.record_modified.add(details="recorded")
+    reaction.provenance.reaction_metadata["note"].string_value = "recorded"
+    source = root / "ord_dataset-pvfull.parquet"
+    parquet.save_dataset(
+        dataset_pb2.Dataset(
+            dataset_id="ord_dataset-pvfull",
+            name="test",
+            description="test",
+            reactions=[reaction],
+        ),
+        str(source),
+    )
+    output = root / "projection.parquet"
+    projection.write_projection(source, output)
+    return output
+
+
 def test_a_written_pivot_carries_its_rows_and_its_ordinals(projected, tmp_path):
     output = tmp_path / "products.parquet"
     written = pivot.write_pivot(projected, output, level_path="outcomes.products")
@@ -211,37 +291,49 @@ def test_a_level_with_no_elements_still_writes_a_readable_file(projected, tmp_pa
     assert pivot.pivot_path(output) == "workups"
 
 
-def test_a_level_with_no_elements_is_never_unnested(projected, tmp_path, caplog):
+def test_a_level_with_no_elements_is_never_unnested(projected, tmp_path, monkeypatch):
     # The saving: discovering that a level holds nothing by unnesting it costs a full
     # pass over every ancestor, and most levels of this schema hold nothing.
-    with caplog.at_level(logging.INFO, logger="ord_schema.artifacts.pivot"):
-        assert (
-            pivot.write_pivot(projected, tmp_path / "w.parquet", level_path="workups")
-            == 0
-        )
-    assert any("no elements at workups" in record.message for record in caplog.records)
+    def refuse(*args: object, **kwargs: object) -> str:
+        raise AssertionError("the level was unnested")
+
+    monkeypatch.setattr(pivot, "select", refuse)
+    output = tmp_path / "workups.parquet"
+    assert pivot.write_pivot(projected, output, level_path="workups") == 0
+    assert pq.read_table(output).num_rows == 0
 
 
 @pytest.mark.parametrize("level_path", sorted(pivot.LEVELS))
-def test_counting_a_level_agrees_with_unnesting_it(projected, tmp_path, level_path):
-    # The count decides whether the unnest runs at all, so a count that disagreed with
-    # it would write an empty artifact over a level that holds rows.
+def test_counting_a_level_agrees_with_unnesting_it(populated, level_path):
+    # Compared against the unnest itself, never against write_pivot: its row count is
+    # zero *because* the count said zero, so those two agree however wrong the count
+    # is. A count wrongly zero publishes an empty artifact over a level that holds
+    # rows, and every quantifier over it then reads as no matches.
+    counted = pivot.count_levels(populated, [level_path])[level_path]
     connection = duckdb.connect()
     try:
-        connection.read_parquet(str(projected)).create_view("reactions")
-        # S608: the expression comes from the module's own walk of the schema.
-        row = connection.execute(
-            f"SELECT {pivot.count_expression(pivot.LEVELS[level_path])} "  # noqa: S608
-            "FROM reactions"
-        ).fetchone()
-        assert row is not None
-        counted = row[0]
+        connection.read_parquet(str(populated)).create_view("reactions")
+        unnested = (
+            connection.execute(pivot.select(pivot.LEVELS[level_path], "reactions"))
+            .to_arrow_table()
+            .num_rows
+        )
     finally:
         connection.close()
-    written = pivot.write_pivot(
-        projected, tmp_path / "level.parquet", level_path=level_path
-    )
-    assert counted == written
+    assert counted == unnested
+
+
+def test_a_count_that_disagrees_with_the_unnest_is_refused(populated, tmp_path):
+    # The count that runs the unnest is checked against what the unnest produced. A
+    # count wrongly zero is a different failure, caught by the agreement test above,
+    # since the unnest it skips has nothing to disagree with.
+    with pytest.raises(ValueError, match="disagree"):
+        pivot.write_pivot(
+            populated,
+            tmp_path / "products.parquet",
+            level_path="outcomes.products",
+            element_count=99,
+        )
 
 
 def test_a_path_that_is_not_a_level_is_refused(projected, tmp_path):

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -474,7 +474,7 @@ def test_each_part_of_a_file_identity_catches_a_replacement_the_others_miss(tmp_
 
 def _miscounted(counts: pivot.Counts, level_path: str, value: int) -> pivot.Counts:
     """Returns ``counts`` with ``level_path`` answered wrongly, everything else kept."""
-    return pivot.Counts(counts.identity, dict(counts.at) | {level_path: value})
+    return pivot.Counts(counts.identity, dict(counts) | {level_path: value})
 
 
 @pytest.mark.parametrize("wrong", [99, 1])
@@ -716,6 +716,17 @@ def _write_through(mapping, key, value) -> None:
         value: The value to assign.
     """
     mapping[key] = value
+
+
+def test_counts_can_be_hashed(populated):
+    # A frozen dataclass advertises hashability, and the generated hash would reach the
+    # mapping and raise -- naming the mapping's type, to a caller who asked about this
+    # one. The near miss is next door: the memo keyed on a file identity needs one.
+    counts = pivot.count_levels(populated, ["workups", "outcomes.products"])
+    assert hash(counts) == hash(
+        pivot.count_levels(populated, ["workups", "outcomes.products"])
+    )
+    assert len({counts, counts}) == 1
 
 
 def test_counts_cannot_be_written_through(populated):

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -173,8 +173,9 @@ def _empty_artifacts(
 
     A file the reader would pick up that is not this level's pivot is skipped rather
     than counted -- an artifact of another level, or something left in the tree by hand
-    -- and so is one that cannot be read at all, which is what a run killed between
-    writing an artifact and publishing it leaves behind.
+    -- and so is one that cannot be read at all, a truncated copy or a bad block. A run
+    killed mid-write is not among them: atomic_io names its temp for the destination
+    with a .tmp suffix, which neither this nor a reader ever lists.
 
     Args:
         pivots_dir: The directory the levels sit under.
@@ -257,26 +258,30 @@ def main(args: argparse.Namespace) -> None:
             len(empty),
             artifacts,
         )
-        for path in empty:
-            logger.info("%s: no elements at %s", path, level_path)
+        if len(empty) < artifacts:
+            # Named one by one where only some are empty, which is the shape that needs
+            # looking at. Where all of them are the warning below says so once, and a
+            # line per artifact would bury it on a corpus whose levels are mostly empty.
+            for path in empty:
+                logger.info("%s: no elements at %s", path, level_path)
         for reason in unread:
             logger.warning("%s: not counted at %s", reason, level_path)
-        if not artifacts:
-            # The run derived something, so a reader that finds none of it is not
-            # reading where the run wrote -- a level directory holding artifacts named
-            # in some other way, which is a tree no query can use. Raised rather than
-            # left to the test below, which no artifacts would satisfy vacuously,
-            # announcing a level nothing could be found for as empty everywhere: the
-            # one thing this report exists to say, said about the search rather than
-            # about the corpus.
+        if artifacts < written + skipped:
+            # Every artifact this run wrote or found current, and a reader cannot list
+            # them all -- so some of them went somewhere nothing looks, and the tree is
+            # not the one a query will read. Orphans left by a larger earlier run push
+            # this the other way and cannot raise it.
+            #
+            # Raised rather than reported, because the denominator below shrinks to
+            # match whatever was found: a level half of which is invisible reports the
+            # visible half as the whole, and a level entirely invisible reports zero of
+            # zero, which reads as every artifact being empty. That is the one thing
+            # this report exists to say, said about the search rather than the corpus.
             raise ValueError(
-                f"{directory} holds no pivot artifacts for {level_path}, though "
-                f"{written} were written and {skipped} were already current"
-                + (
-                    f"; {len(unread)} files were not counted: {unread}"
-                    if unread
-                    else ""
-                )
+                f"{directory} holds {artifacts} pivot artifacts for {level_path}, "
+                f"fewer than the {written + skipped} this run wrote or found current; "
+                "the rest are where no reader looks"
+                + (f" ({len(unread)} not counted: {unread})" if unread else "")
             )
         if len(empty) == artifacts:
             # Ordinary for a level nothing in this corpus records, and identical on

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -46,6 +46,7 @@ run that finds no projections at all.
 import argparse
 import functools
 import pathlib
+from collections.abc import Callable, Sequence
 
 from ord_schema.artifacts import base, pivot, projection
 from ord_schema.logging import get_logger
@@ -78,6 +79,61 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _write_counted(
+    source: pathlib.Path,
+    output: pathlib.Path,
+    /,
+    *,
+    level_path: str,
+    counts: Callable[[pathlib.Path], dict[str, int]],
+    source_md5: str,
+    source_dataset_id: str | None,
+) -> int:
+    """Writes one level's artifact, told how many elements it holds.
+
+    Args:
+        source: The projection to pivot.
+        output: Where the artifact goes.
+        level_path: The level to pivot.
+        counts: Answers how many elements a projection holds at every level being
+            derived, reading it once however many levels ask.
+        source_md5: Hash of the source dataset to stamp.
+        source_dataset_id: Source dataset ID to stamp.
+
+    Returns:
+        The number of rows written.
+    """
+    return pivot.write_pivot(
+        source,
+        output,
+        level_path=level_path,
+        element_count=counts(source)[level_path],
+        source_md5=source_md5,
+        source_dataset_id=source_dataset_id,
+    )
+
+
+def _counter(level_paths: Sequence[str]) -> Callable[[pathlib.Path], dict[str, int]]:
+    """Returns a per-projection count of every level, read once per file.
+
+    Args:
+        level_paths: The levels being derived.
+
+    Returns:
+        A callable taking a projection and returning its count per level. The levels
+        share ancestors, so counting them together reads the projection once where a
+        count per level reads it once per level.
+    """
+    counted: dict[pathlib.Path, dict[str, int]] = {}
+
+    def counts(source: pathlib.Path) -> dict[str, int]:
+        if source not in counted:
+            counted[source] = pivot.count_levels(source, level_paths)
+        return counted[source]
+
+    return counts
+
+
 def main(args: argparse.Namespace) -> None:
     """Derives a pivot artifact per level for every projection matching the pattern.
 
@@ -98,12 +154,15 @@ def main(args: argparse.Namespace) -> None:
             f"not repeated levels of the projection schema: {unknown}; "
             f"known levels are {sorted(pivot.LEVELS)}"
         )
+    counts = _counter(args.levels)
     for level_path in args.levels:
         written, skipped, ignored = base.derive_tree(
             args.input_pattern,
             str(pathlib.Path(args.output_dir) / level_path),
             artifact=pivot.ARTIFACT,
-            write=functools.partial(pivot.write_pivot, level_path=level_path),
+            write=functools.partial(
+                _write_counted, level_path=level_path, counts=counts
+            ),
             force=args.force,
             parent_artifact=projection.ARTIFACT,
         )

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -46,7 +46,6 @@ run that finds no projections at all.
 import argparse
 import functools
 import pathlib
-from collections.abc import Callable, Sequence
 
 from ord_schema.artifacts import base, pivot, projection
 from ord_schema.logging import get_logger
@@ -85,7 +84,7 @@ def _write_counted(
     /,
     *,
     level_path: str,
-    counts: Callable[[pathlib.Path], dict[str, int]],
+    level_paths: tuple[str, ...],
     source_md5: str,
     source_dataset_id: str | None,
 ) -> int:
@@ -95,8 +94,7 @@ def _write_counted(
         source: The projection to pivot.
         output: Where the artifact goes.
         level_path: The level to pivot.
-        counts: Answers how many elements a projection holds at every level being
-            derived, reading it once however many levels ask.
+        level_paths: Every level this run derives, counted together on first need.
         source_md5: Hash of the source dataset to stamp.
         source_dataset_id: Source dataset ID to stamp.
 
@@ -107,31 +105,34 @@ def _write_counted(
         source,
         output,
         level_path=level_path,
-        element_count=counts(source)[level_path],
+        element_count=_counts(source, level_paths)[level_path],
         source_md5=source_md5,
         source_dataset_id=source_dataset_id,
     )
 
 
-def _counter(level_paths: Sequence[str]) -> Callable[[pathlib.Path], dict[str, int]]:
-    """Returns a per-projection count of every level, read once per file.
+@functools.cache
+def _counts(source: pathlib.Path, level_paths: tuple[str, ...]) -> dict[str, int]:
+    """Returns the element count per level for one projection, read once.
+
+    Cached because derive_tree drives one level at a time: the levels share ancestors,
+    so counting them together reads the projection once where a count per level reads
+    it once per level, measured at 15x on a projection recording every level.
+
+    Asked for every level being derived rather than only the one at hand, which is the
+    trade: a run rebuilding one stale level of a projection reads the columns of all of
+    them, against a run rebuilding many reading those columns once instead of once per
+    level. Only projections that need at least one level written are counted at all,
+    since nothing calls this for a source derive_tree skips.
 
     Args:
-        level_paths: The levels being derived.
+        source: The projection to count.
+        level_paths: Every level being derived, so one read answers for all of them.
 
     Returns:
-        A callable taking a projection and returning its count per level. The levels
-        share ancestors, so counting them together reads the projection once where a
-        count per level reads it once per level.
+        The count per level.
     """
-    counted: dict[pathlib.Path, dict[str, int]] = {}
-
-    def counts(source: pathlib.Path) -> dict[str, int]:
-        if source not in counted:
-            counted[source] = pivot.count_levels(source, level_paths)
-        return counted[source]
-
-    return counts
+    return pivot.count_levels(source, level_paths)
 
 
 def main(args: argparse.Namespace) -> None:
@@ -148,20 +149,16 @@ def main(args: argparse.Namespace) -> None:
             Silence there would let a pipeline step downstream proceed as though the
             artifacts had been built.
     """
-    unknown = sorted(set(args.levels) - set(pivot.LEVELS))
-    if unknown:
-        raise ValueError(
-            f"not repeated levels of the projection schema: {unknown}; "
-            f"known levels are {sorted(pivot.LEVELS)}"
-        )
-    counts = _counter(args.levels)
+    pivot.check_levels(args.levels)
     for level_path in args.levels:
         written, skipped, ignored = base.derive_tree(
             args.input_pattern,
             str(pathlib.Path(args.output_dir) / level_path),
             artifact=pivot.ARTIFACT,
             write=functools.partial(
-                _write_counted, level_path=level_path, counts=counts
+                _write_counted,
+                level_path=level_path,
+                level_paths=tuple(args.levels),
             ),
             force=args.force,
             parent_artifact=projection.ARTIFACT,

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -39,8 +39,13 @@ artifact version are skipped, so re-running is cheap; --force rewrites them anyw
 A match that is not a projection -- a source dataset, or an artifact from an earlier
 run -- is ignored rather than derived from, so --output_dir may sit inside a recursive
 pattern's reach. These are errors: an --output_dir that would write over any input, a
-match that cannot be read as Parquet at all, a level the schema does not have, and a
-run that finds no projections at all.
+match that cannot be read as Parquet at all, a level the schema does not have or that
+is named twice, a projection that changed while the run was deriving from it or whose
+count and unnest disagreed, and a run that finds no projections at all.
+
+A level that comes out empty across every projection is logged at WARNING. That is
+ordinary for a level nothing in the corpus records, and it is also what a wrong count
+looks like, which nothing downstream can tell apart.
 """
 
 import argparse
@@ -85,6 +90,7 @@ def _write_counted(
     *,
     level_path: str,
     level_paths: tuple[str, ...],
+    written: list[int],
     source_md5: str,
     source_dataset_id: str | None,
 ) -> int:
@@ -95,31 +101,38 @@ def _write_counted(
         output: Where the artifact goes.
         level_path: The level to pivot.
         level_paths: Every level this run derives, counted together on first need.
+        written: Collects the rows each artifact holds, so the caller can say when a
+            level came out empty everywhere; derive_tree reports artifacts, not rows.
         source_md5: Hash of the source dataset to stamp.
         source_dataset_id: Source dataset ID to stamp.
 
     Returns:
         The number of rows written.
     """
-    return pivot.write_pivot(
+    identity = pivot.file_identity(source)
+    rows = pivot.write_pivot(
         source,
         output,
         level_path=level_path,
-        element_count=_counts(source, source_md5, level_paths)[level_path],
+        element_count=_counts(source, identity, level_paths)[level_path],
+        counted_over=identity,
         source_md5=source_md5,
         source_dataset_id=source_dataset_id,
     )
+    written.append(rows)
+    return rows
 
 
 @functools.cache
 def _counts(
-    source: pathlib.Path, source_md5: str, level_paths: tuple[str, ...]
+    source: pathlib.Path, identity: tuple[int, int, int], level_paths: tuple[str, ...]
 ) -> dict[str, int]:
     """Returns the element count per level for one projection, read once.
 
     Cached because derive_tree drives one level at a time: the levels share ancestors,
     so counting them together reads the projection once where a count per level reads
-    it once per level, measured at 15x on a projection recording every level.
+    it once per level -- measured at 15x on a two-shard tree of projections recording
+    every level, and wider on a corpus, where more levels share more ancestors.
 
     Asked for every level being derived rather than only the one at hand, which is the
     trade: a run rebuilding one stale level of a projection reads the columns of all of
@@ -129,12 +142,12 @@ def _counts(
 
     Args:
         source: The projection to count.
-        source_md5: Hash of the dataset the projection reflects, which is part of the
-            key: a count is only the answer for the content it was taken over, and one
-            process outliving a rewritten projection would otherwise pivot the new
-            content against the old count. A count wrongly zero is the bad way to be
-            wrong, since it skips the unnest and publishes an empty artifact that every
-            later run then finds current.
+        identity: ``pivot.file_identity(source)``, which is what makes the key name the
+            file rather than the path. The dataset hash will not do: it is stamped
+            through from the projection's parent, so a projection rebuilt from an
+            unchanged dataset carries the same one and would hit an entry counted over
+            the previous bytes. The same value is handed to ``write_pivot``, so the end
+            that counted and the end that unnests agree on what they read.
         level_paths: Every level being derived, so one read answers for all of them.
 
     Returns:
@@ -152,13 +165,15 @@ def main(args: argparse.Namespace) -> None:
 
     Raises:
         ValueError: If a requested level is not one the projection schema has or is
-            named twice, or if the pattern matched no projections -- which usually
-            means it was aimed at the source tree, or at an output tree, rather than at
-            the projections. Silence there would let a pipeline step downstream proceed
-            as though the artifacts had been built.
+            named twice; if a projection changed while it was being derived, or its
+            count and its unnest disagreed; or if the pattern matched no projections --
+            which usually means it was aimed at the source tree, or at an output tree,
+            rather than at the projections. Silence there would let a pipeline step
+            downstream proceed as though the artifacts had been built.
     """
-    pivot.check_levels(args.levels)
-    for level_path in args.levels:
+    levels = pivot.check_levels(args.levels)
+    for level_path in levels:
+        rows: list[int] = []
         written, skipped, ignored = base.derive_tree(
             args.input_pattern,
             str(pathlib.Path(args.output_dir) / level_path),
@@ -166,8 +181,10 @@ def main(args: argparse.Namespace) -> None:
             write=functools.partial(
                 _write_counted,
                 level_path=level_path,
-                level_paths=tuple(args.levels),
+                level_paths=tuple(levels),
+                written=rows,
             ),
+            schema=pivot.schema(pivot.LEVELS[level_path]),
             force=args.force,
             parent_artifact=projection.ARTIFACT,
         )
@@ -177,6 +194,15 @@ def main(args: argparse.Namespace) -> None:
                 f"for {args.input_pattern!r} are projections"
             )
         logger.info("%s: %d written, %d already current", level_path, written, skipped)
+        if rows and not any(rows):
+            # Ordinary for a level nothing in this corpus records, and identical on
+            # disk to the level whose count was wrong: an empty artifact is stamped
+            # current like any other, so no later run revisits it and no reader
+            # distinguishes it. Said out loud once per level, because nothing else in
+            # the chain reports rows at all.
+            logger.warning(
+                "%s: every projection derived is empty at this level", level_path
+            )
 
 
 if __name__ == "__main__":

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -43,14 +43,18 @@ match that cannot be read as Parquet at all, a level the schema does not have or
 is named twice, a projection that changed while the run was deriving from it or whose
 count and unnest disagreed, and a run that finds no projections at all.
 
-A level that comes out empty across every projection is logged at WARNING. That is
-ordinary for a level nothing in the corpus records, and it is also what a wrong count
-looks like, which nothing downstream can tell apart.
+Every run reports, per level, how many of the artifacts on disk hold no rows, and warns
+when all of them do. That is ordinary for a level nothing in the corpus records, and it
+is also what a wrong count looks like, which nothing downstream can tell apart. Counted
+from the artifacts rather than from what the run wrote, so a re-run that skips
+everything reports the same thing as the run that built them.
 """
 
 import argparse
 import functools
 import pathlib
+
+import pyarrow.parquet as pq
 
 from ord_schema.artifacts import base, pivot, projection
 from ord_schema.logging import get_logger
@@ -90,7 +94,6 @@ def _write_counted(
     *,
     level_path: str,
     level_paths: tuple[str, ...],
-    written: list[int],
     source_md5: str,
     source_dataset_id: str | None,
 ) -> int:
@@ -101,38 +104,35 @@ def _write_counted(
         output: Where the artifact goes.
         level_path: The level to pivot.
         level_paths: Every level this run derives, counted together on first need.
-        written: Collects the rows each artifact holds, so the caller can say when a
-            level came out empty everywhere; derive_tree reports artifacts, not rows.
         source_md5: Hash of the source dataset to stamp.
         source_dataset_id: Source dataset ID to stamp.
 
     Returns:
         The number of rows written.
     """
-    identity = pivot.file_identity(source)
-    rows = pivot.write_pivot(
+    return pivot.write_pivot(
         source,
         output,
         level_path=level_path,
-        element_count=_counts(source, identity, level_paths)[level_path],
-        counted_over=identity,
+        counts=_counts(source, pivot.file_identity(source), level_paths),
         source_md5=source_md5,
         source_dataset_id=source_dataset_id,
     )
-    written.append(rows)
-    return rows
 
 
 @functools.cache
 def _counts(
-    source: pathlib.Path, identity: tuple[int, int, int], level_paths: tuple[str, ...]
-) -> dict[str, int]:
+    source: pathlib.Path,
+    identity: pivot.FileIdentity,
+    level_paths: tuple[str, ...],
+) -> pivot.Counts:
     """Returns the element count per level for one projection, read once.
 
     Cached because derive_tree drives one level at a time: the levels share ancestors,
     so counting them together reads the projection once where a count per level reads
-    it once per level -- measured at 15x on a two-shard tree of projections recording
-    every level, and wider on a corpus, where more levels share more ancestors.
+    it once per level -- measured at 15x deriving every level of a two-shard tree of
+    projections that record them all. The margin grows with the bytes each level
+    carries, since that is what the count reads and what the extra reads repeat.
 
     Asked for every level being derived rather than only the one at hand, which is the
     trade: a run rebuilding one stale level of a projection reads the columns of all of
@@ -146,14 +146,31 @@ def _counts(
             file rather than the path. The dataset hash will not do: it is stamped
             through from the projection's parent, so a projection rebuilt from an
             unchanged dataset carries the same one and would hit an entry counted over
-            the previous bytes. The same value is handed to ``write_pivot``, so the end
-            that counted and the end that unnests agree on what they read.
+            the previous bytes.
         level_paths: Every level being derived, so one read answers for all of them.
 
     Returns:
-        The count per level.
+        The counts, carrying the identity of the file they were read from.
     """
     return pivot.count_levels(source, level_paths)
+
+
+def _rows_on_disk(directory: pathlib.Path) -> tuple[int, int]:
+    """Returns how many artifacts sit beneath ``directory`` and how many are empty.
+
+    Read from the Parquet footers rather than tallied as the run writes, so the answer
+    covers the artifacts this run skipped as already current and is the same on a
+    re-run as on the run that built them.
+
+    Args:
+        directory: The level's directory beneath the output directory.
+
+    Returns:
+        The number of artifacts and the number of them holding no rows.
+    """
+    artifacts = sorted(directory.rglob("*.parquet"))
+    empty = sum(1 for path in artifacts if pq.read_metadata(path).num_rows == 0)
+    return len(artifacts), empty
 
 
 def main(args: argparse.Namespace) -> None:
@@ -173,18 +190,16 @@ def main(args: argparse.Namespace) -> None:
     """
     levels = pivot.check_levels(args.levels)
     for level_path in levels:
-        rows: list[int] = []
+        directory = pathlib.Path(args.output_dir) / level_path
         written, skipped, ignored = base.derive_tree(
             args.input_pattern,
-            str(pathlib.Path(args.output_dir) / level_path),
+            str(directory),
             artifact=pivot.ARTIFACT,
             write=functools.partial(
                 _write_counted,
                 level_path=level_path,
                 level_paths=tuple(levels),
-                written=rows,
             ),
-            schema=pivot.schema(pivot.LEVELS[level_path]),
             force=args.force,
             parent_artifact=projection.ARTIFACT,
         )
@@ -193,16 +208,22 @@ def main(args: argparse.Namespace) -> None:
                 f"no pivots derived for {level_path}: none of the {ignored} matches "
                 f"for {args.input_pattern!r} are projections"
             )
-        logger.info("%s: %d written, %d already current", level_path, written, skipped)
-        if rows and not any(rows):
+        artifacts, empty = _rows_on_disk(directory)
+        logger.info(
+            "%s: %d written, %d already current, %d of %d empty",
+            level_path,
+            written,
+            skipped,
+            empty,
+            artifacts,
+        )
+        if empty == artifacts:
             # Ordinary for a level nothing in this corpus records, and identical on
-            # disk to the level whose count was wrong: an empty artifact is stamped
-            # current like any other, so no later run revisits it and no reader
-            # distinguishes it. Said out loud once per level, because nothing else in
-            # the chain reports rows at all.
-            logger.warning(
-                "%s: every projection derived is empty at this level", level_path
-            )
+            # disk to a level whose count came back wrong: an empty artifact is stamped
+            # current like any other, so no later run revisits it and no reader tells
+            # the two apart. Nothing else in the chain aggregates rows across a tree,
+            # or says anything about them above INFO.
+            logger.warning("%s: every artifact is empty at this level", level_path)
 
 
 if __name__ == "__main__":

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -105,14 +105,16 @@ def _write_counted(
         source,
         output,
         level_path=level_path,
-        element_count=_counts(source, level_paths)[level_path],
+        element_count=_counts(source, source_md5, level_paths)[level_path],
         source_md5=source_md5,
         source_dataset_id=source_dataset_id,
     )
 
 
 @functools.cache
-def _counts(source: pathlib.Path, level_paths: tuple[str, ...]) -> dict[str, int]:
+def _counts(
+    source: pathlib.Path, source_md5: str, level_paths: tuple[str, ...]
+) -> dict[str, int]:
     """Returns the element count per level for one projection, read once.
 
     Cached because derive_tree drives one level at a time: the levels share ancestors,
@@ -127,6 +129,12 @@ def _counts(source: pathlib.Path, level_paths: tuple[str, ...]) -> dict[str, int
 
     Args:
         source: The projection to count.
+        source_md5: Hash of the dataset the projection reflects, which is part of the
+            key: a count is only the answer for the content it was taken over, and one
+            process outliving a rewritten projection would otherwise pivot the new
+            content against the old count. A count wrongly zero is the bad way to be
+            wrong, since it skips the unnest and publishes an empty artifact that every
+            later run then finds current.
         level_paths: Every level being derived, so one read answers for all of them.
 
     Returns:
@@ -143,11 +151,11 @@ def main(args: argparse.Namespace) -> None:
             and ``force``.
 
     Raises:
-        ValueError: If a requested level is not one the projection schema has, or if
-            the pattern matched no projections -- which usually means it was aimed at
-            the source tree, or at an output tree, rather than at the projections.
-            Silence there would let a pipeline step downstream proceed as though the
-            artifacts had been built.
+        ValueError: If a requested level is not one the projection schema has or is
+            named twice, or if the pattern matched no projections -- which usually
+            means it was aimed at the source tree, or at an output tree, rather than at
+            the projections. Silence there would let a pipeline step downstream proceed
+            as though the artifacts had been built.
     """
     pivot.check_levels(args.levels)
     for level_path in args.levels:

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -41,25 +41,12 @@ run -- is ignored rather than derived from, so --output_dir may sit inside a rec
 pattern's reach. These are errors: an --output_dir that would write over any input, an
 input that cannot be read as Parquet at all, a level the schema does not have or that
 is named twice, a projection that changed while the run was deriving from it or whose
-count and unnest disagreed, a run that finds no projections at all, and a level whose
-artifacts cannot be found once it has derived them.
-
-Every run reports, per level, how many of the artifacts on disk hold no rows, and warns
-when all of them do. That is ordinary for a level nothing in the corpus records, and it
-is also what a wrong count looks like, which nothing downstream can tell apart. Counted
-from the artifacts rather than from what the run wrote, so a re-run that skips
-everything reports the same thing as the run that built them, over exactly the files a
-corpus reads. A file found there that is not this level's pivot -- unreadable,
-unstamped, or another level's -- is reported and left out of the tally rather than
-ending the run, since the output tree is not this script's to police.
+count and unnest disagreed, and a run that finds no projections at all.
 """
 
 import argparse
 import functools
 import pathlib
-
-import pyarrow as pa
-import pyarrow.parquet as pq
 
 from ord_schema.artifacts import base, pivot, projection
 from ord_schema.logging import get_logger
@@ -160,52 +147,6 @@ def _counts(
     return pivot.count_levels(source, level_paths)
 
 
-def _empty_artifacts(
-    pivots_dir: str, level_path: str
-) -> tuple[int, list[str], list[str]]:
-    """Counts a level's artifacts, and says which hold no rows and which were skipped.
-
-    Taken over exactly the files ``pivot.artifact_paths`` lists, which is what a corpus
-    reads: a report over any other set describes a tree nobody queries. Their rows are
-    read from the Parquet footers rather than tallied as the run writes, so the answer
-    covers the artifacts this run skipped as already current, and a re-run says what the
-    run that built them said.
-
-    A file the reader would pick up that is not this level's pivot is skipped rather
-    than counted -- an artifact of another level, or something left in the tree by hand
-    -- and so is one that cannot be read at all, a truncated copy or a bad block. A run
-    killed mid-write is not among them: atomic_io names its temp for the destination
-    with a .tmp suffix, which neither this nor a reader ever lists.
-
-    Args:
-        pivots_dir: The directory the levels sit under.
-        level_path: The level whose artifacts to look for.
-
-    Returns:
-        How many pivots of ``level_path`` there are, the paths of those holding no rows,
-        and the paths skipped -- each named rather than tallied, since a count alone
-        sends whoever reads it looking through the whole tree.
-    """
-    found, empty, skipped = 0, [], []
-    for path in pivot.artifact_paths(pivots_dir, level_path):
-        try:
-            metadata = pq.read_metadata(path)
-        except (OSError, pa.ArrowInvalid, pa.ArrowNotImplementedError):
-            skipped.append(f"{path} cannot be read as Parquet")
-            continue
-        stamped = (metadata.metadata or {}).get(pivot.META_PIVOT_PATH.encode())
-        if stamped is None:
-            skipped.append(f"{path} carries no pivot level")
-            continue
-        if stamped.decode() != level_path:
-            skipped.append(f"{path} holds {stamped.decode()}")
-            continue
-        found += 1
-        if metadata.num_rows == 0:
-            empty.append(str(path))
-    return found, empty, skipped
-
-
 def main(args: argparse.Namespace) -> None:
     """Derives a pivot artifact per level for every projection matching the pattern.
 
@@ -216,12 +157,10 @@ def main(args: argparse.Namespace) -> None:
     Raises:
         ValueError: If a requested level is not one the projection schema has or is
             named twice; if a projection changed while it was being derived, or its
-            count and its unnest disagreed; if the pattern matched no projections --
+            count and its unnest disagreed; or if the pattern matched no projections --
             which usually means it was aimed at the source tree, or at an output tree,
-            rather than at the projections; or if a level's artifacts cannot be found
-            after the run derived them, which means they were written somewhere no
-            reader looks. Silence in any of those would let a pipeline step downstream
-            proceed as though the artifacts had been built.
+            rather than at the projections. Silence there would let a pipeline step
+            downstream proceed as though the artifacts had been built.
     """
     levels = pivot.check_levels(args.levels)
     for level_path in levels:
@@ -249,47 +188,7 @@ def main(args: argparse.Namespace) -> None:
                 f"no pivots derived for {level_path}: none of the {ignored} matches "
                 f"for {args.input_pattern!r} are projections"
             )
-        artifacts, empty, unread = _empty_artifacts(args.output_dir, level_path)
-        logger.info(
-            "%s: %d written, %d already current, %d of %d artifacts empty",
-            level_path,
-            written,
-            skipped,
-            len(empty),
-            artifacts,
-        )
-        if len(empty) < artifacts:
-            # Named one by one where only some are empty, which is the shape that needs
-            # looking at. Where all of them are the warning below says so once, and a
-            # line per artifact would bury it on a corpus whose levels are mostly empty.
-            for path in empty:
-                logger.info("%s: no elements at %s", path, level_path)
-        for reason in unread:
-            logger.warning("%s: not counted at %s", reason, level_path)
-        if artifacts < written + skipped:
-            # Every artifact this run wrote or found current, and a reader cannot list
-            # them all -- so some of them went somewhere nothing looks, and the tree is
-            # not the one a query will read. Orphans left by a larger earlier run push
-            # this the other way and cannot raise it.
-            #
-            # Raised rather than reported, because the denominator below shrinks to
-            # match whatever was found: a level half of which is invisible reports the
-            # visible half as the whole, and a level entirely invisible reports zero of
-            # zero, which reads as every artifact being empty. That is the one thing
-            # this report exists to say, said about the search rather than the corpus.
-            raise ValueError(
-                f"{directory} holds {artifacts} pivot artifacts for {level_path}, "
-                f"fewer than the {written + skipped} this run wrote or found current; "
-                "the rest are where no reader looks"
-                + (f" ({len(unread)} not counted: {unread})" if unread else "")
-            )
-        if len(empty) == artifacts:
-            # Ordinary for a level nothing in this corpus records, and identical on
-            # disk to a level whose count came back wrong: an empty artifact is stamped
-            # current like any other, so no later run revisits it and no reader tells
-            # the two apart. Nothing else in the chain aggregates rows across a tree,
-            # or says anything about them above INFO.
-            logger.warning("%s: every artifact is empty at this level", level_path)
+        logger.info("%s: %d written, %d already current", level_path, written, skipped)
 
 
 if __name__ == "__main__":

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -38,16 +38,20 @@ artifact version are skipped, so re-running is cheap; --force rewrites them anyw
 
 A match that is not a projection -- a source dataset, or an artifact from an earlier
 run -- is ignored rather than derived from, so --output_dir may sit inside a recursive
-pattern's reach. These are errors: an --output_dir that would write over any input, a
-match that cannot be read as Parquet at all, a level the schema does not have or that
+pattern's reach. These are errors: an --output_dir that would write over any input, an
+input that cannot be read as Parquet at all, a level the schema does not have or that
 is named twice, a projection that changed while the run was deriving from it or whose
-count and unnest disagreed, and a run that finds no projections at all.
+count and unnest disagreed, a run that finds no projections at all, and a level whose
+artifacts cannot be found once it has derived them.
 
 Every run reports, per level, how many of the artifacts on disk hold no rows, and warns
 when all of them do. That is ordinary for a level nothing in the corpus records, and it
 is also what a wrong count looks like, which nothing downstream can tell apart. Counted
 from the artifacts rather than from what the run wrote, so a re-run that skips
-everything reports the same thing as the run that built them.
+everything reports the same thing as the run that built them, over exactly the files a
+corpus reads. A file found there that is not this level's pivot -- unreadable,
+unstamped, or another level's -- is reported and left out of the tally rather than
+ending the run, since the output tree is not this script's to police.
 """
 
 import argparse
@@ -156,44 +160,49 @@ def _counts(
     return pivot.count_levels(source, level_paths)
 
 
-def _empty_artifacts(directory: pathlib.Path, level_path: str) -> tuple[int, list[str]]:
-    """Returns the pivots for ``level_path`` beneath ``directory``, and the empty ones.
+def _empty_artifacts(
+    pivots_dir: str, level_path: str
+) -> tuple[int, list[str], list[str]]:
+    """Counts a level's artifacts, and says which hold no rows and which were skipped.
 
-    Read from the Parquet footers rather than tallied as the run writes, so the answer
-    covers the artifacts this run skipped as already current and is the same on a
-    re-run as on the run that built them.
+    Taken over exactly the files ``pivot.artifact_paths`` lists, which is what a corpus
+    reads: a report over any other set describes a tree nobody queries. Their rows are
+    read from the Parquet footers rather than tallied as the run writes, so the answer
+    covers the artifacts this run skipped as already current, and a re-run says what the
+    run that built them said.
 
-    Identified by the level stamped in the footer rather than by their name: an
-    artifact is named for the projection it came from, whatever suffix that carried, so
-    a pattern matching one spelling would find none of them and report a level as empty
-    that is not. The same read passes over a file that is not a pivot of this level at
-    all -- something else left in the tree, or an artifact of another level.
+    A file the reader would pick up that is not this level's pivot is skipped rather
+    than counted -- an artifact of another level, or something left in the tree by hand
+    -- and so is one that cannot be read at all, which is what a run killed between
+    writing an artifact and publishing it leaves behind.
 
     Args:
-        directory: The level's directory beneath the output directory.
+        pivots_dir: The directory the levels sit under.
         level_path: The level whose artifacts to look for.
 
     Returns:
-        How many pivots of ``level_path`` are there, and the paths of those holding no
-        rows -- named, because the run that can still say which projection is empty is
-        the run that writes it, and every run after this one skips it as current.
+        How many pivots of ``level_path`` there are, the paths of those holding no rows,
+        and the paths skipped -- each named rather than tallied, since a count alone
+        sends whoever reads it looking through the whole tree.
     """
-    found, empty = 0, []
-    for path in sorted(directory.rglob("*")):
-        if not path.is_file():
-            continue
+    found, empty, skipped = 0, [], []
+    for path in pivot.artifact_paths(pivots_dir, level_path):
         try:
             metadata = pq.read_metadata(path)
-        except (OSError, pa.ArrowInvalid):
-            logger.warning("%s is not readable as Parquet", path)
+        except (OSError, pa.ArrowInvalid, pa.ArrowNotImplementedError):
+            skipped.append(f"{path} cannot be read as Parquet")
             continue
         stamped = (metadata.metadata or {}).get(pivot.META_PIVOT_PATH.encode())
-        if stamped is None or stamped.decode() != level_path:
+        if stamped is None:
+            skipped.append(f"{path} carries no pivot level")
+            continue
+        if stamped.decode() != level_path:
+            skipped.append(f"{path} holds {stamped.decode()}")
             continue
         found += 1
         if metadata.num_rows == 0:
             empty.append(str(path))
-    return found, empty
+    return found, empty, skipped
 
 
 def main(args: argparse.Namespace) -> None:
@@ -206,10 +215,12 @@ def main(args: argparse.Namespace) -> None:
     Raises:
         ValueError: If a requested level is not one the projection schema has or is
             named twice; if a projection changed while it was being derived, or its
-            count and its unnest disagreed; or if the pattern matched no projections --
+            count and its unnest disagreed; if the pattern matched no projections --
             which usually means it was aimed at the source tree, or at an output tree,
-            rather than at the projections. Silence there would let a pipeline step
-            downstream proceed as though the artifacts had been built.
+            rather than at the projections; or if a level's artifacts cannot be found
+            after the run derived them, which means they were written somewhere no
+            reader looks. Silence in any of those would let a pipeline step downstream
+            proceed as though the artifacts had been built.
     """
     levels = pivot.check_levels(args.levels)
     for level_path in levels:
@@ -237,7 +248,7 @@ def main(args: argparse.Namespace) -> None:
                 f"no pivots derived for {level_path}: none of the {ignored} matches "
                 f"for {args.input_pattern!r} are projections"
             )
-        artifacts, empty = _empty_artifacts(directory, level_path)
+        artifacts, empty, unread = _empty_artifacts(args.output_dir, level_path)
         logger.info(
             "%s: %d written, %d already current, %d of %d artifacts empty",
             level_path,
@@ -248,16 +259,24 @@ def main(args: argparse.Namespace) -> None:
         )
         for path in empty:
             logger.info("%s: no elements at %s", path, level_path)
+        for reason in unread:
+            logger.warning("%s: not counted at %s", reason, level_path)
         if not artifacts:
-            # The run derived something, so its artifacts are somewhere; not finding
-            # them means this is measuring the wrong tree. Raised rather than left to
-            # the test below, which no artifacts would satisfy vacuously -- announcing
-            # that a level nothing could be found for is empty everywhere, which is the
-            # one thing this whole report exists to say and would here be saying it
-            # about a scan that failed.
+            # The run derived something, so a reader that finds none of it is not
+            # reading where the run wrote -- a level directory holding artifacts named
+            # in some other way, which is a tree no query can use. Raised rather than
+            # left to the test below, which no artifacts would satisfy vacuously,
+            # announcing a level nothing could be found for as empty everywhere: the
+            # one thing this report exists to say, said about the search rather than
+            # about the corpus.
             raise ValueError(
                 f"{directory} holds no pivot artifacts for {level_path}, though "
                 f"{written} were written and {skipped} were already current"
+                + (
+                    f"; {len(unread)} files were not counted: {unread}"
+                    if unread
+                    else ""
+                )
             )
         if len(empty) == artifacts:
             # Ordinary for a level nothing in this corpus records, and identical on

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -249,9 +249,12 @@ def main(args: argparse.Namespace) -> None:
         for path in empty:
             logger.info("%s: no elements at %s", path, level_path)
         if not artifacts:
-            # The run derived something, so its artifacts are somewhere; not being able
-            # to find them means this is measuring the wrong tree, and every judgment
-            # below rests on having found them.
+            # The run derived something, so its artifacts are somewhere; not finding
+            # them means this is measuring the wrong tree. Raised rather than left to
+            # the test below, which no artifacts would satisfy vacuously -- announcing
+            # that a level nothing could be found for is empty everywhere, which is the
+            # one thing this whole report exists to say and would here be saying it
+            # about a scan that failed.
             raise ValueError(
                 f"{directory} holds no pivot artifacts for {level_path}, though "
                 f"{written} were written and {skipped} were already current"

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -54,6 +54,7 @@ import argparse
 import functools
 import pathlib
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 
 from ord_schema.artifacts import base, pivot, projection
@@ -155,22 +156,44 @@ def _counts(
     return pivot.count_levels(source, level_paths)
 
 
-def _rows_on_disk(directory: pathlib.Path) -> tuple[int, int]:
-    """Returns how many artifacts sit beneath ``directory`` and how many are empty.
+def _empty_artifacts(directory: pathlib.Path, level_path: str) -> tuple[int, list[str]]:
+    """Returns the pivots for ``level_path`` beneath ``directory``, and the empty ones.
 
     Read from the Parquet footers rather than tallied as the run writes, so the answer
     covers the artifacts this run skipped as already current and is the same on a
     re-run as on the run that built them.
 
+    Identified by the level stamped in the footer rather than by their name: an
+    artifact is named for the projection it came from, whatever suffix that carried, so
+    a pattern matching one spelling would find none of them and report a level as empty
+    that is not. The same read passes over a file that is not a pivot of this level at
+    all -- something else left in the tree, or an artifact of another level.
+
     Args:
         directory: The level's directory beneath the output directory.
+        level_path: The level whose artifacts to look for.
 
     Returns:
-        The number of artifacts and the number of them holding no rows.
+        How many pivots of ``level_path`` are there, and the paths of those holding no
+        rows -- named, because the run that can still say which projection is empty is
+        the run that writes it, and every run after this one skips it as current.
     """
-    artifacts = sorted(directory.rglob("*.parquet"))
-    empty = sum(1 for path in artifacts if pq.read_metadata(path).num_rows == 0)
-    return len(artifacts), empty
+    found, empty = 0, []
+    for path in sorted(directory.rglob("*")):
+        if not path.is_file():
+            continue
+        try:
+            metadata = pq.read_metadata(path)
+        except (OSError, pa.ArrowInvalid):
+            logger.warning("%s is not readable as Parquet", path)
+            continue
+        stamped = (metadata.metadata or {}).get(pivot.META_PIVOT_PATH.encode())
+        if stamped is None or stamped.decode() != level_path:
+            continue
+        found += 1
+        if metadata.num_rows == 0:
+            empty.append(str(path))
+    return found, empty
 
 
 def main(args: argparse.Namespace) -> None:
@@ -200,6 +223,12 @@ def main(args: argparse.Namespace) -> None:
                 level_path=level_path,
                 level_paths=tuple(levels),
             ),
+            # Reaches the ordinals, which are top-level columns: a repeated level added
+            # to the schema above this one gives every level beneath it another one,
+            # and the artifacts carrying the old set are derived again rather than
+            # stamping as current. What it does not reach is the element struct, which
+            # is one column however its fields change; that is what a version is for.
+            schema=pivot.schema(pivot.LEVELS[level_path]),
             force=args.force,
             parent_artifact=projection.ARTIFACT,
         )
@@ -208,16 +237,26 @@ def main(args: argparse.Namespace) -> None:
                 f"no pivots derived for {level_path}: none of the {ignored} matches "
                 f"for {args.input_pattern!r} are projections"
             )
-        artifacts, empty = _rows_on_disk(directory)
+        artifacts, empty = _empty_artifacts(directory, level_path)
         logger.info(
-            "%s: %d written, %d already current, %d of %d empty",
+            "%s: %d written, %d already current, %d of %d artifacts empty",
             level_path,
             written,
             skipped,
-            empty,
+            len(empty),
             artifacts,
         )
-        if empty == artifacts:
+        for path in empty:
+            logger.info("%s: no elements at %s", path, level_path)
+        if not artifacts:
+            # The run derived something, so its artifacts are somewhere; not being able
+            # to find them means this is measuring the wrong tree, and every judgment
+            # below rests on having found them.
+            raise ValueError(
+                f"{directory} holds no pivot artifacts for {level_path}, though "
+                f"{written} were written and {skipped} were already current"
+            )
+        if len(empty) == artifacts:
             # Ordinary for a level nothing in this corpus records, and identical on
             # disk to a level whose count came back wrong: an empty artifact is stamped
             # current like any other, so no later run revisits it and no reader tells

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -523,3 +523,18 @@ def test_an_empty_level_is_not_also_named_artifact_by_artifact(projected, caplog
         _run(projected, "--levels", "observations")
     assert any("observations: every artifact is empty" in m for m in _warnings(caplog))
     assert not [m for m in _messages(caplog) if "no elements at" in m]
+
+
+def test_each_level_is_derived_against_its_own_columns(projected):
+    # The columns a level declares are its own, and a level's are a strict subset of
+    # every level beneath it: "outcomes" has no product_index. A run deriving both
+    # against one of their schemas would find a product artifact short an ordinal
+    # current and leave it, which only a correlation joining on that ordinal notices,
+    # by over-returning. Two levels, the shallower named first.
+    _run(projected, "--levels", "outcomes", "outcomes.products")
+    written = (
+        projected / "pivots" / "outcomes.products" / "aa" / "ord_dataset-aa.parquet"
+    )
+    _drop_column(written, "product_index")
+    _run(projected, "--levels", "outcomes", "outcomes.products")
+    assert "product_index" in pq.read_schema(written).names

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -22,6 +22,7 @@ shortcut, and how an unknown level is refused.
 import logging
 import pathlib
 
+import pyarrow.parquet as pq
 import pytest
 
 from ord_schema import parquet
@@ -47,6 +48,19 @@ def _dataset(dataset_id: str):
     )
 
 
+def _reproject(root: pathlib.Path) -> None:
+    """Derives the projections under ``root`` from the datasets under it."""
+    derive_projection.main(
+        derive_projection.parse_args(
+            [
+                f"--input_pattern={root / 'data' / '*' / '*.parquet'}",
+                f"--output_dir={root / 'projections'}",
+                "--force",
+            ]
+        )
+    )
+
+
 @pytest.fixture
 def projected(tmp_path) -> pathlib.Path:
     """Writes two shards of projections, and returns the root holding them."""
@@ -57,14 +71,7 @@ def projected(tmp_path) -> pathlib.Path:
             _dataset(f"ord_dataset-{shard}"),
             str(directory / f"ord_dataset-{shard}.parquet"),
         )
-    derive_projection.main(
-        derive_projection.parse_args(
-            [
-                f"--input_pattern={tmp_path / 'data' / '*' / '*.parquet'}",
-                f"--output_dir={tmp_path / 'projections'}",
-            ]
-        )
-    )
+    _reproject(tmp_path)
     return tmp_path
 
 
@@ -109,6 +116,31 @@ def test_force_rewrites_a_current_artifact(projected):
     before = written.stat().st_mtime_ns
     _run(projected, "--levels", "workups", "--force")
     assert written.stat().st_mtime_ns != before
+
+
+def test_a_rewritten_projection_is_counted_again(projected):
+    # The count decides whether a level is unnested at all, and it is cached across the
+    # levels of one run. A process that outlives a projection must not pivot the new
+    # content against the old count: counting the workups this dataset does not yet
+    # have would answer zero, skip the unnest, and publish an empty artifact stamped
+    # current -- which every later run skips and every quantifier reads as no matches.
+    without = _dataset("ord_dataset-aa")
+    del without.reactions[0].workups[:]
+    parquet.save_dataset(
+        without, str(projected / "data" / "aa" / "ord_dataset-aa.parquet")
+    )
+    _reproject(projected)
+    _run(projected, "--levels", "workups")
+    written = projected / "pivots" / "workups" / "aa" / "ord_dataset-aa.parquet"
+    assert pq.read_table(written).num_rows == 0
+
+    parquet.save_dataset(
+        _dataset("ord_dataset-aa"),
+        str(projected / "data" / "aa" / "ord_dataset-aa.parquet"),
+    )
+    _reproject(projected)
+    _run(projected, "--levels", "workups")
+    assert pq.read_table(written).num_rows == 1
 
 
 def test_an_unknown_level_is_refused_before_anything_is_written(projected):

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -150,7 +150,11 @@ def test_a_level_empty_in_every_artifact_is_reported(projected, caplog):
     # tree, so without this an empty artifact is published, stamped current, and never
     # looked at again.
     with caplog.at_level(logging.WARNING):
-        _run(projected, "--levels", "observations", "workups")
+        # The empty level named second, and derived after a level whose artifacts are
+        # already on disk: named first it is also levels[0] and the only level in the
+        # tree, so a report that ignored level_path, or that scanned the whole output
+        # directory rather than this level's, would read the same.
+        _run(projected, "--levels", "workups", "observations")
     warnings = _warnings(caplog)
     assert any("observations: every artifact is empty" in m for m in warnings)
     assert not any("workups" in m for m in warnings)
@@ -168,7 +172,7 @@ def test_a_level_empty_in_only_some_artifacts_is_not_reported(tmp_path, caplog):
             str(directory / f"ord_dataset-{shard}.parquet"),
         )
     _reproject(tmp_path)
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         _run(tmp_path, "--levels", "observations")
     rows = [
         pq.read_metadata(path).num_rows
@@ -176,6 +180,11 @@ def test_a_level_empty_in_only_some_artifacts_is_not_reported(tmp_path, caplog):
     ]
     assert sorted(rows) == [0, 1], "the shards must differ for this to prove anything"
     assert not _warnings(caplog)
+    # The tally an operator reads, with the two numbers distinct so their order shows.
+    assert any(
+        "observations: 2 written, 0 already current, 1 of 2 artifacts empty" in record
+        for record in [r.getMessage() for r in caplog.records]
+    )
 
 
 def test_a_level_empty_in_every_artifact_is_reported_again_on_a_re_run(

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -18,7 +18,10 @@ Artifact behavior is covered in ord_schema.artifacts.pivot_test; these cover the
 the per-level layout a Corpus reads, which matches count as sources, the skip-if-current
 shortcut, how an unknown level is refused, that a projection rewritten under a running
 process is counted again, that each level is written the count taken for it rather than
-another level's, and that a level empty in every artifact says so and keeps saying so.
+another level's, that a level empty in every artifact says so and keeps saying so, that
+what is counted is what a reader reads -- and nothing else in the tree -- and that an
+artifact short a column is derived again rather than left current, from here and from a
+Corpus.
 """
 
 import logging
@@ -189,7 +192,7 @@ def test_a_level_empty_in_only_some_artifacts_is_not_reported(tmp_path, caplog):
         for message in messages
     )
     # Named, not just counted: the projection that came out empty is what an operator
-    # would go and look at, and this run is the last one that can say which it was.
+    # would go and look at, and a count alone sends them through the whole tree.
     named = [
         message for message in messages if "no elements at observations" in message
     ]
@@ -200,14 +203,18 @@ def test_a_level_empty_in_only_some_artifacts_is_not_reported(tmp_path, caplog):
 
 def test_files_that_are_not_this_level_s_pivots_are_not_counted(projected, caplog):
     # The tally decides whether a level is reported as empty, so anything it miscounts
-    # either invents that report or suppresses it. All three of these turn up in a real
-    # tree: atomic_io writes its temp as a sibling inside the level's own directory, so
-    # a run killed mid-write leaves one behind, and an output directory is a place
-    # people put things.
+    # either invents that report or suppresses it. All of these turn up in a real tree:
+    # atomic_io writes its temp as a sibling inside the level's own directory, so a run
+    # killed mid-write leaves one behind, and an output directory is a place people put
+    # things.
     _run(projected, "--levels", "workups", "outcomes.products")
     beside = projected / "pivots" / "workups" / "aa"
-    # Sorts before bb's artifact, so a scan that gave up on it would stop short.
+    # A leaked temp is not named like an artifact, so no reader sees it and neither
+    # does the tally -- which matters because this one holds rows, and counting it
+    # would say the level has something no query can reach.
     (beside / "ord_dataset-aa.parquet.q7x1.tmp").write_bytes(b"")
+    # These three a reader would pick up, and each is not this level's pivot.
+    (beside / "corrupt.parquet").write_bytes(b"")
     pq.write_table(pa.table({"x": [1]}), beside / "unstamped.parquet")
     shutil.copy(
         projected / "pivots" / "outcomes.products" / "aa" / "ord_dataset-aa.parquet",
@@ -220,10 +227,39 @@ def test_files_that_are_not_this_level_s_pivots_are_not_counted(projected, caplo
         "workups: 0 written, 2 already current, 0 of 2 artifacts empty" in message
         for message in messages
     )
-    # The unreadable file is called out, and nothing calls the level empty.
     warnings = _warnings(caplog)
-    assert len(warnings) == 1
-    assert "q7x1.tmp is not readable as Parquet" in warnings[0]
+    assert sorted(warning.split("/")[-1] for warning in warnings) == [
+        "another-level.parquet holds outcomes.products: not counted at workups",
+        "corrupt.parquet cannot be read as Parquet: not counted at workups",
+        "unstamped.parquet carries no pivot level: not counted at workups",
+    ]
+
+
+def test_a_level_whose_artifacts_a_reader_cannot_find_is_an_error(tmp_path):
+    # A tree derived from projections a reader's glob does not match is written where
+    # nothing looks: derive_tree reports every artifact current, and every quantifier
+    # over the level falls back to unnesting the projection, forever.
+    for shard in ("aa", "bb"):
+        directory = tmp_path / "data" / shard
+        directory.mkdir(parents=True, exist_ok=True)
+        parquet.save_dataset(
+            _dataset(f"ord_dataset-{shard}"),
+            str(directory / f"ord_dataset-{shard}.parquet"),
+        )
+    _reproject(tmp_path)
+    for projection_path in (tmp_path / "projections").rglob("*.parquet"):
+        projection_path.replace(projection_path.with_suffix(".pq"))
+    with pytest.raises(ValueError, match="holds no pivot artifacts for workups"):
+        derive_pivots.main(
+            derive_pivots.parse_args(
+                [
+                    f"--input_pattern={tmp_path / 'projections' / '*' / '*.pq'}",
+                    f"--output_dir={tmp_path / 'pivots'}",
+                    "--levels",
+                    "workups",
+                ]
+            )
+        )
 
 
 def test_a_level_empty_in_every_artifact_is_reported_again_on_a_re_run(
@@ -260,7 +296,8 @@ def test_a_rewritten_projection_is_counted_again(projected):
     # levels of one run. A process that outlives a projection must not pivot the new
     # content against the old count: counting the workups this dataset does not yet
     # have would answer zero, skip the unnest, and publish an empty artifact stamped
-    # current -- which every later run skips and every quantifier reads as no matches.
+    # current -- which every later run skips, and which answers no exists and
+    # every forall.
     without = _dataset("ord_dataset-aa")
     del without.reactions[0].workups[:]
     parquet.save_dataset(
@@ -337,9 +374,9 @@ def test_a_corpus_reads_the_tree_this_script_writes(projected, caplog):
 def _drop_column(path: pathlib.Path, column: str) -> None:
     """Rewrites the artifact at ``path`` without ``column``, keeping its footer.
 
-    Stands in for an artifact written before the schema carried that column: the stamps
-    are what a run reads to decide the file is current, and they say nothing about its
-    columns.
+    Stands in for an artifact written before the schema carried that column, by a
+    library version that would not have bumped for it: the stamps are what a run reads
+    to decide the file is current, and they say nothing about its columns.
 
     Args:
         path: The artifact to rewrite.
@@ -353,10 +390,11 @@ def _drop_column(path: pathlib.Path, column: str) -> None:
 
 def test_an_artifact_missing_an_ordinal_is_derived_again(projected):
     # A repeated level added above this one gives it another ordinal, and the artifacts
-    # written before that carry stamps indistinguishable from the ones written after --
-    # so the columns are the only difference, and without declaring them the short
-    # artifact is current forever. A query still answers off it, which is why this
-    # asserts on the file rather than on a result.
+    # written before it carry stamps a later run cannot tell apart, absent a version
+    # bump -- so the columns are the only difference, and without declaring them the
+    # short artifact is current forever. An uncorrelated query still answers off it,
+    # and only a correlation joining on the missing ordinal fails, so this asserts on
+    # the file rather than on a result.
     _run(projected, "--levels", "outcomes.products")
     written = (
         projected / "pivots" / "outcomes.products" / "aa" / "ord_dataset-aa.parquet"

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -16,7 +16,8 @@
 
 Artifact behavior is covered in ord_schema.artifacts.pivot_test; these cover the CLI:
 the per-level layout a Corpus reads, which matches count as sources, the skip-if-current
-shortcut, and how an unknown level is refused.
+shortcut, how an unknown level is refused, that each level is written the count taken
+for it rather than another level's, and that a level empty everywhere says so.
 """
 
 import logging
@@ -38,9 +39,14 @@ from ord_schema.search import execute, query
 
 def _dataset(dataset_id: str):
     reaction = reaction_pb2.Reaction(reaction_id=f"ord-{dataset_id}-01")
-    reaction.inputs["a"].components.add().identifiers.add(
-        type="SMILES", value="c1ccccc1"
-    )
+    # Three components against one workup, so a run deriving both levels pairs two
+    # counts that are not interchangeable: a query built in one order and read back in
+    # another would answer each level with the other's count, and levels holding the
+    # same number of elements make every such pairing the identity.
+    for smiles in ("c1ccccc1", "CCO", "CC(=O)O"):
+        reaction.inputs["a"].components.add().identifiers.add(
+            type="SMILES", value=smiles
+        )
     reaction.workups.add(type="EXTRACTION")
     reaction.outcomes.add().products.add(isolated_color="white")
     return dataset_pb2.Dataset(
@@ -100,6 +106,32 @@ def test_each_level_gets_its_own_tree(projected):
     # A level not asked for is not derived, which is what makes naming them cheaper
     # than deriving all 39.
     assert not (projected / "pivots" / "inputs.components").exists()
+
+
+def test_each_level_is_written_its_own_count(projected):
+    # One query carries an aggregate per level and the row is paired back to the levels
+    # by position, so the whole batching optimization rests on that pairing. The two
+    # levels hold different numbers of elements, or any mispairing would be invisible.
+    _run(projected, "--levels", "workups", "inputs.components")
+    for level, rows in (("workups", 1), ("inputs.components", 3)):
+        for shard in ("aa", "bb"):
+            written = (
+                projected / "pivots" / level / shard / f"ord_dataset-{shard}.parquet"
+            )
+            assert pq.read_table(written).num_rows == rows, level
+
+
+def test_a_level_empty_everywhere_is_reported(projected, caplog):
+    # Ordinary for a level this corpus never records, and identical on disk to a level
+    # whose count came back wrong. Nothing else in the chain reports rows at all, so
+    # without this an empty artifact is published, stamped current, and never revisited.
+    with caplog.at_level(logging.WARNING):
+        _run(projected, "--levels", "observations", "workups")
+    warnings = [
+        record.message for record in caplog.records if record.levelno == logging.WARNING
+    ]
+    assert any("observations: every projection derived is empty" in m for m in warnings)
+    assert not any("workups" in m for m in warnings)
 
 
 def test_a_second_run_skips_what_is_already_current(projected):

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -18,17 +18,13 @@ Artifact behavior is covered in ord_schema.artifacts.pivot_test; these cover the
 the per-level layout a Corpus reads, which matches count as sources, the skip-if-current
 shortcut, how an unknown level is refused, that a projection rewritten under a running
 process is counted again, that each level is written the count taken for it rather than
-another level's, that a level empty in every artifact says so and keeps saying so, that
-what is counted is what a reader reads -- and nothing else in the tree -- and that an
-artifact short a column is derived again rather than left current, from here and from a
-Corpus.
+another level's, and that an artifact short a column is derived again rather than left
+current, from here and from a Corpus.
 """
 
 import logging
 import pathlib
-import shutil
 
-import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
@@ -48,11 +44,8 @@ def _dataset(dataset_id: str, *, observations: bool = False):
 
     Args:
         dataset_id: The dataset ID, which also names the reaction.
-        observations: Whether to record an observation. Off in both shards of the
-            default tree, which is what makes ``observations`` a level the whole tree
-            is empty at; on in one shard where a test needs the levels to differ, since
-            two identical shards make "empty in every artifact" and "empty in any of
-            them" the same question.
+        observations: Whether to record an observation, which is a level the default
+            tree records nothing at.
 
     Returns:
         The dataset.
@@ -140,167 +133,6 @@ def test_each_level_is_written_its_own_count(projected):
                 projected / "pivots" / level / shard / f"ord_dataset-{shard}.parquet"
             )
             assert pq.read_table(written).num_rows == rows, level
-
-
-def _messages(caplog) -> list[str]:
-    """Returns every message recorded so far, formatted."""
-    return [record.getMessage() for record in caplog.records]
-
-
-def _warnings(caplog) -> list[str]:
-    """Returns the WARNING messages recorded so far."""
-    return [
-        record.message for record in caplog.records if record.levelno == logging.WARNING
-    ]
-
-
-def test_a_level_empty_in_every_artifact_is_reported(projected, caplog):
-    # Ordinary for a level this corpus never records, and identical on disk to a level
-    # whose count came back wrong. Nothing else in the chain aggregates rows across a
-    # tree, so without this an empty artifact is published, stamped current, and never
-    # looked at again.
-    with caplog.at_level(logging.INFO):
-        # The empty level named second, and derived after a level whose artifacts are
-        # already on disk: named first it is also levels[0] and the only level in the
-        # tree, so a report that ignored level_path, or that scanned the whole output
-        # directory rather than this level's, would read the same.
-        _run(projected, "--levels", "workups", "observations")
-    # The premise above, asserted rather than assumed: workups really was derived
-    # first, so its artifacts were on disk while observations was being measured.
-    reports = [m for m in _messages(caplog) if "artifacts empty" in m]
-    assert [m.split(":")[0] for m in reports] == ["workups", "observations"]
-    warnings = _warnings(caplog)
-    assert any("observations: every artifact is empty" in m for m in warnings)
-    assert not any("workups" in m for m in warnings)
-
-
-def test_a_level_empty_in_only_some_artifacts_is_not_reported(tmp_path, caplog):
-    # The two shards differ at this level, which is the whole point: with identical
-    # shards, "every artifact is empty" and "any artifact is empty" are the same
-    # question and a warning that fired on an ordinary mixed corpus would pass.
-    for shard, observations in (("aa", True), ("bb", False)):
-        directory = tmp_path / "data" / shard
-        directory.mkdir(parents=True, exist_ok=True)
-        parquet.save_dataset(
-            _dataset(f"ord_dataset-{shard}", observations=observations),
-            str(directory / f"ord_dataset-{shard}.parquet"),
-        )
-    _reproject(tmp_path)
-    with caplog.at_level(logging.INFO):
-        _run(tmp_path, "--levels", "observations")
-    rows = [
-        pq.read_metadata(path).num_rows
-        for path in sorted((tmp_path / "pivots" / "observations").rglob("*.parquet"))
-    ]
-    assert sorted(rows) == [0, 1], "the shards must differ for this to prove anything"
-    assert not _warnings(caplog)
-    messages = [record.getMessage() for record in caplog.records]
-    # The tally an operator reads, with the two numbers distinct so their order shows.
-    assert any(
-        "observations: 2 written, 0 already current, 1 of 2 artifacts empty" in message
-        for message in messages
-    )
-    # Named, not just counted: the projection that came out empty is what an operator
-    # would go and look at, and a count alone sends them through the whole tree.
-    named = [
-        message for message in messages if "no elements at observations" in message
-    ]
-    assert len(named) == 1
-    assert "bb" in named[0]
-    assert "aa" not in named[0]
-
-
-def test_files_that_are_not_this_level_s_pivots_are_not_counted(projected, caplog):
-    # The tally decides whether a level is reported as empty, so anything it miscounts
-    # either invents that report or suppresses it. All of these turn up in a real tree:
-    # atomic_io writes its temp as a sibling inside the level's own directory, so a run
-    # killed mid-write leaves one behind, and an output directory is a place people put
-    # things.
-    _run(projected, "--levels", "workups", "outcomes.products")
-    beside = projected / "pivots" / "workups" / "aa"
-    # A leaked temp is not named like an artifact, so no reader sees it and neither
-    # does the tally -- which matters because this one holds rows, and counting it
-    # would say the level has something no query can reach.
-    (beside / "ord_dataset-aa.parquet.q7x1.tmp").write_bytes(b"")
-    # These three a reader would pick up, and each is not this level's pivot.
-    (beside / "corrupt.parquet").write_bytes(b"")
-    pq.write_table(pa.table({"x": [1]}), beside / "unstamped.parquet")
-    shutil.copy(
-        projected / "pivots" / "outcomes.products" / "aa" / "ord_dataset-aa.parquet",
-        beside / "another-level.parquet",
-    )
-    with caplog.at_level(logging.INFO):
-        _run(projected, "--levels", "workups")
-    messages = [record.getMessage() for record in caplog.records]
-    assert any(
-        "workups: 0 written, 2 already current, 0 of 2 artifacts empty" in message
-        for message in messages
-    )
-    warnings = _warnings(caplog)
-    assert sorted(warning.split("/")[-1] for warning in warnings) == [
-        "another-level.parquet holds outcomes.products: not counted at workups",
-        "corrupt.parquet cannot be read as Parquet: not counted at workups",
-        "unstamped.parquet carries no pivot level: not counted at workups",
-    ]
-
-
-def test_a_shard_a_reader_cannot_descend_is_an_error(projected, tmp_path):
-    # A shard directory symlinked onto other storage is written straight through and
-    # then has to be listed back through the link. Half a level going missing while the
-    # run reports success is the shape that has no other alarm: the denominator shrinks
-    # to match, so the level reads as complete.
-    _run(projected, "--levels", "workups")
-    shard = projected / "pivots" / "workups" / "bb"
-    elsewhere = tmp_path / "elsewhere"
-    shard.rename(elsewhere)
-    shard.symlink_to(elsewhere, target_is_directory=True)
-    assert len(pivot.artifact_paths(projected / "pivots", "workups")) == 2
-    # Nothing is rewritten, so a run that could not descend would find one of two.
-    _run(projected, "--levels", "workups")
-
-
-def test_a_level_whose_artifacts_a_reader_cannot_find_is_an_error(tmp_path):
-    # A tree derived from projections a reader's glob does not match is written where
-    # nothing looks: derive_tree reports every artifact current, and every quantifier
-    # over the level falls back to unnesting the projection, forever.
-    for shard in ("aa", "bb"):
-        directory = tmp_path / "data" / shard
-        directory.mkdir(parents=True, exist_ok=True)
-        parquet.save_dataset(
-            _dataset(f"ord_dataset-{shard}"),
-            str(directory / f"ord_dataset-{shard}.parquet"),
-        )
-    _reproject(tmp_path)
-    for projection_path in (tmp_path / "projections").rglob("*.parquet"):
-        projection_path.replace(projection_path.with_suffix(".pq"))
-    arguments = derive_pivots.parse_args(
-        [
-            f"--input_pattern={tmp_path / 'projections' / '*' / '*.pq'}",
-            f"--output_dir={tmp_path / 'pivots'}",
-            "--levels",
-            "workups",
-        ]
-    )
-    with pytest.raises(ValueError, match="holds 0 pivot artifacts for workups"):
-        derive_pivots.main(arguments)
-    # Again, where the artifacts are now current and the run writes nothing: that is
-    # the steady state of every build after the first, and a guard that counted only
-    # what this run wrote would find nothing missing and report the level empty.
-    with pytest.raises(ValueError, match="holds 0 pivot artifacts for workups"):
-        derive_pivots.main(arguments)
-
-
-def test_a_level_empty_in_every_artifact_is_reported_again_on_a_re_run(
-    projected, caplog
-):
-    # Counted from the artifacts rather than from what the run wrote, so a re-run that
-    # skips every artifact says the same thing. The signal would otherwise appear only
-    # on the run that created them and never again -- vanishing exactly once the empty
-    # artifacts are entrenched.
-    _run(projected, "--levels", "observations")
-    with caplog.at_level(logging.WARNING):
-        _run(projected, "--levels", "observations")
-    assert any("observations: every artifact is empty" in m for m in _warnings(caplog))
 
 
 def test_a_second_run_skips_what_is_already_current(projected):
@@ -473,56 +305,6 @@ def test_a_corpus_deriving_pivots_also_derives_an_artifact_missing_an_ordinal(
             )
         )
     assert "workup_index" in pq.read_schema(written).names
-
-
-def test_a_level_whose_artifacts_cannot_be_found_is_an_error(projected, monkeypatch):
-    # Without this, no artifacts found means none of them hold rows, and the run
-    # announces that the level is empty everywhere -- the report this exists to make,
-    # made about a scan that failed rather than about the corpus.
-    def unreadable(path):
-        raise pa.ArrowInvalid(f"{path} is not Parquet")
-
-    monkeypatch.setattr(derive_pivots.pq, "read_metadata", unreadable)
-    # Naming what it could not read is the difference between an actionable error and
-    # "2 were written and a reader found none of them".
-    with pytest.raises(
-        ValueError,
-        match=r"holds 0 pivot artifacts for workups.*"
-        r"2 not counted.*ord_dataset-aa\.parquet cannot be read",
-    ):
-        _run(projected, "--levels", "workups")
-
-
-def test_artifacts_a_shrunken_corpus_left_behind_are_not_an_error(projected, caplog):
-    # A corpus that loses a dataset -- removed, or consolidated into another shard --
-    # leaves its pivots behind with no projection to match. The guard against artifacts
-    # a reader cannot find has to stay one-directional through that: surplus is not the
-    # same failure as absence, and a build that stopped on it would stop on every run
-    # from then on, sending an operator to look for files that are not missing.
-    _run(projected, "--levels", "workups")
-    orphan = projected / "pivots" / "workups" / "cc"
-    orphan.mkdir(parents=True)
-    shutil.copy(
-        projected / "pivots" / "workups" / "aa" / "ord_dataset-aa.parquet",
-        orphan / "ord_dataset-cc.parquet",
-    )
-    with caplog.at_level(logging.INFO):
-        _run(projected, "--levels", "workups")
-    assert any(
-        "workups: 0 written, 2 already current, 0 of 3 artifacts empty" in message
-        for message in _messages(caplog)
-    )
-
-
-def test_an_empty_level_is_not_also_named_artifact_by_artifact(projected, caplog):
-    # The warning already says every artifact is empty. Naming each one as well would
-    # be a line per shard across the levels a corpus records nothing at, which on ORD
-    # is most of them -- burying the case the lines exist for, a level empty in only
-    # some of its artifacts.
-    with caplog.at_level(logging.INFO):
-        _run(projected, "--levels", "observations")
-    assert any("observations: every artifact is empty" in m for m in _warnings(caplog))
-    assert not [m for m in _messages(caplog) if "no elements at" in m]
 
 
 def test_each_level_is_derived_against_its_own_columns(projected):

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -16,8 +16,9 @@
 
 Artifact behavior is covered in ord_schema.artifacts.pivot_test; these cover the CLI:
 the per-level layout a Corpus reads, which matches count as sources, the skip-if-current
-shortcut, how an unknown level is refused, that each level is written the count taken
-for it rather than another level's, and that a level empty everywhere says so.
+shortcut, how an unknown level is refused, that a projection rewritten under a running
+process is counted again, that each level is written the count taken for it rather than
+another level's, and that a level empty in every artifact says so and keeps saying so.
 """
 
 import logging
@@ -37,7 +38,20 @@ from ord_schema.proto import dataset_pb2, reaction_pb2
 from ord_schema.search import execute, query
 
 
-def _dataset(dataset_id: str):
+def _dataset(dataset_id: str, *, observations: bool = False):
+    """Returns a one-reaction dataset.
+
+    Args:
+        dataset_id: The dataset ID, which also names the reaction.
+        observations: Whether to record an observation. Off in both shards of the
+            default tree, which is what makes ``observations`` a level the whole tree
+            is empty at; on in one shard where a test needs the levels to differ, since
+            two identical shards make "empty in every artifact" and "empty in any of
+            them" the same question.
+
+    Returns:
+        The dataset.
+    """
     reaction = reaction_pb2.Reaction(reaction_id=f"ord-{dataset_id}-01")
     # Three components against one workup, so a run deriving both levels pairs two
     # counts that are not interchangeable: a query built in one order and read back in
@@ -49,6 +63,8 @@ def _dataset(dataset_id: str):
         )
     reaction.workups.add(type="EXTRACTION")
     reaction.outcomes.add().products.add(isolated_color="white")
+    if observations:
+        reaction.observations.add(comment="recorded")
     return dataset_pb2.Dataset(
         dataset_id=dataset_id, name="test", description="desc", reactions=[reaction]
     )
@@ -121,17 +137,58 @@ def test_each_level_is_written_its_own_count(projected):
             assert pq.read_table(written).num_rows == rows, level
 
 
-def test_a_level_empty_everywhere_is_reported(projected, caplog):
-    # Ordinary for a level this corpus never records, and identical on disk to a level
-    # whose count came back wrong. Nothing else in the chain reports rows at all, so
-    # without this an empty artifact is published, stamped current, and never revisited.
-    with caplog.at_level(logging.WARNING):
-        _run(projected, "--levels", "observations", "workups")
-    warnings = [
+def _warnings(caplog) -> list[str]:
+    """Returns the WARNING messages recorded so far."""
+    return [
         record.message for record in caplog.records if record.levelno == logging.WARNING
     ]
-    assert any("observations: every projection derived is empty" in m for m in warnings)
+
+
+def test_a_level_empty_in_every_artifact_is_reported(projected, caplog):
+    # Ordinary for a level this corpus never records, and identical on disk to a level
+    # whose count came back wrong. Nothing else in the chain aggregates rows across a
+    # tree, so without this an empty artifact is published, stamped current, and never
+    # looked at again.
+    with caplog.at_level(logging.WARNING):
+        _run(projected, "--levels", "observations", "workups")
+    warnings = _warnings(caplog)
+    assert any("observations: every artifact is empty" in m for m in warnings)
     assert not any("workups" in m for m in warnings)
+
+
+def test_a_level_empty_in_only_some_artifacts_is_not_reported(tmp_path, caplog):
+    # The two shards differ at this level, which is the whole point: with identical
+    # shards, "every artifact is empty" and "any artifact is empty" are the same
+    # question and a warning that fired on an ordinary mixed corpus would pass.
+    for shard, observations in (("aa", True), ("bb", False)):
+        directory = tmp_path / "data" / shard
+        directory.mkdir(parents=True, exist_ok=True)
+        parquet.save_dataset(
+            _dataset(f"ord_dataset-{shard}", observations=observations),
+            str(directory / f"ord_dataset-{shard}.parquet"),
+        )
+    _reproject(tmp_path)
+    with caplog.at_level(logging.WARNING):
+        _run(tmp_path, "--levels", "observations")
+    rows = [
+        pq.read_metadata(path).num_rows
+        for path in sorted((tmp_path / "pivots" / "observations").rglob("*.parquet"))
+    ]
+    assert sorted(rows) == [0, 1], "the shards must differ for this to prove anything"
+    assert not _warnings(caplog)
+
+
+def test_a_level_empty_in_every_artifact_is_reported_again_on_a_re_run(
+    projected, caplog
+):
+    # Counted from the artifacts rather than from what the run wrote, so a re-run that
+    # skips every artifact says the same thing. The signal would otherwise appear only
+    # on the run that created them and never again -- vanishing exactly once the empty
+    # artifacts are entrenched.
+    _run(projected, "--levels", "observations")
+    with caplog.at_level(logging.WARNING):
+        _run(projected, "--levels", "observations")
+    assert any("observations: every artifact is empty" in m for m in _warnings(caplog))
 
 
 def test_a_second_run_skips_what_is_already_current(projected):

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -273,17 +273,21 @@ def test_a_level_whose_artifacts_a_reader_cannot_find_is_an_error(tmp_path):
     _reproject(tmp_path)
     for projection_path in (tmp_path / "projections").rglob("*.parquet"):
         projection_path.replace(projection_path.with_suffix(".pq"))
+    arguments = derive_pivots.parse_args(
+        [
+            f"--input_pattern={tmp_path / 'projections' / '*' / '*.pq'}",
+            f"--output_dir={tmp_path / 'pivots'}",
+            "--levels",
+            "workups",
+        ]
+    )
     with pytest.raises(ValueError, match="holds 0 pivot artifacts for workups"):
-        derive_pivots.main(
-            derive_pivots.parse_args(
-                [
-                    f"--input_pattern={tmp_path / 'projections' / '*' / '*.pq'}",
-                    f"--output_dir={tmp_path / 'pivots'}",
-                    "--levels",
-                    "workups",
-                ]
-            )
-        )
+        derive_pivots.main(arguments)
+    # Again, where the artifacts are now current and the run writes nothing: that is
+    # the steady state of every build after the first, and a guard that counted only
+    # what this run wrote would find nothing missing and report the level empty.
+    with pytest.raises(ValueError, match="holds 0 pivot artifacts for workups"):
+        derive_pivots.main(arguments)
 
 
 def test_a_level_empty_in_every_artifact_is_reported_again_on_a_re_run(
@@ -487,3 +491,35 @@ def test_a_level_whose_artifacts_cannot_be_found_is_an_error(projected, monkeypa
         r"2 not counted.*ord_dataset-aa\.parquet cannot be read",
     ):
         _run(projected, "--levels", "workups")
+
+
+def test_artifacts_a_shrunken_corpus_left_behind_are_not_an_error(projected, caplog):
+    # A corpus that loses a dataset -- removed, or consolidated into another shard --
+    # leaves its pivots behind with no projection to match. The guard against artifacts
+    # a reader cannot find has to stay one-directional through that: surplus is not the
+    # same failure as absence, and a build that stopped on it would stop on every run
+    # from then on, sending an operator to look for files that are not missing.
+    _run(projected, "--levels", "workups")
+    orphan = projected / "pivots" / "workups" / "cc"
+    orphan.mkdir(parents=True)
+    shutil.copy(
+        projected / "pivots" / "workups" / "aa" / "ord_dataset-aa.parquet",
+        orphan / "ord_dataset-cc.parquet",
+    )
+    with caplog.at_level(logging.INFO):
+        _run(projected, "--levels", "workups")
+    assert any(
+        "workups: 0 written, 2 already current, 0 of 3 artifacts empty" in message
+        for message in _messages(caplog)
+    )
+
+
+def test_an_empty_level_is_not_also_named_artifact_by_artifact(projected, caplog):
+    # The warning already says every artifact is empty. Naming each one as well would
+    # be a line per shard across the levels a corpus records nothing at, which on ORD
+    # is most of them -- burying the case the lines exist for, a level empty in only
+    # some of its artifacts.
+    with caplog.at_level(logging.INFO):
+        _run(projected, "--levels", "observations")
+    assert any("observations: every artifact is empty" in m for m in _warnings(caplog))
+    assert not [m for m in _messages(caplog) if "no elements at" in m]

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -244,6 +244,21 @@ def test_files_that_are_not_this_level_s_pivots_are_not_counted(projected, caplo
     ]
 
 
+def test_a_shard_a_reader_cannot_descend_is_an_error(projected, tmp_path):
+    # A shard directory symlinked onto other storage is written straight through and
+    # then has to be listed back through the link. Half a level going missing while the
+    # run reports success is the shape that has no other alarm: the denominator shrinks
+    # to match, so the level reads as complete.
+    _run(projected, "--levels", "workups")
+    shard = projected / "pivots" / "workups" / "bb"
+    elsewhere = tmp_path / "elsewhere"
+    shard.rename(elsewhere)
+    shard.symlink_to(elsewhere, target_is_directory=True)
+    assert len(pivot.artifact_paths(projected / "pivots", "workups")) == 2
+    # Nothing is rewritten, so a run that could not descend would find one of two.
+    _run(projected, "--levels", "workups")
+
+
 def test_a_level_whose_artifacts_a_reader_cannot_find_is_an_error(tmp_path):
     # A tree derived from projections a reader's glob does not match is written where
     # nothing looks: derive_tree reports every artifact current, and every quantifier
@@ -258,7 +273,7 @@ def test_a_level_whose_artifacts_a_reader_cannot_find_is_an_error(tmp_path):
     _reproject(tmp_path)
     for projection_path in (tmp_path / "projections").rglob("*.parquet"):
         projection_path.replace(projection_path.with_suffix(".pq"))
-    with pytest.raises(ValueError, match="holds no pivot artifacts for workups"):
+    with pytest.raises(ValueError, match="holds 0 pivot artifacts for workups"):
         derive_pivots.main(
             derive_pivots.parse_args(
                 [
@@ -468,7 +483,7 @@ def test_a_level_whose_artifacts_cannot_be_found_is_an_error(projected, monkeypa
     # "2 were written and a reader found none of them".
     with pytest.raises(
         ValueError,
-        match=r"holds no pivot artifacts for workups.*"
-        r"2 files were not counted.*ord_dataset-aa\.parquet cannot be read",
+        match=r"holds 0 pivot artifacts for workups.*"
+        r"2 not counted.*ord_dataset-aa\.parquet cannot be read",
     ):
         _run(projected, "--levels", "workups")

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -142,6 +142,11 @@ def test_each_level_is_written_its_own_count(projected):
             assert pq.read_table(written).num_rows == rows, level
 
 
+def _messages(caplog) -> list[str]:
+    """Returns every message recorded so far, formatted."""
+    return [record.getMessage() for record in caplog.records]
+
+
 def _warnings(caplog) -> list[str]:
     """Returns the WARNING messages recorded so far."""
     return [
@@ -154,12 +159,16 @@ def test_a_level_empty_in_every_artifact_is_reported(projected, caplog):
     # whose count came back wrong. Nothing else in the chain aggregates rows across a
     # tree, so without this an empty artifact is published, stamped current, and never
     # looked at again.
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.INFO):
         # The empty level named second, and derived after a level whose artifacts are
         # already on disk: named first it is also levels[0] and the only level in the
         # tree, so a report that ignored level_path, or that scanned the whole output
         # directory rather than this level's, would read the same.
         _run(projected, "--levels", "workups", "observations")
+    # The premise above, asserted rather than assumed: workups really was derived
+    # first, so its artifacts were on disk while observations was being measured.
+    reports = [m for m in _messages(caplog) if "artifacts empty" in m]
+    assert [m.split(":")[0] for m in reports] == ["workups", "observations"]
     warnings = _warnings(caplog)
     assert any("observations: every artifact is empty" in m for m in warnings)
     assert not any("workups" in m for m in warnings)
@@ -455,5 +464,11 @@ def test_a_level_whose_artifacts_cannot_be_found_is_an_error(projected, monkeypa
         raise pa.ArrowInvalid(f"{path} is not Parquet")
 
     monkeypatch.setattr(derive_pivots.pq, "read_metadata", unreadable)
-    with pytest.raises(ValueError, match="holds no pivot artifacts for workups"):
+    # Naming what it could not read is the difference between an actionable error and
+    # "2 were written and a reader found none of them".
+    with pytest.raises(
+        ValueError,
+        match=r"holds no pivot artifacts for workups.*"
+        r"2 files were not counted.*ord_dataset-aa\.parquet cannot be read",
+    ):
         _run(projected, "--levels", "workups")

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -23,7 +23,9 @@ another level's, and that a level empty in every artifact says so and keeps sayi
 
 import logging
 import pathlib
+import shutil
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
@@ -180,11 +182,48 @@ def test_a_level_empty_in_only_some_artifacts_is_not_reported(tmp_path, caplog):
     ]
     assert sorted(rows) == [0, 1], "the shards must differ for this to prove anything"
     assert not _warnings(caplog)
+    messages = [record.getMessage() for record in caplog.records]
     # The tally an operator reads, with the two numbers distinct so their order shows.
     assert any(
-        "observations: 2 written, 0 already current, 1 of 2 artifacts empty" in record
-        for record in [r.getMessage() for r in caplog.records]
+        "observations: 2 written, 0 already current, 1 of 2 artifacts empty" in message
+        for message in messages
     )
+    # Named, not just counted: the projection that came out empty is what an operator
+    # would go and look at, and this run is the last one that can say which it was.
+    named = [
+        message for message in messages if "no elements at observations" in message
+    ]
+    assert len(named) == 1
+    assert "bb" in named[0]
+    assert "aa" not in named[0]
+
+
+def test_files_that_are_not_this_level_s_pivots_are_not_counted(projected, caplog):
+    # The tally decides whether a level is reported as empty, so anything it miscounts
+    # either invents that report or suppresses it. All three of these turn up in a real
+    # tree: atomic_io writes its temp as a sibling inside the level's own directory, so
+    # a run killed mid-write leaves one behind, and an output directory is a place
+    # people put things.
+    _run(projected, "--levels", "workups", "outcomes.products")
+    beside = projected / "pivots" / "workups" / "aa"
+    # Sorts before bb's artifact, so a scan that gave up on it would stop short.
+    (beside / "ord_dataset-aa.parquet.q7x1.tmp").write_bytes(b"")
+    pq.write_table(pa.table({"x": [1]}), beside / "unstamped.parquet")
+    shutil.copy(
+        projected / "pivots" / "outcomes.products" / "aa" / "ord_dataset-aa.parquet",
+        beside / "another-level.parquet",
+    )
+    with caplog.at_level(logging.INFO):
+        _run(projected, "--levels", "workups")
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "workups: 0 written, 2 already current, 0 of 2 artifacts empty" in message
+        for message in messages
+    )
+    # The unreadable file is called out, and nothing calls the level empty.
+    warnings = _warnings(caplog)
+    assert len(warnings) == 1
+    assert "q7x1.tmp is not readable as Parquet" in warnings[0]
 
 
 def test_a_level_empty_in_every_artifact_is_reported_again_on_a_re_run(
@@ -293,3 +332,90 @@ def test_a_corpus_reads_the_tree_this_script_writes(projected, caplog):
     messages = [record.message for record in caplog.records]
     assert any("read 2 pivot artifacts for workups" in message for message in messages)
     assert not any("building the pivot" in message for message in messages)
+
+
+def _drop_column(path: pathlib.Path, column: str) -> None:
+    """Rewrites the artifact at ``path`` without ``column``, keeping its footer.
+
+    Stands in for an artifact written before the schema carried that column: the stamps
+    are what a run reads to decide the file is current, and they say nothing about its
+    columns.
+
+    Args:
+        path: The artifact to rewrite.
+        column: The column to drop.
+    """
+    table = pq.read_table(path)
+    metadata = table.schema.metadata
+    table = table.drop_columns([column])
+    pq.write_table(table.replace_schema_metadata(metadata), path)
+
+
+def test_an_artifact_missing_an_ordinal_is_derived_again(projected):
+    # A repeated level added above this one gives it another ordinal, and the artifacts
+    # written before that carry stamps indistinguishable from the ones written after --
+    # so the columns are the only difference, and without declaring them the short
+    # artifact is current forever. A query still answers off it, which is why this
+    # asserts on the file rather than on a result.
+    _run(projected, "--levels", "outcomes.products")
+    written = (
+        projected / "pivots" / "outcomes.products" / "aa" / "ord_dataset-aa.parquet"
+    )
+    _drop_column(written, "product_index")
+    assert "product_index" not in pq.read_schema(written).names
+    _run(projected, "--levels", "outcomes.products")
+    assert "product_index" in pq.read_schema(written).names
+
+
+def test_a_corpus_deriving_pivots_also_derives_an_artifact_missing_an_ordinal(
+    projected,
+):
+    # The script and the Corpus write into one tree, so they have to agree on which
+    # artifacts are current; one of them accepting a column-short artifact the other
+    # rebuilds would leave the answer to whichever ran last.
+    derive_structures.main(
+        derive_structures.parse_args(
+            [
+                f"--input_pattern={projected / 'projections' / '*' / '*.parquet'}",
+                f"--output_dir={projected / 'structures'}",
+            ]
+        )
+    )
+    _run(projected, "--levels", "workups")
+    written = projected / "pivots" / "workups" / "aa" / "ord_dataset-aa.parquet"
+    _drop_column(written, "workup_index")
+    with execute.Corpus(
+        str(projected / "projections" / "*" / "*.parquet"),
+        str(projected / "structures" / "*" / "*.parquet"),
+        resolver={}.__getitem__,
+        pivots_dir=str(projected / "pivots"),
+        derive_pivots=True,
+    ) as corpus:
+        corpus.search(
+            query.Query.model_validate(
+                {
+                    "where": {
+                        "op": "exists",
+                        "path": "workups",
+                        "where": {
+                            "op": "eq",
+                            "path": "type",
+                            "value": {"literal": "EXTRACTION"},
+                        },
+                    }
+                }
+            )
+        )
+    assert "workup_index" in pq.read_schema(written).names
+
+
+def test_a_level_whose_artifacts_cannot_be_found_is_an_error(projected, monkeypatch):
+    # Without this, no artifacts found means none of them hold rows, and the run
+    # announces that the level is empty everywhere -- the report this exists to make,
+    # made about a scan that failed rather than about the corpus.
+    def unreadable(path):
+        raise pa.ArrowInvalid(f"{path} is not Parquet")
+
+    monkeypatch.setattr(derive_pivots.pq, "read_metadata", unreadable)
+    with pytest.raises(ValueError, match="holds no pivot artifacts for workups"):
+        _run(projected, "--levels", "workups")

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -1112,7 +1112,9 @@ class Corpus:
         found = {}
         for path in sorted(pivot.LEVELS):
             if self._pivot_view(path) is not None:
-                found[path] = len(pivot.artifact_paths(self._pivots_dir, path))
+                found[path] = len(
+                    glob.glob(f"{self._pivots_dir}/{path}/**/*.parquet", recursive=True)
+                )
         logger.info(
             "%d of %d levels are held as artifacts: %s",
             len(found),
@@ -1777,9 +1779,12 @@ class Corpus:
         with self._views_lock:
             if path in self._pivot_views:
                 return self._pivot_views[path]
-            files = [
-                str(found) for found in pivot.artifact_paths(self._pivots_dir, path)
-            ]
+            # Recursive, because a pivot tree mirrors the projections it was derived
+            # from: a sharded corpus puts them under <level>/<shard>/ rather than
+            # directly under the level.
+            files = sorted(
+                glob.glob(f"{self._pivots_dir}/{path}/**/*.parquet", recursive=True)
+            )
             if not files:
                 self._pivot_views[path] = None
                 return None

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -1112,9 +1112,7 @@ class Corpus:
         found = {}
         for path in sorted(pivot.LEVELS):
             if self._pivot_view(path) is not None:
-                found[path] = len(
-                    glob.glob(f"{self._pivots_dir}/{path}/**/*.parquet", recursive=True)
-                )
+                found[path] = len(pivot.artifact_paths(self._pivots_dir, path))
         logger.info(
             "%d of %d levels are held as artifacts: %s",
             len(found),
@@ -1779,12 +1777,9 @@ class Corpus:
         with self._views_lock:
             if path in self._pivot_views:
                 return self._pivot_views[path]
-            # Recursive, because a pivot tree mirrors the projections it was derived
-            # from: a sharded corpus puts them under <level>/<shard>/ rather than
-            # directly under the level.
-            files = sorted(
-                glob.glob(f"{self._pivots_dir}/{path}/**/*.parquet", recursive=True)
-            )
+            files = [
+                str(found) for found in pivot.artifact_paths(self._pivots_dir, path)
+            ]
             if not files:
                 self._pivot_views[path] = None
                 return None

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -1895,6 +1895,9 @@ class Corpus:
                 str(pathlib.Path(self._pivots_dir) / path),
                 artifact=pivot.ARTIFACT,
                 write=functools.partial(pivot.write_pivot, level_path=path),
+                # The same columns derive_pivots declares, so a tree built by one and
+                # extended by the other agrees on which artifacts are current.
+                schema=pivot.schema(pivot.LEVELS[path]),
                 parent_artifact=projection.ARTIFACT,
             )
             logger.info(

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -3584,15 +3584,23 @@ def test_a_pivoted_quantifier_still_reaches_the_structures_artifact(corpus):
     assert found == {"ord-bb01"}
 
 
-def test_check_pivots_reports_the_levels_held_as_artifacts(wide_root):
-    pivots = _write_pivots(wide_root, ("outcomes.products", "workups"))
+def test_check_pivots_reports_the_levels_held_as_artifacts(wide_root, tmp_path):
+    # An operator reads these counts to see that a sharded corpus has all its shards,
+    # so the two levels are held by different numbers of artifacts, and neither by one:
+    # a constant, an off-by-one, and a level answered with another's count all agree
+    # wherever every level holds the same number.
+    pivots = _write_pivots(wide_root, ("outcomes.products", "workups"), into=tmp_path)
+    duplicate = pivots / "outcomes.products" / "second"
+    duplicate.mkdir(parents=True)
+    for artifact in sorted((pivots / "outcomes.products").rglob("*.parquet")):
+        shutil.copy(artifact, duplicate / artifact.name)
     with execute.Corpus(
         str(wide_root / "projections" / "*.parquet"),
         str(wide_root / "structures" / "*.parquet"),
         resolver={}.__getitem__,
         pivots_dir=str(pivots),
     ) as corpus:
-        assert corpus.check_pivots() == {"outcomes.products": 1, "workups": 1}
+        assert corpus.check_pivots() == {"outcomes.products": 2, "workups": 1}
 
 
 def test_check_pivots_is_empty_without_a_directory(wide_corpus):


### PR DESCRIPTION
## Summary

Deriving every pivot of the ORD corpus takes about five hours, and 3.9 of those produce nothing: 32 of the schema's 39 repeated levels hold no elements, and discovering that costs a full pass over every ancestor. The five levels under `inputs.components` cost roughly a hundred minutes between them to write 27 rows.

Counting the level first settles it from the list offsets — what `len` needs is how long a list is, not what is in it.

The count is only worth trusting if a wrong one cannot pass unnoticed, and one wrong answer is special: a count of zero skips the unnest, so nothing downstream contradicts it. The empty artifact that follows is stamped current, skipped by every later run, and makes every `forall` over the level vacuously true of the whole corpus. Most of this diff is what makes that answer falsifiable.

## Changes

- `pivot.count_levels` counts a level from the list offsets, summing lengths level by level so a reaction's elements are never all resident. `write_pivot` runs it first and skips the unnest when nothing is recorded.
- A nonzero count is checked against the rows the unnest produced, in either direction, from inside the atomic write — so a rejected artifact is removed rather than published.
- Zero is checked differently, because it skips the unnest. `count_levels` returns a `Counts` carrying the counts **and** the identity of the file they were read from; `write_pivot` takes the level's own count out of it and refuses one taken over other bytes. The caller never assembles the pair, so an honest count of one level cannot be spent on another.
- `derive_pivots` counts every level of a projection in one query rather than one per level — 15x on a two-shard tree recording them all — memoized on the file's identity rather than its path.
- Both derivers declare the pivot schema to `derive_tree`, so an artifact short an ordinal is derived again rather than stamped current forever.

## Testing

- `uv run pytest -n auto`: 1462 passed.
- The count is compared against the unnest at **every** level of the schema, on a fixture recording elements at all 39 — with `assert counted > 0` first, so a repeated field added upstream joins the sweep and fails rather than comparing nothing to nothing.
- Reviewed in thirteen rounds by four independent reviewers (correctness, test vacuity, silent failures, comment accuracy), each round mutating the source and reporting only what survived. Round 13 ran 40 mutations and found no gap.
- Measured on a projection holding 8% of the corpus by bytes: counting all 39 levels takes 18.6s, about four minutes extrapolated to the whole corpus, against the 3.9 hours it saves.

## Notes

- A count that is simply wrong over the right file is outside both checks. That is held by the all-levels comparison above and by a level that comes out empty across a whole tree saying so.
- Footer statistics looked cheaper still and are not sound: they are absent on some columns, and Parquet writes an empty list and a list holding one null-filled element identically. Measured, rejected, not in the diff.
- Reporting on the artifacts this leaves — which hold no rows, and whether a reader can find them at all — is a separate change, on `agent/pivot-empty-report`. It is observability rather than correctness, and it is the only reason this branch would otherwise reach into the corpus reader.
- `base.derive_tree` does not deduplicate its glob matches, so a pattern with two `**` segments double-counts a source. Pre-existing, cannot be reached by the documented invocations, and a separate fix.
- The remaining hour is ancestors re-unnested once per descendant — `inputs.components` is rebuilt by each of its five children — worth a measured 2.2x on that subtree. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR avoids unnecessary pivot unnesting by counting repeated levels first while adding source-identity, row-count, artifact-schema, and reader-consistency checks.
- Adds batched repeated-level counting and immutable, source-bound count results.
- Skips unnesting for empty levels and atomically rejects nonzero count mismatches.
- Caches counts by projection identity during multi-level derivation.
- Aligns pivot derivation freshness checks with expected schemas and expands regression coverage.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/artifacts/pivot.py | Adds source-bound level counting, zero-row fast paths, and atomic count-versus-unnest validation. |
| ord_schema/artifacts/scripts/derive_pivots.py | Counts requested levels together, caches results by file identity, and supplies expected pivot schemas to derivation. |
| ord_schema/search/execute.py | Aligns in-process pivot derivation freshness checks with the schema-aware command-line path. |
| ord_schema/artifacts/pivot_test.py | Adds broad coverage for counting correctness, source replacement, immutable counts, and rejected publication. |
| ord_schema/artifacts/scripts/derive_pivots_test.py | Covers multi-level count pairing, projection replacement, and rebuilding schema-incomplete artifacts. |
| ord_schema/search/execute_test.py | Expands validation of pivot artifact counts and reader-visible artifact layouts. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  P[Projection artifact] --> C[Count requested repeated levels]
  C --> I{Projection identity unchanged?}
  I -- No --> R[Reject derivation]
  I -- Yes --> Z{Level count is zero?}
  Z -- Yes --> E[Atomically publish empty pivot]
  Z -- No --> U[Unnest level into pivot rows]
  U --> M{Written rows equal count?}
  M -- No --> R
  M -- Yes --> A[Atomically publish populated pivot]
  E --> Q[Corpus query acceleration]
  A --> Q
```
</details>

<sub>Reviews (13): Last reviewed commit: ["Leave the empty-level report to its own ..."](https://github.com/open-reaction-database/ord-schema/commit/d7d8132e6b011af952160b4bea7fd7b43be44e83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57349800)</sub>

**Context used:**

- Knowledge Base — [Reaction artifacts and projections](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/reaction-artifacts.md)
- Knowledge Base — [Structured reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/structured-reaction-search.md)

<!-- /greptile_comment -->