### PR TITLE
Read the occurrence index from pivot artifacts

### DIFF
--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -456,6 +456,7 @@ def test_a_corpus_deriving_pivots_also_derives_an_artifact_missing_an_ordinal(
         resolver={}.__getitem__,
         pivots_dir=str(projected / "pivots"),
         derive_pivots=True,
+        warm=False,
     ) as corpus:
         corpus.search(
             query.Query.model_validate(

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -203,9 +203,11 @@ authentic standards — is a level with no elements: nothing satisfies an `exist
 and nothing contradicts a `forall`, so "reactions **without** pyridine in the workup"
 includes every reaction that has no workup at all.
 
-The index is built by the first query that spends it, one pass over the projections per
-indexed path, so a server wanting its first real query to be fast should issue a
-throwaway structure query at startup.
+The index is built at open, which `Corpus(warm=False)` defers to the first query that
+spends it. Where a pivot artifact covers an indexed path the build reads that level
+instead of unnesting the projection — over ORD **3.3s against 59.4s** for the same
+18,847,978 occurrences — and every path no artifact covers still costs its own pass over
+the projections.
 
 ## Pivoted levels
 
@@ -287,6 +289,10 @@ corpus's own projections: a pivot names its reactions by ID, so one derived else
 answers against rows this corpus does not hold, confidently and wrongly. A level with no
 artifacts is still built in process, so a partial set is a partial speedup rather than a
 missing answer.
+
+The occurrence index reads them too, one indexed path at a time: an artifact holds one
+row per element of the nearest repeated level, which is what the build would otherwise
+unnest the projection to produce.
 
 `Corpus(..., pivots_dir=..., derive_pivots=True)` writes the missing ones instead of
 building them: the same pass, spent where it outlives the process and costs no budget,
@@ -370,13 +376,14 @@ on DuckDB's own 6.3 GiB default was killed 85s in; a 12 GiB container holding Du
 `6500MiB` finished, peaking at 9.3 GB resident. `Corpus` warns at open when a cap it can
 read leaves less than 4 GB above the limit ([logbook][cache-entry], finding 19).
 
-Which is survivable but should not be discovered by a user. The index is built by the
-first query that can spend it, so a container short of the floor starts cleanly, passes
-`check_pivots()`, answers scalar queries, and then raises at whoever runs the first
-substructure search. `Corpus.check_index()` moves that to startup, where it is a failed
-deployment rather than a failed request. It is opt-in for the same reason the build is
-lazy — a minute and 1.19 GB that a corpus asked only for scalar or similarity queries
-never needs to spend.
+Which is survivable but should not be discovered by a user. A corpus opened with
+`warm=False` builds the index on the first query that can spend it, so a container short
+of the floor starts cleanly, passes `check_pivots()`, answers scalar queries, and then
+raises at whoever runs the first substructure search. Warming, or `Corpus.check_index()`
+over a cold corpus, puts that at startup, where it is a failed deployment rather than a
+failed request. What a cold corpus buys is the memory floor above and the 1.19 GB the
+index holds, which one asked only for scalar or similarity queries never needs to
+spend.
 
 Across a mixed workload pairing an indexed structure clause with one the index cannot
 carry, the index is **2–24× ahead** of the same corpus answering every quantifier from

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -175,8 +175,8 @@ Substructure runs through an RDKit `SubstructLibrary` built over the corpus: a
 fingerprint **screen** — complete but not exact — over every distinct molecule in the
 corpus, then exact subgraph **verification** of the survivors. It runs on RDKit's own
 threads with the GIL released, so one `Corpus` serves concurrent requests without
-forking; the library is built on the first substructure query and costs seconds and
-about 1.5 GB for the full corpus.
+forking; the library is built at open, which `Corpus(warm=False)` defers to the first
+substructure query, and costs seconds and about 1.5 GB for the full corpus.
 Each search takes its own DuckDB cursor, since a connection holds the pending result of
 its last `execute` and concurrent searches sharing one would read each other's rows.
 `threads` is per search rather than per corpus, so a server expecting several at once
@@ -301,7 +301,8 @@ the budget is still derivable this way. Artifacts already current are skipped, s
 interrupted run is finished by the next rather than started again. It is off by default,
 and `check_pivots()` never triggers it: that call reaches all 39 levels, and deriving
 there would unnest the projection 39 times at startup for a deployment that asks about
-two.
+two. It needs `warm=False`, since deriving a level has to precede the read that would
+refuse it half-derived and warming reads the levels the occurrence index covers.
 
 ## What a projection query costs
 
@@ -346,8 +347,11 @@ derived artifacts spends none of it: those are views over Parquet, not tables.
 ## Sizing a deployment
 
 Budget **about 8 GiB of resident memory** for a corpus serving substructure search over
-ORD: 1.1 GiB to open, 2.2 GiB for the `SubstructLibrary`, 1.19 GiB for the occurrence
-index, and DuckDB's own caches on top, which fill whatever `memory_limit` allows. `Corpus`
+ORD: 1.1 GiB for the relations, 2.2 GiB for the `SubstructLibrary`, 1.19 GiB for the
+occurrence index, and DuckDB's own caches on top, which fill whatever `memory_limit`
+allows. An open corpus holds all three, since the two builds happen at open unless it
+was given `warm=False` — which is what makes the resident figure something to size a
+container against rather than a floor a later query raises it to. `Corpus`
 takes that limit as an argument; left unset, DuckDB claims about 80% of the machine — or
 of the container's cap, which it does read. The step-by-step breakdown is in
 [the logbook entry][cache-entry], finding 16.
@@ -379,11 +383,13 @@ read leaves less than 4 GB above the limit ([logbook][cache-entry], finding 19).
 Which is survivable but should not be discovered by a user. A corpus opened with
 `warm=False` builds the index on the first query that can spend it, so a container short
 of the floor starts cleanly, passes `check_pivots()`, answers scalar queries, and then
-raises at whoever runs the first substructure search. Warming, or `Corpus.check_index()`
-over a cold corpus, puts that at startup, where it is a failed deployment rather than a
-failed request. What a cold corpus buys is the memory floor above and the 1.19 GB the
-index holds, which one asked only for scalar or similarity queries never needs to
-spend.
+raises at whoever runs the first substructure search. Warming puts both builds at open,
+where falling short is a failed deployment rather than a failed request;
+`Corpus.check_index()` does the same for the index alone over a cold corpus, which is
+what a deployment answering scalar and similarity queries wants — those spend the index
+but never the library. What a cold corpus buys is the memory floor above, the 1.19 GB
+the index holds, and the 2.2 GB the library holds, none of which a scalar-only corpus
+needs to spend.
 
 Across a mixed workload pairing an indexed structure clause with one the index cannot
 carry, the index is **2–24× ahead** of the same corpus answering every quantifier from

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -1032,7 +1032,7 @@ class Corpus:
         # The artifacts found for each level, under their own lock: the occurrence
         # build reads them as files while a query reads the same level as a view, and
         # neither should wait on the other's DDL to learn whether any exist.
-        self._pivot_artifacts_found: dict[str, list[str] | None] = {}
+        self._pivot_artifacts_found: dict[str, dict[str, str] | None] = {}
         self._artifacts_lock = threading.Lock()
         # What a dataset's structure IDs add to reach a corpus-wide one, keyed by the
         # source every artifact derived from it names; filled by _prepare.
@@ -1476,7 +1476,8 @@ class Corpus:
             path: The indexed path.
 
         Returns:
-            The SELECT, or None where no artifact covers the path's level.
+            The SELECT, or None where no repeated level covers the path, or where the
+            directory holds no artifact for the level that does.
 
         Raises:
             PairingError: If the artifacts do not pair with this corpus; see
@@ -1486,12 +1487,10 @@ class Corpus:
         if reached is None:
             return None
         level, remainder, _ = reached
-        files = self._pivot_artifacts(level.path)
-        if files is None:
+        sources = self._pivot_artifacts(level.path)
+        if sources is None:
             return None
-        offsets = self._pivot_offsets(level.path, files)
-        if offsets is None:
-            return None
+        offsets = self._pivot_offsets(level.path, sources)
         element = ".".join(["x", pivot.ELEMENT, *remainder])
         # S608: the level and its remainder come from this module's walk of the schema,
         # and the paths from this process's own glob, quoted with their quotes escaped.
@@ -1500,12 +1499,12 @@ class Corpus:
                    ({element}.structure_id + o.{query.STRUCTURE_OFFSET})::UINTEGER
                        AS global_id,
                    {element}.{_INDEXED_FIELD} AS {_INDEXED_FIELD}
-            FROM read_parquet({_sql_paths(files)}, filename=true) x
+            FROM read_parquet({_sql_paths(sources)}, filename=true) x
             JOIN {offsets} o ON x.filename = o.pivot_filename
             WHERE {element}.structure_id IS NOT NULL
             """  # noqa: S608
 
-    def _pivot_offsets(self, level: str, files: list[str]) -> str | None:
+    def _pivot_offsets(self, level: str, sources: dict[str, str]) -> str:
         """Publishes what each pivot artifact's rows add to reach a corpus-wide ID.
 
         A pivot and the projection it was derived from restate one source dataset, so
@@ -1516,18 +1515,17 @@ class Corpus:
 
         Args:
             level: The repeated level the artifacts hold, which names the relation.
-            files: The artifacts to map, from ``_pivot_artifacts``.
+            sources: The source each artifact names, from ``_pivot_artifacts``.
 
         Returns:
-            The relation's name, or None if any artifact names a source the corpus does
-            not hold -- which ``_check_pivots`` refuses first, leaving this a guard
-            rather than a path taken.
+            The relation's name.
         """
         rows = []
-        for name in files:
-            offset = self._offset_of_source.get(base.load_stamps(name).source_md5)
-            if offset is None:
-                return None
+        for name, source in sources.items():
+            offset = self._offset_of_source.get(source)
+            # _check_pivots requires these artifacts' sources to be exactly the
+            # projections', and the offsets are keyed by those same hashes.
+            assert offset is not None, f"{name} names a source the corpus does not hold"
             rows.append((name, offset))
         # Named for the level rather than per attempt, so a retry after a refusal
         # replaces these rows rather than leaving a relation behind for each try.
@@ -1587,15 +1585,15 @@ class Corpus:
             # scan of a few hundred megabytes against a traversal of every reaction.
             # Decided per path, so a directory holding some levels and not others is a
             # partial speedup rather than a missing index.
-            selects, from_pivots = [], []
+            reads, from_pivots = [], []
             for path, expression in INDEXED_PATHS.items():
                 reading = self._occurrences_from_pivot(path)
                 if reading is None:
-                    selects.append(_occurrences_from_projection(path, expression))
+                    reads.append(_occurrences_from_projection(path, expression))
                 else:
-                    selects.append(reading)
+                    reads.append(reading)
                     from_pivots.append(path)
-            selects = "\nUNION ALL\n".join(selects)
+            selects = "\nUNION ALL\n".join(reads)
             # Its own cursor: this runs while searches are in flight, and the shared
             # connection holds their results.
             cursor = self._connection.cursor()
@@ -1994,9 +1992,10 @@ class Corpus:
                 confidently and wrongly, since its reaction IDs resolve against the
                 wrong rows -- or, with ``require_current``, if any of them is stale.
         """
-        files = self._pivot_artifacts(path)
-        if files is None:
+        sources = self._pivot_artifacts(path)
+        if sources is None:
             return None
+        files = list(sources)
         with self._views_lock:
             published = self._pivot_views.get(path)
             if published is not None:
@@ -2012,18 +2011,21 @@ class Corpus:
             self._pivot_views[path] = name
             return name
 
-    def _pivot_artifacts(self, path: str) -> list[str] | None:
+    def _pivot_artifacts(self, path: str) -> dict[str, str] | None:
         """Returns the artifacts holding the pivot over ``path``, checked, or None.
 
         Globbed and checked once per level and remembered, including the answer that
         there are none, so a corpus without artifacts reads the directory once rather
-        than on every query.
+        than on every query. The stamps the check reads are kept with the paths, since
+        the source an artifact names is what pairs it with an offset and reading the
+        footers again would be one open per artifact per level.
 
         Args:
             path: The repeated level, as the query grammar names it.
 
         Returns:
-            The artifact paths, or None where the directory holds none for this level.
+            The source dataset each artifact was derived from, keyed by its path, or
+            None where the directory holds none for this level.
 
         Raises:
             PairingError: If the artifacts were not derived from the projections this
@@ -2040,11 +2042,11 @@ class Corpus:
             if not files:
                 self._pivot_artifacts_found[path] = None
                 return None
-            self._check_pivots(path, files)
-            self._pivot_artifacts_found[path] = files
-            return files
+            sources = self._check_pivots(path, files)
+            self._pivot_artifacts_found[path] = sources
+            return sources
 
-    def _check_pivots(self, path: str, files: list[str]) -> None:
+    def _check_pivots(self, path: str, files: list[str]) -> dict[str, str]:
         """Refuses pivot artifacts that do not belong to this corpus.
 
         A pivot names its reactions by ID, and an ID resolves against whatever rows the
@@ -2056,13 +2058,20 @@ class Corpus:
             path: The repeated level the files claim to hold.
             files: The artifacts found for it.
 
+        Returns:
+            The source dataset each artifact was derived from, keyed by its path. What
+            pairs an artifact with the offset its projection was given, and read here
+            rather than again later; see ``_pivot_offsets``.
+
         Raises:
-            PairingError: If a file is not a pivot over ``path``, if the set of source
-                datasets differs from the projections', or -- with ``require_current``
-                -- if any artifact is stale.
+            PairingError: If a file is not a pivot over ``path``, if two artifacts
+                restate one source dataset, if the set of source datasets differs from
+                the projections', or -- with ``require_current`` -- if any artifact is
+                stale.
         """
         wanted = {base.load_stamps(name).source_md5 for name in self._projections}
-        found = set()
+        sources: dict[str, str] = {}
+        derived_from: dict[str, str] = {}
         for name in files:
             stamps = base.load_stamps(name)
             if stamps.artifact != pivot.ARTIFACT:
@@ -2079,14 +2088,28 @@ class Corpus:
                 stamps, pivot.ARTIFACT
             ):
                 raise PairingError(f"{name} is a stale {pivot.ARTIFACT}")
-            found.add(stamps.source_md5)
-        if found != wanted:
+            # Two artifacts of one dataset pass the set comparison below and are then
+            # both read, so every element of the level is stated twice: a quantifier
+            # cannot see it, since a semi-join returns a reaction once however many
+            # rows name it, but the occurrence index counts those rows and check_index
+            # reports the count.
+            if stamps.source_md5 in derived_from:
+                raise PairingError(
+                    f"{name} and {derived_from[stamps.source_md5]} are both "
+                    f"{pivot.ARTIFACT} artifacts over {path} of the same source "
+                    "dataset, so the level's elements would each be read twice"
+                )
+            derived_from[stamps.source_md5] = name
+            sources[name] = stamps.source_md5
+        if set(sources.values()) != wanted:
+            found = set(sources.values())
             raise PairingError(
                 f"the {pivot.ARTIFACT} artifacts for {path} were derived from "
                 f"{len(found)} source datasets and the projections from {len(wanted)}, "
                 f"and {len(wanted - found)} of the projections' are missing; a pivot "
                 "of another corpus names reactions this one does not hold"
             )
+        return sources
 
     def _derive_pivot(self, path: str) -> str | None:
         """Writes the pivot artifacts for ``path`` and publishes them.

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -885,26 +885,29 @@ class Corpus:
                 to leave that much. Over ORD, ``6500MiB`` under a 12 GiB cap builds the
                 occurrence index, where DuckDB's own default under an 8 GiB cap is
                 killed partway.
-
             warm: Build the occurrence index at open rather than on the query that
-                first wants it. What it costs is a read of the pivot artifacts covering
-                the indexed paths, and a pass over the projections for any they do not
-                cover -- which over ORD is the difference between a second and a minute.
-                The build also wants 5-6.5 GB of DuckDB memory and leaves 1.19 GB
-                resident, so a deployment without those artifacts, or one whose queries
-                are all scalar or similarity and never reach the index, may prefer to
-                charge that to a query rather than to startup; see ``check_index``. The
-                substructure library is left to first use either way: it costs gigabytes
-                on top, and only a structure query needs it.
+                first wants it, on by default. What it costs is a read of the pivot
+                artifacts covering the indexed paths, and a pass over the projections
+                for any they do not cover -- which over ORD is the difference between a
+                second and a minute. The build also wants 5-6.5 GB of DuckDB memory and
+                leaves 1.19 GB resident, so a deployment without those artifacts, or one
+                whose queries are all scalar or similarity and never reach the index,
+                may prefer to charge that to a query rather than to startup; see
+                ``check_index``. The substructure library is left to first use either
+                way: it costs gigabytes on top, and only a substructure query needs it.
 
         Raises:
             PairingError: If either pattern matches nothing, a file on one side has no
                 partner on the other, a pair's stamps disagree about the source
                 dataset, or -- with ``require_current`` -- any artifact is stale. With
                 ``warm``, also whatever building the occurrence index refuses: a corpus
-                stating a reaction twice, or one whose index does not reach every
-                structure it holds, both of which otherwise surface on the first query
-                that needs the index rather than at open.
+                stating a reaction twice, one whose index does not reach every structure
+                it holds, or pivot artifacts over an indexed level that belong to
+                another corpus, all of which otherwise surface on the first query that
+                needs the index rather than at open.
+            duckdb.OutOfMemoryException: With ``warm``, if DuckDB is held below what the
+                occurrence index wants to build; see ``check_index`` for that floor, and
+                for the container cap that kills the process rather than raising.
             ValueError: If ``require_pivots`` is set beside a ``pivot_budget_bytes``,
                 which budgets for a build it rules out. If ``pivot_budget_bytes`` is
                 negative, which no amount of
@@ -1478,8 +1481,8 @@ class Corpus:
             if offset is None:
                 return None
             rows.append((name, offset))
-        # Named for the level, so a build the last one refused partway replaces these
-        # rows rather than leaving a relation per attempt behind.
+        # Named for the level rather than per attempt, so a retry after a refusal
+        # replaces these rows rather than leaving a relation behind for each try.
         published = f"{pivot.table_name(level)}_offsets"
         registered = pa.table(
             {
@@ -1489,12 +1492,17 @@ class Corpus:
                 ),
             }
         )
-        self._connection.register("registered_pivot_offsets", registered)
-        self._connection.execute(
-            f"CREATE OR REPLACE TABLE {published} AS "  # noqa: S608
-            "SELECT * FROM registered_pivot_offsets"
-        )
-        self._connection.unregister("registered_pivot_offsets")
+        # Under the build lock, which every statement that puts a table in this database
+        # takes, so a materialization measuring what a pivot costs does not read these
+        # rows into its own total. S608: the name comes from this module's walk of the
+        # schema.
+        with self._build_lock:
+            self._connection.register("registered_pivot_offsets", registered)
+            self._connection.execute(
+                f"CREATE OR REPLACE TABLE {published} AS "  # noqa: S608
+                "SELECT * FROM registered_pivot_offsets"
+            )
+            self._connection.unregister("registered_pivot_offsets")
         return published
 
     def _occurrences(self) -> None:
@@ -1922,9 +1930,9 @@ class Corpus:
     def _pivot_view(self, path: str) -> str | None:
         """Returns a view over the pivot artifacts for ``path``, or None if none exist.
 
-        Published once per level and remembered, including the answer that there is
-        nothing to publish, so a corpus without artifacts globs the directory once
-        rather than on every query.
+        Published once per level, over whichever artifacts ``_pivot_artifacts`` found
+        and checked, and remembered under its own lock so a query over a published level
+        waits on nothing.
 
         Args:
             path: The repeated level, as the query grammar names it.

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -889,11 +889,13 @@ class Corpus:
             warm: Build the occurrence index at open rather than on the query that
                 first wants it. What it costs is a read of the pivot artifacts covering
                 the indexed paths, and a pass over the projections for any they do not
-                cover -- which over ORD is the difference between a second and a minute,
-                so a deployment without those artifacts may prefer to charge it to a
-                query rather than to startup. The substructure library is left to first
-                use either way: it costs gigabytes, and a corpus asked only for
-                similarity or scalar queries never needs it.
+                cover -- which over ORD is the difference between a second and a minute.
+                The build also wants 5-6.5 GB of DuckDB memory and leaves 1.19 GB
+                resident, so a deployment without those artifacts, or one whose queries
+                are all scalar or similarity and never reach the index, may prefer to
+                charge that to a query rather than to startup; see ``check_index``. The
+                substructure library is left to first use either way: it costs gigabytes
+                on top, and only a structure query needs it.
 
         Raises:
             PairingError: If either pattern matches nothing, a file on one side has no
@@ -1193,14 +1195,14 @@ class Corpus:
     def check_index(self) -> dict[str, int]:
         """Builds the occurrence index and returns what it reached, per path.
 
-        The sibling of ``check_pivots``, and for the same reason: the index is
-        otherwise built by the first query that can spend it, so a corpus it refuses --
-        a reaction stated twice, a structure no indexed path reaches -- fails that query
-        rather than the deployment. It also has a memory floor, and meeting that one the
-        other way is worse still. Over ORD the build wants 5-6.5 GB of DuckDB memory and
-        writes 16-25 GB of temporary files getting there; below that it raises
-        ``duckdb.OutOfMemoryException`` rather than running slowly, since a block it
-        cannot pin is not one it can spill.
+        The sibling of ``check_pivots``, and for the same reason: a corpus opened
+        without ``warm`` builds the index on the first query that can spend it, so a
+        corpus it refuses -- a reaction stated twice, a structure no indexed path
+        reaches -- fails that query rather than the deployment. It also has a memory
+        floor, and meeting that one the other way is worse still. Over ORD the build
+        wants 5-6.5 GB of DuckDB memory and writes 16-25 GB of temporary files getting
+        there; below that it raises ``duckdb.OutOfMemoryException`` rather than running
+        slowly, since a block it cannot pin is not one it can spill.
 
         That exception is the good outcome, and under a cgroup cap it is only reached
         with room to spare above ``memory_limit``: the build holds up to 2.8 GB outside
@@ -1210,9 +1212,10 @@ class Corpus:
         holding DuckDB to 6500MiB finishes at 9.3 GB resident. ``Corpus`` warns at open
         when a cap it can read leaves too little.
 
-        Opt-in rather than done at open, because the cost is real and a corpus asked
-        only for scalar or similarity queries never pays it: about a minute, and 1.19 GB
-        resident afterwards at ORD's scale.
+        A corpus opened with ``warm`` has paid the build already, and the call is then
+        its counts. Leaving it cold suits one asked only for scalar or similarity
+        queries, which never spends what the index costs: about a minute over ORD where
+        no pivot artifact covers a path, and 1.19 GB resident however it was built.
 
         Returns:
             The number of occurrences found per indexed path, including the paths that
@@ -1503,8 +1506,9 @@ class Corpus:
         condition on one row rather than an intersection of two reaction sets, which
         over-returns.
 
-        Costs one pass over the projections per indexed path, so it is built when a
-        query first wants it rather than at open. Concurrent first queries serialize
+        Costs a read of the pivot artifacts covering the indexed paths and one pass over
+        the projections per path they do not cover, charged at open under ``warm`` and
+        otherwise to the query that first wants it. Concurrent first queries serialize
         here and share the result.
 
         Raises:

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -471,9 +471,9 @@ INDEXED_PATHS = _indexed_paths()
 def _occurrences_from_projection(path: str, expression: str) -> str:
     """Returns the SELECT unnesting ``path``'s occurrences out of the projection.
 
-    What the index is built from where no pivot covers the level. A path's elements are
-    already a list, so unnest yields one row each, and the offset comes from the row's
-    own file, which the reactions view carries.
+    Used where no pivot artifact covers the path's level. A path's elements are already
+    a list, so unnest yields one row each, and the offset comes from the row's own file,
+    which the reactions view carries.
 
     Args:
         path: The indexed path.
@@ -482,7 +482,8 @@ def _occurrences_from_projection(path: str, expression: str) -> str:
     Returns:
         The SELECT.
     """
-    # S608: the traversal is the compiler's own, resolved against the projection schema.
+    # S608: the traversal is the compiler's own, resolved against the projection schema,
+    # and the path is a key of INDEXED_PATHS, quoted.
     return f"""
         SELECT reaction_id, {sql_string(path)} AS path,
                (element.structure_id + {query.STRUCTURE_OFFSET})::UINTEGER AS global_id,
@@ -1002,12 +1003,11 @@ class Corpus:
             )
         if derive_pivots and warm:
             # The index reads the artifacts over the levels it indexes as files, so
-            # warming would check a level derive_pivots means to complete before the
+            # warming checks a level derive_pivots means to complete before the
             # derivation that completes it has run -- and a set covering some of the
-            # projections is exactly what the check refuses; see _derive_pivot. Refused
-            # rather than ordered around, because the ordering that works is a
-            # derivation of every indexed level at open, which is minutes charged to a
-            # corpus that asked for artifacts to be filled in as they were wanted.
+            # projections is exactly what the check refuses; see _derive_pivot. The
+            # ordering that would work derives every indexed level at open, minutes
+            # charged to a corpus that asked for artifacts as they were wanted.
             raise ValueError(
                 "derive_pivots was set beside warm, which reads the levels the "
                 "occurrence index covers before the derivation can complete them; open "
@@ -1029,9 +1029,10 @@ class Corpus:
         self._projections = [pair[0] for pair in pairs]
         self._pivot_views: dict[str, str] = {}
         self._views_lock = threading.Lock()
-        # The artifacts found for each level, under their own lock: the occurrence
-        # build reads them as files while a query reads the same level as a view, and
-        # neither should wait on the other's DDL to learn whether any exist.
+        # The artifacts found for each level, with the source each names, under their
+        # own lock: the occurrence build reads them as files while a query reads the
+        # same level as a view, and the lock holds a footer read per artifact, which is
+        # not something to hold the lock a published view is looked up under.
         self._pivot_artifacts_found: dict[str, dict[str, str] | None] = {}
         self._artifacts_lock = threading.Lock()
         # What a dataset's structure IDs add to reach a corpus-wide one, keyed by the
@@ -1142,10 +1143,10 @@ class Corpus:
         # the reachable one, since read_parquet globs each element it is handed --
         # drops rows from the join rather than failing, leaving a corpus that answers
         # every query with silence. Each side is counted against the total its own
-        # footers state, which is the only place the loss is visible: a reaction the
-        # view lost is one no query can find, and the occurrence index cannot stand in
-        # for the count, since a path read from a pivot artifact reaches the structures
-        # whatever the view holds.
+        # footers state, which is where the loss is visible: a reaction the view lost is
+        # one no query can find, and the occurrence index cannot stand in for the count,
+        # since a path read from a pivot artifact reaches the structures whatever the
+        # view holds.
         counts = self._connection.execute(
             "SELECT count(*), count(pattern_fp) FROM corpus_structures"
         ).fetchone()
@@ -1493,7 +1494,8 @@ class Corpus:
         offsets = self._pivot_offsets(level.path, sources)
         element = ".".join(["x", pivot.ELEMENT, *remainder])
         # S608: the level and its remainder come from this module's walk of the schema,
-        # and the paths from this process's own glob, quoted with their quotes escaped.
+        # and the paths from this process's own glob, quoted with their single quotes
+        # escaped.
         return f"""
             SELECT x.{pivot.REACTION_ID}, {sql_string(path)} AS path,
                    ({element}.structure_id + o.{query.STRUCTURE_OFFSET})::UINTEGER
@@ -1527,8 +1529,8 @@ class Corpus:
             # projections', and the offsets are keyed by those same hashes.
             assert offset is not None, f"{name} names a source the corpus does not hold"
             rows.append((name, offset))
-        # Named for the level rather than per attempt, so a retry after a refusal
-        # replaces these rows rather than leaving a relation behind for each try.
+        # Named for the level, so a retry after a refusal replaces these rows instead of
+        # leaving a relation behind per attempt.
         published = f"{pivot.table_name(level)}_offsets"
         registered = pa.table(
             {
@@ -1538,10 +1540,9 @@ class Corpus:
                 ),
             }
         )
-        # Under the build lock, which every statement that puts a table in this database
-        # takes, so a materialization measuring what a pivot costs does not read these
-        # rows into its own total. S608: the name comes from this module's walk of the
-        # schema.
+        # Under the build lock, for the reason _build states: a materialization brackets
+        # its table with two memory readings taken across everyone. S608: the name comes
+        # from this module's walk of the schema.
         with self._build_lock:
             self._connection.register("registered_pivot_offsets", registered)
             self._connection.execute(
@@ -2059,9 +2060,9 @@ class Corpus:
             files: The artifacts found for it.
 
         Returns:
-            The source dataset each artifact was derived from, keyed by its path. What
-            pairs an artifact with the offset its projection was given, and read here
-            rather than again later; see ``_pivot_offsets``.
+            The source dataset each artifact was derived from, keyed by its path, which
+            is what pairs an artifact with the offset its projection was given; see
+            ``_pivot_offsets``.
 
         Raises:
             PairingError: If a file is not a pivot over ``path``, if two artifacts
@@ -2088,11 +2089,11 @@ class Corpus:
                 stamps, pivot.ARTIFACT
             ):
                 raise PairingError(f"{name} is a stale {pivot.ARTIFACT}")
-            # Two artifacts of one dataset pass the set comparison below and are then
-            # both read, so every element of the level is stated twice: a quantifier
-            # cannot see it, since a semi-join returns a reaction once however many
-            # rows name it, but the occurrence index counts those rows and check_index
-            # reports the count.
+            # Two artifacts of one dataset pass the set comparison below and are both
+            # read, so every element of the level is stated twice. A quantifier cannot
+            # see it -- a semi-join returns a reaction once however many rows name it --
+            # but the occurrence index counts those rows, and check_index reports the
+            # count.
             if stamps.source_md5 in derived_from:
                 raise PairingError(
                     f"{name} and {derived_from[stamps.source_md5]} are both "

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -72,11 +72,11 @@ The grammar bounds what a query can cost (one pass and a sort), and ``search``
 takes a wall-clock timeout that interrupts the final query. Name resolution, the
 one-time library and index builds, screening, and verification all run before the timer
 starts: each is bounded by the corpus rather than by the query, so a slow one is slow
-for every caller and shows up in the logs rather than in a timeout. The two builds have
-separate triggers -- the library on the first substructure predicate, and the index at
-open unless the corpus was given ``warm=False``, which leaves it to the first query that
-takes a clause of it. A search that pays for either pays upwards of a minute over the
-whole corpus, on top of whatever timeout it was given.
+for every caller and shows up in the logs rather than in a timeout. Both builds happen
+at open unless the corpus was given ``warm=False``, which leaves the index to the first
+query taking a clause of it and the library to the first substructure predicate. A
+search that pays for either pays upwards of a minute over the whole corpus, on top of
+whatever timeout it was given.
 """
 
 import array
@@ -875,7 +875,9 @@ class Corpus:
                 for the budget is still derivable. Off by default: a deployment reading
                 artifacts someone else derives should not start writing them because a
                 directory was mistyped, and a corpus-scale derivation belongs in
-                ``ord_schema.artifacts.scripts.derive_pivots``.
+                ``ord_schema.artifacts.scripts.derive_pivots``. Needs ``warm`` off,
+                since warming reads the levels the occurrence index covers and a
+                derivation has to precede the read of the level it completes.
             memory_limit: What DuckDB may hold, spelled as it spells sizes: ``6500MiB``,
                 ``8GB``. Left unset, DuckDB takes about 80% of the machine, or of the
                 container's cap, which it does read. That default suits a process that
@@ -886,34 +888,38 @@ class Corpus:
                 to leave that much. Over ORD, ``6500MiB`` under a 12 GiB cap builds the
                 occurrence index, where DuckDB's own default under an 8 GiB cap is
                 killed partway.
-            warm: Build the occurrence index at open rather than on the query that
-                first wants it, on by default. What it costs is a read of the pivot
-                artifacts covering the indexed paths, and a pass over the projections
-                for any they do not cover -- which over ORD is the difference between a
-                second and a minute. The build also wants 5-6.5 GB of DuckDB memory and
-                leaves 1.19 GB resident, so a deployment without those artifacts, or one
-                whose queries are all scalar or similarity and never reach the index,
-                may prefer to charge that to a query rather than to startup; see
-                ``check_index``. The substructure library is left to first use either
-                way: it costs gigabytes on top, and only a substructure query needs it.
+            warm: Build at open what a structure query would otherwise build on the
+                query itself, on by default: the occurrence index, then the substructure
+                library. The index costs a read of the pivot artifacts covering the
+                indexed paths and a pass over the projections for every path they do not
+                cover -- over ORD the difference between a second and a minute -- and it
+                wants 5-6.5 GB of DuckDB memory to build and holds 1.19 GB afterwards.
+                The library is about 8s and 2.2 GB on top. Together they are most of
+                what a container is sized against, which is the reason to spend them
+                where falling short is a failed deployment rather than a failed request;
+                see ``check_index``. A corpus asked only scalar queries needs neither,
+                and one asked scalar and similarity queries needs the index without the
+                library -- ``warm=False`` beside ``check_index`` builds that pair.
 
         Raises:
             PairingError: If either pattern matches nothing, a file on one side has no
                 partner on the other, a pair's stamps disagree about the source
                 dataset, or -- with ``require_current`` -- any artifact is stale. With
-                ``warm``, also whatever building the occurrence index refuses: a corpus
-                stating a reaction twice, one whose index does not reach every structure
-                it holds, or pivot artifacts over an indexed level that belong to
-                another corpus, all of which otherwise surface on the first query that
-                needs the index rather than at open.
+                ``warm``, also whatever building the occurrence index and the
+                substructure library refuse: a corpus stating a reaction twice, one
+                whose index does not reach every structure it holds, one whose IDs are
+                not every integer from zero, or pivot artifacts over an indexed level
+                that belong to another corpus, all of which otherwise surface on the
+                first query that wants what refused them rather than at open.
             duckdb.OutOfMemoryException: With ``warm``, if DuckDB is held below what the
                 occurrence index wants to build; see ``check_index`` for that floor, and
                 for the container cap that kills the process rather than raising.
             ValueError: If ``require_pivots`` is set beside a ``pivot_budget_bytes``,
-                which budgets for a build it rules out. If ``pivot_budget_bytes`` is
-                negative, which no amount of
-                memory is; zero is allowed, and materializes nothing; or if
-                ``derive_pivots`` or ``require_pivots`` is set without a
+                which budgets for a build it rules out. If ``derive_pivots`` is set
+                beside ``warm``, which reads the levels the index covers before the
+                derivation can complete them. If ``pivot_budget_bytes`` is negative,
+                which no amount of memory is; zero is allowed, and materializes nothing;
+                or if ``derive_pivots`` or ``require_pivots`` is set without a
                 ``pivots_dir``.
         """
         self._resolver = resolver if resolver is not None else _resolve_with_resolvers
@@ -994,6 +1000,20 @@ class Corpus:
                 "require_pivots was set without a pivots_dir, so there is nowhere to "
                 "look for what it would require"
             )
+        if derive_pivots and warm:
+            # The index reads the artifacts over the levels it indexes as files, so
+            # warming would check a level derive_pivots means to complete before the
+            # derivation that completes it has run -- and a set covering some of the
+            # projections is exactly what the check refuses; see _derive_pivot. Refused
+            # rather than ordered around, because the ordering that works is a
+            # derivation of every indexed level at open, which is minutes charged to a
+            # corpus that asked for artifacts to be filled in as they were wanted.
+            raise ValueError(
+                "derive_pivots was set beside warm, which reads the levels the "
+                "occurrence index covers before the derivation can complete them; open "
+                "with warm=False and let a query or check_index build the index once "
+                "the artifacts are there"
+            )
         pairs, self._fingerprint = _pair(
             projection_pattern, structures_pattern, require_current
         )
@@ -1027,20 +1047,36 @@ class Corpus:
             if require_pivots:
                 self._require_every_pivot()
             if warm:
-                self._occurrences()
+                self._warm()
         except Exception:
             # Nothing else holds the connection yet, and the caller has no object to
             # close one from if __init__ does not return.
             self._connection.close()
             raise
 
+    def _warm(self) -> None:
+        """Builds at open everything a structure query would otherwise build on demand.
+
+        The index before the library, so the library's gigabytes are not resident
+        through the build that wants the most memory of anything here.
+
+        Raises:
+            PairingError: Whatever the index or the library refuses; see
+                ``_occurrences`` and ``_library``.
+        """
+        self._occurrences()
+        self._library()
+
     def _prepare(self, pairs: list[tuple[str, str, str]]) -> tuple[int, int]:
         """Publishes the relations, and returns the total and searchable row counts."""
         offsets = []
         total = 0
+        stated = 0
         for projected, structured, source in pairs:
             with pq.ParquetFile(structured) as artifact:
                 count = artifact.metadata.num_rows
+            with pq.ParquetFile(projected) as artifact:
+                stated += artifact.metadata.num_rows
             # The IDs the projection carries have to land inside the partner's rows.
             # Stamps cannot see this: an artifact rederived from a rewritten
             # projection keeps the same source hash, so a short one pairs cleanly and
@@ -1105,10 +1141,11 @@ class Corpus:
         # that makes the two disagree -- a glob metacharacter in a directory name is
         # the reachable one, since read_parquet globs each element it is handed --
         # drops rows from the join rather than failing, leaving a corpus that answers
-        # every query with silence. The structures side is counted against a total
-        # taken from the footers; the reactions side has no such total to check
-        # against, so a projection whose path failed the same way goes unnoticed here
-        # and shows up only as reactions nobody can find.
+        # every query with silence. Each side is counted against the total its own
+        # footers state, which is the only place the loss is visible: a reaction the
+        # view lost is one no query can find, and the occurrence index cannot stand in
+        # for the count, since a path read from a pivot artifact reaches the structures
+        # whatever the view holds.
         counts = self._connection.execute(
             "SELECT count(*), count(pattern_fp) FROM corpus_structures"
         ).fetchone()
@@ -1118,6 +1155,15 @@ class Corpus:
             raise PairingError(
                 f"the structures artifacts hold {total} rows but only {joined} joined "
                 "to their offsets; a path did not survive read_parquet"
+            )
+        reactions = self._connection.execute(
+            f"SELECT count(*) FROM {query.TABLE}"  # noqa: S608
+        ).fetchone()
+        assert reactions is not None  # An aggregate over any relation returns one row.
+        if reactions[0] != stated:
+            raise PairingError(
+                f"the projections hold {stated} reactions but only {reactions[0]} "
+                "joined to their offsets; a path did not survive read_parquet"
             )
         return total, searchable
 
@@ -1291,8 +1337,9 @@ class Corpus:
     def _library(self) -> rdSubstructLibrary.SubstructLibrary:
         """Returns the substructure library, building it on first use.
 
-        Built lazily because it costs seconds and gigabytes, and a corpus asked only
-        for similarity or scalar queries never needs it.
+        Built at open under ``warm``, and otherwise on the first substructure query: it
+        costs seconds and gigabytes, and a corpus asked only for similarity or scalar
+        queries never needs it.
 
         Structures are deduplicated per dataset, so a molecule used by several datasets
         occupies a row in each and would otherwise be matched once per copy. The library
@@ -1572,9 +1619,10 @@ class Corpus:
                         "glob one artifact per reaction"
                     )
                     raise PairingError(self._refused)
-                # Under the build lock, so the only other thing that puts a table
-                # in this database does not do it while a materialization is measuring
-                # what one costs -- a difference of two readings taken across everyone.
+                # Under the build lock, which every statement that puts a table in this
+                # database takes, so none of them lands while a materialization is
+                # measuring what one costs -- a difference of two readings taken across
+                # everyone.
                 # OR REPLACE, so a build interrupted after the table exists is a build
                 # the next query repeats rather than one that collides with itself
                 # forever. S608: the fragments are this module's own schema walk and
@@ -1599,10 +1647,9 @@ class Corpus:
                 if reached[0] != self._total:
                     self._refused = (
                         f"the occurrence index reached {reached[0]} of the corpus's "
-                        f"{self._total} structures over {sorted(INDEXED_PATHS)}; "
-                        "either the projections are not the schema this walk was built "
-                        "from, or their rows did not survive the filename join, so the "
-                        "reactions holding the rest cannot be found"
+                        f"{self._total} structures over {sorted(INDEXED_PATHS)}, so "
+                        "the reactions holding the rest cannot be found; the "
+                        "projections are not the schema this walk was built from"
                     )
                     raise PairingError(self._refused)
                 self._occurrences_built = True

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -360,8 +360,8 @@ def _fingerprint(stamps: Iterable[base.Stamps]) -> str:
 
 def _pair(
     projection_pattern: str, structures_pattern: str, require_current: bool
-) -> tuple[list[tuple[str, str]], str]:
-    """Returns (projection, structures) path pairs, verified by their stamps.
+) -> tuple[list[tuple[str, str, str]], str]:
+    """Returns (projection, structures, source) triples, verified by their stamps.
 
     Args:
         projection_pattern: Glob matching the projection base.
@@ -369,7 +369,9 @@ def _pair(
         require_current: Refuse artifacts not written by the current versions.
 
     Returns:
-        One pair per source dataset, ordered by the projection's source hash, and the
+        One triple per source dataset, ordered by the source hash, carrying that hash
+        beside the paths -- every artifact derived from the dataset names it, so it is
+        what pairs a pivot with the offset this corpus gave its projection. Also the
         fingerprint over the stamps this already read to verify them.
 
     Raises:
@@ -393,7 +395,8 @@ def _pair(
             f"counterpart derived from the same source dataset: {orphans}"
         )
     pairs = [
-        (projections[key][0], structure_files[key][0]) for key in sorted(projections)
+        (projections[key][0], structure_files[key][0], key)
+        for key in sorted(projections)
     ]
     fingerprint = _fingerprint(
         stamps
@@ -462,6 +465,30 @@ def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
 
 
 INDEXED_PATHS = _indexed_paths()
+
+
+def _occurrences_from_projection(path: str, expression: str) -> str:
+    """Returns the SELECT unnesting ``path``'s occurrences out of the projection.
+
+    What the index is built from where no pivot covers the level. A path's elements are
+    already a list, so unnest yields one row each, and the offset comes from the row's
+    own file, which the reactions view carries.
+
+    Args:
+        path: The indexed path.
+        expression: The traversal yielding its elements, from ``INDEXED_PATHS``.
+
+    Returns:
+        The SELECT.
+    """
+    # S608: the traversal is the compiler's own, resolved against the projection schema.
+    return f"""
+        SELECT reaction_id, {sql_string(path)} AS path,
+               (element.structure_id + {query.STRUCTURE_OFFSET})::UINTEGER AS global_id,
+               element.{_INDEXED_FIELD} AS {_INDEXED_FIELD}
+        FROM {query.TABLE}, unnest({expression}) AS unnested(element)
+        WHERE element.structure_id IS NOT NULL
+        """  # noqa: S608
 
 
 def _index_condition(
@@ -795,6 +822,7 @@ class Corpus:
         derive_pivots: bool = False,
         require_pivots: bool = False,
         memory_limit: str | None = None,
+        warm: bool = True,
     ) -> None:
         """Pairs the artifacts, checks their stamps, and prepares the relations.
 
@@ -858,10 +886,23 @@ class Corpus:
                 occurrence index, where DuckDB's own default under an 8 GiB cap is
                 killed partway.
 
+            warm: Build the occurrence index at open rather than on the query that
+                first wants it. What it costs is a read of the pivot artifacts covering
+                the indexed paths, and a pass over the projections for any they do not
+                cover -- which over ORD is the difference between a second and a minute,
+                so a deployment without those artifacts may prefer to charge it to a
+                query rather than to startup. The substructure library is left to first
+                use either way: it costs gigabytes, and a corpus asked only for
+                similarity or scalar queries never needs it.
+
         Raises:
             PairingError: If either pattern matches nothing, a file on one side has no
                 partner on the other, a pair's stamps disagree about the source
-                dataset, or -- with ``require_current`` -- any artifact is stale.
+                dataset, or -- with ``require_current`` -- any artifact is stale. With
+                ``warm``, also whatever building the occurrence index refuses: a corpus
+                stating a reaction twice, or one whose index does not reach every
+                structure it holds, both of which otherwise surface on the first query
+                that needs the index rather than at open.
             ValueError: If ``require_pivots`` is set beside a ``pivot_budget_bytes``,
                 which budgets for a build it rules out. If ``pivot_budget_bytes`` is
                 negative, which no amount of
@@ -960,8 +1001,16 @@ class Corpus:
         # The projections a pivot artifact has to have been derived from, and the views
         # already published over the artifacts that were; see _pivot_view.
         self._projections = [pair[0] for pair in pairs]
-        self._pivot_views: dict[str, str | None] = {}
+        self._pivot_views: dict[str, str] = {}
         self._views_lock = threading.Lock()
+        # The artifacts found for each level, under their own lock: the occurrence
+        # build reads them as files while a query reads the same level as a view, and
+        # neither should wait on the other's DDL to learn whether any exist.
+        self._pivot_artifacts_found: dict[str, list[str] | None] = {}
+        self._artifacts_lock = threading.Lock()
+        # What a dataset's structure IDs add to reach a corpus-wide one, keyed by the
+        # source every artifact derived from it names; filled by _prepare.
+        self._offset_of_source: dict[str, int] = {}
         self._connection = duckdb.connect(
             config={"memory_limit": memory_limit} if memory_limit is not None else {}
         )
@@ -971,17 +1020,19 @@ class Corpus:
             self._total, self._searchable = self._prepare(pairs)
             if require_pivots:
                 self._require_every_pivot()
+            if warm:
+                self._occurrences()
         except Exception:
             # Nothing else holds the connection yet, and the caller has no object to
             # close one from if __init__ does not return.
             self._connection.close()
             raise
 
-    def _prepare(self, pairs: list[tuple[str, str]]) -> tuple[int, int]:
+    def _prepare(self, pairs: list[tuple[str, str, str]]) -> tuple[int, int]:
         """Publishes the relations, and returns the total and searchable row counts."""
         offsets = []
         total = 0
-        for projected, structured in pairs:
+        for projected, structured, source in pairs:
             with pq.ParquetFile(structured) as artifact:
                 count = artifact.metadata.num_rows
             # The IDs the projection carries have to land inside the partner's rows.
@@ -999,6 +1050,10 @@ class Corpus:
                     "projection again"
                 )
             offsets.append((projected, structured, total))
+            # Keyed by the source rather than by the file, so an artifact derived from
+            # this projection finds the offset wherever it is filed; see
+            # ``_pivot_offsets``.
+            self._offset_of_source[source] = total
             total += count
         registered = pa.table(
             {
@@ -1350,6 +1405,95 @@ class Corpus:
             self._substructure_library = library
             return self._substructure_library
 
+    def _occurrences_from_pivot(self, path: str) -> str | None:
+        """Returns the SELECT reading ``path``'s occurrences from a pivot, or None.
+
+        A pivot holds one row per element of the nearest repeated level, so an indexed
+        path that descends from one through singular struct fields is read from that
+        level's artifact rather than unnested out of the projection.
+
+        The corpus-wide structure ID is the element's own plus its dataset's offset,
+        which is a running total over the corpus's pairs and so belongs to no artifact:
+        the same pivot read beside a different set of datasets needs a different
+        offset. It is joined here from the file each row came from, keyed by the source
+        the file and its projection both name.
+
+        Args:
+            path: The indexed path.
+
+        Returns:
+            The SELECT, or None where no artifact covers the path's level.
+
+        Raises:
+            PairingError: If the artifacts do not pair with this corpus; see
+                ``_pivot_artifacts``.
+        """
+        reached = pivot.reach(path)
+        if reached is None:
+            return None
+        level, remainder, _ = reached
+        files = self._pivot_artifacts(level.path)
+        if files is None:
+            return None
+        offsets = self._pivot_offsets(level.path, files)
+        if offsets is None:
+            return None
+        element = ".".join(["x", pivot.ELEMENT, *remainder])
+        # S608: the level and its remainder come from this module's walk of the schema,
+        # and the paths from this process's own glob, quoted with their quotes escaped.
+        return f"""
+            SELECT x.{pivot.REACTION_ID}, {sql_string(path)} AS path,
+                   ({element}.structure_id + o.{query.STRUCTURE_OFFSET})::UINTEGER
+                       AS global_id,
+                   {element}.{_INDEXED_FIELD} AS {_INDEXED_FIELD}
+            FROM read_parquet({_sql_paths(files)}, filename=true) x
+            JOIN {offsets} o ON x.filename = o.pivot_filename
+            WHERE {element}.structure_id IS NOT NULL
+            """  # noqa: S608
+
+    def _pivot_offsets(self, level: str, files: list[str]) -> str | None:
+        """Publishes what each pivot artifact's rows add to reach a corpus-wide ID.
+
+        A pivot and the projection it was derived from restate one source dataset, so
+        they carry the same ``source_md5`` however many derivations apart they sit, and
+        that hash is what pairs an artifact with the offset its projection was given.
+        Pairing on the filename instead would rest on the two trees being laid out
+        alike, which nothing enforces.
+
+        Args:
+            level: The repeated level the artifacts hold, which names the relation.
+            files: The artifacts to map, from ``_pivot_artifacts``.
+
+        Returns:
+            The relation's name, or None if any artifact names a source the corpus does
+            not hold -- which ``_check_pivots`` refuses first, leaving this a guard
+            rather than a path taken.
+        """
+        rows = []
+        for name in files:
+            offset = self._offset_of_source.get(base.load_stamps(name).source_md5)
+            if offset is None:
+                return None
+            rows.append((name, offset))
+        # Named for the level, so a build the last one refused partway replaces these
+        # rows rather than leaving a relation per attempt behind.
+        published = f"{pivot.table_name(level)}_offsets"
+        registered = pa.table(
+            {
+                "pivot_filename": [row[0] for row in rows],
+                query.STRUCTURE_OFFSET: pa.array(
+                    [row[1] for row in rows], type=pa.int64()
+                ),
+            }
+        )
+        self._connection.register("registered_pivot_offsets", registered)
+        self._connection.execute(
+            f"CREATE OR REPLACE TABLE {published} AS "  # noqa: S608
+            "SELECT * FROM registered_pivot_offsets"
+        )
+        self._connection.unregister("registered_pivot_offsets")
+        return published
+
     def _occurrences(self) -> None:
         """Builds the occurrence index, once.
 
@@ -1378,19 +1522,20 @@ class Corpus:
             if self._occurrences_built:
                 return
             start = time.perf_counter()
-            # A path's elements are already a list, so unnest yields one row each. The
-            # offset comes from the row's own file, which the reactions view carries.
-            selects = "\nUNION ALL\n".join(
-                f"""
-                SELECT reaction_id, {sql_string(path)} AS path,
-                       (element.structure_id + {query.STRUCTURE_OFFSET})::UINTEGER
-                           AS global_id,
-                       element.{_INDEXED_FIELD} AS {_INDEXED_FIELD}
-                FROM {query.TABLE}, unnest({expression}) AS unnested(element)
-                WHERE element.structure_id IS NOT NULL
-                """  # noqa: S608
-                for path, expression in INDEXED_PATHS.items()
-            )
+            # A level's pivot already holds one row per element, which is what this
+            # build would otherwise unnest the projection to produce. Reading it is a
+            # scan of a few hundred megabytes against a traversal of every reaction.
+            # Decided per path, so a directory holding some levels and not others is a
+            # partial speedup rather than a missing index.
+            selects, from_pivots = [], []
+            for path, expression in INDEXED_PATHS.items():
+                reading = self._occurrences_from_pivot(path)
+                if reading is None:
+                    selects.append(_occurrences_from_projection(path, expression))
+                else:
+                    selects.append(reading)
+                    from_pivots.append(path)
+            selects = "\nUNION ALL\n".join(selects)
             # Its own cursor: this runs while searches are in flight, and the shared
             # connection holds their results.
             cursor = self._connection.cursor()
@@ -1455,9 +1600,12 @@ class Corpus:
             # authentic standards -- which is why the refusal above counts structures
             # rather than paths.
             logger.info(
-                "indexed %d structure occurrences in %.1fs: %s",
+                "indexed %d structure occurrences in %.1fs, %d of %d paths read from "
+                "pivot artifacts: %s",
                 sum(counts.values()),
                 time.perf_counter() - start,
+                len(from_pivots),
+                len(INDEXED_PATHS),
                 ", ".join(f"{path} {counts.get(path, 0)}" for path in INDEXED_PATHS),
             )
 
@@ -1786,18 +1934,13 @@ class Corpus:
                 confidently and wrongly, since its reaction IDs resolve against the
                 wrong rows -- or, with ``require_current``, if any of them is stale.
         """
-        if self._pivots_dir is None:
+        files = self._pivot_artifacts(path)
+        if files is None:
             return None
         with self._views_lock:
-            if path in self._pivot_views:
-                return self._pivot_views[path]
-            files = [
-                str(found) for found in pivot.artifact_paths(self._pivots_dir, path)
-            ]
-            if not files:
-                self._pivot_views[path] = None
-                return None
-            self._check_pivots(path, files)
+            published = self._pivot_views.get(path)
+            if published is not None:
+                return published
             name = pivot.table_name(path)
             # S608: the name comes from this module's walk of the schema, and the paths
             # from this process's own glob, quoted with their single quotes escaped.
@@ -1808,6 +1951,38 @@ class Corpus:
             logger.info("read %d pivot artifacts for %s", len(files), path)
             self._pivot_views[path] = name
             return name
+
+    def _pivot_artifacts(self, path: str) -> list[str] | None:
+        """Returns the artifacts holding the pivot over ``path``, checked, or None.
+
+        Globbed and checked once per level and remembered, including the answer that
+        there are none, so a corpus without artifacts reads the directory once rather
+        than on every query.
+
+        Args:
+            path: The repeated level, as the query grammar names it.
+
+        Returns:
+            The artifact paths, or None where the directory holds none for this level.
+
+        Raises:
+            PairingError: If the artifacts were not derived from the projections this
+                corpus reads, or -- with ``require_current`` -- if any is stale.
+        """
+        if self._pivots_dir is None:
+            return None
+        with self._artifacts_lock:
+            if path in self._pivot_artifacts_found:
+                return self._pivot_artifacts_found[path]
+            files = [
+                str(found) for found in pivot.artifact_paths(self._pivots_dir, path)
+            ]
+            if not files:
+                self._pivot_artifacts_found[path] = None
+                return None
+            self._check_pivots(path, files)
+            self._pivot_artifacts_found[path] = files
+            return files
 
     def _check_pivots(self, path: str, files: list[str]) -> None:
         """Refuses pivot artifacts that do not belong to this corpus.
@@ -1922,8 +2097,8 @@ class Corpus:
                 return None
             # A glob that found nothing is remembered, so it has to be forgotten before
             # the same call can find what this just wrote.
-            with self._views_lock:
-                self._pivot_views.pop(path, None)
+            with self._artifacts_lock:
+                self._pivot_artifacts_found.pop(path, None)
             return self._pivot_view(path)
 
     @contextlib.contextmanager

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -73,9 +73,10 @@ takes a wall-clock timeout that interrupts the final query. Name resolution, the
 one-time library and index builds, screening, and verification all run before the timer
 starts: each is bounded by the corpus rather than by the query, so a slow one is slow
 for every caller and shows up in the logs rather than in a timeout. The two builds have
-separate triggers -- the library on the first substructure predicate, the index on the
-first query it takes a clause of -- and a search wanting both pays both, upwards of a
-minute over the whole corpus, on top of whatever timeout it was given.
+separate triggers -- the library on the first substructure predicate, and the index at
+open unless the corpus was given ``warm=False``, which leaves it to the first query that
+takes a clause of it. A search that pays for either pays upwards of a minute over the
+whole corpus, on top of whatever timeout it was given.
 """
 
 import array

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -3819,10 +3819,9 @@ def test_a_stranger_s_pivot_over_an_indexed_level_is_refused_at_open(
 
 
 def test_two_pivots_of_one_dataset_under_a_level_are_refused(corpus_dir, tmp_path):
-    # A set comparison accepts a stray copy, and both are then read, so every element of
-    # the level is stated twice. A quantifier cannot see it -- a semi-join returns a
-    # reaction once however many rows name it -- but the occurrence index counts those
-    # rows, and check_index reports the count a deployment baselines against.
+    # A stray copy under the level satisfies the set comparison over source hashes, and
+    # both artifacts are then read. What that costs is in _check_pivots; what makes it
+    # worth a refusal here is that the corpus opens and answers, so nothing else says.
     pivots = _write_pivots(corpus_dir, ("inputs.components",), into=tmp_path / "pivots")
     stray = pivots / "inputs.components" / "again"
     stray.mkdir(parents=True)

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -3309,15 +3309,6 @@ _OCCURRENCE_LEVELS = (
 )
 
 
-@pytest.fixture(scope="module")
-def indexed_root(tmp_path_factory, corpus_dir) -> pathlib.Path:
-    """The two-dataset corpus with pivots over every level the index reads from."""
-    _write_pivots(
-        corpus_dir, _OCCURRENCE_LEVELS, into=tmp_path_factory.mktemp("pivots")
-    )
-    return corpus_dir
-
-
 def _indexed_corpus(root, pivots, **kwargs) -> execute.Corpus:
     return execute.Corpus(
         str(root / "projections" / "*.parquet"),

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -664,6 +664,7 @@ def test_structure_ids_that_are_not_one_unbroken_run_are_refused(
             str(root / "projections" / "*.parquet"),
             str(root / "structures" / "*.parquet"),
             resolver={}.__getitem__,
+            warm=False,
         ) as value,
         pytest.raises(execute.PairingError, match="not one unbroken run"),
     ):
@@ -688,6 +689,7 @@ def test_half_a_derived_structure_is_refused(corpus_dir, tmp_path, missing):
             str(root / "projections" / "*.parquet"),
             str(root / "structures" / "*.parquet"),
             resolver={}.__getitem__,
+            warm=False,
         ) as value,
         pytest.raises(execute.PairingError, match="writes both or neither"),
     ):
@@ -1192,6 +1194,7 @@ def test_concurrent_first_searches_build_one_library(corpus_dir, monkeypatch):
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver=resolver,
+        warm=False,
     ) as value:
         request = query.Query.model_validate(
             {
@@ -1659,6 +1662,74 @@ def test_a_cold_corpus_leaves_the_index_to_the_first_query(corpus_dir):
         warm=False,
     ) as value:
         assert not value._occurrences_built
+
+
+def test_a_corpus_builds_the_substructure_library_at_open(corpus_dir):
+    # Warming covers both builds a substructure query needs, so what an open corpus
+    # holds is what a container has to be sized for rather than a floor a later query
+    # raises it to.
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        assert value._substructure_library is not None
+
+
+def test_a_cold_corpus_leaves_the_library_to_the_first_query(corpus_dir):
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        warm=False,
+    ) as value:
+        assert value._substructure_library is None
+
+
+def test_projections_that_do_not_join_to_their_offsets_are_refused(
+    corpus_dir, tmp_path, monkeypatch
+):
+    # read_parquet globs every path it is handed, so anything making DuckDB resolve one
+    # differently than Python did drops that file's rows from the join rather than
+    # failing, leaving reactions no query can find. Staged by pointing the view at
+    # copies filed elsewhere, which is what such a resolution looks like from here. The
+    # structures side has been counted against its footers all along; the reactions
+    # side was covered only by the occurrence index reaching every structure, and a
+    # path read from a pivot artifact reaches them whatever the view holds.
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    for projected in sorted((corpus_dir / "projections").glob("*.parquet")):
+        shutil.copy(projected, elsewhere / projected.name)
+    original = execute._sql_paths
+
+    def redirected(paths):
+        listed = [str(path) for path in paths]
+        if all("projections" in path for path in listed):
+            return original(str(elsewhere / pathlib.Path(path).name) for path in listed)
+        return original(listed)
+
+    monkeypatch.setattr(execute, "_sql_paths", redirected)
+    with pytest.raises(execute.PairingError, match="the projections hold"):
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+        )
+
+
+def test_deriving_pivots_beside_warming_is_refused(corpus_dir, tmp_path):
+    # Warming reads the levels the index covers, and a set covering some of the
+    # projections is what that read refuses -- so the two together would make an
+    # interrupted derivation permanent, the pass that completes it sitting behind the
+    # refusal.
+    with pytest.raises(ValueError, match="derive_pivots was set beside warm"):
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(tmp_path / "pivots"),
+            derive_pivots=True,
+        )
 
 
 def test_warming_refuses_at_open_what_the_index_would_refuse_on_a_query(tmp_path):
@@ -2796,6 +2867,7 @@ def test_a_library_that_lost_a_molecule_is_refused(corpus_dir, monkeypatch):
             str(corpus_dir / "projections" / "*.parquet"),
             str(corpus_dir / "structures" / "*.parquet"),
             resolver={}.__getitem__,
+            warm=False,
         ) as value,
         pytest.raises(execute.PairingError, match="distinct SMILES"),
     ):
@@ -3506,6 +3578,7 @@ def test_a_level_with_no_artifacts_is_derived_rather_than_built(
             resolver={}.__getitem__,
             pivots_dir=str(pivots),
             derive_pivots=True,
+            warm=False,
         ) as corpus,
     ):
         assert _search(corpus, _white("exists")) == expected
@@ -3529,6 +3602,7 @@ def test_a_derived_pivot_is_read_by_the_next_corpus_over_the_directory(
         resolver={}.__getitem__,
         pivots_dir=str(pivots),
         derive_pivots=True,
+        warm=False,
     ) as deriving:
         expected = _search(deriving, _white("exists"))
     caplog.clear()
@@ -3559,6 +3633,7 @@ def test_a_level_already_derived_is_not_derived_again(wide_root, tmp_path, caplo
             resolver={}.__getitem__,
             pivots_dir=str(pivots),
             derive_pivots=True,
+            warm=False,
         ) as corpus,
     ):
         _search(corpus, _white("exists"))
@@ -3636,6 +3711,7 @@ def test_checking_the_pivots_derives_none_of_them(wide_root, tmp_path):
         resolver={}.__getitem__,
         pivots_dir=str(pivots),
         derive_pivots=True,
+        warm=False,
     ) as corpus:
         assert corpus.check_pivots() == {}
     assert not pivots.exists()

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -100,8 +100,8 @@ def corpus_dir(tmp_path_factory) -> pathlib.Path:
 
 
 @pytest.fixture(scope="module")
-def deep_corpus(tmp_path_factory) -> Iterator[execute.Corpus]:
-    """A corpus holding a structure at every indexed path, and a reaction at none.
+def deep_root(tmp_path_factory) -> pathlib.Path:
+    """Sources, projections, and structures holding a structure at every indexed path.
 
     A workup's components and a product measurement's authentic standard are reached by
     the longest traversals the index generates, and the main fixture has neither, so
@@ -141,8 +141,16 @@ def deep_corpus(tmp_path_factory) -> Iterator[execute.Corpus]:
     structured = root / "structures" / source.name
     structured.parent.mkdir(parents=True, exist_ok=True)
     structures.write_structures(projected, structured)
+    return root
+
+
+@pytest.fixture(scope="module")
+def deep_corpus(deep_root) -> Iterator[execute.Corpus]:
+    """The corpus over ``deep_root``, holding no pivot artifacts."""
     with execute.Corpus(
-        str(projected), str(structured), resolver={}.__getitem__
+        str(deep_root / "projections" / "*.parquet"),
+        str(deep_root / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
     ) as value:
         yield value
 
@@ -157,8 +165,12 @@ def corpus(corpus_dir) -> Iterator[execute.Corpus]:
         yield value
 
 
+def _exists_at(path, where):
+    return {"op": "exists", "path": path, "where": where}
+
+
 def _exists(where):
-    return {"op": "exists", "path": "inputs.components", "where": where}
+    return _exists_at("inputs.components", where)
 
 
 def _reactions(table) -> set[str]:
@@ -3425,6 +3437,44 @@ def test_an_index_read_from_pivots_keeps_a_structure_in_its_own_dataset(
     assert matched == {"ord-bb01"}
 
 
+def test_an_index_read_from_pivots_keeps_the_element_s_role(tmp_path, corpus_dir):
+    # The role travels beside the structure, and it is what binds a query to one
+    # element: aa01 holds benzene as a reactant and pyridine as its solvent. A role read
+    # wrong from the artifact answers "pyridine as the solvent" with silence and
+    # "benzene as the solvent" with aa01, neither of which raises.
+    pivots = _write_pivots(corpus_dir, _OCCURRENCE_LEVELS, into=tmp_path / "pivots")
+    with _indexed_corpus(corpus_dir, pivots) as corpus:
+        assert _search(corpus, _role_and_structure("c1ccncc1", "SOLVENT")) == {
+            "ord-aa01"
+        }
+        assert _search(corpus, _role_and_structure("c1ccccc1", "SOLVENT")) == set()
+
+
+# One structure per indexed path, with the reactions holding it. The two deepest paths
+# are why this runs over deep_root: the main corpus records no workups and no authentic
+# standards, so a differential there compares nothing to nothing at exactly the paths
+# whose traversal is longest -- and the authentic standard is the one whose level is not
+# the indexed path, reached from the measurements' artifact through the remainder.
+_INDEXED_OCCURRENCES = (
+    ("inputs.components", "CCO", {"ord-cc01", "ord-cc02"}),
+    ("workups.input.components", "c1ccncc1", {"ord-cc01"}),
+    ("outcomes.products", "Cc1ccccc1", {"ord-cc01"}),
+    ("outcomes.products.measurements.authentic_standard", "c1ccccc1", {"ord-cc01"}),
+)
+
+
+@pytest.mark.parametrize(("path", "smarts", "expected"), _INDEXED_OCCURRENCES)
+def test_an_index_read_from_pivots_answers_at_every_indexed_path(
+    tmp_path, deep_root, path, smarts, expected
+):
+    pivots = _write_pivots(deep_root, _OCCURRENCE_LEVELS, into=tmp_path / "pivots")
+    where = _exists_at(path, {"op": "substructure", "path": "smiles", "smarts": smarts})
+    with _indexed_corpus(deep_root, None) as unnested:
+        assert _search(unnested, where) == expected
+    with _indexed_corpus(deep_root, pivots) as read:
+        assert _search(read, where) == expected
+
+
 def test_an_index_reads_the_pivots_rather_than_unnesting_the_projection(
     tmp_path, corpus_dir, caplog
 ):
@@ -3437,7 +3487,8 @@ def test_an_index_reads_the_pivots_rather_than_unnesting_the_projection(
             corpus, _exists({"op": "substructure", "path": "smiles", "smarts": "[Pt]"})
         )
     assert any(
-        "4 of 4 paths read from pivot artifacts" in record.message
+        f"{len(execute.INDEXED_PATHS)} of {len(execute.INDEXED_PATHS)} "
+        "paths read from pivot artifacts" in record.message
         for record in caplog.records
     )
 
@@ -3457,7 +3508,8 @@ def test_a_path_whose_level_has_no_pivot_is_still_unnested(
     ):
         assert _search(corpus, where) == expected
     assert any(
-        "1 of 4 paths read from pivot artifacts" in record.message
+        f"1 of {len(execute.INDEXED_PATHS)} paths read from pivot artifacts"
+        in record.message
         for record in caplog.records
     )
 
@@ -3744,6 +3796,23 @@ def test_a_pivot_from_another_corpus_is_refused(wide_root, corpus_dir, tmp_path)
         pytest.raises(execute.PairingError, match="another corpus"),
     ):
         _search(corpus, _white("exists"))
+
+
+def test_a_stranger_s_pivot_over_an_indexed_level_is_refused_at_open(
+    wide_root, corpus_dir
+):
+    # Warming reads the levels the index covers, so a pivots_dir belonging to another
+    # corpus fails the deployment rather than whichever query first quantified over one
+    # of those levels. Filed at an indexed level for that reason: the levels the index
+    # does not cover are still found by the query that wants them.
+    stranger = _write_pivots(corpus_dir, ("inputs.components",))
+    with pytest.raises(execute.PairingError, match="another corpus"):
+        execute.Corpus(
+            str(wide_root / "projections" / "*.parquet"),
+            str(wide_root / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(stranger),
+        )
 
 
 def test_a_pivot_filed_under_the_wrong_level_is_refused(wide_root, tmp_path):

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -3405,7 +3405,7 @@ def _indexed_corpus(root, pivots, **kwargs) -> execute.Corpus:
 
 @pytest.mark.parametrize(
     "smarts",
-    ["c1ccncc1", "[OX2H]", "c1ccccc1", "[Pt]"],
+    ["c1ccncc1", "[OX2H]", "c1ccccc1", "[#6]"],
 )
 def test_an_index_read_from_pivots_answers_what_unnesting_answers(
     tmp_path, corpus_dir, smarts
@@ -3418,6 +3418,9 @@ def test_an_index_read_from_pivots_answers_what_unnesting_answers(
     where = _exists({"op": "substructure", "path": "smiles", "smarts": smarts})
     with _indexed_corpus(corpus_dir, None) as unnested:
         expected = _search(unnested, where)
+    # Every pattern here matches something, so neither route is compared against the
+    # empty set it would also return had the build produced no rows at all.
+    assert expected
     with _indexed_corpus(corpus_dir, pivots) as read:
         assert _search(read, where) == expected
 
@@ -3815,6 +3818,47 @@ def test_a_stranger_s_pivot_over_an_indexed_level_is_refused_at_open(
         )
 
 
+def test_two_pivots_of_one_dataset_under_a_level_are_refused(corpus_dir, tmp_path):
+    # A set comparison accepts a stray copy, and both are then read, so every element of
+    # the level is stated twice. A quantifier cannot see it -- a semi-join returns a
+    # reaction once however many rows name it -- but the occurrence index counts those
+    # rows, and check_index reports the count a deployment baselines against.
+    pivots = _write_pivots(corpus_dir, ("inputs.components",), into=tmp_path / "pivots")
+    stray = pivots / "inputs.components" / "again"
+    stray.mkdir(parents=True)
+    for artifact in sorted((pivots / "inputs.components").rglob("*.parquet")):
+        shutil.copy(artifact, stray / artifact.name)
+    with pytest.raises(execute.PairingError, match="the same source dataset"):
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(pivots),
+        )
+
+
+def test_a_stale_pivot_is_refused(corpus_dir, tmp_path):
+    # Warming reads the levels the index covers, so what a stale artifact fails is the
+    # deployment. The stamps are the only thing saying an artifact was written by the
+    # library reading it; a pivot derived by an older one can hold columns this schema
+    # walk does not find.
+    pivots = _write_pivots(corpus_dir, ("inputs.components",), into=tmp_path / "pivots")
+    target = next((pivots / "inputs.components").rglob("*.parquet"))
+    with pq.ParquetFile(target) as artifact:
+        table = artifact.read()
+        schema = artifact.schema_arrow
+    metadata = dict(schema.metadata)
+    metadata[b"ord.rdkit_version"] = b"0000.00.0"
+    pq.write_table(table.cast(schema.with_metadata(metadata)), target)
+    with pytest.raises(execute.PairingError, match="is a stale"):
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(pivots),
+        )
+
+
 def test_a_pivot_filed_under_the_wrong_level_is_refused(wide_root, tmp_path):
     pivots = tmp_path / "pivots"
     (pivots / "outcomes.products").mkdir(parents=True)
@@ -3918,23 +3962,19 @@ def test_a_pivot_under_a_directory_that_looks_like_a_pattern_is_read(
     assert found.num_rows > 0
 
 
-def test_check_pivots_reports_the_levels_held_as_artifacts(wide_root, tmp_path):
-    # An operator reads these counts to see that a sharded corpus has all its shards,
-    # so the two levels are held by different numbers of artifacts, and neither by one:
-    # a constant, an off-by-one, and a level answered with another's count all agree
-    # wherever every level holds the same number.
-    pivots = _write_pivots(wide_root, ("outcomes.products", "workups"), into=tmp_path)
-    duplicate = pivots / "outcomes.products" / "second"
-    duplicate.mkdir(parents=True)
-    for artifact in sorted((pivots / "outcomes.products").rglob("*.parquet")):
-        shutil.copy(artifact, duplicate / artifact.name)
+def test_check_pivots_reports_the_levels_held_as_artifacts(corpus_dir, tmp_path):
+    # An operator reads these counts to see that a sharded corpus has all its shards, so
+    # this runs over the two-dataset corpus: a count of one, or one taken from the
+    # levels rather than the files, would agree with the answer over a single shard. A
+    # level with no artifacts is absent rather than zero, since most levels have none.
+    pivots = _write_pivots(corpus_dir, ("outcomes.products",), into=tmp_path)
     with execute.Corpus(
-        str(wide_root / "projections" / "*.parquet"),
-        str(wide_root / "structures" / "*.parquet"),
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
         pivots_dir=str(pivots),
     ) as corpus:
-        assert corpus.check_pivots() == {"outcomes.products": 2, "workups": 1}
+        assert corpus.check_pivots() == {"outcomes.products": 2}
 
 
 def test_check_pivots_is_empty_without_a_directory(wide_corpus):

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -1613,6 +1613,7 @@ def test_the_index_is_built_once_and_only_when_wanted(corpus_dir, caplog):
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
+        warm=False,
     ) as value:
         # An element predicate with no structure in it cannot use the index, so it must
         # not pay to build one.
@@ -1637,6 +1638,57 @@ def test_the_index_is_built_once_and_only_when_wanted(corpus_dir, caplog):
         record for record in caplog.records if record.message.startswith("indexed ")
     ]
     assert len(builds) == 1
+
+
+def test_a_corpus_builds_the_occurrence_index_at_open(corpus_dir):
+    # The default, so the first structure query answers from an index that is already
+    # there rather than paying for one -- over ORD a pass per uncovered path.
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        assert value._occurrences_built
+
+
+def test_a_cold_corpus_leaves_the_index_to_the_first_query(corpus_dir):
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        warm=False,
+    ) as value:
+        assert not value._occurrences_built
+
+
+def test_warming_refuses_at_open_what_the_index_would_refuse_on_a_query(tmp_path):
+    # Two datasets stating one reaction pair cleanly and only the index refuses them,
+    # so this is the refusal warming is able to move. Opening such a corpus and failing
+    # later leaves one that looks searchable and is not.
+    for shard, smiles in (("aa", "c1ccncc1"), ("bb", "CCO")):
+        source = tmp_path / "data" / f"ord_dataset-{shard}.parquet"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        parquet.save_dataset(
+            dataset_pb2.Dataset(
+                dataset_id=f"ord_dataset-{shard}",
+                name="test",
+                description="test",
+                reactions=[_reaction("ord-x01", components=[(smiles, _ROLE.SOLVENT)])],
+            ),
+            str(source),
+        )
+        projected = tmp_path / "projections" / source.name
+        projected.parent.mkdir(parents=True, exist_ok=True)
+        projection.write_projection(source, projected)
+        structured = tmp_path / "structures" / source.name
+        structured.parent.mkdir(parents=True, exist_ok=True)
+        structures.write_structures(projected, structured)
+    with pytest.raises(execute.PairingError, match="ord-x01 is stated by 2 rows"):
+        execute.Corpus(
+            str(tmp_path / "projections" / "*.parquet"),
+            str(tmp_path / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+        )
 
 
 def test_checking_the_index_builds_it_and_counts_every_path(corpus_dir):
@@ -1671,6 +1723,7 @@ def test_checking_a_corpus_the_index_refuses_fails_the_check(corpus_dir, tmp_pat
             str(root / "structures" / "*.parquet"),
             resolver={}.__getitem__,
             require_current=False,
+            warm=False,
         ) as value,
         pytest.raises(execute.PairingError, match="is stated by 2 rows"),
     ):
@@ -1878,6 +1931,7 @@ def test_concurrent_first_searches_build_one_index(corpus_dir, caplog, monkeypat
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={"pyridine": "c1ccncc1"}.__getitem__,
+        warm=False,
     ) as value:
         request = query.Query.model_validate(_ROUTABLE["a compound name"])
         results: list[int] = []
@@ -1924,6 +1978,7 @@ def test_an_index_that_reaches_nothing_is_refused(corpus_dir, monkeypatch):
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
+        warm=False,
     ) as value:
         with pytest.raises(execute.PairingError, match="reached 0 of the corpus's 5"):
             value.search(request)
@@ -1967,6 +2022,7 @@ def test_a_reaction_two_files_both_state_is_refused(tmp_path):
             str(tmp_path / "projections" / "*.parquet"),
             str(tmp_path / "structures" / "*.parquet"),
             resolver={}.__getitem__,
+            warm=False,
         ) as value,
         pytest.raises(execute.PairingError, match="ord-x01 is stated by 2 rows"),
     ):
@@ -1993,6 +2049,7 @@ def test_an_index_that_misses_one_path_is_refused(corpus_dir, monkeypatch):
             str(corpus_dir / "projections" / "*.parquet"),
             str(corpus_dir / "structures" / "*.parquet"),
             resolver={}.__getitem__,
+            warm=False,
         ) as value,
         pytest.raises(execute.PairingError, match="reached 3 of the corpus's 5"),
     ):
@@ -2019,6 +2076,7 @@ def test_a_path_the_index_does_not_cover_is_left_to_the_projection(
         str(corpus_dir / "projections" / "*.parquet"),
         str(corpus_dir / "structures" / "*.parquet"),
         resolver={}.__getitem__,
+        warm=False,
     ) as value:
         # Answered from the projection, which needs no index and so never builds one.
         assert _reactions(value.search(request)) == {"ord-aa01", "ord-aa02", "ord-bb01"}
@@ -3240,6 +3298,107 @@ def test_a_pivot_artifact_is_read_rather_than_built(wide_root, caplog):
     assert not any("building the pivot" in message for message in messages)
 
 
+# The levels the occurrence index's paths range within: three are indexed paths of
+# their own, and the authentic standard is one compound per measurement, so its rows
+# come from the measurements' pivot.
+_OCCURRENCE_LEVELS = (
+    "inputs.components",
+    "workups.input.components",
+    "outcomes.products",
+    "outcomes.products.measurements",
+)
+
+
+@pytest.fixture(scope="module")
+def indexed_root(tmp_path_factory, corpus_dir) -> pathlib.Path:
+    """The two-dataset corpus with pivots over every level the index reads from."""
+    _write_pivots(
+        corpus_dir, _OCCURRENCE_LEVELS, into=tmp_path_factory.mktemp("pivots")
+    )
+    return corpus_dir
+
+
+def _indexed_corpus(root, pivots, **kwargs) -> execute.Corpus:
+    return execute.Corpus(
+        str(root / "projections" / "*.parquet"),
+        str(root / "structures" / "*.parquet"),
+        resolver={"pyridine": "c1ccncc1", "ethanol": "CCO"}.__getitem__,
+        pivots_dir=None if pivots is None else str(pivots),
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize(
+    "smarts",
+    ["c1ccncc1", "[OX2H]", "c1ccccc1", "[Pt]"],
+)
+def test_an_index_read_from_pivots_answers_what_unnesting_answers(
+    tmp_path, corpus_dir, smarts
+):
+    # The index is the same occurrences by another route, so the routes cannot disagree.
+    # Run over both datasets, because an occurrence's ID is its element's plus its
+    # dataset's offset and only a corpus with a second dataset has a nonzero one: a
+    # build that dropped the offset answers identically on the first dataset alone.
+    pivots = _write_pivots(corpus_dir, _OCCURRENCE_LEVELS, into=tmp_path / "pivots")
+    where = _exists({"op": "substructure", "path": "smiles", "smarts": smarts})
+    with _indexed_corpus(corpus_dir, None) as unnested:
+        expected = _search(unnested, where)
+    with _indexed_corpus(corpus_dir, pivots) as read:
+        assert _search(read, where) == expected
+
+
+def test_an_index_read_from_pivots_keeps_a_structure_in_its_own_dataset(
+    tmp_path, corpus_dir
+):
+    # The hydroxyl is only in bb, whose IDs are only correct through its offset. An
+    # offset dropped or taken from the wrong dataset still lands inside the corpus's
+    # structures, so it returns a reaction rather than raising -- the wrong one.
+    pivots = _write_pivots(corpus_dir, _OCCURRENCE_LEVELS, into=tmp_path / "pivots")
+    with _indexed_corpus(corpus_dir, pivots) as corpus:
+        matched = _search(
+            corpus,
+            _exists({"op": "substructure", "path": "smiles", "smarts": "[OX2H]"}),
+        )
+    assert matched == {"ord-bb01"}
+
+
+def test_an_index_reads_the_pivots_rather_than_unnesting_the_projection(
+    tmp_path, corpus_dir, caplog
+):
+    pivots = _write_pivots(corpus_dir, _OCCURRENCE_LEVELS, into=tmp_path / "pivots")
+    with (
+        caplog.at_level(logging.INFO, logger="ord_schema.search.execute"),
+        _indexed_corpus(corpus_dir, pivots) as corpus,
+    ):
+        _search(
+            corpus, _exists({"op": "substructure", "path": "smiles", "smarts": "[Pt]"})
+        )
+    assert any(
+        "4 of 4 paths read from pivot artifacts" in record.message
+        for record in caplog.records
+    )
+
+
+def test_a_path_whose_level_has_no_pivot_is_still_unnested(
+    tmp_path, corpus_dir, caplog
+):
+    # A directory holding some levels and not others is a partial speedup rather than a
+    # missing index, so the answer has to be the whole answer either way.
+    pivots = _write_pivots(corpus_dir, ("inputs.components",), into=tmp_path / "pivots")
+    where = _exists({"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"})
+    with _indexed_corpus(corpus_dir, None) as unnested:
+        expected = _search(unnested, where)
+    with (
+        caplog.at_level(logging.INFO, logger="ord_schema.search.execute"),
+        _indexed_corpus(corpus_dir, pivots) as corpus,
+    ):
+        assert _search(corpus, where) == expected
+    assert any(
+        "1 of 4 paths read from pivot artifacts" in record.message
+        for record in caplog.records
+    )
+
+
 def test_requiring_pivots_refuses_a_level_with_no_artifacts(wide_root):
     # The silent case: a missing level is otherwise unnested in process on the query
     # that first wants it, minutes charged to whoever asked with no error anywhere.
@@ -3438,6 +3597,7 @@ def test_a_derivation_interrupted_partway_is_finished_by_the_next(
             resolver={}.__getitem__,
             pivots_dir=str(tmp_path / "pivots"),
             derive_pivots=True,
+            warm=False,
         ) as corpus,
     ):
         found = _search(
@@ -3468,6 +3628,7 @@ def test_a_stranger_s_pivots_are_still_refused_when_deriving(
             resolver={}.__getitem__,
             pivots_dir=str(tmp_path / "pivots"),
             derive_pivots=True,
+            warm=False,
         ) as corpus,
         pytest.raises(execute.PairingError, match="another corpus"),
     ):
@@ -3511,6 +3672,7 @@ def test_a_pivot_from_another_corpus_is_refused(wide_root, corpus_dir, tmp_path)
             str(wide_root / "structures" / "*.parquet"),
             resolver={}.__getitem__,
             pivots_dir=str(stranger),
+            warm=False,
         ) as corpus,
         pytest.raises(execute.PairingError, match="another corpus"),
     ):
@@ -3532,6 +3694,7 @@ def test_a_pivot_filed_under_the_wrong_level_is_refused(wide_root, tmp_path):
             str(wide_root / "structures" / "*.parquet"),
             resolver={}.__getitem__,
             pivots_dir=str(pivots),
+            warm=False,
         ) as corpus,
         pytest.raises(execute.PairingError, match="wrong level"),
     ):
@@ -3654,6 +3817,7 @@ def test_check_pivots_refuses_a_stranger_at_startup(wide_root, corpus_dir):
             str(wide_root / "structures" / "*.parquet"),
             resolver={}.__getitem__,
             pivots_dir=str(stranger),
+            warm=False,
         ) as corpus,
         pytest.raises(execute.PairingError, match="another corpus"),
     ):


### PR DESCRIPTION
## Summary

The occurrence index unnests the same repeated levels the pivot artifacts already hold, so a corpus with those artifacts derives them twice. Where a pivot covers an indexed path, this reads it instead: 3.3s against 59.4s over ORD, for the same 18,847,978 occurrences.

That index build was the whole of a process's cold-start cost for structure queries — not the substructure library, which is 8.1s. A cold first substructure query over ORD goes from ~65s to 17.7s; warm queries were already sub-second and are unchanged.

## Changes

- The build decides per path, so a directory holding some levels and not others is a partial speedup rather than a missing index.
- `Corpus` takes `warm`, on by default, building the index at open rather than inside whichever query first wants it. Refusals the build makes therefore surface at open too; the tests covering the lazy path ask for it explicitly.
- `warm` covers the substructure library too, built after the index so the library's 2.2 GB is not resident through the build that wants the most memory. What an open corpus holds is then what a container is sized against rather than a floor a later request raises it to. A corpus asked only scalar queries needs neither build; one asked scalar and similarity queries wants the index alone, which is `warm=False` beside `check_index`.
- `_pair` carries each dataset's source hash beside its paths, so nothing re-reads stamps to find it.
- `check_index` and the search README state the lifecycle warming leaves, rather than the lazy build they described: what a cold corpus buys is the index's memory floor and the 1.19 GB it holds.
- `derive_pivots` beside `warm` is refused. The index reads the levels it covers as files rather than through `_pivot_view`, so warming checked a partially derived level before the derivation that completes it had run — which is what `_derive_pivot` is ordered the way it is to prevent, and it made an interrupted derivation permanent.
- `_prepare` counts the reactions view against the projections' footers, the way it has always counted the structures view against theirs. A path read from a pivot artifact reaches the corpus's structures whatever the view holds, so the occurrence index no longer stands in for that count.
- Two artifacts of one source dataset under a level are refused, as `_index` refuses the same for projections: the set comparison over source hashes accepted a stray copy, both were read, and the occurrence index counted every element twice — invisible to a quantifier, but `check_index` reports that count. `_check_pivots` returns the source each artifact names, so `_pivot_offsets` no longer reopens the footers it just read.

## Testing

- `uv run pytest`: 1469 passed outside `ord_schema/orm`, whose fixtures need a local Postgres.
- Sixteen new tests, 22 cases with parametrization, each checked against a mutant rather than assumed to bite: disabling the pivot path fails 2, dropping the offset fails 7, disabling warming fails 2, dropping the library from warming fails 1, dropping the reactions count fails 1, dropping the derive_pivots refusal fails 1, emitting NULL for the element's role fails 1, dropping the remainder that reaches an authentic standard fails 4, and dropping either the duplicate or the stale pivot refusal fails 1 each.
- Verified over the full corpus that the two builds agree tuple for tuple, both directions and per path, not merely on row count — 0 rows in either `EXCEPT ALL`.
- Timings are three interleaved rounds with CPU beside wall time.

## Notes

An occurrence's corpus-wide structure ID is its element's own plus its dataset's offset, and that offset is a running total over the corpus's pairs — so it belongs to no artifact. Baking it into a pivot would leave IDs that stay in range beside a different set of datasets while aliasing another dataset's molecules, passing on the full corpus and failing only on subsets. It is joined from the file each row came from, keyed by the source hash the pivot and its projection both carry.

Follow-up: the remaining cold-start cost is the substructure library's Python row loop over 2,016,224 structures. The Parquet scan under it is 0.08s, so that 8.1s is all interpreter time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



















<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR accelerates occurrence-index construction by reading covered paths from existing pivot artifacts and adds eager corpus warming by default.
- Carries source hashes through artifact pairing so pivot rows receive the correct corpus-wide structure offsets.
- Validates projection row counts and pivot provenance before publishing search relations.
- Adds coverage for eager and deferred initialization, pivot-backed indexing, partial pivot coverage, and artifact mismatch handling.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/execute.py | Adds pivot-backed occurrence indexing, source-based offsets, corpus validation, and eager warming. |
| ord_schema/search/execute_test.py | Expands coverage for warming, pivot-backed paths, offsets, artifact validation, and fallback behavior. |
| ord_schema/search/README.md | Updates the search architecture and deployment guidance for pivot-backed indexing and eager initialization. |
| ord_schema/artifacts/scripts/derive_pivots_test.py | Keeps the pivot-derivation lifecycle test cold so derivation can precede index initialization. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Projection artifacts] --> P[Pair by source hash]
  S[Structure artifacts] --> P
  V[Pivot artifacts] --> C{Indexed path covered?}
  P --> O[Dataset structure offsets]
  O --> I[Occurrence index]
  C -->|Yes| I
  C -->|No| U[Unnest projection]
  U --> I
  I --> L[Build substructure library]
  L --> Q[Warm Corpus ready]
```
</details>

<sub>Reviews (8): Last reviewed commit: ["Distill the comments this branch added"](https://github.com/open-reaction-database/ord-schema/commit/0f05a828451805107df6497a24599e4f87de94c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58488667)</sub>

**Context used:**

- Knowledge Base — [Reaction artifacts and projections](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/reaction-artifacts.md)
- Knowledge Base — [Structured reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/structured-reaction-search.md)

<!-- /greptile_comment -->