### PR TITLE
Say which pivot artifacts hold nothing, and whether a reader finds them

### DIFF
--- a/ord_schema/artifacts/base.py
+++ b/ord_schema/artifacts/base.py
@@ -506,7 +506,10 @@ def derive_tree(
         ValueError: If the input pattern matches nothing, if any match cannot be read as
             Parquet, or if any destination would land on a parent.
     """
-    matches = sorted(glob.glob(input_pattern, recursive=True))
+    # Deduplicated: a pattern with more than one ** reaches the same file by more than
+    # one route, and a source derived twice is written twice -- the second pass reading
+    # what the first just wrote, and counted again in what this returns.
+    matches = sorted(set(glob.glob(input_pattern, recursive=True)))
     if not matches:
         raise ValueError(f"no datasets matched: {input_pattern}")
     sources = []

--- a/ord_schema/artifacts/base_test.py
+++ b/ord_schema/artifacts/base_test.py
@@ -224,6 +224,30 @@ def test_derive_tree_writes_one_artifact_per_source(tmp_path):
     assert {path.parent.name for path in written_paths} == {"aa", "bb"}
 
 
+def test_derive_tree_derives_a_source_reached_twice_only_once(tmp_path):
+    # A pattern with more than one ** reaches the same file by more than one route.
+    # Derived twice, the second pass reads what the first wrote and the counts returned
+    # say two sources where the tree holds one -- which a caller comparing them against
+    # the artifacts on disk reads as artifacts having gone missing.
+    (tmp_path / "aa").mkdir()
+    _fake_source(tmp_path / "aa" / "source.parquet")
+    seen = []
+
+    def _write_one(path, output, *, source_md5, source_dataset_id):
+        seen.append(str(path))
+        pathlib.Path(output).write_bytes(b"")
+        return 1
+
+    written, skipped, _ = base.derive_tree(
+        str(tmp_path / "**" / "**" / "*.parquet"),
+        str(tmp_path / "out"),
+        artifact="structures",
+        write=_write_one,
+    )
+    assert len(seen) == 1
+    assert (written, skipped) == (1, 0)
+
+
 def test_derive_tree_hands_the_writer_the_source_and_its_provenance(tmp_path):
     (tmp_path / "aa").mkdir()
     source = tmp_path / "aa" / "source.parquet"

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -504,9 +504,14 @@ def artifact_paths(
         The paths, sorted. Empty if the level has no directory at all.
     """
     directory = pathlib.Path(pivots_dir) / level_path
+    # Escaped, because only the last two segments are a pattern: a directory is a name
+    # someone chose, and one holding a bracket or a star would otherwise be read as a
+    # character class or a wildcard and match somewhere else, or nowhere.
     return sorted(
         pathlib.Path(found)
-        for found in glob.glob(f"{directory}/**/*.parquet", recursive=True)
+        for found in glob.glob(
+            f"{glob.escape(str(directory))}/**/*.parquet", recursive=True
+        )
     )
 
 

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -45,6 +45,7 @@ reaction in the corpus. See ``Counts``.
 """
 
 import dataclasses
+import glob
 import os
 import pathlib
 import types
@@ -472,6 +473,41 @@ class Counts(Mapping[str, int]):
         than this one, to a caller who asked about this one.
         """
         return hash((self.identity, frozenset(self.at.items())))
+
+
+def artifact_paths(
+    pivots_dir: str | os.PathLike[str], level_path: str
+) -> list[pathlib.Path]:
+    """Returns the artifacts a reader finds for one level, in a stable order.
+
+    The one definition of what a level's artifacts are. A build that judges its own
+    output by a wider rule than a reader applies calls a tree healthy that no query can
+    read: the level then has no artifacts as far as the corpus is concerned, and every
+    quantifier over it falls back to unnesting the projection, or is refused.
+
+    Recursive, because a pivot tree mirrors the projections it was derived from: a
+    sharded corpus puts them under ``<level>/<shard>/`` rather than directly under the
+    level. Named rather than stamped, so listing a level costs no reads -- and so a
+    build writing anything else has written something nothing here will find.
+
+    Through ``glob``, which descends a symlinked shard directory and passes over a
+    file whose name begins with a dot. Both matter: a deployment is free to put a shard
+    on other storage and link it into place, and the tree may sit on a filesystem whose
+    tools leave dotted siblings of their own. It is also how the projections and
+    structures beside these are found, so one corpus cannot read part of itself.
+
+    Args:
+        pivots_dir: The directory the levels sit under.
+        level_path: The level, as the query grammar names it.
+
+    Returns:
+        The paths, sorted. Empty if the level has no directory at all.
+    """
+    directory = pathlib.Path(pivots_dir) / level_path
+    return sorted(
+        pathlib.Path(found)
+        for found in glob.glob(f"{directory}/**/*.parquet", recursive=True)
+    )
 
 
 def _check_projection(source: str | os.PathLike[str]) -> base.Stamps:

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -499,6 +499,22 @@ def test_two_files_alike_but_for_their_filesystem_are_told_apart(tmp_path, monke
     assert there != here
 
 
+def test_artifact_paths_are_sorted(tmp_path):
+    # The order artifacts are read in is the order a view holds their rows, and the
+    # order a report names them. A glob answers in directory order, which is whatever
+    # the filesystem last did.
+    directory = tmp_path / "workups"
+    for shard in ("cc", "aa", "bb"):
+        (directory / shard).mkdir(parents=True)
+        (directory / shard / f"ord_dataset-{shard}.parquet").write_bytes(b"")
+    found = pivot.artifact_paths(tmp_path, "workups")
+    assert [path.parent.name for path in found] == ["aa", "bb", "cc"]
+
+
+def test_artifact_paths_finds_nothing_where_there_is_no_level(tmp_path):
+    assert pivot.artifact_paths(tmp_path, "workups") == []
+
+
 def _miscounted(counts: pivot.Counts, level_path: str, value: int) -> pivot.Counts:
     """Returns ``counts`` with ``level_path`` answered wrongly, everything else kept."""
     return pivot.Counts(counts.identity, dict(counts) | {level_path: value})

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -511,6 +511,17 @@ def test_artifact_paths_are_sorted(tmp_path):
     assert [path.parent.name for path in found] == ["aa", "bb", "cc"]
 
 
+def test_artifact_paths_reads_a_directory_whose_name_looks_like_a_pattern(tmp_path):
+    # Only the last two segments are a pattern; everything above them is a name someone
+    # chose. A bracket in it would be read as a character class and match nothing, and
+    # the build would then reject a level whose artifacts are all present.
+    directory = tmp_path / "pivots[v2]"
+    (directory / "workups" / "aa").mkdir(parents=True)
+    written = directory / "workups" / "aa" / "ord_dataset-aa.parquet"
+    written.write_bytes(b"")
+    assert pivot.artifact_paths(directory, "workups") == [written]
+
+
 def test_artifact_paths_finds_nothing_where_there_is_no_level(tmp_path):
     assert pivot.artifact_paths(tmp_path, "workups") == []
 

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -41,12 +41,25 @@ run -- is ignored rather than derived from, so --output_dir may sit inside a rec
 pattern's reach. These are errors: an --output_dir that would write over any input, an
 input that cannot be read as Parquet at all, a level the schema does not have or that
 is named twice, a projection that changed while the run was deriving from it or whose
-count and unnest disagreed, and a run that finds no projections at all.
+count and unnest disagreed, a run that finds no projections at all, and a level whose
+artifacts cannot be found once it has derived them.
+
+Every run reports, per level, how many of the artifacts on disk hold no rows, and warns
+when all of them do. That is ordinary for a level nothing in the corpus records, and it
+is also what a wrong count looks like, which nothing downstream can tell apart. Counted
+from the artifacts rather than from what the run wrote, so a re-run that skips
+everything reports the same thing as the run that built them, over exactly the files a
+corpus reads. A file found there that is not this level's pivot -- unreadable,
+unstamped, or another level's -- is reported and left out of the tally rather than
+ending the run, since the output tree is not this script's to police.
 """
 
 import argparse
 import functools
 import pathlib
+
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 from ord_schema.artifacts import base, pivot, projection
 from ord_schema.logging import get_logger
@@ -147,6 +160,52 @@ def _counts(
     return pivot.count_levels(source, level_paths)
 
 
+def _empty_artifacts(
+    pivots_dir: str, level_path: str
+) -> tuple[int, list[str], list[str]]:
+    """Counts a level's artifacts, and says which hold no rows and which were skipped.
+
+    Taken over exactly the files ``pivot.artifact_paths`` lists, which is what a corpus
+    reads: a report over any other set describes a tree nobody queries. Their rows are
+    read from the Parquet footers rather than tallied as the run writes, so the answer
+    covers the artifacts this run skipped as already current, and a re-run says what the
+    run that built them said.
+
+    A file the reader would pick up that is not this level's pivot is skipped rather
+    than counted -- an artifact of another level, or something left in the tree by hand
+    -- and so is one that cannot be read at all, a truncated copy or a bad block. A run
+    killed mid-write is not among them: atomic_io names its temp for the destination
+    with a .tmp suffix, which neither this nor a reader ever lists.
+
+    Args:
+        pivots_dir: The directory the levels sit under.
+        level_path: The level whose artifacts to look for.
+
+    Returns:
+        How many pivots of ``level_path`` there are, the paths of those holding no rows,
+        and the paths skipped -- each named rather than tallied, since a count alone
+        sends whoever reads it looking through the whole tree.
+    """
+    found, empty, skipped = 0, [], []
+    for path in pivot.artifact_paths(pivots_dir, level_path):
+        try:
+            metadata = pq.read_metadata(path)
+        except (OSError, pa.ArrowInvalid, pa.ArrowNotImplementedError):
+            skipped.append(f"{path} cannot be read as Parquet")
+            continue
+        stamped = (metadata.metadata or {}).get(pivot.META_PIVOT_PATH.encode())
+        if stamped is None:
+            skipped.append(f"{path} carries no pivot level")
+            continue
+        if stamped.decode() != level_path:
+            skipped.append(f"{path} holds {stamped.decode()}")
+            continue
+        found += 1
+        if metadata.num_rows == 0:
+            empty.append(str(path))
+    return found, empty, skipped
+
+
 def main(args: argparse.Namespace) -> None:
     """Derives a pivot artifact per level for every projection matching the pattern.
 
@@ -157,10 +216,12 @@ def main(args: argparse.Namespace) -> None:
     Raises:
         ValueError: If a requested level is not one the projection schema has or is
             named twice; if a projection changed while it was being derived, or its
-            count and its unnest disagreed; or if the pattern matched no projections --
+            count and its unnest disagreed; if the pattern matched no projections --
             which usually means it was aimed at the source tree, or at an output tree,
-            rather than at the projections. Silence there would let a pipeline step
-            downstream proceed as though the artifacts had been built.
+            rather than at the projections; or if a level's artifacts cannot be found
+            after the run derived them, which means they were written somewhere no
+            reader looks. Silence in any of those would let a pipeline step downstream
+            proceed as though the artifacts had been built.
     """
     levels = pivot.check_levels(args.levels)
     for level_path in levels:
@@ -188,7 +249,47 @@ def main(args: argparse.Namespace) -> None:
                 f"no pivots derived for {level_path}: none of the {ignored} matches "
                 f"for {args.input_pattern!r} are projections"
             )
-        logger.info("%s: %d written, %d already current", level_path, written, skipped)
+        artifacts, empty, unread = _empty_artifacts(args.output_dir, level_path)
+        logger.info(
+            "%s: %d written, %d already current, %d of %d artifacts empty",
+            level_path,
+            written,
+            skipped,
+            len(empty),
+            artifacts,
+        )
+        if len(empty) < artifacts:
+            # Named one by one where only some are empty, which is the shape that needs
+            # looking at. Where all of them are the warning below says so once, and a
+            # line per artifact would bury it on a corpus whose levels are mostly empty.
+            for path in empty:
+                logger.info("%s: no elements at %s", path, level_path)
+        for reason in unread:
+            logger.warning("%s: not counted at %s", reason, level_path)
+        if artifacts < written + skipped:
+            # Every artifact this run wrote or found current, and a reader cannot list
+            # them all -- so some of them went somewhere nothing looks, and the tree is
+            # not the one a query will read. Orphans left by a larger earlier run push
+            # this the other way and cannot raise it.
+            #
+            # Raised rather than reported, because the denominator below shrinks to
+            # match whatever was found: a level half of which is invisible reports the
+            # visible half as the whole, and a level entirely invisible reports zero of
+            # zero, which reads as every artifact being empty. That is the one thing
+            # this report exists to say, said about the search rather than the corpus.
+            raise ValueError(
+                f"{directory} holds {artifacts} pivot artifacts for {level_path}, "
+                f"fewer than the {written + skipped} this run wrote or found current; "
+                "the rest are where no reader looks"
+                + (f" ({len(unread)} not counted: {unread})" if unread else "")
+            )
+        if len(empty) == artifacts:
+            # Ordinary for a level nothing in this corpus records, and identical on
+            # disk to a level whose count came back wrong: an empty artifact is stamped
+            # current like any other, so no later run revisits it and no reader tells
+            # the two apart. Nothing else in the chain aggregates rows across a tree,
+            # or says anything about them above INFO.
+            logger.warning("%s: every artifact is empty at this level", level_path)
 
 
 if __name__ == "__main__":

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -18,13 +18,17 @@ Artifact behavior is covered in ord_schema.artifacts.pivot_test; these cover the
 the per-level layout a Corpus reads, which matches count as sources, the skip-if-current
 shortcut, how an unknown level is refused, that a projection rewritten under a running
 process is counted again, that each level is written the count taken for it rather than
-another level's, and that an artifact short a column is derived again rather than left
-current, from here and from a Corpus.
+another level's, that a level empty in every artifact says so and keeps saying so, that
+what is counted is what a reader reads -- and nothing else in the tree -- and that an
+artifact short a column is derived again rather than left current, from here and from a
+Corpus.
 """
 
 import logging
 import pathlib
+import shutil
 
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
@@ -44,8 +48,11 @@ def _dataset(dataset_id: str, *, observations: bool = False):
 
     Args:
         dataset_id: The dataset ID, which also names the reaction.
-        observations: Whether to record an observation, which is a level the default
-            tree records nothing at.
+        observations: Whether to record an observation. Off in both shards of the
+            default tree, which is what makes ``observations`` a level the whole tree
+            is empty at; on in one shard where a test needs the levels to differ, since
+            two identical shards make "empty in every artifact" and "empty in any of
+            them" the same question.
 
     Returns:
         The dataset.
@@ -133,6 +140,167 @@ def test_each_level_is_written_its_own_count(projected):
                 projected / "pivots" / level / shard / f"ord_dataset-{shard}.parquet"
             )
             assert pq.read_table(written).num_rows == rows, level
+
+
+def _messages(caplog) -> list[str]:
+    """Returns every message recorded so far, formatted."""
+    return [record.getMessage() for record in caplog.records]
+
+
+def _warnings(caplog) -> list[str]:
+    """Returns the WARNING messages recorded so far."""
+    return [
+        record.message for record in caplog.records if record.levelno == logging.WARNING
+    ]
+
+
+def test_a_level_empty_in_every_artifact_is_reported(projected, caplog):
+    # Ordinary for a level this corpus never records, and identical on disk to a level
+    # whose count came back wrong. Nothing else in the chain aggregates rows across a
+    # tree, so without this an empty artifact is published, stamped current, and never
+    # looked at again.
+    with caplog.at_level(logging.INFO):
+        # The empty level named second, and derived after a level whose artifacts are
+        # already on disk: named first it is also levels[0] and the only level in the
+        # tree, so a report that ignored level_path, or that scanned the whole output
+        # directory rather than this level's, would read the same.
+        _run(projected, "--levels", "workups", "observations")
+    # The premise above, asserted rather than assumed: workups really was derived
+    # first, so its artifacts were on disk while observations was being measured.
+    reports = [m for m in _messages(caplog) if "artifacts empty" in m]
+    assert [m.split(":")[0] for m in reports] == ["workups", "observations"]
+    warnings = _warnings(caplog)
+    assert any("observations: every artifact is empty" in m for m in warnings)
+    assert not any("workups" in m for m in warnings)
+
+
+def test_a_level_empty_in_only_some_artifacts_is_not_reported(tmp_path, caplog):
+    # The two shards differ at this level, which is the whole point: with identical
+    # shards, "every artifact is empty" and "any artifact is empty" are the same
+    # question and a warning that fired on an ordinary mixed corpus would pass.
+    for shard, observations in (("aa", True), ("bb", False)):
+        directory = tmp_path / "data" / shard
+        directory.mkdir(parents=True, exist_ok=True)
+        parquet.save_dataset(
+            _dataset(f"ord_dataset-{shard}", observations=observations),
+            str(directory / f"ord_dataset-{shard}.parquet"),
+        )
+    _reproject(tmp_path)
+    with caplog.at_level(logging.INFO):
+        _run(tmp_path, "--levels", "observations")
+    rows = [
+        pq.read_metadata(path).num_rows
+        for path in sorted((tmp_path / "pivots" / "observations").rglob("*.parquet"))
+    ]
+    assert sorted(rows) == [0, 1], "the shards must differ for this to prove anything"
+    assert not _warnings(caplog)
+    messages = [record.getMessage() for record in caplog.records]
+    # The tally an operator reads, with the two numbers distinct so their order shows.
+    assert any(
+        "observations: 2 written, 0 already current, 1 of 2 artifacts empty" in message
+        for message in messages
+    )
+    # Named, not just counted: the projection that came out empty is what an operator
+    # would go and look at, and a count alone sends them through the whole tree.
+    named = [
+        message for message in messages if "no elements at observations" in message
+    ]
+    assert len(named) == 1
+    assert "bb" in named[0]
+    assert "aa" not in named[0]
+
+
+def test_files_that_are_not_this_level_s_pivots_are_not_counted(projected, caplog):
+    # The tally decides whether a level is reported as empty, so anything it miscounts
+    # either invents that report or suppresses it. All of these turn up in a real tree:
+    # atomic_io writes its temp as a sibling inside the level's own directory, so a run
+    # killed mid-write leaves one behind, and an output directory is a place people put
+    # things.
+    _run(projected, "--levels", "workups", "outcomes.products")
+    beside = projected / "pivots" / "workups" / "aa"
+    # A leaked temp is not named like an artifact, so no reader sees it and neither
+    # does the tally -- which matters because this one holds rows, and counting it
+    # would say the level has something no query can reach.
+    (beside / "ord_dataset-aa.parquet.q7x1.tmp").write_bytes(b"")
+    # These three a reader would pick up, and each is not this level's pivot.
+    (beside / "corrupt.parquet").write_bytes(b"")
+    pq.write_table(pa.table({"x": [1]}), beside / "unstamped.parquet")
+    shutil.copy(
+        projected / "pivots" / "outcomes.products" / "aa" / "ord_dataset-aa.parquet",
+        beside / "another-level.parquet",
+    )
+    with caplog.at_level(logging.INFO):
+        _run(projected, "--levels", "workups")
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "workups: 0 written, 2 already current, 0 of 2 artifacts empty" in message
+        for message in messages
+    )
+    warnings = _warnings(caplog)
+    assert sorted(warning.split("/")[-1] for warning in warnings) == [
+        "another-level.parquet holds outcomes.products: not counted at workups",
+        "corrupt.parquet cannot be read as Parquet: not counted at workups",
+        "unstamped.parquet carries no pivot level: not counted at workups",
+    ]
+
+
+def test_a_shard_a_reader_cannot_descend_is_an_error(projected, tmp_path):
+    # A shard directory symlinked onto other storage is written straight through and
+    # then has to be listed back through the link. Half a level going missing while the
+    # run reports success is the shape that has no other alarm: the denominator shrinks
+    # to match, so the level reads as complete.
+    _run(projected, "--levels", "workups")
+    shard = projected / "pivots" / "workups" / "bb"
+    elsewhere = tmp_path / "elsewhere"
+    shard.rename(elsewhere)
+    shard.symlink_to(elsewhere, target_is_directory=True)
+    assert len(pivot.artifact_paths(projected / "pivots", "workups")) == 2
+    # Nothing is rewritten, so a run that could not descend would find one of two.
+    _run(projected, "--levels", "workups")
+
+
+def test_a_level_whose_artifacts_a_reader_cannot_find_is_an_error(tmp_path):
+    # A tree derived from projections a reader's glob does not match is written where
+    # nothing looks: derive_tree reports every artifact current, and every quantifier
+    # over the level falls back to unnesting the projection, forever.
+    for shard in ("aa", "bb"):
+        directory = tmp_path / "data" / shard
+        directory.mkdir(parents=True, exist_ok=True)
+        parquet.save_dataset(
+            _dataset(f"ord_dataset-{shard}"),
+            str(directory / f"ord_dataset-{shard}.parquet"),
+        )
+    _reproject(tmp_path)
+    for projection_path in (tmp_path / "projections").rglob("*.parquet"):
+        projection_path.replace(projection_path.with_suffix(".pq"))
+    arguments = derive_pivots.parse_args(
+        [
+            f"--input_pattern={tmp_path / 'projections' / '*' / '*.pq'}",
+            f"--output_dir={tmp_path / 'pivots'}",
+            "--levels",
+            "workups",
+        ]
+    )
+    with pytest.raises(ValueError, match="holds 0 pivot artifacts for workups"):
+        derive_pivots.main(arguments)
+    # Again, where the artifacts are now current and the run writes nothing: that is
+    # the steady state of every build after the first, and a guard that counted only
+    # what this run wrote would find nothing missing and report the level empty.
+    with pytest.raises(ValueError, match="holds 0 pivot artifacts for workups"):
+        derive_pivots.main(arguments)
+
+
+def test_a_level_empty_in_every_artifact_is_reported_again_on_a_re_run(
+    projected, caplog
+):
+    # Counted from the artifacts rather than from what the run wrote, so a re-run that
+    # skips every artifact says the same thing. The signal would otherwise appear only
+    # on the run that created them and never again -- vanishing exactly once the empty
+    # artifacts are entrenched.
+    _run(projected, "--levels", "observations")
+    with caplog.at_level(logging.WARNING):
+        _run(projected, "--levels", "observations")
+    assert any("observations: every artifact is empty" in m for m in _warnings(caplog))
 
 
 def test_a_second_run_skips_what_is_already_current(projected):
