### PR TITLE
Bound what a search may return

### DIFF
--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -747,10 +747,15 @@ statement timeout, row cap, or memory limit.
 The grammar leaves `limit` optional, so the unbounded query is the ordinary one — a
 predicate matching much of the corpus returns millions of rows, built into an Arrow table
 in the executing process. `Corpus(..., max_rows=...)` bounds every search, filling in a
-limit where the query states none and clamping one that asks for more; the clamp is
-logged, since nothing in the result says the answer was cut. `search(timeout_seconds=)`
-bounds the SQL and only the SQL: name resolution, the library and index builds, screening,
-and verification all run before that timer starts.
+limit where the query states none and clamping one that asks for more. An answer that
+comes back *at* the bound is logged as possibly cut, since nothing in the table says so;
+one the bound never reached is not, because a warning on every generous limit is how a
+reader learns to skip the line that matters. On an **aggregated** query the bound cuts
+groups rather than reactions — part of a distribution read as the whole of it, and an
+arbitrary part where the query ordered by nothing — so that one says more.
+
+`search(timeout_seconds=)` bounds the SQL and only the SQL: name resolution, the library
+and index builds, screening, and verification all run before that timer starts.
 
 ## Not yet solved
 

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -744,6 +744,14 @@ It is a check on the compiler's own output; the guard is the grammar. It **does 
 cost**, and says so: a caller running arbitrary SQL against a real corpus needs its own
 statement timeout, row cap, or memory limit.
 
+The grammar leaves `limit` optional, so the unbounded query is the ordinary one — a
+predicate matching much of the corpus returns millions of rows, built into an Arrow table
+in the executing process. `Corpus(..., max_rows=...)` bounds every search, filling in a
+limit where the query states none and clamping one that asks for more; the clamp is
+logged, since nothing in the result says the answer was cut. `search(timeout_seconds=)`
+bounds the SQL and only the SQL: name resolution, the library and index builds, screening,
+and verification all run before that timer starts.
+
 ## Not yet solved
 
 Execution has no sandbox. `enable_external_access=false` cannot be combined with a lazy Parquet

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -493,6 +493,46 @@ def _occurrences_from_projection(path: str, expression: str) -> str:
         """  # noqa: S608
 
 
+def _warn_when_the_bound_was_reached(
+    request: query.Query, compiled: query.Compiled, returned: int
+) -> None:
+    """Says when this corpus's bound, not the query's, may have cut the answer short.
+
+    Said after the query rather than while compiling it, because a bound applied is not
+    an answer cut short: a query the bound never reached is the ordinary case, and
+    warning about it on every generous limit is how a reader learns to skip the line
+    that matters. A result that comes back exactly full is the most a row count can say
+    -- it may hold every match and end there -- and nothing in the table says which.
+
+    An aggregated query is the louder case. A truncated list of reactions is a sample of
+    the matching ones; a truncated list of groups is part of a distribution read as the
+    whole of it, and where the query ordered by nothing it is an arbitrary part.
+
+    Args:
+        request: The query as asked, whose own ``limit`` is not this corpus's doing.
+        compiled: What it compiled to, carrying the limit that reached the SQL.
+        returned: Rows the query returned.
+    """
+    if compiled.limit is None or compiled.limit == request.limit:
+        return
+    if returned < compiled.limit:
+        return
+    if request.aggregate is not None:
+        logger.warning(
+            "this query grouped into at least the %d rows the corpus bounds it at, so "
+            "the groups it returned are %s of the distribution rather than all of it; "
+            "ask for fewer groups, or raise max_rows",
+            compiled.limit,
+            "an arbitrary part" if not request.order_by else "the leading part",
+        )
+    else:
+        logger.warning(
+            "this query returned the %d rows the corpus bounds it at, so there may be "
+            "matches it did not return; raise max_rows to see them",
+            compiled.limit,
+        )
+
+
 def _index_condition(
     path: str,
     fields: dict[str, str],
@@ -896,7 +936,7 @@ class Corpus:
                 indexed paths and a pass over the projections for every path they do not
                 cover -- over ORD the difference between a second and a minute -- and it
                 wants 5-6.5 GB of DuckDB memory to build and holds 1.19 GB afterwards.
-                The library is about 8s and 2.4 GB on top. Together they are most of
+                The library is about 8s and 2.2 GB on top. Together they are most of
                 what a container is sized against, which is the reason to spend them
                 where falling short is a failed deployment rather than a failed request;
                 see ``check_index``. A corpus asked only scalar queries needs neither,
@@ -926,10 +966,11 @@ class Corpus:
             ValueError: If ``require_pivots`` is set beside a ``pivot_budget_bytes``,
                 which budgets for a build it rules out. If ``derive_pivots`` is set
                 beside ``warm``, which reads the levels the index covers before the
-                derivation can complete them. If ``pivot_budget_bytes`` is negative,
-                which no amount of memory is; zero is allowed, and materializes nothing;
-                or if ``derive_pivots`` or ``require_pivots`` is set without a
-                ``pivots_dir``.
+                derivation can complete them. If ``max_rows`` is less than one, which is
+                a bound no query can satisfy rather than a small one. If
+                ``pivot_budget_bytes`` is negative, which no amount of memory is; zero
+                is allowed, and materializes nothing; or if ``derive_pivots`` or
+                ``require_pivots`` is set without a ``pivots_dir``.
         """
         self._resolver = resolver if resolver is not None else _resolve_with_resolvers
         if max_rows is not None and max_rows <= 0:
