### PR TITLE
State the enum nesting rationale as a design, not an apology

### DIFF
--- a/js/ord-schema-protobufjs/index.d.ts
+++ b/js/ord-schema-protobufjs/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Open Reaction Database Project Authors
+ * Copyright 2026 Open Reaction Database Project Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,11 +62,18 @@ export namespace ord {
      * enums contain a CUSTOM field, which must be accompanied by setting the
      * 'details' field, where appropriate).
      *
-     * NOTE(kearnes): In many places, we deliberately violate the style guide for
-     * enums by nesting instead of prefixing; this is not done lightly. The primary
-     * consideration is API consistency and the ability to use unqualified strings
-     * as enum values. For instance, we want 'CUSTOM' to be a valid value for all
-     * enums that support custom types.
+     * Enums are nested inside the message they describe, rather than declared at
+     * the top level with each value prefixed by the enum name. Both forms avoid the
+     * collisions that protobuf's enum scoping would otherwise produce, and the
+     * style guide accepts either; nesting is what keeps the values unqualified, so
+     * 'CUSTOM' and 'UNSPECIFIED' are spelled the same way in every enum that has
+     * them.
+     *
+     * That uniformity is relied upon rather than merely tidy. Validation reads
+     * `type` and `details` off any message carrying them through one shared check,
+     * and both the text format and the tabular projection store value names rather
+     * than numbers, so the unqualified spelling is what a person reads in a pbtxt
+     * and what a query compares against.
      */
     class Reaction implements IReaction {
 

--- a/js/ord-schema-protobufjs/index.d.ts
+++ b/js/ord-schema-protobufjs/index.d.ts
@@ -60,20 +60,15 @@ export namespace ord {
      * not wish to restrict what users are able to specify if their synthesis
      * does not fit cleanly into a pre-existing enum field. For that reason, many
      * enums contain a CUSTOM field, which must be accompanied by setting the
-     * 'details' field, where appropriate).
+     * 'details' field, where appropriate.
      *
-     * Enums are nested inside the message they describe, rather than declared at
-     * the top level with each value prefixed by the enum name. Both forms avoid the
-     * collisions that protobuf's enum scoping would otherwise produce, and the
-     * style guide accepts either; nesting is what keeps the values unqualified, so
-     * 'CUSTOM' and 'UNSPECIFIED' are spelled the same way in every enum that has
-     * them.
-     *
-     * That uniformity is relied upon rather than merely tidy. Validation reads
-     * `type` and `details` off any message carrying them through one shared check,
-     * and both the text format and the tabular projection store value names rather
-     * than numbers, so the unqualified spelling is what a person reads in a pbtxt
-     * and what a query compares against.
+     * Enums are nested in the message they describe rather than declared at top
+     * level with prefixed values; the style guide accepts either, and both avoid
+     * the collisions protobuf's enum scoping would otherwise produce. Nesting keeps
+     * values unqualified, so CUSTOM and UNSPECIFIED are spelled the same in every
+     * enum that has them: one shared check reads 'type' and 'details' off any
+     * message carrying them, and text format and the projection store value names,
+     * so that spelling is what a pbtxt shows and what a query compares against.
      */
     class Reaction implements IReaction {
 

--- a/js/ord-schema-protobufjs/index.d.ts
+++ b/js/ord-schema-protobufjs/index.d.ts
@@ -67,8 +67,8 @@ export namespace ord {
      * the collisions protobuf's enum scoping would otherwise produce. Nesting keeps
      * values unqualified, so CUSTOM and UNSPECIFIED are spelled the same in every
      * enum that has them: one shared check reads 'type' and 'details' off any
-     * message carrying them, and text format and the projection store value names,
-     * so that spelling is what a pbtxt shows and what a query compares against.
+     * message carrying them, and text format and the projection store value names
+     * rather than numbers.
      */
     class Reaction implements IReaction {
 

--- a/js/ord-schema-protobufjs/index.js
+++ b/js/ord-schema-protobufjs/index.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2025 Open Reaction Database Project Authors
+ * Copyright 2026 Open Reaction Database Project Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,11 +61,18 @@ export const ord = $root.ord = (() => {
          * enums contain a CUSTOM field, which must be accompanied by setting the
          * 'details' field, where appropriate).
          * 
-         * NOTE(kearnes): In many places, we deliberately violate the style guide for
-         * enums by nesting instead of prefixing; this is not done lightly. The primary
-         * consideration is API consistency and the ability to use unqualified strings
-         * as enum values. For instance, we want 'CUSTOM' to be a valid value for all
-         * enums that support custom types.
+         * Enums are nested inside the message they describe, rather than declared at
+         * the top level with each value prefixed by the enum name. Both forms avoid the
+         * collisions that protobuf's enum scoping would otherwise produce, and the
+         * style guide accepts either; nesting is what keeps the values unqualified, so
+         * 'CUSTOM' and 'UNSPECIFIED' are spelled the same way in every enum that has
+         * them.
+         * 
+         * That uniformity is relied upon rather than merely tidy. Validation reads
+         * `type` and `details` off any message carrying them through one shared check,
+         * and both the text format and the tabular projection store value names rather
+         * than numbers, so the unqualified spelling is what a person reads in a pbtxt
+         * and what a query compares against.
          * @implements IReaction
          * @constructor
          * @param {ord.IReaction=} [properties] Properties to set

--- a/js/ord-schema-protobufjs/index.js
+++ b/js/ord-schema-protobufjs/index.js
@@ -59,20 +59,15 @@ export const ord = $root.ord = (() => {
          * not wish to restrict what users are able to specify if their synthesis
          * does not fit cleanly into a pre-existing enum field. For that reason, many
          * enums contain a CUSTOM field, which must be accompanied by setting the
-         * 'details' field, where appropriate).
+         * 'details' field, where appropriate.
          * 
-         * Enums are nested inside the message they describe, rather than declared at
-         * the top level with each value prefixed by the enum name. Both forms avoid the
-         * collisions that protobuf's enum scoping would otherwise produce, and the
-         * style guide accepts either; nesting is what keeps the values unqualified, so
-         * 'CUSTOM' and 'UNSPECIFIED' are spelled the same way in every enum that has
-         * them.
-         * 
-         * That uniformity is relied upon rather than merely tidy. Validation reads
-         * `type` and `details` off any message carrying them through one shared check,
-         * and both the text format and the tabular projection store value names rather
-         * than numbers, so the unqualified spelling is what a person reads in a pbtxt
-         * and what a query compares against.
+         * Enums are nested in the message they describe rather than declared at top
+         * level with prefixed values; the style guide accepts either, and both avoid
+         * the collisions protobuf's enum scoping would otherwise produce. Nesting keeps
+         * values unqualified, so CUSTOM and UNSPECIFIED are spelled the same in every
+         * enum that has them: one shared check reads 'type' and 'details' off any
+         * message carrying them, and text format and the projection store value names,
+         * so that spelling is what a pbtxt shows and what a query compares against.
          * @implements IReaction
          * @constructor
          * @param {ord.IReaction=} [properties] Properties to set

--- a/js/ord-schema-protobufjs/index.js
+++ b/js/ord-schema-protobufjs/index.js
@@ -66,8 +66,8 @@ export const ord = $root.ord = (() => {
          * the collisions protobuf's enum scoping would otherwise produce. Nesting keeps
          * values unqualified, so CUSTOM and UNSPECIFIED are spelled the same in every
          * enum that has them: one shared check reads 'type' and 'details' off any
-         * message carrying them, and text format and the projection store value names,
-         * so that spelling is what a pbtxt shows and what a query compares against.
+         * message carrying them, and text format and the projection store value names
+         * rather than numbers.
          * @implements IReaction
          * @constructor
          * @param {ord.IReaction=} [properties] Properties to set

--- a/proto/reaction.proto
+++ b/proto/reaction.proto
@@ -26,11 +26,18 @@ package ord;
  * enums contain a CUSTOM field, which must be accompanied by setting the
  * 'details' field, where appropriate).
  *
- * NOTE(kearnes): In many places, we deliberately violate the style guide for
- * enums by nesting instead of prefixing; this is not done lightly. The primary
- * consideration is API consistency and the ability to use unqualified strings
- * as enum values. For instance, we want 'CUSTOM' to be a valid value for all
- * enums that support custom types.
+ * Enums are nested inside the message they describe, rather than declared at
+ * the top level with each value prefixed by the enum name. Both forms avoid the
+ * collisions that protobuf's enum scoping would otherwise produce, and the
+ * style guide accepts either; nesting is what keeps the values unqualified, so
+ * 'CUSTOM' and 'UNSPECIFIED' are spelled the same way in every enum that has
+ * them.
+ *
+ * That uniformity is relied upon rather than merely tidy. Validation reads
+ * `type` and `details` off any message carrying them through one shared check,
+ * and both the text format and the tabular projection store value names rather
+ * than numbers, so the unqualified spelling is what a person reads in a pbtxt
+ * and what a query compares against.
  */
 message Reaction {
   repeated ReactionIdentifier identifiers = 1;

--- a/proto/reaction.proto
+++ b/proto/reaction.proto
@@ -31,8 +31,8 @@ package ord;
  * the collisions protobuf's enum scoping would otherwise produce. Nesting keeps
  * values unqualified, so CUSTOM and UNSPECIFIED are spelled the same in every
  * enum that has them: one shared check reads 'type' and 'details' off any
- * message carrying them, and text format and the projection store value names,
- * so that spelling is what a pbtxt shows and what a query compares against.
+ * message carrying them, and text format and the projection store value names
+ * rather than numbers.
  */
 message Reaction {
   repeated ReactionIdentifier identifiers = 1;

--- a/proto/reaction.proto
+++ b/proto/reaction.proto
@@ -24,20 +24,15 @@ package ord;
  * not wish to restrict what users are able to specify if their synthesis
  * does not fit cleanly into a pre-existing enum field. For that reason, many
  * enums contain a CUSTOM field, which must be accompanied by setting the
- * 'details' field, where appropriate).
+ * 'details' field, where appropriate.
  *
- * Enums are nested inside the message they describe, rather than declared at
- * the top level with each value prefixed by the enum name. Both forms avoid the
- * collisions that protobuf's enum scoping would otherwise produce, and the
- * style guide accepts either; nesting is what keeps the values unqualified, so
- * 'CUSTOM' and 'UNSPECIFIED' are spelled the same way in every enum that has
- * them.
- *
- * That uniformity is relied upon rather than merely tidy. Validation reads
- * `type` and `details` off any message carrying them through one shared check,
- * and both the text format and the tabular projection store value names rather
- * than numbers, so the unqualified spelling is what a person reads in a pbtxt
- * and what a query compares against.
+ * Enums are nested in the message they describe rather than declared at top
+ * level with prefixed values; the style guide accepts either, and both avoid
+ * the collisions protobuf's enum scoping would otherwise produce. Nesting keeps
+ * values unqualified, so CUSTOM and UNSPECIFIED are spelled the same in every
+ * enum that has them: one shared check reads 'type' and 'details' off any
+ * message carrying them, and text format and the projection store value names,
+ * so that spelling is what a pbtxt shows and what a query compares against.
  */
 message Reaction {
   repeated ReactionIdentifier identifiers = 1;


### PR DESCRIPTION
## Summary

`reaction.proto` opened by saying the schema "deliberately violate[s] the style guide for enums by nesting instead of prefixing." It does not. The [style guide](https://protobuf.dev/programming-guides/style/#enums) says "either option is enough to mitigate collision risks, but prefer top-level enums with prefixed values over creating a message simply to mitigate the issue" — nesting is a sanctioned way to avoid the collisions protobuf's enum scoping produces, and the stated preference is scoped to messages created *solely* for that purpose, which is not what these are.

This rewrites the note to say what nesting buys instead of apologizing for it, and closes a parenthesis the paragraph above never opened.

## Changes

- `proto/reaction.proto` — the block comment above `Reaction`.
- `js/ord-schema-protobufjs/` — the comment is carried into the generated docs. The other generated files differ only in the copyright year, which the drift check ignores, so they are left alone.

## Testing

- Wrappers regenerated with protoc 22.3 and the plugin versions CI pins, then `addlicense`; only the protobufjs bundle showed a real diff.
- Pre-commit clean, including `clang-format` and `ty`.

## Notes

The claim in the new text is checkable: `_check_type_and_details` reads `message.UNSPECIFIED` and `message.CUSTOM` off whatever it is handed, and 28 message types route through it. That works only while every enum spells those two values identically — which is what nesting preserves. #992 demonstrates the failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates the rationale for nesting enums to describe the resulting naming consistency and corrects an unmatched parenthesis.
- Revises the canonical comment above `Reaction`.
- Propagates the comment into the protobufjs JavaScript and TypeScript outputs.
- Updates copyright years in the regenerated protobufjs files.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| proto/reaction.proto | Rewords documentation about nested enums and fixes comment punctuation without changing the protobuf contract. |
| js/ord-schema-protobufjs/index.js | Carries the revised schema comment into the generated JavaScript output and updates its copyright year. |
| js/ord-schema-protobufjs/index.d.ts | Carries the revised schema comment into the generated TypeScript declarations and updates their copyright year. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Drop the restated clause from the enum r..."](https://github.com/open-reaction-database/ord-schema/commit/61039dc6cda75d27b11678cd152301bb9c7c0446) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57351225)</sub>

<!-- /greptile_comment -->