@@ -305,6 +473,56 @@ def test_a_corpus_deriving_pivots_also_derives_an_artifact_missing_an_ordinal(
             )
         )
     assert "workup_index" in pq.read_schema(written).names
+
+
+def test_a_level_whose_artifacts_cannot_be_found_is_an_error(projected, monkeypatch):
+    # Without this, no artifacts found means none of them hold rows, and the run
+    # announces that the level is empty everywhere -- the report this exists to make,
+    # made about a scan that failed rather than about the corpus.
+    def unreadable(path):
+        raise pa.ArrowInvalid(f"{path} is not Parquet")
+
+    monkeypatch.setattr(derive_pivots.pq, "read_metadata", unreadable)
+    # Naming what it could not read is the difference between an actionable error and
+    # "2 were written and a reader found none of them".
+    with pytest.raises(
+        ValueError,
+        match=r"holds 0 pivot artifacts for workups.*"
+        r"2 not counted.*ord_dataset-aa\.parquet cannot be read",
+    ):
+        _run(projected, "--levels", "workups")
+
+
+def test_artifacts_a_shrunken_corpus_left_behind_are_not_an_error(projected, caplog):
+    # A corpus that loses a dataset -- removed, or consolidated into another shard --
+    # leaves its pivots behind with no projection to match. The guard against artifacts
+    # a reader cannot find has to stay one-directional through that: surplus is not the
+    # same failure as absence, and a build that stopped on it would stop on every run
+    # from then on, sending an operator to look for files that are not missing.
+    _run(projected, "--levels", "workups")
+    orphan = projected / "pivots" / "workups" / "cc"
+    orphan.mkdir(parents=True)
+    shutil.copy(
+        projected / "pivots" / "workups" / "aa" / "ord_dataset-aa.parquet",
+        orphan / "ord_dataset-cc.parquet",
+    )
+    with caplog.at_level(logging.INFO):
+        _run(projected, "--levels", "workups")
+    assert any(
+        "workups: 0 written, 2 already current, 0 of 3 artifacts empty" in message
+        for message in _messages(caplog)
+    )
+
+
+def test_an_empty_level_is_not_also_named_artifact_by_artifact(projected, caplog):
+    # The warning already says every artifact is empty. Naming each one as well would
+    # be a line per shard across the levels a corpus records nothing at, which on ORD
+    # is most of them -- burying the case the lines exist for, a level empty in only
+    # some of its artifacts.
+    with caplog.at_level(logging.INFO):
+        _run(projected, "--levels", "observations")
+    assert any("observations: every artifact is empty" in m for m in _warnings(caplog))
+    assert not [m for m in _messages(caplog) if "no elements at" in m]
 
 
 def test_each_level_is_derived_against_its_own_columns(projected):

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -1112,9 +1112,7 @@ class Corpus:
         found = {}
         for path in sorted(pivot.LEVELS):
             if self._pivot_view(path) is not None:
-                found[path] = len(
-                    glob.glob(f"{self._pivots_dir}/{path}/**/*.parquet", recursive=True)
-                )
+                found[path] = len(pivot.artifact_paths(self._pivots_dir, path))
         logger.info(
             "%d of %d levels are held as artifacts: %s",
             len(found),
@@ -1779,12 +1777,9 @@ class Corpus:
         with self._views_lock:
             if path in self._pivot_views:
                 return self._pivot_views[path]
-            # Recursive, because a pivot tree mirrors the projections it was derived
-            # from: a sharded corpus puts them under <level>/<shard>/ rather than
-            # directly under the level.
-            files = sorted(
-                glob.glob(f"{self._pivots_dir}/{path}/**/*.parquet", recursive=True)
-            )
+            files = [
+                str(found) for found in pivot.artifact_paths(self._pivots_dir, path)
+            ]
             if not files:
                 self._pivot_views[path] = None
                 return None

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -232,9 +232,23 @@ def sql_string(value: str) -> str:
     return f"'{escaped}'"
 
 
-def _sql_strings(values: Iterable[str]) -> str:
-    """Returns ``values`` as a SQL list literal, single quotes escaped."""
-    return "[" + ", ".join(sql_string(value) for value in values) + "]"
+def _sql_paths(paths: Iterable[str]) -> str:
+    """Returns ``paths`` as a SQL list literal naming each file and no other.
+
+    read_parquet reads its arguments as globs, so a path is not simply itself: a
+    directory named with a bracket becomes a character class that matches a sibling
+    instead, and one with a star or a question mark matches its neighbors as well as
+    itself. Either way the query answers off files nobody asked for, which is the kind
+    of wrong that arrives as data rather than as an error.
+
+    Args:
+        paths: Paths to files, as this process found them.
+
+    Returns:
+        A SQL list literal, single quotes escaped and glob characters spelled as the
+        one-character classes that match them literally.
+    """
+    return "[" + ", ".join(sql_string(glob.escape(path)) for path in paths) + "]"
 
 
 def _max_structure_id(path: str) -> int | None:
@@ -1005,8 +1019,8 @@ class Corpus:
         self._connection.unregister("registered_offsets")
         # Inlined rather than bound because DuckDB refuses parameters in DDL. The
         # paths came from this process's own glob, and the quoting still escapes them.
-        projection_files = _sql_strings(pair[0] for pair in pairs)
-        structure_files = _sql_strings(pair[1] for pair in pairs)
+        projection_files = _sql_paths(pair[0] for pair in pairs)
+        structure_files = _sql_paths(pair[1] for pair in pairs)
         # S608: the fragments are this module's constants and this process's own
         # glob results, quoted with their single quotes escaped.
         self._connection.execute(
@@ -1789,7 +1803,7 @@ class Corpus:
             # from this process's own glob, quoted with their single quotes escaped.
             self._connection.execute(
                 f"CREATE OR REPLACE VIEW {name} AS "  # noqa: S608
-                f"SELECT * FROM read_parquet({_sql_strings(files)})"
+                f"SELECT * FROM read_parquet({_sql_paths(files)})"
             )
             logger.info("read %d pivot artifacts for %s", len(files), path)
             self._pivot_views[path] = name

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -3584,6 +3584,41 @@ def test_a_pivoted_quantifier_still_reaches_the_structures_artifact(corpus):
     assert found == {"ord-bb01"}
 
 
+def test_a_pivot_under_a_directory_that_looks_like_a_pattern_is_read(
+    wide_root, tmp_path
+):
+    # read_parquet reads its arguments as globs, so a bracket in a directory name is a
+    # character class, and it matches the sibling this decoy provides rather than the
+    # artifact itself. The decoy holds no rows, so a query reading it answers nothing
+    # and says nothing about having done so.
+    pivots = _write_pivots(
+        wide_root, ("outcomes.products",), into=tmp_path / "pivots[v2]"
+    )
+    real = next(iter(pivots.rglob("*.parquet")))
+    decoy = tmp_path / "pivotsv" / "outcomes.products" / real.parent.name
+    decoy.mkdir(parents=True)
+    empty = pq.read_table(real)
+    pq.write_table(
+        empty.slice(0, 0).replace_schema_metadata(empty.schema.metadata),
+        decoy / real.name,
+    )
+    assert pq.read_table(real).num_rows > 0
+
+    where = {
+        "op": "exists",
+        "path": "outcomes.products",
+        "where": {"op": "not_null", "path": "is_desired_product"},
+    }
+    with execute.Corpus(
+        str(wide_root / "projections" / "*.parquet"),
+        str(wide_root / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        pivots_dir=str(pivots),
+    ) as corpus:
+        found = corpus.search(query.Query.model_validate({"where": where}))
+    assert found.num_rows > 0
+
+
 def test_check_pivots_reports_the_levels_held_as_artifacts(wide_root, tmp_path):
     # An operator reads these counts to see that a sharded corpus has all its shards,
     # so the two levels are held by different numbers of artifacts, and neither by one:


### PR DESCRIPTION
## Summary

A pivot artifact holding no rows is ordinary — most levels of the ORD schema record nothing — and it is also exactly what a count that came back wrongly zero leaves behind. Nothing in the chain could tell those apart, or report on rows at all: `derive_tree` counts artifacts, the reader counts levels, and an empty artifact is stamped current like any other, so no later run revisits it.

Follow-up to #991, which added the counting this reports on.

## Changes

- Every run reports, per level, how many artifacts on disk hold no rows; names them when only some do; warns when all of them do. Read from the Parquet footers rather than tallied as the run writes, so it covers artifacts a run skips as current and a re-run says what the run that built them said.
- `pivot.artifact_paths` becomes the one definition of a level's artifacts, used by the build and by both readers in `execute.py`. A build that judges its own output by a wider rule than a reader applies calls a tree healthy that no query can use.
- A run that wrote or found more artifacts than a reader can list is an error, not a report: writing goes straight through a symlinked shard directory that listing will not descend, so half a level can go missing while the run reports success, with the empty tally shrinking to match. Orphans from a larger earlier run push the comparison the other way and cannot raise it.
- A file a reader would pick up that is not this level's pivot — another level's, unstamped, or unreadable — is named and left out of the tally rather than ending the run.
- The directory is escaped before it becomes part of a glob, so a level under a name holding a bracket or a star is found rather than missed. The two `Corpus` globs this helper replaces had the same defect.
- `base.derive_tree` deduplicates its matches, so a pattern reaching one file by two routes derives it once.

## Testing

- `uv run pytest -n auto`: 1476 passed.
- Each guarantee is pinned by a mutation that fails exactly one test: the guard going blind on re-runs (`< written`), orphans raising (`!=`), naming empty artifacts unconditionally, dropping the wrong-level report, and `rglob` in place of `glob` (which stops descending a symlinked shard).
- The scan is exercised against a tree holding a leaked `.tmp`, an unstamped Parquet, another level's artifact, and a corrupt file.

## Notes

- No exit code on "every artifact is empty": 32 of 39 levels are legitimately empty on ORD, so it would fire on nearly every full run and be routed to `/dev/null` — taking `main`'s real failures with it. WARNING is the right level for a condition that is normally benign and needs a human to correlate against expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR centralizes pivot artifact discovery, reports empty or unreadable artifacts after derivation, and ensures literal filesystem paths remain literal through both Python and DuckDB glob processing.
- Adds stable, escaped artifact discovery shared by pivot builders and readers.
- Reports empty artifacts and rejects outputs that readers cannot rediscover.
- Escapes paths passed to DuckDB and deduplicates recursive derivation matches.
- Adds regression coverage for metacharacter-bearing directories, symlinked shards, skipped files, empty artifacts, and duplicate glob matches.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/artifacts/base.py | Deduplicates recursive glob matches before deriving sources, preventing duplicate processing and inflated counts. |
| ord_schema/artifacts/pivot.py | Introduces the shared, stable artifact discovery helper and escapes literal directory components. |
| ord_schema/artifacts/scripts/derive_pivots.py | Adds footer-based empty-artifact reporting, invalid-file diagnostics, and reader-visibility validation. |
| ord_schema/search/execute.py | Reuses shared pivot discovery and escapes literal file paths before passing them to DuckDB. |
| ord_schema/artifacts/scripts/derive_pivots_test.py | Covers empty-level reporting, invalid artifacts, symlinked shards, reruns, and reader-invisible outputs. |
| ord_schema/search/execute_test.py | Verifies pivot queries read the intended artifact when the directory contains glob metacharacters. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    P[Projection artifacts] --> D[derive_pivots]
    D --> W[Pivot artifacts on disk]
    W --> A[pivot.artifact_paths]
    A --> V[Visibility and empty-artifact checks]
    A --> E[Corpus pivot reader]
    E --> S[_sql_paths literal escaping]
    S --> Q[DuckDB read_parquet]
    Q --> R[Pivot-backed queries]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Name a file to DuckDB, not a pattern tha..."](https://github.com/open-reaction-database/ord-schema/commit/952bbcb6481d281236610758c18d348793adc48e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58294558)</sub>

<!-- /greptile_comment -->