### PR TITLE
Unnest a level into tables rather than in one query

### DIFF
--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -276,10 +276,10 @@ def _ancestor_path(level: RepeatedLevel, depth: int) -> str:
         depth: Index into ``level.steps`` of the last step to take.
 
     Returns:
-        The ancestor as the query grammar names it. A level's own path is the join of
-        every step's segments, so the steps through ``depth`` name a prefix of it. That
-        prefix is a repeated level of the schema, though not necessarily a key of
-        ``LEVELS``, which omits a level whose elements are entirely repeated.
+        The ancestor as the query grammar names it: a level's path is the join of every
+        step's segments, so the steps through ``depth`` name a prefix of it. That prefix
+        is a repeated level of the schema but not necessarily a key of ``LEVELS``, which
+        omits a level whose elements are entirely repeated.
     """
     steps = level.steps[: depth + 1]
     reached = (segment for step in steps for segment in step.segments)
@@ -295,8 +295,8 @@ def _stage_table(level: RepeatedLevel, depth: int) -> str:
 
     Returns:
         A bare identifier, as ``table_name`` returns for a pivot. Naming it for the
-        ancestor rather than the depth is what keeps two levels of one chain from
-        meaning different things by one name.
+        ancestor means two levels of one chain ask for one name rather than giving one
+        name two meanings.
     """
     return f"stage_{_ancestor_path(level, depth).replace('.', '_')}"
 
@@ -306,18 +306,16 @@ def stage(
 ) -> str:
     """Unnests ``level`` a step at a time through temp tables, returning the last query.
 
-    ``select`` reaches a level in one query, so every unnest and the element prune sit
-    in a single pipeline. Giving each step a table of its own instead lets the engine
-    work on one at a time, and the whole difference is how much of the machine it can
-    put on that: over the 1.77M-reaction ORD projection the two forms cost about the
-    same CPU, and staging spends it roughly six times faster in wall clock on an
-    18-core machine. Expect it to fall with the core count rather than hold.
+    A step given a table of its own can run on its own, where a whole level reached in
+    one query -- every unnest and the element prune in a single pipeline, which is what
+    ``select`` returns -- runs largely serially. The work is the same either way; what
+    differs is how much of the machine it can occupy. Over the 1.77M-reaction ORD
+    projection the two cost about the same CPU and staging spends it some six times
+    faster in wall clock on 18 cores, so expect the margin to fall with the core count.
 
-    Every step but the last gets a table, and the last is fused into the returned
-    SELECT because it has nowhere cheaper to go -- but fusing more than one is what
-    re-serializes the pipeline, so a level whose only step is fused gives the saving
-    back entirely. A single-step level is therefore the case that must be staged, not
-    the case that can be skipped.
+    Every step but the last gets a table. Fusing more than one re-serializes them, so a
+    single-step level is the case that must be staged rather than the case that can be
+    skipped.
 
     The tables hold the element whole, unlike the artifact: pruning is what removes the
     repeated fields, and a child reaches its own through the field a pruned parent would
@@ -325,18 +323,20 @@ def stage(
 
     Args:
         connection: Connection to create the temp tables in, holding ``table``. They
-            live as long as it does and are named for the level's own ancestors, so a
-            second call for a *different* level replaces any table they share -- which
-            a reader still streaming the first call's query would see as rows that
-            stop. Give each call a connection it can have to itself.
+            live as long as it does and are named for the level's ancestors, so staging
+            a second level that shares one raises rather than answering short. Give
+            each call a connection it can have to itself.
         level: The level to pivot.
         table: The relation holding the reactions.
 
     Returns:
         A SELECT of ``reaction_id``, the level's ordinals, and the pruned element, one
         row per element of the level, reading the last temp table rather than ``table``.
+
+    Raises:
+        duckdb.Error: If a table this level would stage is already in ``connection``.
     """
-    # Fused: reached from the final SELECT's own FROM rather than given a table. Every
+    # Fused: reached from the final SELECT's own FROM rather than given a table -- every
     # step but the last, unless that would fuse the only step there is.
     staged = level.steps[:-1] or level.steps
     fused = level.steps[-1] if len(level.steps) > 1 else None