@@ -2376,7 +2417,10 @@ class Corpus:
 
         Returns:
             The selected columns: ``reaction_id`` for a plain query, the group and
-            measure columns for an aggregated one.
+            measure columns for an aggregated one. At most this corpus's ``max_rows``,
+            where it has one: an answer that reached the bound is logged as possibly
+            cut, and the table itself does not say. ``Compiled.limit`` is what actually
+            reached the SQL, for a caller that wants to check rather than read a log.
 
         Raises:
             query.QueryError: If the query does not compile.
@@ -2422,18 +2466,8 @@ class Corpus:
             compiled = query.compile_query(
                 request, index=index, pivot=pivot_table, max_rows=self._max_rows
             )
-            if request.limit is None and compiled.limit is not None:
+            if compiled.limit != request.limit:
                 logger.info("the corpus bounds this query at %d rows", compiled.limit)
-            elif compiled.limit != request.limit:
-                # Said rather than raised: the caller asked for rows this corpus does
-                # not serve, and an answer cut to what it does serve is nearer what they
-                # wanted than an error. Whoever reads the result cannot tell it was cut.
-                logger.warning(
-                    "this query asked for %d rows and the corpus bounds it at %d, so "
-                    "the answer is cut short",
-                    request.limit,
-                    compiled.limit,
-                )
             if indexing:
                 # Built after compiling and before running: the condition names the
                 # table, so the table has to exist by the time the query does. Logged
@@ -2453,9 +2487,12 @@ class Corpus:
                         cursor, parameter, resolve
                     )
                 if timeout_seconds is None:
-                    return cursor.execute(compiled.sql, parameters).to_arrow_table()
-                return _run_with_timeout(
-                    cursor, compiled.sql, parameters, timeout_seconds
-                )
+                    answered = cursor.execute(compiled.sql, parameters).to_arrow_table()
+                else:
+                    answered = _run_with_timeout(
+                        cursor, compiled.sql, parameters, timeout_seconds
+                    )
+                _warn_when_the_bound_was_reached(request, compiled, answered.num_rows)
+                return answered
             finally:
                 cursor.close()

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -825,6 +825,7 @@ class Corpus:
         require_pivots: bool = False,
         memory_limit: str | None = None,
         warm: bool = True,
