### PR TITLE
Call GetValence instead of the deprecated GetExplicitValence

### DIFF
--- a/ord_schema/message_helpers.py
+++ b/ord_schema/message_helpers.py
@@ -1092,7 +1092,8 @@ def set_dative_bonds(
             # excedes its default valence
             elif nbr_atom in from_atoms and nbr_atom != "C":
                 if (
-                    nbr.GetExplicitValence() > p_table.GetDefaultValence(nbr_atom)
+                    nbr.GetValence(Chem.ValenceType.EXPLICIT)
+                    > p_table.GetDefaultValence(nbr_atom)
                     and edit_mol.GetBondBetweenAtoms(
                         nbr.GetIdx(), metal.GetIdx()
                     ).GetBondType()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,11 @@ dependencies = [
     "protobuf>=4.22.3,<6",
     "pyarrow>=14",
     "python-dateutil>=1.10.0",
-    "rdkit>=2021.9.5",
+    # 2025.03.1 introduced Chem.ValenceType and deprecated Atom.GetExplicitValence,
+    # which set_dative_bonds calls the replacement for; 2025.03.4 is the first release
+    # with CPython 3.14 wheels, and this package claims to support 3.14, so a floor
+    # below it would send anyone installing there into a source build.
+    "rdkit>=2025.03.4",
     "tqdm>=4.61.2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2071,7 +2071,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'tests'", specifier = ">=3.0.0" },
     { name = "pytest-xdist", marker = "extra == 'tests'", specifier = ">=3.0.2" },
     { name = "python-dateutil", specifier = ">=1.10.0" },
-    { name = "rdkit", specifier = ">=2021.9.5" },
+    { name = "rdkit", specifier = ">=2025.3.4" },
     { name = "ruff", marker = "extra == 'tests'", specifier = ">=0.9.9" },
     { name = "scikit-learn", marker = "extra == 'examples'", specifier = ">=0.24.1" },
     { name = "sphinx", marker = "extra == 'docs'", specifier = ">=5.3.0" },


### PR DESCRIPTION
## Summary

`set_dative_bonds` calls `Atom.GetExplicitValence`, which RDKit deprecated in 2025.03.1. It prints `DEPRECATION WARNING: please use GetValence(Chem.ValenceType.EXPLICIT) instead` once per neighboring atom considered. This calls what that message names.

Supersedes #997, whose branch was stacked on #995 and predates five merges; only two files of it were ever its own.

## Changes

- `message_helpers.set_dative_bonds` — `nbr.GetValence(Chem.ValenceType.EXPLICIT)`.
- `pyproject.toml` — `rdkit>=2025.03.4`. 2025.03.1 introduced the method; 2025.03.4 is the first release with CPython 3.14 wheels, and this package claims to support 3.14, so a floor below it sends anyone installing there into a source build.

## Testing

- Full suite: 1477 passed, including the two `set_dative_bonds` tests.
- `examples/tools/set_dative_bonds` notebook: 10 passed, and `output.csv` is unchanged — main's lockfile already resolved rdkit 2026.03.5, so this raises the declared floor without moving what anything actually runs against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces RDKit’s deprecated explicit-valence accessor with its supported equivalent and raises the minimum RDKit version accordingly.
- Calls `GetValence(Chem.ValenceType.EXPLICIT)` when identifying dative bonds.
- Raises the declared RDKit floor to 2025.03.4.
- Synchronizes the updated dependency requirement into `uv.lock`.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness, security, or packaging failures identified.

The replacement preserves explicit-valence semantics, the dependency floor supplies the required API, and the lockfile metadata remains consistent with the project manifest.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/message_helpers.py | Replaces the deprecated valence accessor with the explicit-valence form of the supported API without changing the comparison logic. |
| pyproject.toml | Raises the RDKit dependency floor to a release supporting the replacement API and CPython 3.14 wheels. |
| uv.lock | Synchronizes the project’s RDKit requirement metadata without changing the resolved RDKit package. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Call GetValence instead of the deprecate..."](https://github.com/open-reaction-database/ord-schema/commit/60959253f5d0daae7964ea29c6c4dd1c10c53b71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58307354)</sub>

<!-- /greptile_comment -->