@@ -347,9 +347,8 @@ def stage(
         carried.append(step.ordinal)
         # S608: every fragment is this module's own walk of the projection schema.
         connection.execute(
-            # Not OR REPLACE: replacing a table a reader is still streaming from ends
-            # its rows early and raises nothing, so a second call on one connection has
-            # to fail here instead of answering short.
+            # Plain CREATE, so a name already taken raises here: replacing a table a
+            # reader is still streaming from ends its rows early and raises nothing.
             f"CREATE TEMP TABLE {_stage_table(level, depth)} AS "  # noqa: S608
             f"SELECT {kept}, e AS {_STAGED_ELEMENT}, {step.ordinal} "
             f"FROM {source}, unnest({step.expression(element)}) "
@@ -815,11 +814,10 @@ def write_pivot(
 
     One artifact holds one level of one projection, because the levels have different
     schemas and a reader globs the one it wants. The rows stream out of DuckDB a batch
-    at a time, so the artifact side of a level that explodes -- a corpus of long
-    measurement lists -- costs a batch rather than the whole level. What ``stage``
-    materializes on the way there does not: a level's ancestors are held whole, with
-    their repeated fields still on them, and DuckDB spills them under its own memory
-    limit rather than the caller's.
+    at a time, so a level that explodes -- a corpus of long measurement lists -- costs a
+    batch rather than the whole level on the way out. Its ancestors are another matter:
+    ``stage`` holds each one whole, repeated fields and all, under DuckDB's memory limit
+    rather than the caller's.
 
     The output is published atomically, so a failure partway leaves any existing
     artifact untouched.
@@ -881,12 +879,12 @@ def write_pivot(
     connection = duckdb.connect()
     written = 0
     try:
-        # A pivot has no meaningful row order: a reader semi-joins it on reaction_id and
-        # the ordinals, and which element came back first says nothing. Holding an
-        # order nobody reads costs the parallelism of the unnest that produces it,
-        # which over ORD's largest projection is most of what a build costs. The price
-        # is that two builds of one artifact need not agree byte for byte, which
-        # nothing checks: currency is keyed on the source hash, not the bytes written.
+        # A pivot has no row order to keep: a reader semi-joins it on reaction_id and
+        # the ordinals, and which element came back first says nothing. Keeping one
+        # costs the parallelism of the unnest that produces it, which over ORD's
+        # largest projection is most of what a build costs. The price is that two
+        # builds of one artifact need not agree byte for byte, which nothing checks --
+        # currency is keyed on the source hash, not on the bytes written.
         connection.execute("SET preserve_insertion_order=false")
         # Through the relational API rather than a path interpolated into SQL, which a
         # filename holding a quote would otherwise close. One view serves the count and

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -268,17 +268,18 @@ def select(level: RepeatedLevel, table: str) -> str:
     return f"SELECT {', '.join(selected)} FROM {', '.join(froms)}"  # noqa: S608
 
 
-def ancestor_path(level: RepeatedLevel, depth: int) -> str:
-    """Returns the level reached by unnesting ``level``'s steps down to ``depth``.
+def _ancestor_path(level: RepeatedLevel, depth: int) -> str:
+    """Returns the level reached by unnesting ``level``'s steps through ``depth``.
 
     Args:
         level: The level whose ancestor to name.
-        depth: How many steps to take, as an index into ``level.steps``.
+        depth: Index into ``level.steps`` of the last step to take.
 
     Returns:
         The ancestor as the query grammar names it. A level's own path is the join of
-        every step's segments, so a prefix of the steps names a prefix of the path --
-        and each one is itself a repeated level, since that is what a step is.
+        every step's segments, so the steps through ``depth`` name a prefix of it. That
+        prefix is a repeated level of the schema, though not necessarily a key of
+        ``LEVELS``, which omits a level whose elements are entirely repeated.
     """
     steps = level.steps[: depth + 1]
     reached = (segment for step in steps for segment in step.segments)
@@ -286,45 +287,57 @@ def ancestor_path(level: RepeatedLevel, depth: int) -> str:
 
 
 def _stage_table(level: RepeatedLevel, depth: int) -> str:
-    """Returns the temp-table name holding ``level``'s ancestor at ``depth``."""
-    return f"stage_{ancestor_path(level, depth).replace('.', '_')}"
+    """Returns the temp-table name holding ``level``'s ancestor at ``depth``.
+
+    Args:
+        level: The level being staged.
+        depth: Index into ``level.steps`` of the step the table holds.
+
+    Returns:
+        A bare identifier, as ``table_name`` returns for a pivot. Naming it for the
+        ancestor rather than the depth is what keeps two levels of one chain from
+        meaning different things by one name.
+    """
+    return f"stage_{_ancestor_path(level, depth).replace('.', '_')}"
 
 
 def stage(
     connection: duckdb.DuckDBPyConnection, level: RepeatedLevel, table: str
 ) -> str:
-    """Unnests ``level``'s steps into temp tables, returning the query over the last.
+    """Unnests ``level`` a step at a time through temp tables, returning the last query.
 
-    ``select`` reaches a level in one query, which fuses the element prune into an
-    unnest reading the projection's nested column. That is what costs: DuckDB prunes a
-    flat relation far more cheaply than it prunes mid-pipeline. Unnesting into a table
-    first, and pruning what comes back, is the same rows for a fraction of the work --
-    measured over the 1.77M-reaction projection, ``inputs`` took 134.5 s in one query
-    and 22.5 s staged, and ``inputs.components.identifiers`` 666 s against 34 s.
+    ``select`` reaches a level in one query, so every unnest and the element prune sit
+    in a single pipeline. Giving each step a table of its own instead lets the engine
+    work on one at a time, and the whole difference is how much of the machine it can
+    put on that: over the 1.77M-reaction ORD projection the two forms cost about the
+    same CPU, and staging spends it roughly six times faster in wall clock on an
+    18-core machine. Expect it to fall with the core count rather than hold.
 
-    Only the first unnest reads the nested column, so only it has to be materialized;
-    below that the input is already flat and the last step fuses for free. A level with
-    a single step is therefore the one where everything must be materialized, not the
-    one where nothing is.
+    Every step but the last gets a table, and the last is fused into the returned
+    SELECT because it has nowhere cheaper to go -- but fusing more than one is what
+    re-serializes the pipeline, so a level whose only step is fused gives the saving
+    back entirely. A single-step level is therefore the case that must be staged, not
+    the case that can be skipped.
 
-    The tables are named for the ancestor rather than for the depth, so a connection
-    deriving several levels of one chain builds each shared prefix once. They hold the
-    element whole, unlike the artifact: pruning is what removes the repeated fields, and
-    a child reaches its own through the field a pruned parent would have dropped.
+    The tables hold the element whole, unlike the artifact: pruning is what removes the
+    repeated fields, and a child reaches its own through the field a pruned parent would
+    have dropped.
 
     Args:
         connection: Connection to create the temp tables in, holding ``table``. They
-            live as long as it does, so it should be the one the caller is about to
-            read the result on and then close.
+            live as long as it does and are named for the level's own ancestors, so a
+            second call for a *different* level replaces any table they share -- which
+            a reader still streaming the first call's query would see as rows that
+            stop. Give each call a connection it can have to itself.
         level: The level to pivot.
         table: The relation holding the reactions.
 
     Returns:
-        A SELECT producing the same rows and columns as ``select``, reading the last
-        table rather than the reactions.
+        A SELECT of ``reaction_id``, the level's ordinals, and the pruned element, one
+        row per element of the level, reading the last temp table rather than ``table``.
     """
-    # Every step but the last, which fuses into the final SELECT -- unless that would
-    # leave the one unnest that reads the nested column fused, which is the whole cost.
+    # Fused: reached from the final SELECT's own FROM rather than given a table. Every
+    # step but the last, unless that would fuse the only step there is.
     staged = level.steps[:-1] or level.steps
     fused = level.steps[-1] if len(level.steps) > 1 else None
     source, carried = table, []
@@ -334,7 +347,10 @@ def stage(
         carried.append(step.ordinal)
         # S608: every fragment is this module's own walk of the projection schema.
         connection.execute(
-            f"CREATE OR REPLACE TEMP TABLE {_stage_table(level, depth)} AS "  # noqa: S608
+            # Not OR REPLACE: replacing a table a reader is still streaming from ends
+            # its rows early and raises nothing, so a second call on one connection has
+            # to fail here instead of answering short.
+            f"CREATE TEMP TABLE {_stage_table(level, depth)} AS "  # noqa: S608
             f"SELECT {kept}, e AS {_STAGED_ELEMENT}, {step.ordinal} "
             f"FROM {source}, unnest({step.expression(element)}) "
             f"WITH ORDINALITY AS u(e, {step.ordinal})"
@@ -799,8 +815,11 @@ def write_pivot(
 
     One artifact holds one level of one projection, because the levels have different
     schemas and a reader globs the one it wants. The rows stream out of DuckDB a batch
-    at a time, so a level that explodes -- a corpus of long measurement lists -- costs
-    a batch of memory rather than the whole level.
+    at a time, so the artifact side of a level that explodes -- a corpus of long
+    measurement lists -- costs a batch rather than the whole level. What ``stage``
+    materializes on the way there does not: a level's ancestors are held whole, with
+    their repeated fields still on them, and DuckDB spills them under its own memory
+    limit rather than the caller's.
 
     The output is published atomically, so a failure partway leaves any existing
     artifact untouched.
@@ -863,11 +882,11 @@ def write_pivot(
     written = 0
     try:
         # A pivot has no meaningful row order: a reader semi-joins it on reaction_id and
-        # the ordinals, and which element came back first says nothing. Holding the
-        # order of a 8.3M-row unnest, on the other hand, serializes the pipeline that
-        # produces it -- 777 s against 88 s over the largest level of the corpus, at the
-        # same total CPU, because the difference is how much of the machine it may use.
-        # The cost is that two builds of one artifact need not agree byte for byte.
+        # the ordinals, and which element came back first says nothing. Holding an
+        # order nobody reads costs the parallelism of the unnest that produces it,
+        # which over ORD's largest projection is most of what a build costs. The price
+        # is that two builds of one artifact need not agree byte for byte, which
+        # nothing checks: currency is keyed on the source hash, not the bytes written.
         connection.execute("SET preserve_insertion_order=false")
         # Through the relational API rather than a path interpolated into SQL, which a
         # filename holding a quote would otherwise close. One view serves the count and

--- a/ord_schema/artifacts/pivot.py
+++ b/ord_schema/artifacts/pivot.py
@@ -72,6 +72,8 @@ META_PIVOT_PATH = "ord.pivot_path"
 # The column the element's own fields sit under, and the row's join key.
 ELEMENT = "element"
 REACTION_ID = "reaction_id"
+# The whole element, as a staged ancestor carries it -- not the artifact's pruned one.
+_STAGED_ELEMENT = "staged_element"
 
 # What an ordinal is stored as. A reaction cannot hold four billion of anything at one
 # level, and the narrower column is the one a pivot carries once per row.
@@ -264,6 +266,95 @@ def select(level: RepeatedLevel, table: str) -> str:
     ]
     # S608: every fragment is this module's own walk of the projection schema.
     return f"SELECT {', '.join(selected)} FROM {', '.join(froms)}"  # noqa: S608
+
+
+def ancestor_path(level: RepeatedLevel, depth: int) -> str:
+    """Returns the level reached by unnesting ``level``'s steps down to ``depth``.
+
+    Args:
+        level: The level whose ancestor to name.
+        depth: How many steps to take, as an index into ``level.steps``.
+
+    Returns:
+        The ancestor as the query grammar names it. A level's own path is the join of
+        every step's segments, so a prefix of the steps names a prefix of the path --
+        and each one is itself a repeated level, since that is what a step is.
+    """
+    steps = level.steps[: depth + 1]
+    reached = (segment for step in steps for segment in step.segments)
+    return ".".join(reached)
+
+
+def _stage_table(level: RepeatedLevel, depth: int) -> str:
+    """Returns the temp-table name holding ``level``'s ancestor at ``depth``."""
+    return f"stage_{ancestor_path(level, depth).replace('.', '_')}"
+
+
+def stage(
+    connection: duckdb.DuckDBPyConnection, level: RepeatedLevel, table: str
+) -> str:
+    """Unnests ``level``'s steps into temp tables, returning the query over the last.
+
+    ``select`` reaches a level in one query, which fuses the element prune into an
+    unnest reading the projection's nested column. That is what costs: DuckDB prunes a
+    flat relation far more cheaply than it prunes mid-pipeline. Unnesting into a table
+    first, and pruning what comes back, is the same rows for a fraction of the work --
+    measured over the 1.77M-reaction projection, ``inputs`` took 134.5 s in one query
+    and 22.5 s staged, and ``inputs.components.identifiers`` 666 s against 34 s.
+
+    Only the first unnest reads the nested column, so only it has to be materialized;
+    below that the input is already flat and the last step fuses for free. A level with
+    a single step is therefore the one where everything must be materialized, not the
+    one where nothing is.
+
+    The tables are named for the ancestor rather than for the depth, so a connection
+    deriving several levels of one chain builds each shared prefix once. They hold the
+    element whole, unlike the artifact: pruning is what removes the repeated fields, and
+    a child reaches its own through the field a pruned parent would have dropped.
+
+    Args:
+        connection: Connection to create the temp tables in, holding ``table``. They
+            live as long as it does, so it should be the one the caller is about to
+            read the result on and then close.
+        level: The level to pivot.
+        table: The relation holding the reactions.
+
+    Returns:
+        A SELECT producing the same rows and columns as ``select``, reading the last
+        table rather than the reactions.
+    """
+    # Every step but the last, which fuses into the final SELECT -- unless that would
+    # leave the one unnest that reads the nested column fused, which is the whole cost.
+    staged = level.steps[:-1] or level.steps
+    fused = level.steps[-1] if len(level.steps) > 1 else None
+    source, carried = table, []
+    element: str | None = None
+    for depth, step in enumerate(staged):
+        kept = ", ".join([REACTION_ID, *carried])
+        carried.append(step.ordinal)
+        # S608: every fragment is this module's own walk of the projection schema.
+        connection.execute(
+            f"CREATE OR REPLACE TEMP TABLE {_stage_table(level, depth)} AS "  # noqa: S608
+            f"SELECT {kept}, e AS {_STAGED_ELEMENT}, {step.ordinal} "
+            f"FROM {source}, unnest({step.expression(element)}) "
+            f"WITH ORDINALITY AS u(e, {step.ordinal})"
+        )
+        source, element = _stage_table(level, depth), _STAGED_ELEMENT
+    # Cast for the reason select does: the ordinals carried through the tables and any
+    # the last step contributes are all BIGINT, and the artifact's schema is a promise.
+    ordinals = [f"{ordinal}::{ORDINAL_SQL} AS {ordinal}" for ordinal in level.ordinals]
+    reached = "e" if fused is not None else str(element)
+    selected = [
+        REACTION_ID,
+        *ordinals,
+        f"{element_expression(level.element_type, reached)} AS {ELEMENT}",
+    ]
+    if fused is None:
+        return f"SELECT {', '.join(selected)} FROM {source}"  # noqa: S608
+    return (
+        f"SELECT {', '.join(selected)} FROM {source}, "  # noqa: S608
+        f"unnest({fused.expression(element)}) WITH ORDINALITY AS u(e, {fused.ordinal})"
+    )
 
 
 def schema(level: RepeatedLevel) -> pa.Schema:
@@ -771,6 +862,13 @@ def write_pivot(
     connection = duckdb.connect()
     written = 0
     try:
+        # A pivot has no meaningful row order: a reader semi-joins it on reaction_id and
+        # the ordinals, and which element came back first says nothing. Holding the
+        # order of a 8.3M-row unnest, on the other hand, serializes the pipeline that
+        # produces it -- 777 s against 88 s over the largest level of the corpus, at the
+        # same total CPU, because the difference is how much of the machine it may use.
+        # The cost is that two builds of one artifact need not agree byte for byte.
+        connection.execute("SET preserve_insertion_order=false")
         # Through the relational API rather than a path interpolated into SQL, which a
         # filename holding a quote would otherwise close. One view serves the count and
         # the unnest, which read the same nested column.
@@ -790,9 +888,9 @@ def write_pivot(
             if element_count:
                 # Counting settled the other case: the unnest would walk every ancestor
                 # of a level this projection never records to reach the same nothing.
-                reader = connection.execute(select(level, "reactions")).to_arrow_reader(
-                    row_group_size
-                )
+                reader = connection.execute(
+                    stage(connection, level, "reactions")
+                ).to_arrow_reader(row_group_size)
                 for batch in reader:
                     # Cast rather than trust: DuckDB's own widths are its business, and
                     # the artifact's schema is a promise to whoever reads it later.

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -380,14 +380,12 @@ def test_a_level_with_no_elements_is_never_unnested(projected, tmp_path, monkeyp
     # The saving: discovering that a level holds nothing by unnesting it costs a full
     # pass over every ancestor, and this projection records nothing at most levels.
     # Patched by name, which is the only way to assert that work did *not* happen --
-    # and which stops holding the moment select is called any way but through the
-    # module global.
+    # and which stops holding the moment the query is built any way but through one of
+    # these module globals. Both are patched: write_pivot builds through stage, and
+    # select is the unstaged form it stands in for.
     def refuse(*args: object, **kwargs: object) -> str:
         raise AssertionError("the level was unnested")
 
-    # Both names: write_pivot builds its query through stage, and select is what stage
-    # is the staged counterpart of. Patching only the one write_pivot does not call
-    # leaves this passing however much work the zero-count path does.
     monkeypatch.setattr(pivot, "select", refuse)
     monkeypatch.setattr(pivot, "stage", refuse)
     output = tmp_path / "workups.parquet"
@@ -420,7 +418,8 @@ def test_staging_a_level_produces_what_unnesting_it_in_one_query_does(
     # correlation joining on that prefix is what would notice, in production rather than
     # here, so this compares the rows themselves.
     #
-    # Sorted, because neither form promises an order and the artifact does not need one.
+    # Sorted reprs, because neither form promises an order and the artifact does not
+    # need one -- and a row is a dict, which sorted() cannot order directly.
     level = pivot.LEVELS[level_path]
     connection = duckdb.connect()
     try:
@@ -438,21 +437,111 @@ def test_staging_a_level_produces_what_unnesting_it_in_one_query_does(
     )
 
 
-def test_staging_materializes_the_unnest_that_reads_the_projection(populated):
-    # The cost being avoided is pruning the element inside an unnest over the nested
-    # column, which is the first step and only the first. A level with one step is
-    # therefore the case that has to be staged rather than the case that can be skipped
-    # -- measured at 134.5 s against 22.5 s for inputs over the 1.77M-reaction corpus --
-    # and an implementation returning select for it would look like an optimization
-    # while giving that back.
+def _staged_tables(connection) -> list[str]:
+    """Returns the names of the temp tables staging left in ``connection``."""
+    rows = connection.execute(
+        "SELECT table_name FROM duckdb_tables() ORDER BY table_name"
+    ).fetchall()
+    return [name for (name,) in rows if name.startswith("stage_")]
+
+
+def test_staging_leaves_a_table_behind_for_every_step_but_the_last(populated):
+    # A table, specifically. A view here would read as staged and plan as though it
+    # were not, since the engine inlines it and the pipeline collapses back to the one
+    # select builds -- the whole saving given back, with nothing in the SQL to show it.
+    connection = duckdb.connect()
+    try:
+        connection.read_parquet(str(populated)).create_view("reactions")
+        level = pivot.LEVELS["inputs.components.analyses"]
+        connection.execute(pivot.stage(connection, level, "reactions")).fetchall()
+        assert _staged_tables(connection) == ["stage_inputs", "stage_inputs_components"]
+    finally:
+        connection.close()
+
+
+def test_a_level_with_one_step_is_staged_rather_than_fused(populated):
+    # Staging is what lets each unnest run on its own, and a step left fused runs with
+    # whatever follows it. A level with a single step therefore has to be staged, or
+    # its one unnest is fused and the saving is given back entirely -- which would look
+    # like an optimization for the case with nothing to stage.
     connection = duckdb.connect()
     try:
         connection.read_parquet(str(populated)).create_view("reactions")
         one_step = pivot.LEVELS["workups"]
         assert len(one_step.steps) == 1
-        assert "unnest" not in pivot.stage(connection, one_step, "reactions").lower()
+        connection.execute(pivot.stage(connection, one_step, "reactions")).fetchall()
+        assert _staged_tables(connection) == ["stage_workups"]
     finally:
         connection.close()
+
+
+def test_staging_a_second_level_on_one_connection_is_refused(populated):
+    # The tables are named for the level's ancestors, so two levels of one chain want
+    # the same name. Replacing one a reader is still streaming from ends its rows early
+    # and raises nothing, so the second call has to fail rather than answer short.
+    connection = duckdb.connect()
+    try:
+        connection.read_parquet(str(populated)).create_view("reactions")
+        pivot.stage(connection, pivot.LEVELS["inputs"], "reactions")
+        with pytest.raises(duckdb.Error, match="stage_inputs"):
+            pivot.stage(connection, pivot.LEVELS["inputs.components"], "reactions")
+    finally:
+        connection.close()
+
+
+def test_write_pivot_stages_rather_than_unnesting_in_one_query(
+    populated, tmp_path, monkeypatch
+):
+    # The inverse of the zero-element test: there select must not be called at all,
+    # here it must not be what write_pivot builds with. Without this the change is
+    # invisible to the suite -- both forms answer identically, which is what the
+    # equivalence test proves, so every other assertion passes either way and a merge
+    # whose base predates the call restores select with no conflict and no failure.
+    def refuse(*args: object, **kwargs: object) -> str:
+        raise AssertionError("write_pivot built its query with select")
+
+    monkeypatch.setattr(pivot, "select", refuse)
+    output = tmp_path / "components.parquet"
+    written = pivot.write_pivot(populated, output, level_path="inputs.components")
+    assert written > 0
+    assert pq.read_table(output).num_rows == written
+
+
+def test_write_pivot_does_not_hold_the_order_of_the_unnest(
+    populated, tmp_path, monkeypatch
+):
+    # A pivot has no row order worth holding, and holding one costs the parallelism of
+    # the unnest that produces it. Asserted on the connection rather than on a
+    # duration, which here would be a flake; the setting is the mechanism.
+    #
+    # Read as the connection closes, since write_pivot closes it before returning and
+    # the setting is per-instance: asking any other connection answers for a different
+    # database.
+    seen = []
+
+    class Watched:
+        """Delegates to a connection, reading the setting as it closes."""
+
+        def __init__(self, connection) -> None:
+            self._connection = connection
+
+        def __getattr__(self, name: str):
+            return getattr(self._connection, name)
+
+        def close(self) -> None:
+            seen.append(
+                self._connection.execute(
+                    "SELECT current_setting('preserve_insertion_order')"
+                ).fetchone()[0]
+            )
+            self._connection.close()
+
+    original = duckdb.connect
+    monkeypatch.setattr(
+        pivot.duckdb, "connect", lambda *a, **k: Watched(original(*a, **k))
+    )
+    pivot.write_pivot(populated, tmp_path / "workups.parquet", level_path="workups")
+    assert seen == [False]
 
 
 @pytest.mark.parametrize("level_path", sorted(pivot.LEVELS))

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -385,7 +385,11 @@ def test_a_level_with_no_elements_is_never_unnested(projected, tmp_path, monkeyp
     def refuse(*args: object, **kwargs: object) -> str:
         raise AssertionError("the level was unnested")
 
+    # Both names: write_pivot builds its query through stage, and select is what stage
+    # is the staged counterpart of. Patching only the one write_pivot does not call
+    # leaves this passing however much work the zero-count path does.
     monkeypatch.setattr(pivot, "select", refuse)
+    monkeypatch.setattr(pivot, "stage", refuse)
     output = tmp_path / "workups.parquet"
     assert pivot.write_pivot(projected, output, level_path="workups") == 0
     assert pq.read_table(output).num_rows == 0
@@ -401,6 +405,52 @@ def _unnested(source: pathlib.Path, level_path: str) -> int:
             .to_arrow_table()
             .num_rows
         )
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize("level_path", sorted(pivot.LEVELS))
+def test_staging_a_level_produces_what_unnesting_it_in_one_query_does(
+    populated, level_path
+):
+    # stage is an optimization, so what makes it safe is that it answers identically --
+    # and the part most easily got wrong is invisible in a row count. Each temp table
+    # has to carry the ordinals accumulated above it, and a level whose prefix is
+    # dropped or misordered still produces exactly as many rows, with the wrong ones. A
+    # correlation joining on that prefix is what would notice, in production rather than
+    # here, so this compares the rows themselves.
+    #
+    # Sorted, because neither form promises an order and the artifact does not need one.
+    level = pivot.LEVELS[level_path]
+    connection = duckdb.connect()
+    try:
+        connection.read_parquet(str(populated)).create_view("reactions")
+        direct = connection.execute(pivot.select(level, "reactions")).to_arrow_table()
+        staged = connection.execute(
+            pivot.stage(connection, level, "reactions")
+        ).to_arrow_table()
+    finally:
+        connection.close()
+    assert staged.schema == direct.schema
+    assert staged.num_rows > 0, f"{level_path} is unpopulated; this proves nothing"
+    assert sorted(map(repr, staged.to_pylist())) == sorted(
+        map(repr, direct.to_pylist())
+    )
+
+
+def test_staging_materializes_the_unnest_that_reads_the_projection(populated):
+    # The cost being avoided is pruning the element inside an unnest over the nested
+    # column, which is the first step and only the first. A level with one step is
+    # therefore the case that has to be staged rather than the case that can be skipped
+    # -- measured at 134.5 s against 22.5 s for inputs over the 1.77M-reaction corpus --
+    # and an implementation returning select for it would look like an optimization
+    # while giving that back.
+    connection = duckdb.connect()
+    try:
+        connection.read_parquet(str(populated)).create_view("reactions")
+        one_step = pivot.LEVELS["workups"]
+        assert len(one_step.steps) == 1
+        assert "unnest" not in pivot.stage(connection, one_step, "reactions").lower()
     finally:
         connection.close()
 

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -411,12 +411,11 @@ def _unnested(source: pathlib.Path, level_path: str) -> int:
 def test_staging_a_level_produces_what_unnesting_it_in_one_query_does(
     populated, level_path
 ):
-    # stage is an optimization, so what makes it safe is that it answers identically --
-    # and the part most easily got wrong is invisible in a row count. Each temp table
-    # has to carry the ordinals accumulated above it, and a level whose prefix is
-    # dropped or misordered still produces exactly as many rows, with the wrong ones. A
-    # correlation joining on that prefix is what would notice, in production rather than
-    # here, so this compares the rows themselves.
+    # What makes staging safe is that it answers identically, and the part most easily
+    # got wrong is invisible in a row count: each temp table carries the ordinals
+    # accumulated above it, and a level whose prefix is dropped or misordered produces
+    # exactly as many rows, with the wrong ones. Only a correlation joining on that
+    # prefix would notice, in production rather than here, so compare the rows.
     #
     # Sorted reprs, because neither form promises an order and the artifact does not
     # need one -- and a row is a dict, which sorted() cannot order directly.
@@ -446,9 +445,9 @@ def _staged_tables(connection) -> list[str]:
 
 
 def test_staging_leaves_a_table_behind_for_every_step_but_the_last(populated):
-    # A table, specifically. A view here would read as staged and plan as though it
-    # were not, since the engine inlines it and the pipeline collapses back to the one
-    # select builds -- the whole saving given back, with nothing in the SQL to show it.
+    # A table, specifically: a view would read as staged and plan as though it were
+    # not, since the engine inlines it and the pipeline collapses back into one. The
+    # saving would be gone with nothing in the SQL to show it.
     connection = duckdb.connect()
     try:
         connection.read_parquet(str(populated)).create_view("reactions")
@@ -460,10 +459,9 @@ def test_staging_leaves_a_table_behind_for_every_step_but_the_last(populated):
 
 
 def test_a_level_with_one_step_is_staged_rather_than_fused(populated):
-    # Staging is what lets each unnest run on its own, and a step left fused runs with
-    # whatever follows it. A level with a single step therefore has to be staged, or
-    # its one unnest is fused and the saving is given back entirely -- which would look
-    # like an optimization for the case with nothing to stage.
+    # Staging is what lets an unnest run on its own, and a fused step runs with
+    # whatever follows it. A single-step level fused is therefore the whole saving
+    # given back, in the case that looks like it has nothing to stage.
     connection = duckdb.connect()
     try:
         connection.read_parquet(str(populated)).create_view("reactions")
@@ -476,9 +474,9 @@ def test_a_level_with_one_step_is_staged_rather_than_fused(populated):
 
 
 def test_staging_a_second_level_on_one_connection_is_refused(populated):
-    # The tables are named for the level's ancestors, so two levels of one chain want
-    # the same name. Replacing one a reader is still streaming from ends its rows early
-    # and raises nothing, so the second call has to fail rather than answer short.
+    # The tables are named for the level's ancestors, so two levels of one chain ask
+    # for one name. Replacing a table a reader is still streaming from ends its rows
+    # early and raises nothing, so the second call has to fail instead.
     connection = duckdb.connect()
     try:
         connection.read_parquet(str(populated)).create_view("reactions")
@@ -493,10 +491,10 @@ def test_write_pivot_stages_rather_than_unnesting_in_one_query(
     populated, tmp_path, monkeypatch
 ):
     # The inverse of the zero-element test: there select must not be called at all,
-    # here it must not be what write_pivot builds with. Without this the change is
-    # invisible to the suite -- both forms answer identically, which is what the
-    # equivalence test proves, so every other assertion passes either way and a merge
-    # whose base predates the call restores select with no conflict and no failure.
+    # here it must not be what write_pivot builds with. Nothing else can tell the two
+    # apart -- they answer identically, which is what the equivalence test proves -- so
+    # every other assertion holds whichever one runs, and only this fails when a merge
+    # or an edit quietly puts the level back in a single query.
     def refuse(*args: object, **kwargs: object) -> str:
         raise AssertionError("write_pivot built its query with select")
 
@@ -510,13 +508,11 @@ def test_write_pivot_stages_rather_than_unnesting_in_one_query(
 def test_write_pivot_does_not_hold_the_order_of_the_unnest(
     populated, tmp_path, monkeypatch
 ):
-    # A pivot has no row order worth holding, and holding one costs the parallelism of
-    # the unnest that produces it. Asserted on the connection rather than on a
-    # duration, which here would be a flake; the setting is the mechanism.
+    # Asserted on the connection rather than on a duration, which here would be a
+    # flake; the setting is the mechanism, and what it buys is in pivot.write_pivot.
     #
     # Read as the connection closes, since write_pivot closes it before returning and
-    # the setting is per-instance: asking any other connection answers for a different
-    # database.
+    # the setting is per-instance: any other connection answers for another database.
     seen = []
 
     class Watched:

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -1860,9 +1860,9 @@ class Corpus:
         projections: one artifact per projection, stamped, and skipped where one is
         already current -- so a run interrupted partway is finished by the next rather
         than started again. It reads a projection at a time and streams the artifact's
-        rows out a batch at a time, though the level's ancestors are materialized whole
-        on the way -- under DuckDB's own memory limit, not the pivot budget, which
-        covers what this corpus holds in process rather than what a derivation spends.
+        rows out a batch at a time, but holds the level's ancestors whole on the way --
+        under DuckDB's own memory limit rather than the pivot budget, which bounds what
+        this corpus holds in process and not what a derivation spends.
 
         Derived before the level is read rather than after refusing to read it. What an
         interrupted run leaves behind is a set covering some of the projections, which

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -1859,8 +1859,10 @@ class Corpus:
         The same derivation ``derive_pivots`` runs offline, aimed at this corpus's own
         projections: one artifact per projection, stamped, and skipped where one is
         already current -- so a run interrupted partway is finished by the next rather
-        than started again. It reads a projection at a time and streams the rows out, so
-        it holds a batch where building the level in memory holds the level.
+        than started again. It reads a projection at a time and streams the artifact's
+        rows out a batch at a time, though the level's ancestors are materialized whole
+        on the way -- under DuckDB's own memory limit, not the pivot budget, which
+        covers what this corpus holds in process rather than what a derivation spends.
 
         Derived before the level is read rather than after refusing to read it. What an
         interrupted run leaves behind is a set covering some of the projections, which


### PR DESCRIPTION
## Summary

Deriving a pivot fused the element prune into an unnest over the projection's nested column, and DuckDB held the order of what that produced. Both are avoidable, and together they were most of the cost of a build.

Over the largest level of the corpus — 8.3M identifiers under the 1.77M reactions of the USPTO projection, which is 96% of ORD by bytes — deriving it takes **88 s where it took 777 s**.

## Changes

- `pivot.stage` unnests each step into a temp table and prunes what comes back, returning a query that produces exactly what `select` does. Tables are named for the ancestor, so a connection deriving several levels of one chain builds each shared prefix once.
- `write_pivot` sets `preserve_insertion_order=false`. A pivot has no row order worth holding: a reader semi-joins it on `reaction_id` and the ordinals.

## Testing

- `stage` and `select` compared on **all 39 levels** over the fixture that populates every one: identical schema, identical rows. Dropping the accumulated ordinal prefix from a staged table fails 19 of them — the failure a row count cannot see.
- Full suite: 1517 passed.
- Full scale, interleaved on AC power, two rounds: 91.0 s and 88.3 s against 776.9 s, identical row counts (8,339,834) and identical output size (219 MB).

## Notes

Most of the win is parallelism rather than less work: at the same total CPU, the ordered pipeline runs under 2x and the unordered one about 12x. **It therefore scales with cores** — measured on 18, and a smaller builder should expect proportionally less. CPU did fall about a third as well, so it is not purely scheduling.

Only the first unnest reads the nested column, so only it must be materialized; below that the input is flat and the last step fuses for free. A level with one step is therefore the case that must be staged rather than the one that can be skipped — 134.5 s against 22.5 s for `inputs`.

Two builds of one artifact need no longer agree byte for byte. Nothing reads a pivot positionally, and no test asserts an order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR accelerates pivot artifact generation by materializing repeated-level ancestors into temporary DuckDB tables and disabling insertion-order preservation.
- Adds staged, prefix-based unnesting while retaining complete ordinal paths.
- Routes artifact generation through the staged query and verifies equivalence with direct unnesting.
- Documents the changed memory and ordering behavior in the search execution path.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no eligible blocking failure remains.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/artifacts/pivot.py | Adds staged ancestor materialization and unordered pivot writing while preserving the artifact schema and complete ordinal prefix. |
| ord_schema/artifacts/pivot_test.py | Adds all-level row-and-schema equivalence coverage plus tests for staging behavior, collisions, and insertion-order configuration. |
| ord_schema/search/execute.py | Updates execution documentation to explain that persisted pivot derivation holds staged ancestors under DuckDB’s memory management. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  P[Projection] --> S1[Stage first repeated ancestor]
  S1 --> SN[Stage intermediate ancestors]
  SN --> U[Unnest final repeated level]
  U --> R[Prune element and retain ordinal prefix]
  R --> A[Write unordered pivot artifact]
  A --> Q[Search semi-joins pivot by reaction ID and ordinals]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Distill the staging prose"](https://github.com/open-reaction-database/ord-schema/commit/e8724c881c67eea8bc97358ccfa3fcf9438bf00e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58471664)</sub>

**Context used:**

- Knowledge Base — [Reaction artifacts and projections](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/reaction-artifacts.md)
- Knowledge Base — [Structured reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/structured-reaction-search.md)

<!-- /greptile_comment -->