+        max_rows: int | None = None,
     ) -> None:
         """Pairs the artifacts, checks their stamps, and prepares the relations.
 
@@ -895,12 +896,19 @@ class Corpus:
                 indexed paths and a pass over the projections for every path they do not
                 cover -- over ORD the difference between a second and a minute -- and it
                 wants 5-6.5 GB of DuckDB memory to build and holds 1.19 GB afterwards.
-                The library is about 8s and 2.2 GB on top. Together they are most of
+                The library is about 8s and 2.4 GB on top. Together they are most of
                 what a container is sized against, which is the reason to spend them
                 where falling short is a failed deployment rather than a failed request;
                 see ``check_index``. A corpus asked only scalar queries needs neither,
                 and one asked scalar and similarity queries needs the index without the
                 library -- ``warm=False`` beside ``check_index`` builds that pair.
+            max_rows: Most rows a search may return, applied whether or not the query
+                asked for a limit and clamping one that asks for more. The grammar
+                leaves ``limit`` optional, so a query without one returns every matching
+                reaction -- at ORD's scale millions of rows, built into an Arrow table
+                in this process, from a query that reads as ordinary. A caller serving
+                queries it did not write wants this set. None leaves every query's own
+                limit, or none, exactly as stated.
 
         Raises:
             PairingError: If either pattern matches nothing, a file on one side has no
@@ -924,6 +932,12 @@ class Corpus:
                 ``pivots_dir``.
         """
         self._resolver = resolver if resolver is not None else _resolve_with_resolvers
+        if max_rows is not None and max_rows <= 0:
+            raise ValueError(
+                f"max_rows is {max_rows}, which no query can return; leave it unset to "
+                "bound nothing"
+            )
+        self._max_rows = max_rows
         if pivot_budget_bytes is not None and pivot_budget_bytes < 0:
             raise ValueError(
                 f"pivot_budget_bytes is {pivot_budget_bytes}, which is not an amount "
@@ -2405,7 +2419,21 @@ class Corpus:
                     pivoted[path] = reading.enter_context(self._pivoted_table(path))
                 return pivoted[path]
 
-            compiled = query.compile_query(request, index=index, pivot=pivot_table)
+            compiled = query.compile_query(
+                request, index=index, pivot=pivot_table, max_rows=self._max_rows
+            )
+            if request.limit is None and compiled.limit is not None:
+                logger.info("the corpus bounds this query at %d rows", compiled.limit)
+            elif compiled.limit != request.limit:
+                # Said rather than raised: the caller asked for rows this corpus does
+                # not serve, and an answer cut to what it does serve is nearer what they
+                # wanted than an error. Whoever reads the result cannot tell it was cut.
+                logger.warning(
+                    "this query asked for %d rows and the corpus bounds it at %d, so "
+                    "the answer is cut short",
+                    request.limit,
+                    compiled.limit,
+                )
             if indexing:
                 # Built after compiling and before running: the condition names the
                 # table, so the table has to exist by the time the query does. Logged

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -1692,7 +1692,7 @@ def test_max_rows_bounds_what_a_search_returns(corpus_dir, caplog):
     assert any("bounds this query at 2 rows" in m for m in _messages(caplog))
 
 
-def test_max_rows_clamps_a_query_asking_for_more_and_says_so(corpus_dir, caplog):
+def test_an_answer_that_reaches_the_bound_says_it_may_be_cut(corpus_dir, caplog):
     # Cut rather than refused: the answer is nearer what the caller wanted than an
     # error, and nothing in the result says it was cut, so the log has to.
     with (
@@ -1706,7 +1706,46 @@ def test_max_rows_clamps_a_query_asking_for_more_and_says_so(corpus_dir, caplog)
     ):
         found = value.search(query.Query.model_validate({"limit": 3}))
     assert found.num_rows == 1
-    assert any("asked for 3 rows" in m for m in _messages(caplog))
+    assert any("there may be matches it did not return" in m for m in _messages(caplog))
+
+
+def test_an_answer_the_bound_never_reached_says_nothing(corpus_dir, caplog):
+    # The ordinary case, and the reason the warning waits for the result: warning
+    # wherever the bound was merely applied is how a reader learns to skip the line.
+    with (
+        caplog.at_level(logging.WARNING, logger="ord_schema.search.execute"),
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            max_rows=100,
+        ) as value,
+    ):
+        assert value.search(query.Query.model_validate({"limit": 5000})).num_rows == 3
+    assert not _messages(caplog)
+
+
+def test_a_truncated_aggregate_says_the_distribution_is_partial(corpus_dir, caplog):
+    # A truncated list of reactions is a sample of the matching ones; a truncated list
+    # of groups is part of a distribution read as the whole of it, and ordered by
+    # nothing it is an arbitrary part.
+    request = {
+        "aggregate": {
+            "group_by": ["reaction_id"],
+            "measures": [{"fn": "count", "name": "n"}],
+        }
+    }
+    with (
+        caplog.at_level(logging.WARNING, logger="ord_schema.search.execute"),
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            max_rows=2,
+        ) as value,
+    ):
+        assert value.search(query.Query.model_validate(request)).num_rows == 2
+    assert any("an arbitrary part of the distribution" in m for m in _messages(caplog))
 
 
 def test_a_search_under_a_smaller_limit_than_max_rows_is_untouched(corpus_dir):

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -1676,6 +1676,59 @@ def test_a_cold_corpus_leaves_the_index_to_the_first_query(corpus_dir):
         assert not value._occurrences_built
 
 
+def test_max_rows_bounds_what_a_search_returns(corpus_dir, caplog):
+    # The corpus holds three reactions and the query asks for none of them in
+    # particular, which is the shape that returns everything at corpus scale.
+    with (
+        caplog.at_level(logging.INFO, logger="ord_schema.search.execute"),
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            max_rows=2,
+        ) as value,
+    ):
+        assert value.search(query.Query.model_validate({})).num_rows == 2
+    assert any("bounds this query at 2 rows" in m for m in _messages(caplog))
+
+
+def test_max_rows_clamps_a_query_asking_for_more_and_says_so(corpus_dir, caplog):
+    # Cut rather than refused: the answer is nearer what the caller wanted than an
+    # error, and nothing in the result says it was cut, so the log has to.
+    with (
+        caplog.at_level(logging.WARNING, logger="ord_schema.search.execute"),
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            max_rows=1,
+        ) as value,
+    ):
+        found = value.search(query.Query.model_validate({"limit": 3}))
+    assert found.num_rows == 1
+    assert any("asked for 3 rows" in m for m in _messages(caplog))
+
+
+def test_a_search_under_a_smaller_limit_than_max_rows_is_untouched(corpus_dir):
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        max_rows=100,
+    ) as value:
+        assert value.search(query.Query.model_validate({"limit": 2})).num_rows == 2
+
+
+def test_a_max_rows_no_query_can_satisfy_is_refused(corpus_dir):
+    with pytest.raises(ValueError, match="which no query can return"):
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            max_rows=0,
+        )
+
+
 def test_a_corpus_builds_the_substructure_library_at_open(corpus_dir):
     # Warming covers both builds a substructure query needs, so what an open corpus
     # holds is what a container has to be sized for rather than a floor a later query

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -193,11 +193,16 @@ class Compiled:
     predicates the caller evaluates against the structures artifact, each bound as a
     bitmap over corpus-wide structure IDs; a query carrying any also references the
     ``STRUCTURE_OFFSET`` column, so it runs only against the executor's relation.
+
+    ``limit`` is the row bound the SQL carries, which is the query's own where it asked
+    for one within ``max_rows`` and ``max_rows`` where it did not. A caller comparing it
+    against ``Query.limit`` learns whether the answer was cut short.
     """
 
     sql: str
     compounds: tuple[str, ...]
     structures: tuple[StructureParameter, ...] = ()
+    limit: int | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -1198,6 +1203,7 @@ def compile_query(
     table: str = TABLE,
     index: ElementIndex | None = None,
     pivot: PivotIndex | None = None,
+    max_rows: int | None = None,
 ) -> Compiled:
     """Compiles a query to DuckDB SQL over the projection.
 
@@ -1214,6 +1220,12 @@ def compile_query(
         pivot: Pivoted levels to spend where they can answer a quantifier; see
             ``PivotIndex``. Consulted after ``index``, and for ``forall`` as well as
             ``exists``.
+        max_rows: Most rows the SQL may return, applied whether or not the query asked
+            for a limit and clamping one that asks for more. The grammar leaves
+            ``limit`` optional, and a query without one returns every matching
+            reaction -- millions of rows at corpus scale, materialized in whatever
+            process is executing. A caller serving queries it did not write wants this
+            set; None leaves the query's own limit, or none, exactly as stated.
 
     Returns:
         The SQL, the compound names whose resolved SMILES the caller binds, and the
@@ -1294,6 +1306,7 @@ def compile_query(
                 )
             keys.append(f"{key} DESC" if order.descending else key)
         sql += " ORDER BY " + ", ".join(keys)
-    if query.limit is not None:
-        sql += f" LIMIT {query.limit}"
-    return Compiled(sql, tuple(compounds), tuple(structures))
+    limit = query.limit if max_rows is None else min(query.limit or max_rows, max_rows)
+    if limit is not None:
+        sql += f" LIMIT {limit}"
+    return Compiled(sql, tuple(compounds), tuple(structures), limit)

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -1225,7 +1225,10 @@ def compile_query(
             ``limit`` optional, and a query without one returns every matching
             reaction -- millions of rows at corpus scale, materialized in whatever
             process is executing. A caller serving queries it did not write wants this
-            set; None leaves the query's own limit, or none, exactly as stated.
+            set; None leaves the query's own limit, or none, exactly as stated. It
+            bounds an aggregated query's *groups*, where a truncated answer is an
+            arbitrary part of a distribution rather than a sample of the matching
+            reactions; ``Corpus.search`` says so when one comes back full.
 
     Returns:
         The SQL, the compound names whose resolved SMILES the caller binds, and the
@@ -1235,9 +1238,18 @@ def compile_query(
         QueryError: If ``table`` is not an identifier, if any path, operator, or
             ordering key cannot be meant against the schema, or if a compound name
             collides with a generated structure parameter.
+        ValueError: If ``max_rows`` is less than one, which is a bound no query can
+            satisfy rather than a small one.
     """
     if not _NAME.match(table):
         raise QueryError(f"table is not an identifier: {table!r}")
+    if max_rows is not None and max_rows < 1:
+        # Zero compiles to a LIMIT no query can satisfy and a negative one to SQL
+        # DuckDB refuses at execution, both of them far from whoever passed it.
+        raise ValueError(
+            f"max_rows is {max_rows}, which no query can return; leave it unset to "
+            "bound nothing"
+        )
     compounds: list[str] = []
     structures: list[StructureParameter] = []
     if query.aggregate:
@@ -1306,7 +1318,12 @@ def compile_query(
                 )
             keys.append(f"{key} DESC" if order.descending else key)
         sql += " ORDER BY " + ", ".join(keys)
-    limit = query.limit if max_rows is None else min(query.limit or max_rows, max_rows)
+    if max_rows is None:
+        limit = query.limit
+    elif query.limit is None:
+        limit = max_rows
+    else:
+        limit = min(query.limit, max_rows)
     if limit is not None:
         sql += f" LIMIT {limit}"
     return Compiled(sql, tuple(compounds), tuple(structures), limit)

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -438,6 +438,22 @@ def test_max_rows_leaves_a_smaller_limit_alone():
     assert compiled.limit == 10
 
 
+def test_a_limit_of_zero_is_not_read_as_no_limit():
+    # The trap in `query.limit or max_rows`: a falsy limit reads as absent, so a query
+    # asking for no rows would be served max_rows of them. Held off by the model's
+    # gt=0 today, which is not where the compiler should rest.
+    compiled = query.compile_query(query.Query.model_construct(limit=0), max_rows=100)
+    assert compiled.limit == 0
+
+
+def test_a_max_rows_no_query_can_satisfy_is_refused():
+    # Zero compiles to a LIMIT nothing satisfies and a negative one to SQL DuckDB
+    # refuses at execution, both far from whoever passed it.
+    for value in (0, -5):
+        with pytest.raises(ValueError, match="which no query can return"):
+            _compile({}, max_rows=value)
+
+
 def test_without_max_rows_a_query_is_as_stated():
     assert _compile({}).limit is None
     assert " LIMIT " not in _compile({}).sql

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -25,8 +25,8 @@ from ord_schema.artifacts import pivot, projection
 from ord_schema.search import query, sql
 
 
-def _compile(payload):
-    return query.compile_query(query.Query.model_validate(payload))
+def _compile(payload, **kwargs):
+    return query.compile_query(query.Query.model_validate(payload), **kwargs)
 
 
 def _run(compiled, parameters=None):
@@ -415,6 +415,33 @@ def test_ordering_by_a_reduction_over_a_repeated_path():
     )
     assert "list_max(" in compiled.sql
     assert compiled.sql.endswith("DESC LIMIT 10")
+
+
+def test_max_rows_bounds_a_query_that_asked_for_no_limit():
+    # The grammar leaves limit optional, so the unbounded query is the ordinary one: a
+    # predicate matching much of the corpus returns millions of rows to whoever ran it.
+    compiled = _compile({}, max_rows=100)
+    assert compiled.sql.endswith(" LIMIT 100")
+    assert compiled.limit == 100
+
+
+def test_max_rows_clamps_a_query_asking_for_more():
+    # A bound an explicit limit can exceed bounds nothing.
+    compiled = _compile({"limit": 5000}, max_rows=100)
+    assert compiled.sql.endswith(" LIMIT 100")
+    assert compiled.limit == 100
+
+
+def test_max_rows_leaves_a_smaller_limit_alone():
+    compiled = _compile({"limit": 10}, max_rows=100)
+    assert compiled.sql.endswith(" LIMIT 10")
+    assert compiled.limit == 10
+
+
+def test_without_max_rows_a_query_is_as_stated():
+    assert _compile({}).limit is None
+    assert " LIMIT " not in _compile({}).sql
+    assert _compile({"limit": 5000}).limit == 5000
 
 
 def test_a_reduction_reaches_the_same_rows_the_elements_do():


### PR DESCRIPTION
## Summary

The grammar leaves `limit` optional, so the unbounded query is the ordinary one: a predicate matching much of the corpus returns millions of `reaction_id`s, built into an Arrow table in whatever process is executing, from a query that reads as ordinary. Nothing bounded it — `search(timeout_seconds=)` bounds the SQL, and only after screening.

Part of the review in [ord-logbook#51](https://github.com/open-reaction-database/ord-logbook/pull/51), finding 7.

## Changes

- `Corpus` takes `max_rows`, and `compile_query` takes it through. It fills in a limit where the query states none and clamps one that asks for more — a bound an explicit limit can exceed bounds nothing.
- Cut rather than refused: the answer is nearer what the caller wanted than an error is. Because nothing in the result says it was cut, the clamp is logged at WARNING and the fill-in at INFO.
- `Compiled` carries the limit it applied, so a caller can compare it against `Query.limit` itself.
- `max_rows` below one is refused, in `compile_query` as well as `Corpus` — the compiler is public and called directly from `nl.py` and `check.py`. A `limit` of zero is no longer read as no limit at all.

- The README says `max_rows` exists and that the search timeout bounds the SQL, not the screen.

## Testing

- `uv run pytest`: 1481 passed outside `ord_schema/orm`, whose fixtures need a local Postgres.
- Twelve new tests, covering the bound applied, the bound reached, the bound never reached, and a truncated aggregate. Dropping the clamp fails four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds an optional corpus-wide result-row cap for structured searches and reports when that cap may have truncated an answer.
- Threads `max_rows` from `Corpus` through query compilation.
- Fills missing query limits and clamps explicit limits that exceed the corpus bound.
- Logs potentially truncated plain and aggregated results.
- Documents the row-bound and SQL-timeout behavior and adds focused tests.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/query.py | Adds the effective compiled limit and applies the optional corpus maximum when generating SQL. |
| ord_schema/search/execute.py | Adds Corpus.max_rows forwarding and post-execution logging when the imposed bound is reached. |
| ord_schema/search/query_test.py | Covers limit insertion, clamping, preservation, zero handling, validation, and unbounded compatibility. |
| ord_schema/search/execute_test.py | Covers end-to-end row bounds, warning behavior, aggregate truncation, and invalid configuration. |
| ord_schema/search/README.md | Documents corpus row limits, aggregate truncation semantics, and the scope of search timeouts. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Query] --> B[Corpus.search]
    B --> C[compile_query with max_rows]
    C --> D[SQL with effective LIMIT]
    D --> E[DuckDB execution]
    E --> F[Arrow table]
    F --> G{Reached corpus bound?}
    G -->|Yes| H[Log possible truncation]
    G -->|No| I[Return without warning]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Warn when the bound was reached, not whe..."](https://github.com/open-reaction-database/ord-schema/commit/0de6a781d7990afbd1534565dfd3141a86570b43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58497779)</sub>

<!-- /greptile_comment -->