### PR TITLE
Derive the occurrence index as an artifact

### DIFF
--- a/ord_schema/artifacts/README.md
+++ b/ord_schema/artifacts/README.md
@@ -18,7 +18,7 @@ flowchart LR
     S -.->|"paired by source dataset"| C["ord_schema.search.Corpus"]
     P -.-> C
     V -.-> C
-    O -.-> C
+    O -. "not yet" .-> C
 ```
 
 | artifact | one file per | holds | read by |
@@ -26,7 +26,7 @@ flowchart LR
 | [`projection`](projection.py) | source dataset | every field of every message reachable from `Reaction`, as `STRUCT` / `LIST` / `MAP` | any query engine; the compiler in [`ord_schema.search`](../search/) |
 | [`structures`](structures.py) | projection | one row per distinct structure: `pattern_fp`, `morgan_fp`, `morgan_popcount`, `mol_binary`, keyed by `structure_id` | the screen and verify steps of substructure search |
 | [`pivot`](pivot.py) | projection × repeated level | one row per element, carrying `reaction_id`, the ordinal of every enclosing level, and the element's own non-repeated fields | quantifiers, as a semi-join |
-| [`occurrences`](occurrences.py) | pivot × indexed path | one row per structure occurrence: `reaction_id`, `structure_id`, `reaction_role` | which reactions hold a structure match, as a semi-join |
+| [`occurrences`](occurrences.py) | pivot × indexed path | one row per structure occurrence: `reaction_id`, `structure_id`, `reaction_role` | *nothing yet* — the corpus assembles these rows in process; reading them is a separate change |
 
 The projection leaves **no field out** — a field left out is a question nobody can ask.
 Its schema is generated from the proto descriptors, so a field added upstream appears
@@ -81,7 +81,7 @@ each match:
   source tree maps one dataset onto a *different* one, which a per-source check passes
   while destroying a source the run has not reached yet.
 
-Three scripts wrap it, in dependency order:
+Four scripts wrap it, in dependency order:
 
 ```bash
 python -m ord_schema.artifacts.scripts.derive_projection \
@@ -92,7 +92,7 @@ python -m ord_schema.artifacts.scripts.derive_structures \
 
 python -m ord_schema.artifacts.scripts.derive_pivots \
     --input_pattern='projections/*/*.parquet' --output_dir=pivots \
-    --levels outcomes.products outcomes.products.measurements
+    --levels $(python -m ord_schema.artifacts.scripts.derive_occurrences --print_levels)
 
 python -m ord_schema.artifacts.scripts.derive_occurrences \
     --pivots_dir=pivots --output_dir=occurrences
@@ -100,10 +100,10 @@ python -m ord_schema.artifacts.scripts.derive_occurrences \
 
 Each takes `--force` to rewrite what is already current. `derive_pivots` defaults to all
 39 repeated levels, which is far more than a deployment answers questions over; naming
-the levels it does is the cheaper run. `derive_occurrences` reads the pivots over four of
-those levels and covers every path a structure can sit at, which is not a choice — a path
-left out is one whose structures no query can find. `derive_occurrences --print_levels`
-prints exactly the `--levels` its pivots need.
+the levels it does is the cheaper run — and `derive_occurrences --print_levels` names the
+four it reads, which is why the command above asks it rather than spelling them.
+`derive_occurrences` covers every path a structure can sit at, which is not a choice: a
+path left out is one whose structures no query can find.
 
 ## What pairs with what
 
@@ -133,7 +133,8 @@ file would stay *in range* while naming another dataset's molecule — passing o
 corpus and failing only on a subset of it, which is the shape of bug that reaches
 production. The corpus assigns offsets at open and joins them on, keyed by the source
 dataset every artifact names. That rule is what lets the occurrence index be an artifact
-at all rather than a table rebuilt at every startup.
+at all rather than a relation rebuilt at every startup — which is what
+[`Corpus`](../search/execute.py) still does, since nothing reads the artifact yet.
 
 ## Querying a projection
 

--- a/ord_schema/artifacts/README.md
+++ b/ord_schema/artifacts/README.md
@@ -134,7 +134,7 @@ corpus and failing only on a subset of it, which is the shape of bug that reache
 production. The corpus assigns offsets at open and joins them on, keyed by the source
 dataset every artifact names. That rule is what lets the occurrence index be an artifact
 at all rather than a relation rebuilt at every startup — which is what
-[`Corpus`](../search/execute.py) still does, since nothing reads the artifact yet.
+[`Corpus`](../search/execute.py) does, since nothing reads the artifact yet.
 
 ## Querying a projection
 

--- a/ord_schema/artifacts/README.md
+++ b/ord_schema/artifacts/README.md
@@ -7,16 +7,18 @@ consumer can read cheaply. It adds no information, which is the whole discipline
 artifact is *wrong* if it disagrees with its source, and *stale* if its source has moved
 on. Both have to be detectable without reading a single column of data.
 
-Three artifacts, derived in a chain:
+Four artifacts, derived in a chain:
 
 ```mermaid
 flowchart LR
     D["source dataset<br/>ord-data, wire-format bytes"] --> P["<b>projection</b><br/>every field, as nested Parquet"]
     P --> S["<b>structures</b><br/>one row per distinct molecule<br/>fingerprints + serialized mol"]
     P --> V["<b>pivot</b><br/>one row per element of<br/>one repeated level"]
+    V --> O["<b>occurrences</b><br/>one row per structure occurrence<br/>at one indexed path"]
     S -.->|"paired by source dataset"| C["ord_schema.search.Corpus"]
     P -.-> C
     V -.-> C
+    O -.-> C
 ```
 
 | artifact | one file per | holds | read by |
@@ -24,6 +26,7 @@ flowchart LR
 | [`projection`](projection.py) | source dataset | every field of every message reachable from `Reaction`, as `STRUCT` / `LIST` / `MAP` | any query engine; the compiler in [`ord_schema.search`](../search/) |
 | [`structures`](structures.py) | projection | one row per distinct structure: `pattern_fp`, `morgan_fp`, `morgan_popcount`, `mol_binary`, keyed by `structure_id` | the screen and verify steps of substructure search |
 | [`pivot`](pivot.py) | projection × repeated level | one row per element, carrying `reaction_id`, the ordinal of every enclosing level, and the element's own non-repeated fields | quantifiers, as a semi-join |
+| [`occurrences`](occurrences.py) | pivot × indexed path | one row per structure occurrence: `reaction_id`, `structure_id`, `reaction_role` | which reactions hold a structure match, as a semi-join |
 
 The projection leaves **no field out** — a field left out is a question nobody can ask.
 Its schema is generated from the proto descriptors, so a field added upstream appears
@@ -90,11 +93,17 @@ python -m ord_schema.artifacts.scripts.derive_structures \
 python -m ord_schema.artifacts.scripts.derive_pivots \
     --input_pattern='projections/*/*.parquet' --output_dir=pivots \
     --levels outcomes.products outcomes.products.measurements
+
+python -m ord_schema.artifacts.scripts.derive_occurrences \
+    --pivots_dir=pivots --output_dir=occurrences
 ```
 
 Each takes `--force` to rewrite what is already current. `derive_pivots` defaults to all
 39 repeated levels, which is far more than a deployment answers questions over; naming
-the levels it does is the cheaper run.
+the levels it does is the cheaper run. `derive_occurrences` reads the pivots over four of
+those levels and covers every path a structure can sit at, which is not a choice — a path
+left out is one whose structures no query can find. `derive_occurrences --print_levels`
+prints exactly the `--levels` its pivots need.
 
 ## What pairs with what
 
@@ -115,6 +124,16 @@ derivation and are meaningful only together:
 A pivot names its reactions by ID, so one derived from another corpus resolves against
 rows this one does not hold — confidently and wrongly. `Corpus` refuses pivot artifacts
 whose source datasets are not its projections'.
+
+**No artifact carries a corpus-wide ID.** A `structure_id` is local to its dataset; the
+corpus-wide one a bitmap is indexed by is that plus an offset, and the offset is a running
+total over the datasets the corpus opened. It therefore belongs to no artifact: the same
+rows read beside a different set of datasets need a different offset, and one baked into a
+file would stay *in range* while naming another dataset's molecule — passing on the whole
+corpus and failing only on a subset of it, which is the shape of bug that reaches
+production. The corpus assigns offsets at open and joins them on, keyed by the source
+dataset every artifact names. That rule is what lets the occurrence index be an artifact
+at all rather than a table rebuilt at every startup.
 
 ## Querying a projection
 

--- a/ord_schema/artifacts/base.py
+++ b/ord_schema/artifacts/base.py
@@ -360,9 +360,31 @@ def glob_root(pattern: str) -> pathlib.PurePath:
     return pathlib.PurePath(*fixed)
 
 
-def output_path(source: str, pattern: str, output_dir: str) -> pathlib.Path:
-    """Maps a source path to its artifact path under ``output_dir``."""
-    relative = pathlib.PurePath(source).relative_to(glob_root(pattern))
+def output_path(
+    source: str,
+    pattern: str,
+    output_dir: str,
+    *,
+    root: str | os.PathLike[str] | None = None,
+) -> pathlib.Path:
+    """Maps a source path to its artifact path under ``output_dir``.
+
+    Args:
+        source: Path the pattern matched.
+        pattern: The glob it matched, whose wildcard-free prefix the output mirrors from
+            when ``root`` is not given.
+        output_dir: Directory to write beneath.
+        root: The directory to mirror from, for a caller that has one. A caller building
+            a pattern around a directory name has to escape it, and an escaped ``[`` is
+            a character class as far as ``glob_root`` can tell -- so the prefix it finds
+            stops short and the mirror carries the source layout twice.
+
+    Returns:
+        Where ``source``'s artifact goes.
+    """
+    relative = pathlib.PurePath(source).relative_to(
+        glob_root(pattern) if root is None else pathlib.PurePath(root)
+    )
     return pathlib.Path(output_dir) / relative
 
 
@@ -477,6 +499,7 @@ def derive_tree(
     schema: pa.Schema | None = None,
     force: bool = False,
     parent_artifact: str | None = None,
+    root: str | os.PathLike[str] | None = None,
 ) -> tuple[int, int, int]:
     """Derives one artifact per file matching ``input_pattern``.
 
@@ -497,6 +520,9 @@ def derive_tree(
         parent_artifact: Artifact the parents hold, for a derivation that reads another
             artifact rather than a source dataset. None means the parents are source
             datasets.
+        root: The directory outputs mirror from, for a caller that has one rather than a
+            pattern. Defaults to ``input_pattern``'s wildcard-free leading directories,
+            which is what a caller who wrote the pattern means by it.
 
     Returns:
         ``(written, skipped, ignored)`` counts: artifacts derived, artifacts already
@@ -529,7 +555,8 @@ def derive_tree(
     # in the source tree maps one dataset onto a *different* one, which a per-source
     # check passes, destroying a source the run had not reached yet.
     destinations = {
-        source: output_path(source, input_pattern, output_dir) for source in sources
+        source: output_path(source, input_pattern, output_dir, root=root)
+        for source in sources
     }
     resolved_sources = {pathlib.Path(source).resolve() for source in sources}
     clobbered = sorted(

--- a/ord_schema/artifacts/base_test.py
+++ b/ord_schema/artifacts/base_test.py
@@ -15,6 +15,7 @@
 """Tests for ord_schema.artifacts.base."""
 
 import dataclasses
+import glob
 import pathlib
 from importlib import metadata
 
@@ -172,6 +173,21 @@ def test_output_path_for_an_exact_filename_writes_into_the_directory():
     assert base.output_path(
         "data/aa/one.parquet", "data/aa/one.parquet", "structures"
     ) == pathlib.Path("structures/one.parquet")
+
+
+def test_an_explicit_root_mirrors_from_where_the_caller_says():
+    # A caller building a pattern around a directory name has to escape it, and the
+    # escape is spelled with the wildcard it is escaping: glob_root stops at "data[[]1]"
+    # and mirrors the source layout a second time beneath output_dir. The caller knows
+    # the directory it meant, so it says so rather than spelling it as a pattern.
+    pattern = glob.escape("data[1]/aa") + "/*.parquet"
+    source = "data[1]/aa/ord_dataset-x.parquet"
+    assert base.output_path(source, pattern, "structures") == pathlib.Path(
+        "structures/data[1]/aa/ord_dataset-x.parquet"
+    )
+    assert base.output_path(
+        source, pattern, "structures", root="data[1]/aa"
+    ) == pathlib.Path("structures/ord_dataset-x.parquet")
 
 
 # Driver

--- a/ord_schema/artifacts/occurrences.py
+++ b/ord_schema/artifacts/occurrences.py
@@ -31,12 +31,12 @@ the whole corpus and failing only on a subset of it. The corpus joins the offset
 open, keyed by the source dataset every artifact names; see
 :mod:`ord_schema.search.execute`.
 
-That rule is what lets this be an artifact at all rather than a table built at open, and
-the difference is the deployment: built, the relation is 18,847,978 rows and 1.19 GiB
-held over ORD, wants 5-6.5 GB of DuckDB memory and 16-25 GB of temporary files to get
-there, and costs seconds to a minute before the first query. Read, it is 256 MB of
-Parquet and a view, and the semi-join over it costs about 1.28x what the built table
-costs.
+That rule is what lets this be an artifact at all rather than a relation assembled at
+open, which is what :mod:`ord_schema.search.execute` still does: over ORD it builds
+18,847,978 rows holding 1.19 GiB, wanting 5-6.5 GB of DuckDB memory and 16-25 GB of
+temporary files to get there, before the first query can be answered. The same rows
+derived here are 242 MB of Parquet. **Nothing reads them yet** -- the corpus that does
+is a separate change, and until it lands a tree derived from this is inert.
 
 Derived from the **pivot** over the level an indexed path ranges within, which already
 holds one row per element: this artifact is that projected down to three columns, so the
@@ -46,7 +46,6 @@ read from that level's pivot through the remainder; see ``ord_schema.artifacts.p
 """
 
 import glob
-import logging
 import os
 import pathlib
 
@@ -56,8 +55,9 @@ import pyarrow.parquet as pq
 
 from ord_schema import atomic_io
 from ord_schema.artifacts import base, pivot, projection, structures
+from ord_schema.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 ARTIFACT = "occurrences"
 
@@ -106,6 +106,11 @@ def indexed_paths(
             because the answer is to change this module rather than to retry.
     """
     paths: dict[str, tuple[pivot.RepeatedLevel, tuple[str, ...]]] = {}
+    # Walked from the schema the caller passed rather than from the module default, so
+    # asking what a written file covers is answered about that file. A reach against the
+    # default levels would answer about the schema this library was imported with, which
+    # is the disagreement between two walks that this function exists to prevent.
+    levels = pivot.repeated_levels(schema)
     for _, path, dtype in structures.structure_levels(schema):
         if INDEXED_FIELD not in [field.name for field in dtype]:
             raise ValueError(
@@ -113,7 +118,7 @@ def indexed_paths(
                 "row cannot bind a query to the element it matched, and a structure "
                 "sitting only there would look like one this artifact lost"
             )
-        reached = pivot.reach(path)
+        reached = pivot.reach(path, levels)
         if reached is None:
             raise ValueError(
                 f"{path} carries a structure but no repeated level reaches it, so no "

--- a/ord_schema/artifacts/occurrences.py
+++ b/ord_schema/artifacts/occurrences.py
@@ -32,7 +32,7 @@ open, keyed by the source dataset every artifact names; see
 :mod:`ord_schema.search.execute`.
 
 That rule is what lets this be an artifact at all rather than a relation assembled at
-open, which is what :mod:`ord_schema.search.execute` still does: over ORD it builds
+open, which is what :mod:`ord_schema.search.execute` does: over ORD it builds
 18,847,978 rows holding 1.19 GiB, wanting 5-6.5 GB of DuckDB memory and 16-25 GB of
 temporary files to get there, before the first query can be answered. The same rows
 derived here are 242 MB of Parquet. **Nothing reads them yet** -- the corpus that does
@@ -106,10 +106,10 @@ def indexed_paths(
             because the answer is to change this module rather than to retry.
     """
     paths: dict[str, tuple[pivot.RepeatedLevel, tuple[str, ...]]] = {}
-    # Walked from the schema the caller passed rather than from the module default, so
-    # asking what a written file covers is answered about that file. A reach against the
-    # default levels would answer about the schema this library was imported with, which
-    # is the disagreement between two walks that this function exists to prevent.
+    # Levels from the schema the caller passed, so asking what a written file covers is
+    # answered about that file. Reaching against the module's default levels would
+    # answer about the schema this library was imported with -- the disagreement between
+    # two walks that this function exists to prevent.
     levels = pivot.repeated_levels(schema)
     for _, path, dtype in structures.structure_levels(schema):
         if INDEXED_FIELD not in [field.name for field in dtype]:

--- a/ord_schema/artifacts/occurrences.py
+++ b/ord_schema/artifacts/occurrences.py
@@ -1,0 +1,310 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""One row per structure occurrence, for the paths a structure query can be routed to.
+
+A quantifier whose body is a structure predicate on the element's own ``smiles`` is
+answered by a semi-join rather than by reading the projection: which reactions hold a
+match is a separate cost from the chemistry, and the larger one. The relation that
+answers it is one row per occurrence, carrying the reaction, the structure, and the
+element's own ``reaction_role`` -- keeping the role beside the structure is what makes
+"pyridine as the solvent" a condition on one row rather than an intersection of two
+reaction sets, which over-returns.
+
+**Dataset-local IDs, always.** An occurrence names its structure by the ``structure_id``
+its own dataset assigned, never by a corpus-wide one. A corpus-wide ID is that plus an
+offset that is a running total over the corpus's datasets, so it belongs to no artifact:
+the same rows read beside a different set of datasets need a different offset, and an ID
+baked in here would stay in range while naming another dataset's molecule -- passing on
+the whole corpus and failing only on a subset of it. The corpus joins the offset on at
+open, keyed by the source dataset every artifact names; see
+:mod:`ord_schema.search.execute`.
+
+That rule is what lets this be an artifact at all rather than a table built at open, and
+the difference is the deployment: built, the relation is 18,847,978 rows and 1.19 GiB
+held over ORD, wants 5-6.5 GB of DuckDB memory and 16-25 GB of temporary files to get
+there, and costs seconds to a minute before the first query. Read, it is 256 MB of
+Parquet and a view, and the semi-join over it costs about 1.28x what the built table
+costs.
+
+Derived from the **pivot** over the level an indexed path ranges within, which already
+holds one row per element: this artifact is that projected down to three columns, so the
+two cannot disagree about which elements exist. A path descending from its level through
+singular struct fields -- an authentic standard is one compound per measurement -- is
+read from that level's pivot through the remainder; see ``ord_schema.artifacts.pivot``.
+"""
+
+import glob
+import logging
+import os
+import pathlib
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from ord_schema import atomic_io
+from ord_schema.artifacts import base, pivot, projection, structures
+
+logger = logging.getLogger(__name__)
+
+ARTIFACT = "occurrences"
+
+# The indexed path a file holds, stamped so a reader can tell one from another without
+# trusting where it sits; see ``occurrence_path``.
+META_OCCURRENCE_PATH = "ord.occurrence_path"
+
+# The element field an occurrence carries beside its structure. One rather than all of
+# them: a row is what a semi-join reads, and every column on it is paid for by every
+# occurrence in the corpus.
+INDEXED_FIELD = "reaction_role"
+
+SCHEMA = pa.schema(
+    [
+        pa.field("reaction_id", pa.string(), nullable=False),
+        # Local to the dataset this was derived from, and meaningless beside another's
+        # structures artifact; see the module docstring.
+        pa.field("structure_id", pa.uint32(), nullable=False),
+        pa.field(INDEXED_FIELD, pa.string()),
+    ]
+)
+
+
+def indexed_paths(
+    schema: pa.Schema = projection.SCHEMA,
+) -> dict[str, tuple[pivot.RepeatedLevel, tuple[str, ...]]]:
+    """Returns the paths this artifact covers, and the pivot each is read from.
+
+    Taken from the same schema walk the structures artifact is built from, so the
+    occurrences reach the elements the projection does by construction rather than by a
+    list here agreeing with one there. Every path the schema can carry a structure at
+    has to come out covered: one dropped would leave the structures sitting only there
+    reachable by no query, which reads as a corpus holding none of them.
+
+    Args:
+        schema: The projection schema.
+
+    Returns:
+        Each structure-bearing path, mapped to the repeated level whose pivot holds it
+        and the segments from that level's element down to the structure.
+
+    Raises:
+        ValueError: If a structure-bearing path is reached by no repeated level, or
+            carries no ``INDEXED_FIELD``, so no pivot can answer for it; or if the
+            schema carries no structure at all. Raised at import, naming the path,
+            because the answer is to change this module rather than to retry.
+    """
+    paths: dict[str, tuple[pivot.RepeatedLevel, tuple[str, ...]]] = {}
+    for _, path, dtype in structures.structure_levels(schema):
+        if INDEXED_FIELD not in [field.name for field in dtype]:
+            raise ValueError(
+                f"{path} carries a structure but no {INDEXED_FIELD}, so an occurrence "
+                "row cannot bind a query to the element it matched, and a structure "
+                "sitting only there would look like one this artifact lost"
+            )
+        reached = pivot.reach(path)
+        if reached is None:
+            raise ValueError(
+                f"{path} carries a structure but no repeated level reaches it, so no "
+                "pivot holds its elements and they can be read only by unnesting the "
+                "projection"
+            )
+        level, remainder, _ = reached
+        paths[path] = (level, remainder)
+    if not paths:
+        raise ValueError(
+            "the schema carries no structure at any path, so this artifact has nothing "
+            "to hold and a corpus reading it would index nothing"
+        )
+    return paths
+
+
+PATHS = indexed_paths()
+
+
+def _select(level: pivot.RepeatedLevel, remainder: tuple[str, ...]) -> str:
+    """Returns the SELECT projecting a pivot's rows down to occurrences.
+
+    Args:
+        level: The repeated level the pivot holds.
+        remainder: Segments from that level's element down to the structure.
+
+    Returns:
+        The SELECT, over a view named ``elements``.
+    """
+    element = ".".join([pivot.ELEMENT, *remainder])
+    # An element carrying no structure is no occurrence: the pivot is complete, holding
+    # a row for every element including one whose fields are all NULL, and this is not.
+    # S608: the level and its remainder come from this module's walk of the schema.
+    return f"""
+        SELECT {pivot.REACTION_ID}, {element}.structure_id AS structure_id,
+               {element}.{INDEXED_FIELD} AS {INDEXED_FIELD}
+        FROM elements
+        WHERE {element}.structure_id IS NOT NULL
+        """  # noqa: S608
+
+
+def _check_pivot(source: str | os.PathLike[str], level: str) -> base.Stamps:
+    """Returns the stamps of a current pivot over ``level``, refusing anything else.
+
+    Args:
+        source: Path to the artifact to derive from.
+        level: The level it has to hold.
+
+    Returns:
+        Its stamps, which this artifact passes through.
+
+    Raises:
+        ValueError: If it is not a pivot, holds another level, or is stale.
+    """
+    stamps = base.load_stamps(source)
+    if stamps.artifact != pivot.ARTIFACT:
+        raise ValueError(f"{source} is a {stamps.artifact}, not a {pivot.ARTIFACT}")
+    held = pivot.pivot_path(source)
+    if held != level:
+        raise ValueError(
+            f"{source} holds the pivot over {held}, but the occurrences at this path "
+            f"are read from {level}"
+        )
+    if not base.stamps_are_current(stamps, pivot.ARTIFACT):
+        raise ValueError(
+            f"{source} is stale, and occurrences derived from it would claim a "
+            "provenance they do not have; derive the pivot again first"
+        )
+    return stamps
+
+
+def write_occurrences(
+    source: str | os.PathLike[str],
+    output: str | os.PathLike[str],
+    /,
+    *,
+    path: str,
+    source_md5: str | None = None,
+    source_dataset_id: str | None = None,
+    compression: str = "zstd",
+    row_group_size: int = 100_000,
+) -> int:
+    """Derives the occurrences at one indexed path from a pivot artifact.
+
+    Args:
+        source: The pivot over the level ``path`` ranges within.
+        output: Where to write.
+        path: The indexed path, which must be a key of ``PATHS``.
+        source_md5: The source dataset's hash; taken from ``source`` when unset.
+        source_dataset_id: The source dataset's ID; taken from ``source`` when unset.
+        compression: Parquet codec.
+        row_group_size: Rows per group.
+
+    Returns:
+        How many occurrences were written. Zero is ordinary -- most corpora record no
+        authentic standards -- and produces a valid empty file rather than none.
+
+    Raises:
+        ValueError: If ``path`` is not an indexed path, or if ``source`` is not a
+            current pivot over the level that path ranges within.
+    """
+    reached = PATHS.get(path)
+    if reached is None:
+        raise ValueError(
+            f"{path} is not a path this artifact covers, so it has nothing to hold. "
+            f"Known paths: {sorted(PATHS)}"
+        )
+    level, remainder = reached
+    parent = _check_pivot(source, level.path)
+    if source_md5 is None:
+        source_md5 = parent.source_md5
+    if source_dataset_id is None:
+        source_dataset_id = parent.source_dataset_id
+    stamps = base.current_stamps(ARTIFACT, source_dataset_id, source_md5)
+    metadata = base.to_metadata(stamps) | {META_OCCURRENCE_PATH: path}
+    target = SCHEMA.with_metadata(metadata)
+    connection = duckdb.connect()
+    written = 0
+    try:
+        # No row order to keep: a reader semi-joins this on reaction_id, and which
+        # occurrence came back first says nothing. Same trade the pivot makes.
+        connection.execute("SET preserve_insertion_order=false")
+        # Through the relational API rather than a path interpolated into SQL, which a
+        # filename holding a quote would otherwise close.
+        connection.read_parquet(str(pathlib.Path(source))).create_view("elements")
+        with (
+            atomic_io.atomic_path(output) as temp_path,
+            pq.ParquetWriter(temp_path, target, compression=compression) as writer,
+        ):
+            # A path with no occurrences writes no batches, and the writer's close still
+            # produces a valid zero-row file carrying the schema and stamps -- what a
+            # reader globs and finds nothing in, rather than a file that is missing.
+            reader = connection.execute(_select(level, remainder)).to_arrow_reader(
+                row_group_size
+            )
+            for batch in reader:
+                # Cast rather than trust: DuckDB's own widths are its business, and the
+                # artifact's schema is a promise to whoever reads it later.
+                writer.write_table(
+                    pa.Table.from_batches([batch])
+                    .cast(SCHEMA)
+                    .replace_schema_metadata(metadata)
+                )
+                written += batch.num_rows
+    finally:
+        connection.close()
+    logger.info("%s: %d occurrences at %s", source, written, path)
+    return written
+
+
+def occurrence_path(path: str | os.PathLike[str]) -> str | None:
+    """Returns the indexed path an artifact holds, or None if it holds none.
+
+    Args:
+        path: Path to a Parquet file.
+
+    Returns:
+        The dotted path stamped in the footer, or None if the file is not an
+        occurrences artifact.
+    """
+    metadata = pq.read_schema(path).metadata or {}
+    value = metadata.get(META_OCCURRENCE_PATH.encode())
+    return value.decode() if value is not None else None
+
+
+def artifact_paths(
+    occurrences_dir: str | os.PathLike[str], path: str
+) -> list[pathlib.Path]:
+    """Returns the artifacts a reader finds for one indexed path, in a stable order.
+
+    The one definition of what a path's artifacts are, for the same reason
+    ``pivot.artifact_paths`` is: a build judging its own output by a wider rule than a
+    reader applies calls a tree healthy that no corpus can read.
+
+    Recursive, because the tree mirrors the projections it descends from: a sharded
+    corpus puts its files under ``<path>/<shard>/`` rather than directly under the path.
+
+    Args:
+        occurrences_dir: The directory the indexed paths sit under.
+        path: The indexed path, as the query grammar names it.
+
+    Returns:
+        The paths, sorted. Empty if the path has no directory at all.
+    """
+    directory = pathlib.Path(occurrences_dir) / path
+    # Escaped, because only the last two segments are a pattern: a directory is a name
+    # someone chose, and one holding a bracket or a star would otherwise be read as a
+    # character class and match somewhere else, or nowhere.
+    return sorted(
+        pathlib.Path(found)
+        for found in glob.glob(
+            f"{glob.escape(str(directory))}/**/*.parquet", recursive=True
+        )
+    )

--- a/ord_schema/artifacts/occurrences_test.py
+++ b/ord_schema/artifacts/occurrences_test.py
@@ -160,13 +160,42 @@ def test_a_path_below_its_level_is_read_through_the_remainder(pivots, tmp_path):
     assert _rows(written) == [("ord-oc01", 4, None)]
 
 
-def test_a_level_the_source_never_recorded_writes_an_empty_artifact(pivots, tmp_path):
-    # Empty rather than missing: a reader globs a path and finds a file holding nothing,
-    # which is what a corpus recording no workups looks like from here.
-    for level in ("workups.input.components", "inputs.components"):
-        (pivots / level).exists()
+def test_a_workup_component_is_read_from_its_own_level(pivots, tmp_path):
     written = _derive(pivots, tmp_path, "workups.input.components")
     assert _rows(written) == [("ord-oc01", 2, "SOLVENT")]
+
+
+def test_a_path_the_source_never_recorded_writes_an_empty_artifact(tmp_path):
+    # Empty rather than missing: a reader globs a path and finds a file holding nothing
+    # but carrying the schema and the stamps, which is what a corpus recording no
+    # workups looks like from here. A missing file is a path a reader cannot tell from
+    # one nobody derived.
+    reaction = reaction_pb2.Reaction(reaction_id="ord-oc03")
+    _component(reaction.inputs["in"], "CCO", _ROLE.REACTANT)
+    source = tmp_path / "ord_dataset-oc3.parquet"
+    parquet.save_dataset(
+        dataset_pb2.Dataset(
+            dataset_id="ord_dataset-oc3",
+            name="test",
+            description="test",
+            reactions=[reaction],
+        ),
+        str(source),
+    )
+    projected = tmp_path / "projection.parquet"
+    projection.write_projection(source, projected)
+    pivoted = tmp_path / "pivot.parquet"
+    pivot.write_pivot(projected, pivoted, level_path="workups.input.components")
+    assert pq.read_metadata(pivoted).num_rows == 0
+    written = tmp_path / "occurrences.parquet"
+    assert (
+        occurrences.write_occurrences(pivoted, written, path="workups.input.components")
+        == 0
+    )
+    assert written.exists()
+    assert pq.read_metadata(written).num_rows == 0
+    assert pq.read_schema(written).remove_metadata() == occurrences.SCHEMA
+    assert occurrences.occurrence_path(written) == "workups.input.components"
 
 
 def test_the_artifact_carries_the_schema_it_promises(pivots, tmp_path):

--- a/ord_schema/artifacts/occurrences_test.py
+++ b/ord_schema/artifacts/occurrences_test.py
@@ -1,0 +1,255 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.artifacts.occurrences."""
+
+import pathlib
+import shutil
+
+import pyarrow.parquet as pq
+import pytest
+
+from ord_schema import parquet
+from ord_schema.artifacts import base, occurrences, pivot, projection, structures
+from ord_schema.proto import dataset_pb2, reaction_pb2
+
+_ROLE = reaction_pb2.ReactionRole.ReactionRoleType
+
+
+def _component(reaction_input, smiles: str, role) -> None:
+    component = reaction_input.components.add(reaction_role=role)
+    component.identifiers.add(type="SMILES", value=smiles)
+
+
+@pytest.fixture(scope="module")
+def projected(tmp_path_factory) -> pathlib.Path:
+    """A projection carrying a structure at every indexed path, and one at none.
+
+    The second reaction has inputs and nothing else, so the deeper paths are what the
+    projection writes for a level the source never recorded. The third component of the
+    first reaction carries no identifier at all, which is the element a pivot holds a
+    row for and this artifact must not.
+    """
+    reaction = reaction_pb2.Reaction(reaction_id="ord-oc01")
+    _component(reaction.inputs["in"], "CCO", _ROLE.REACTANT)
+    _component(reaction.inputs["in"], "c1ccncc1", _ROLE.SOLVENT)
+    reaction.inputs["in"].components.add(reaction_role=_ROLE.CATALYST)
+    _component(reaction.workups.add(type="EXTRACTION").input, "CCOCC", _ROLE.SOLVENT)
+    product = reaction.outcomes.add().products.add()
+    product.identifiers.add(type="SMILES", value="Cc1ccccc1")
+    standard = product.measurements.add(analysis_key="nmr").authentic_standard
+    standard.identifiers.add(type="SMILES", value="c1ccccc1")
+    shallow = reaction_pb2.Reaction(reaction_id="ord-oc02")
+    _component(shallow.inputs["in"], "CCO", _ROLE.REACTANT)
+    root = tmp_path_factory.mktemp("occurrences")
+    source = root / "ord_dataset-oc.parquet"
+    parquet.save_dataset(
+        dataset_pb2.Dataset(
+            dataset_id="ord_dataset-oc",
+            name="test",
+            description="test",
+            reactions=[reaction, shallow],
+        ),
+        str(source),
+    )
+    output = root / "projection.parquet"
+    projection.write_projection(source, output)
+    return output
+
+
+@pytest.fixture(scope="module")
+def pivots(projected, tmp_path_factory) -> pathlib.Path:
+    """A pivot per level the indexed paths are read from."""
+    root = tmp_path_factory.mktemp("pivots")
+    for level in {level.path for level, _ in occurrences.PATHS.values()}:
+        target = root / level / projected.name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        pivot.write_pivot(projected, target, level_path=level)
+    return root
+
+
+def _rows(path: pathlib.Path) -> list[tuple]:
+    table = pq.read_table(path)
+    return sorted(
+        zip(
+            *(table.column(name).to_pylist() for name in table.schema.names),
+            strict=True,
+        )
+    )
+
+
+def _derive(pivots: pathlib.Path, into: pathlib.Path, path: str) -> pathlib.Path:
+    level = occurrences.PATHS[path][0].path
+    source = next((pivots / level).glob("*.parquet"))
+    target = into / path / source.name
+    target.parent.mkdir(parents=True, exist_ok=True)
+    occurrences.write_occurrences(source, target, path=path)
+    return target
+
+
+# What the artifact covers
+
+
+def test_the_covered_paths_are_the_structure_bearing_ones():
+    # Walked rather than listed, so a compound field added upstream is covered wherever
+    # it lands. A path dropped here is one whose structures no query can find, which
+    # reads as a corpus holding none of them.
+    walked = {path for _, path, _ in structures.structure_levels()}
+    assert set(occurrences.PATHS) == walked
+
+
+def test_a_path_is_read_from_the_level_it_ranges_within():
+    # Three of the four name a repeated level of their own; the authentic standard is
+    # one compound per measurement, so it is reached through the remainder.
+    level, remainder = occurrences.PATHS["inputs.components"]
+    assert (level.path, remainder) == ("inputs.components", ())
+    level, remainder = occurrences.PATHS[
+        "outcomes.products.measurements.authentic_standard"
+    ]
+    assert (level.path, remainder) == (
+        "outcomes.products.measurements",
+        ("authentic_standard",),
+    )
+
+
+# Derivation
+
+
+def test_an_occurrence_carries_the_reaction_the_structure_and_the_role(
+    pivots, tmp_path
+):
+    written = _derive(pivots, tmp_path, "inputs.components")
+    assert _rows(written) == [
+        ("ord-oc01", 0, "REACTANT"),
+        ("ord-oc01", 1, "SOLVENT"),
+        ("ord-oc02", 0, "REACTANT"),
+    ]
+
+
+def test_an_element_carrying_no_structure_is_no_occurrence(pivots, tmp_path):
+    # The pivot is complete -- every element gets a row, including one whose fields are
+    # all NULL -- and this is not: a row with no structure_id would join to no molecule
+    # and count against the structures the index has to reach.
+    level = occurrences.PATHS["inputs.components"][0].path
+    source = next((pivots / level).glob("*.parquet"))
+    assert pq.read_metadata(source).num_rows == 4
+    written = _derive(pivots, tmp_path, "inputs.components")
+    assert pq.read_metadata(written).num_rows == 3
+
+
+def test_a_path_below_its_level_is_read_through_the_remainder(pivots, tmp_path):
+    # The authentic standard sits inside the measurement's element rather than being an
+    # element of its own, so this is the one path whose read is not the level itself.
+    # Its role is NULL, which is what the source records: a standard is named to
+    # identify a peak rather than to play a part in the reaction, so a role-bound query
+    # over this path matches nothing, and that is the right answer.
+    written = _derive(
+        pivots, tmp_path, "outcomes.products.measurements.authentic_standard"
+    )
+    assert _rows(written) == [("ord-oc01", 4, None)]
+
+
+def test_a_level_the_source_never_recorded_writes_an_empty_artifact(pivots, tmp_path):
+    # Empty rather than missing: a reader globs a path and finds a file holding nothing,
+    # which is what a corpus recording no workups looks like from here.
+    for level in ("workups.input.components", "inputs.components"):
+        (pivots / level).exists()
+    written = _derive(pivots, tmp_path, "workups.input.components")
+    assert _rows(written) == [("ord-oc01", 2, "SOLVENT")]
+
+
+def test_the_artifact_carries_the_schema_it_promises(pivots, tmp_path):
+    written = _derive(pivots, tmp_path, "inputs.components")
+    assert pq.read_schema(written).remove_metadata() == occurrences.SCHEMA
+
+
+def test_the_artifact_names_the_path_it_holds(pivots, tmp_path):
+    written = _derive(pivots, tmp_path, "outcomes.products")
+    assert occurrences.occurrence_path(written) == "outcomes.products"
+
+
+def test_a_file_that_is_not_this_artifact_names_no_path(projected):
+    assert occurrences.occurrence_path(projected) is None
+
+
+def test_the_source_dataset_is_passed_through_rather_than_rehashed(pivots, tmp_path):
+    # Every artifact derived from a dataset names that dataset, however many
+    # derivations away it sits, so one comparison answers "is this current for it?"
+    level = occurrences.PATHS["inputs.components"][0].path
+    source = next((pivots / level).glob("*.parquet"))
+    written = _derive(pivots, tmp_path, "inputs.components")
+    assert base.load_stamps(written).source_md5 == base.load_stamps(source).source_md5
+    assert base.load_stamps(written).artifact == occurrences.ARTIFACT
+
+
+# What it refuses
+
+
+def test_a_path_the_schema_carries_no_structure_at_is_refused(pivots, tmp_path):
+    level = occurrences.PATHS["inputs.components"][0].path
+    source = next((pivots / level).glob("*.parquet"))
+    with pytest.raises(ValueError, match="not a path this artifact covers"):
+        occurrences.write_occurrences(source, tmp_path / "x.parquet", path="workups")
+
+
+def test_a_parent_that_is_not_a_pivot_is_refused(projected, tmp_path):
+    # A projection holds the same elements nested, so deriving from one would produce
+    # something -- against a schema walk this module does not do.
+    with pytest.raises(ValueError, match="is a projection, not a pivot"):
+        occurrences.write_occurrences(
+            projected, tmp_path / "x.parquet", path="inputs.components"
+        )
+
+
+def test_a_pivot_over_another_level_is_refused(pivots, tmp_path):
+    # The rows would be the wrong elements, and every column this reads exists on both.
+    source = next((pivots / "outcomes.products").glob("*.parquet"))
+    with pytest.raises(ValueError, match=r"holds the pivot over outcomes\.products"):
+        occurrences.write_occurrences(
+            source, tmp_path / "x.parquet", path="inputs.components"
+        )
+
+
+def test_a_stale_pivot_is_refused(pivots, tmp_path):
+    # The stamps are the only thing saying an artifact was written by the library
+    # reading it, and occurrences derived from a stale one would claim its provenance.
+    level = occurrences.PATHS["inputs.components"][0].path
+    source = next((pivots / level).glob("*.parquet"))
+    staled = tmp_path / "stale.parquet"
+    table = pq.read_table(source)
+    metadata = dict(table.schema.metadata)
+    metadata[b"ord.rdkit_version"] = b"0000.00.0"
+    pq.write_table(table.replace_schema_metadata(metadata), staled)
+    with pytest.raises(ValueError, match="is stale"):
+        occurrences.write_occurrences(
+            staled, tmp_path / "x.parquet", path="inputs.components"
+        )
+
+
+# Finding them
+
+
+def test_artifacts_are_found_beneath_a_shard_directory(pivots, tmp_path):
+    # The tree mirrors the projections it descends from, so a sharded corpus puts them
+    # a directory deeper and a reader that does not descend finds nothing.
+    written = _derive(pivots, tmp_path, "inputs.components")
+    sharded = tmp_path / "sharded" / "inputs.components" / "aa"
+    sharded.mkdir(parents=True)
+    shutil.copy(written, sharded / written.name)
+    found = occurrences.artifact_paths(tmp_path / "sharded", "inputs.components")
+    assert [path.name for path in found] == [written.name]
+
+
+def test_a_path_with_no_directory_has_no_artifacts(tmp_path):
+    assert occurrences.artifact_paths(tmp_path, "inputs.components") == []

--- a/ord_schema/artifacts/scripts/derive_occurrences.py
+++ b/ord_schema/artifacts/scripts/derive_occurrences.py
@@ -179,12 +179,18 @@ def main(args: argparse.Namespace) -> None:
         raise ValueError("--pivots_dir and --output_dir are both required")
     for path in paths:
         level = occurrences.PATHS[path][0].path
-        pattern = f"{pathlib.Path(args.pivots_dir) / level}/**/*.parquet"
+        # --pivots_dir is a directory someone named, not a pattern they wrote, so a
+        # bracket or a star in it is part of the name: escaped, it matches that tree
+        # rather than a sibling fitting the character class. The root goes separately
+        # because glob_root reads the escape as the wildcard it is spelled with, and
+        # would stop the mirror short of it.
+        root = pathlib.Path(args.pivots_dir) / level
+        pattern = f"{glob.escape(str(root))}/**/*.parquet"
         directory = pathlib.Path(args.output_dir) / path
         # Globbed exactly as derive_tree will glob it, rather than through
-        # pivot.artifact_paths, which escapes the directory it is handed: a check that
-        # finds pivots the derivation then cannot would turn this friendly message into
-        # derive_tree's report of an empty pattern.
+        # pivot.artifact_paths: a check that finds pivots the derivation then cannot
+        # would turn this friendly message into derive_tree's report of an empty
+        # pattern.
         if not glob.glob(pattern, recursive=True):
             raise ValueError(
                 f"no pivots over {level} under {args.pivots_dir}, so there are no "
@@ -199,6 +205,7 @@ def main(args: argparse.Namespace) -> None:
             schema=occurrences.SCHEMA,
             force=args.force,
             parent_artifact=pivot.ARTIFACT,
+            root=root,
         )
         if not written and not skipped:
             raise ValueError(
@@ -206,7 +213,7 @@ def main(args: argparse.Namespace) -> None:
                 f"{pattern!r} are pivots over {level}. Derive them first with "
                 f"derive_pivots.py --levels {level}"
             )
-        artifacts, empty, mismatched = _audit(args.output_dir, path)
+        found, empty, mismatched = _audit(args.output_dir, path)
         for name, held in mismatched:
             logger.error("%s: holds %s, not %s", name, held or "no path", path)
         if mismatched:
@@ -221,7 +228,6 @@ def main(args: argparse.Namespace) -> None:
                 f"path; they are current for {path} by every other measure and would "
                 "answer its quantifiers with the wrong elements"
             )
-        found = artifacts
         logger.info(
             "%s: %d written, %d already current, %d of %d artifacts empty",
             path,

--- a/ord_schema/artifacts/scripts/derive_occurrences.py
+++ b/ord_schema/artifacts/scripts/derive_occurrences.py
@@ -1,0 +1,193 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Derives occurrence artifacts from pivots, one per structure-bearing path.
+
+A structure query finds the reactions holding a match by semi-joining a relation of one
+row per structure occurrence; see ``ord_schema.artifacts.occurrences`` for the shape and
+why it holds dataset-local IDs. Built in process that relation is 1.19 GiB and a minute
+over ORD, and wants several gigabytes of DuckDB memory to assemble, so it belongs here.
+
+Each indexed path gets its own subdirectory, mirroring the pivots it descends from::
+
+    derive_occurrences.py --pivots_dir=pivots --output_dir=occurrences
+
+    pivots/inputs.components/aa/ord_dataset-<id>.parquet
+        -> occurrences/inputs.components/aa/ord_dataset-<id>.parquet
+    pivots/outcomes.products.measurements/aa/ord_dataset-<id>.parquet
+        -> occurrences/outcomes.products.measurements.authentic_standard/aa/...
+
+Which paths those are is not a choice: a corpus checks that its index reaches every
+structure it holds, so a tree missing one leaves structures no query can find. Deriving
+a subset with --paths is for rebuilding one, not for choosing what to carry.
+
+The pivots for the levels those paths range within have to exist first --
+``derive_pivots.py --levels`` names them, and ``--print_levels`` here prints exactly
+that list. Deriving from the pivot rather than from the projection is what keeps the two
+from disagreeing about which elements exist: the occurrences are that artifact projected
+down to three columns.
+
+Artifacts whose footer already records the current source content, library version, and
+artifact version are skipped, so re-running is cheap; --force rewrites them anyway.
+
+These are errors: an --output_dir that would write over any input, a path this schema
+does not carry a structure at, a pivot that is stale or holds another level, and a run
+that finds no pivots for a path at all.
+"""
+
+import argparse
+import functools
+import pathlib
+
+from ord_schema.artifacts import base, occurrences, pivot
+from ord_schema.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parses command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--pivots_dir", help="Directory holding the pivot artifacts to derive from"
+    )
+    parser.add_argument("--output_dir", help="Directory to write artifacts beneath")
+    parser.add_argument(
+        "--paths",
+        nargs="+",
+        default=sorted(occurrences.PATHS),
+        help="Indexed paths to derive; every one the schema carries by default",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Rewrite artifacts that are already current",
+    )
+    parser.add_argument(
+        "--print_levels",
+        action="store_true",
+        help="Print the pivot levels these paths need, for derive_pivots --levels",
+    )
+    return parser.parse_args(argv)
+
+
+def check_paths(paths: list[str]) -> list[str]:
+    """Returns the requested paths, refusing any this artifact does not cover.
+
+    Args:
+        paths: The paths asked for.
+
+    Returns:
+        Them, deduplicated and sorted.
+
+    Raises:
+        ValueError: If a path is not one the schema carries a structure at, or is named
+            twice -- which would derive it twice and report the second as already
+            current.
+    """
+    unknown = sorted(set(paths) - set(occurrences.PATHS))
+    if unknown:
+        raise ValueError(
+            f"no structure sits at {unknown}, so there are no occurrences to derive "
+            f"there. Known paths: {sorted(occurrences.PATHS)}"
+        )
+    repeated = sorted({path for path in paths if paths.count(path) > 1})
+    if repeated:
+        raise ValueError(f"named more than once: {repeated}")
+    return sorted(set(paths))
+
+
+def levels_for(paths: list[str]) -> list[str]:
+    """Returns the pivot levels the given paths are read from.
+
+    Args:
+        paths: Indexed paths, already checked.
+
+    Returns:
+        The levels, deduplicated and sorted, as ``derive_pivots --levels`` takes them.
+    """
+    return sorted({occurrences.PATHS[path][0].path for path in paths})
+
+
+def main(args: argparse.Namespace) -> None:
+    """Derives the occurrences at each requested path.
+
+    Args:
+        args: Parsed command-line arguments.
+
+    Raises:
+        ValueError: If a requested path is not one the schema carries a structure at or
+            is named twice; if a pivot is stale or holds another level; or if a path's
+            level has no pivots at all -- which usually means they have not been derived
+            yet, and would otherwise leave a tree a corpus refuses for reaching too few
+            structures.
+    """
+    paths = check_paths(args.paths)
+    if args.print_levels:
+        print(" ".join(levels_for(paths)))
+        return
+    if not args.pivots_dir or not args.output_dir:
+        raise ValueError("--pivots_dir and --output_dir are both required")
+    for path in paths:
+        level = occurrences.PATHS[path][0].path
+        # Escaped for the same reason artifact_paths escapes: only the last segments
+        # are a pattern, and a shard directory holding a bracket is a name, not a class.
+        pattern = f"{pathlib.Path(args.pivots_dir) / level}/**/*.parquet"
+        directory = pathlib.Path(args.output_dir) / path
+        if not pivot.artifact_paths(args.pivots_dir, level):
+            # Said here rather than left to derive_tree, which reports an empty glob
+            # against the pattern it was handed and cannot know what would fill it.
+            raise ValueError(
+                f"no pivots over {level} under {args.pivots_dir}, so there are no "
+                f"occurrences to derive for {path}. Derive them first with "
+                f"derive_pivots.py --levels {level}"
+            )
+        written, skipped, ignored = base.derive_tree(
+            pattern,
+            str(directory),
+            artifact=occurrences.ARTIFACT,
+            write=functools.partial(occurrences.write_occurrences, path=path),
+            schema=occurrences.SCHEMA,
+            force=args.force,
+            parent_artifact=pivot.ARTIFACT,
+        )
+        if not written and not skipped:
+            raise ValueError(
+                f"no occurrences derived for {path}: none of the {ignored} matches for "
+                f"{pattern!r} are pivots over {level}. Derive them first with "
+                f"derive_pivots.py --levels {level}"
+            )
+        found = len(occurrences.artifact_paths(args.output_dir, path))
+        logger.info(
+            "%s: %d written, %d already current, %d artifacts",
+            path,
+            written,
+            skipped,
+            found,
+        )
+        if found < written + skipped:
+            # Every artifact this run wrote or found current, and a reader cannot list
+            # them all, so some went where nothing looks and the tree is not the one a
+            # corpus will read.
+            raise ValueError(
+                f"{directory} holds {found} occurrence artifacts for {path}, fewer "
+                f"than the {written + skipped} this run wrote or found current; the "
+                "rest are where no reader looks"
+            )
+
+
+if __name__ == "__main__":
+    main(parse_args())

--- a/ord_schema/artifacts/scripts/derive_occurrences.py
+++ b/ord_schema/artifacts/scripts/derive_occurrences.py
@@ -48,7 +48,10 @@ that finds no pivots for a path at all.
 
 import argparse
 import functools
+import glob
 import pathlib
+
+import pyarrow.parquet as pq
 
 from ord_schema.artifacts import base, occurrences, pivot
 from ord_schema.logging import get_logger
@@ -122,6 +125,39 @@ def levels_for(paths: list[str]) -> list[str]:
     return sorted({occurrences.PATHS[path][0].path for path in paths})
 
 
+def _audit(
+    output_dir: str, path: str
+) -> tuple[int, list[str], list[tuple[str, str | None]]]:
+    """Reads back what a reader would find for one path, and says what is wrong with it.
+
+    Taken over exactly the files ``occurrences.artifact_paths`` lists, which is what a
+    corpus reads: a report over any other set describes a tree nobody queries. Rows come
+    from the Parquet footers rather than being tallied as the run writes, so the answer
+    covers artifacts this run skipped as already current, and a re-run says what the run
+    that built them said.
+
+    Args:
+        output_dir: The directory the paths sit under.
+        path: The indexed path to audit.
+
+    Returns:
+        How many artifacts a reader finds, which of them hold no rows, and which are
+        stamped with a path other than this one -- the last carrying what each holds,
+        which is None for a file that is not an occurrences artifact at all.
+    """
+    empty: list[str] = []
+    mismatched: list[tuple[str, str | None]] = []
+    found = occurrences.artifact_paths(output_dir, path)
+    for artifact in found:
+        held = occurrences.occurrence_path(artifact)
+        if held != path:
+            mismatched.append((str(artifact), held))
+            continue
+        if not pq.read_metadata(artifact).num_rows:
+            empty.append(str(artifact))
+    return len(found), empty, mismatched
+
+
 def main(args: argparse.Namespace) -> None:
     """Derives the occurrences at each requested path.
 
@@ -143,13 +179,13 @@ def main(args: argparse.Namespace) -> None:
         raise ValueError("--pivots_dir and --output_dir are both required")
     for path in paths:
         level = occurrences.PATHS[path][0].path
-        # Escaped for the same reason artifact_paths escapes: only the last segments
-        # are a pattern, and a shard directory holding a bracket is a name, not a class.
         pattern = f"{pathlib.Path(args.pivots_dir) / level}/**/*.parquet"
         directory = pathlib.Path(args.output_dir) / path
-        if not pivot.artifact_paths(args.pivots_dir, level):
-            # Said here rather than left to derive_tree, which reports an empty glob
-            # against the pattern it was handed and cannot know what would fill it.
+        # Globbed exactly as derive_tree will glob it, rather than through
+        # pivot.artifact_paths, which escapes the directory it is handed: a check that
+        # finds pivots the derivation then cannot would turn this friendly message into
+        # derive_tree's report of an empty pattern.
+        if not glob.glob(pattern, recursive=True):
             raise ValueError(
                 f"no pivots over {level} under {args.pivots_dir}, so there are no "
                 f"occurrences to derive for {path}. Derive them first with "
@@ -170,14 +206,41 @@ def main(args: argparse.Namespace) -> None:
                 f"{pattern!r} are pivots over {level}. Derive them first with "
                 f"derive_pivots.py --levels {level}"
             )
-        found = len(occurrences.artifact_paths(args.output_dir, path))
+        artifacts, empty, mismatched = _audit(args.output_dir, path)
+        for name, held in mismatched:
+            logger.error("%s: holds %s, not %s", name, held or "no path", path)
+        if mismatched:
+            # Every indexed path writes the same three columns, so a file filed under
+            # the wrong one passes the currency check: same artifact name, same source
+            # hash, same versions, same columns. It is then skipped by every later run
+            # and read as this path's occurrences ever after, answering a quantifier
+            # with another level's elements. The stamped path is the only thing that
+            # tells them apart, and this is the only place that reads it.
+            raise ValueError(
+                f"{directory} holds {len(mismatched)} artifacts stamped with another "
+                f"path; they are current for {path} by every other measure and would "
+                "answer its quantifiers with the wrong elements"
+            )
+        found = artifacts
         logger.info(
-            "%s: %d written, %d already current, %d artifacts",
+            "%s: %d written, %d already current, %d of %d artifacts empty",
             path,
             written,
             skipped,
+            len(empty),
             found,
         )
+        if len(empty) < found:
+            # Named one by one where only some are empty, which is the shape worth
+            # looking at. Where all of them are, the warning below says so once.
+            for name in empty:
+                logger.info("%s: no occurrences at %s", name, path)
+        elif found:
+            # Ordinary for a path nothing in this corpus records -- most corpora have no
+            # authentic standards -- and identical on disk to a derivation that filtered
+            # wrongly: an empty artifact is stamped current like any other, so no later
+            # run revisits it and no reader tells the two apart.
+            logger.warning("%s: every artifact is empty at this path", path)
         if found < written + skipped:
             # Every artifact this run wrote or found current, and a reader cannot list
             # them all, so some went where nothing looks and the tree is not the one a

--- a/ord_schema/artifacts/scripts/derive_occurrences_test.py
+++ b/ord_schema/artifacts/scripts/derive_occurrences_test.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Open Reaction Database Project Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ord_schema.artifacts.scripts.derive_occurrences."""
+
+import pathlib
+
+import pyarrow.parquet as pq
+import pytest
+
+from ord_schema import parquet
+from ord_schema.artifacts import occurrences, pivot, projection
+from ord_schema.artifacts.scripts import derive_occurrences
+from ord_schema.proto import dataset_pb2, reaction_pb2
+
+_ROLE = reaction_pb2.ReactionRole.ReactionRoleType
+
+
+@pytest.fixture
+def pivots(tmp_path) -> pathlib.Path:
+    """Pivots over every level the indexed paths are read from, in two shards."""
+    root = tmp_path / "pivots"
+    for shard in ("aa", "bb"):
+        reaction = reaction_pb2.Reaction(reaction_id=f"ord-{shard}01")
+        component = reaction.inputs["in"].components.add(reaction_role=_ROLE.SOLVENT)
+        component.identifiers.add(type="SMILES", value="CCO")
+        source = tmp_path / "data" / shard / f"ord_dataset-{shard}.parquet"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        parquet.save_dataset(
+            dataset_pb2.Dataset(
+                dataset_id=f"ord_dataset-{shard}",
+                name="test",
+                description="test",
+                reactions=[reaction],
+            ),
+            str(source),
+        )
+        projected = tmp_path / "projections" / shard / source.name
+        projected.parent.mkdir(parents=True, exist_ok=True)
+        projection.write_projection(source, projected)
+        for level in {level.path for level, _ in occurrences.PATHS.values()}:
+            target = root / level / shard / source.name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            pivot.write_pivot(projected, target, level_path=level)
+    return root
+
+
+def _run(pivots: pathlib.Path, output: pathlib.Path, *extra: str) -> None:
+    derive_occurrences.main(
+        derive_occurrences.parse_args(
+            [f"--pivots_dir={pivots}", f"--output_dir={output}", *extra]
+        )
+    )
+
+
+def test_a_run_covers_every_path_and_mirrors_the_shards(pivots, tmp_path):
+    # The layout is a contract with whatever reads it: a corpus globs a path's
+    # directory recursively, so a file written anywhere else is one it cannot find.
+    output = tmp_path / "occurrences"
+    _run(pivots, output)
+    for path in occurrences.PATHS:
+        found = occurrences.artifact_paths(output, path)
+        assert [artifact.parent.name for artifact in found] == ["aa", "bb"], path
+    held = occurrences.artifact_paths(output, "inputs.components")
+    assert sum(pq.read_metadata(artifact).num_rows for artifact in held) == 2
+
+
+def test_a_second_run_writes_nothing(pivots, tmp_path, caplog):
+    # Stamps say an artifact is current for its source, so a re-run over an unchanged
+    # tree is footer reads. An interrupted run is finished by the next rather than
+    # started again.
+    output = tmp_path / "occurrences"
+    _run(pivots, output)
+    with caplog.at_level("INFO"):
+        _run(pivots, output)
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("0 written, 2 already current" in message for message in messages)
+
+
+def test_forcing_rewrites_what_is_current(pivots, tmp_path, caplog):
+    output = tmp_path / "occurrences"
+    _run(pivots, output)
+    with caplog.at_level("INFO"):
+        _run(pivots, output, "--force")
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("2 written, 0 already current" in message for message in messages)
+
+
+def test_a_path_the_schema_carries_no_structure_at_is_refused(pivots, tmp_path):
+    with pytest.raises(ValueError, match="no structure sits at"):
+        _run(pivots, tmp_path / "occurrences", "--paths", "workups")
+
+
+def test_a_path_named_twice_is_refused(pivots, tmp_path):
+    # Deriving it twice would report the second pass as already current, which reads
+    # like a tree that was half up to date.
+    with pytest.raises(ValueError, match="named more than once"):
+        _run(
+            pivots,
+            tmp_path / "occurrences",
+            "--paths",
+            "inputs.components",
+            "inputs.components",
+        )
+
+
+def test_a_level_with_no_pivots_is_refused_rather_than_left_empty(tmp_path):
+    # The silent case: a path with no artifacts leaves the structures sitting only
+    # there reachable by no query, and a corpus reading the tree refuses it for having
+    # lost them -- minutes into a load rather than here.
+    with pytest.raises(ValueError, match="Derive them first with derive_pivots"):
+        _run(tmp_path / "empty", tmp_path / "occurrences")
+
+
+def test_the_levels_to_derive_first_are_printed(capsys):
+    # The pivots have to exist before this script can read them, and which levels those
+    # are is not obvious from the paths: three name a level of their own and the
+    # authentic standard is read from the measurements'.
+    derive_occurrences.main(derive_occurrences.parse_args(["--print_levels"]))
+    printed = capsys.readouterr().out.split()
+    assert printed == sorted({level.path for level, _ in occurrences.PATHS.values()})

--- a/ord_schema/artifacts/scripts/derive_occurrences_test.py
+++ b/ord_schema/artifacts/scripts/derive_occurrences_test.py
@@ -15,6 +15,7 @@
 """Tests for ord_schema.artifacts.scripts.derive_occurrences."""
 
 import pathlib
+import shutil
 
 import pyarrow.parquet as pq
 import pytest
@@ -130,3 +131,35 @@ def test_the_levels_to_derive_first_are_printed(capsys):
     derive_occurrences.main(derive_occurrences.parse_args(["--print_levels"]))
     printed = capsys.readouterr().out.split()
     assert printed == sorted({level.path for level, _ in occurrences.PATHS.values()})
+
+
+def test_an_artifact_filed_under_another_path_is_refused(pivots, tmp_path):
+    # Every path writes the same three columns, so a file copied from one to another
+    # passes the currency check on every measure it has -- artifact name, source hash,
+    # versions, columns -- and is skipped by every later run, answering that path's
+    # quantifiers with another level's elements. The stamped path is the only thing
+    # that tells them apart.
+    output = tmp_path / "occurrences"
+    _run(pivots, output)
+    stranger = occurrences.artifact_paths(output, "inputs.components")[0]
+    shutil.copy(stranger, output / "outcomes.products" / "aa" / stranger.name)
+    with pytest.raises(ValueError, match="stamped with another path"):
+        _run(pivots, output)
+
+
+def test_a_path_whose_artifacts_all_hold_nothing_warns(pivots, tmp_path, caplog):
+    # Ordinary for a path nothing in the corpus records, and identical on disk to a
+    # derivation that filtered wrongly: an empty artifact is stamped current like any
+    # other, so no later run revisits it and no reader tells the two apart.
+    output = tmp_path / "occurrences"
+    with caplog.at_level("WARNING"):
+        _run(pivots, output, "--paths", "workups.input.components")
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("every artifact is empty at this path" in m for m in messages)
+
+
+def test_a_path_holding_rows_does_not_warn(pivots, tmp_path, caplog):
+    output = tmp_path / "occurrences"
+    with caplog.at_level("WARNING"):
+        _run(pivots, output, "--paths", "inputs.components")
+    assert not [record.getMessage() for record in caplog.records]

--- a/ord_schema/artifacts/scripts/derive_occurrences_test.py
+++ b/ord_schema/artifacts/scripts/derive_occurrences_test.py
@@ -163,3 +163,29 @@ def test_a_path_holding_rows_does_not_warn(pivots, tmp_path, caplog):
     with caplog.at_level("WARNING"):
         _run(pivots, output, "--paths", "inputs.components")
     assert not [record.getMessage() for record in caplog.records]
+
+
+def test_a_pivots_dir_named_with_a_glob_metacharacter_is_read_literally(
+    pivots, tmp_path
+):
+    # A directory is a name someone chose, not a pattern they wrote. Read as a pattern,
+    # "pivots[1]" is the character class matching "pivots1", so the run derives from
+    # whatever sits there -- completely, and without saying it went somewhere else --
+    # while the tree the operator named is never opened.
+    named = tmp_path / "pivots[1]"
+    pivots.rename(named)
+    decoy = tmp_path / "pivots1"
+    shutil.copytree(named, decoy)
+    for level in decoy.iterdir():
+        shutil.rmtree(level / "bb")
+    output = tmp_path / "occurrences"
+    _run(named, output)
+    for path in occurrences.PATHS:
+        found = occurrences.artifact_paths(output, path)
+        # Both shards, each exactly one directory below its own: the mirror is rooted at
+        # the level's directory, rather than at the prefix of the name that a glob stops
+        # reading at, which lands the sources' whole layout a second time underneath.
+        assert [artifact.relative_to(output / path).parts for artifact in found] == [
+            ("aa", "ord_dataset-aa.parquet"),
+            ("bb", "ord_dataset-bb.parquet"),
+        ], path

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -100,7 +100,13 @@ from rdkit import Chem, DataStructs
 from rdkit.Chem import rdSubstructLibrary
 
 from ord_schema import resolvers
-from ord_schema.artifacts import base, pivot, projection, structures
+from ord_schema.artifacts import (
+    base,
+    occurrences,
+    pivot,
+    projection,
+    structures,
+)
 from ord_schema.logging import get_logger
 from ord_schema.search import query
 
@@ -415,19 +421,22 @@ _NO_BITS = DataStructs.ExplicitBitVect(structures.PATTERN_FP_SIZE)
 
 # The one element field the occurrence index carries besides the structure. A query
 # binding anything else to the element runs against the projection instead.
-_INDEXED_FIELD = "reaction_role"
+# Read from the artifact rather than restated, so the column the index filters on and
+# the column an occurrences artifact carries cannot come apart.
+_INDEXED_FIELD = occurrences.INDEXED_FIELD
 
 
 def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
     """Returns the paths an occurrence index covers, mapped to their traversals.
 
-    Taken from the same schema walk the structures artifact is built from and resolved
-    through the compiler, so the index reaches the elements the projection does by
-    construction rather than by a list here agreeing with one there.
+    Which paths those are is ``occurrences.indexed_paths``, so the compiler routes a
+    quantifier to the index exactly where an artifact carries the rows to answer it. Two
+    walks of the schema would be two answers waiting to disagree, and the disagreement
+    is silent: a path routed here that no artifact holds is a quantifier answered from
+    nothing.
 
-    Every path the schema can carry a structure at has to come out covered, which is
-    what lets the build check what it indexed against what the corpus says it holds. A
-    path this walk dropped would make a whole corpus look like one that lost structures.
+    What this adds is the traversal, which only the compiler knows -- the expression
+    unnesting the level out of the projection, for the paths no artifact covers.
 
     Args:
         schema: The projection schema.
@@ -437,31 +446,20 @@ def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
         level whose elements carry a structure.
 
     Raises:
-        ValueError: If a structure-bearing level carries no ``_INDEXED_FIELD`` or does
-            not resolve to a repeated expression, so the index cannot cover it; or if
-            the schema carries no structure at all. Raised at import, naming the path,
-            because the answer is to change this module rather than to retry.
+        ValueError: If a structure-bearing path does not resolve to a repeated
+            expression, so the build cannot unnest it; or whatever
+            ``occurrences.indexed_paths`` refuses. Raised at import, naming the path,
+            because the answer is to change one of these modules rather than to retry.
     """
     paths: dict[str, str] = {}
-    for _, path, dtype in structures.structure_levels(schema):
+    for path in occurrences.indexed_paths(schema):
         resolved = query.resolve(path, schema=schema, allow_internal=True)
-        if _INDEXED_FIELD not in [field.name for field in dtype]:
-            raise ValueError(
-                f"{path} carries a structure but no {_INDEXED_FIELD}, so the "
-                "occurrence index cannot cover it and a structure sitting only "
-                "there would look like one the index lost"
-            )
         if not resolved.repeated:
             raise ValueError(
                 f"{path} carries a structure but resolves to one element rather than "
                 "a repeated expression, which the build cannot unnest"
             )
         paths[path] = resolved.expression
-    if not paths:
-        raise ValueError(
-            "the schema carries no structure at any path, so an occurrence index has "
-            "nothing to index and its build would assemble no SQL at all"
-        )
     return paths
 
 

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -420,9 +420,9 @@ _UNPARSEABLE = Chem.Mol().ToBinary()
 _NO_BITS = DataStructs.ExplicitBitVect(structures.PATTERN_FP_SIZE)
 
 # The one element field the occurrence index carries besides the structure. A query
-# binding anything else to the element runs against the projection instead.
-# Read from the artifact rather than restated, so the column the index filters on and
-# the column an occurrences artifact carries cannot come apart.
+# binding anything else to the element runs against the projection instead. Taken from
+# the artifact, so the column the index filters on and the column an occurrences
+# artifact carries cannot come apart.
 _INDEXED_FIELD = occurrences.INDEXED_FIELD
 
 
@@ -435,8 +435,8 @@ def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
     is silent: a path routed here that no artifact holds is a quantifier answered from
     nothing.
 
-    What this adds is the traversal, which only the compiler knows -- the expression
-    unnesting the level out of the projection, for the paths no artifact covers.
+    What this adds is the traversal, which only the compiler knows: the expression
+    unnesting the level out of the projection, for the paths no pivot artifact covers.
 
     Args:
         schema: The projection schema.
@@ -447,9 +447,10 @@ def _indexed_paths(schema: pa.Schema = projection.SCHEMA) -> dict[str, str]:
 
     Raises:
         ValueError: If a structure-bearing path does not resolve to a repeated
-            expression, so the build cannot unnest it; or whatever
-            ``occurrences.indexed_paths`` refuses. Raised at import, naming the path,
-            because the answer is to change one of these modules rather than to retry.
+            expression, so the build cannot unnest it, or if
+            ``occurrences.indexed_paths`` refuses the schema. Raised at import, naming
+            the path, because the answer is to change one of these modules, not to
+            retry.
     """
     paths: dict[str, str] = {}
     for path in occurrences.indexed_paths(schema):

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -1661,10 +1661,13 @@ def test_the_index_is_built_once_and_only_when_wanted(corpus_dir, caplog):
     assert len(builds) == 1
 
 
-def test_the_indexed_paths_are_the_ones_the_artifact_carries():
-    # Two walks are two answers waiting to disagree: a path this compiler routes to the
-    # index that the artifact does not carry is a quantifier answered from nothing.
+def test_the_indexed_paths_and_field_come_from_the_artifact():
+    # Not an agreement between two walks -- there is one walk, in the artifact, and this
+    # pins that it stays that way. A path routed here that no artifact carries is a
+    # quantifier answered from nothing, and a field name restated here rather than read
+    # is a column the artifact does not hold.
     assert set(execute.INDEXED_PATHS) == set(occurrences.PATHS)
+    assert execute._INDEXED_FIELD == occurrences.INDEXED_FIELD
 
 
 def test_a_corpus_builds_the_occurrence_index_at_open(corpus_dir):
@@ -2201,8 +2204,10 @@ def test_the_indexed_paths_are_the_ones_a_structure_can_sit_at():
                 ]
             )
         )
-    # A structure on a level that is not repeated is one the build cannot unnest.
-    with pytest.raises(ValueError, match="rather than a repeated expression"):
+    # A structure on a level that is not repeated is one no pivot holds the elements of,
+    # so no artifact can carry it and the build would have to unnest a level that is not
+    # one. Refused by the artifact's walk, which is the walk this reads.
+    with pytest.raises(ValueError, match="no repeated level reaches it"):
         execute._indexed_paths(
             pa.schema(
                 [

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -32,7 +32,13 @@ from rdkit import Chem
 from rdkit.Chem import rdSubstructLibrary
 
 from ord_schema import parquet
-from ord_schema.artifacts import base, pivot, projection, structures
+from ord_schema.artifacts import (
+    base,
+    occurrences,
+    pivot,
+    projection,
+    structures,
+)
 from ord_schema.proto import dataset_pb2, reaction_pb2
 from ord_schema.search import execute, query
 
@@ -1653,6 +1659,12 @@ def test_the_index_is_built_once_and_only_when_wanted(corpus_dir, caplog):
         record for record in caplog.records if record.message.startswith("indexed ")
     ]
     assert len(builds) == 1
+
+
+def test_the_indexed_paths_are_the_ones_the_artifact_carries():
+    # Two walks are two answers waiting to disagree: a path this compiler routes to the
+    # index that the artifact does not carry is a quantifier answered from nothing.
+    assert set(execute.INDEXED_PATHS) == set(occurrences.PATHS)
 
 
 def test_a_corpus_builds_the_occurrence_index_at_open(corpus_dir):

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -1662,10 +1662,9 @@ def test_the_index_is_built_once_and_only_when_wanted(corpus_dir, caplog):
 
 
 def test_the_indexed_paths_and_field_come_from_the_artifact():
-    # Not an agreement between two walks -- there is one walk, in the artifact, and this
-    # pins that it stays that way. A path routed here that no artifact carries is a
-    # quantifier answered from nothing, and a field name restated here rather than read
-    # is a column the artifact does not hold.
+    # One walk, in the artifact, and this pins that it stays one. A path routed here
+    # that no artifact carries is a quantifier answered from nothing, and a field name
+    # spelled here rather than read is a column the artifact does not hold.
     assert set(execute.INDEXED_PATHS) == set(occurrences.PATHS)
     assert execute._INDEXED_FIELD == occurrences.INDEXED_FIELD
 


### PR DESCRIPTION
## Summary

The relation a structure query semi-joins is built at open: 18.8M rows and 1.19 GiB held over ORD, wanting 5–6.5 GB of DuckDB memory and 16–25 GB of temporary files to assemble, and costing seconds to a minute before the first query. It is built rather than read because its structure ID is corpus-wide — the dataset's own plus an offset that is a running total over the corpus's datasets — and that number belongs to no artifact.

The constraint binds the corpus-wide ID, not the index. Written with the dataset-local `structure_id` every projection already carries, the same rows are an ordinary derived artifact, and the offset is the join the corpus already performs for a pivot. Measured in [ord-logbook#52](https://github.com/open-reaction-database/ord-logbook/pull/52).

This adds the artifact, its derivation, and the script. **Nothing reads it yet** — `Corpus` does that in a follow-up, so this one can be reviewed as a format decision on its own.

## Changes

- `ord_schema.artifacts.occurrences`: `reaction_id`, `structure_id`, `reaction_role`, one file per dataset per indexed path. `PATHS` comes from the same schema walk the structures artifact uses, so the paths cannot drift from the ones the compiler routes to — `execute_test` now pins that.
- Derived from the **pivot** over the level a path ranges within, not from the projection, so the two cannot disagree about which elements exist: the occurrences are that artifact projected down to three columns, which is what `Corpus._occurrences_from_pivot` already reads out of a pivot.
- `scripts/derive_occurrences.py`, with `--print_levels` printing the `derive_pivots --levels` its input needs. It audits the tree it wrote: every path writes the same three columns, so an artifact copied from one path to another is current by every measure `derive_tree` checks — the stamped path is the only thing that tells them apart, and a mismatch is refused. Empty artifacts are reported per path, and a path where every artifact is empty warns.
- `base.derive_tree` takes the mirror root explicitly, for a caller that has a directory rather than a pattern. `derive_occurrences` builds its glob from `--pivots_dir`, so a directory whose name holds a glob metacharacter was read as a pattern — `pivots[1]` is the character class matching `pivots1`, and a run pointed at the first derived from the second in full, silently. Escaping fixes the match but not the layout: `glob.escape` spells `[` as `[[]`, which `glob_root` reads as the wildcard it is, rooting the mirror above it.
- The artifacts README gains the artifact, the script, and the rule the whole design rests on: no artifact carries a corpus-wide ID.

## Testing

- `uv run pytest`: 1511 passed outside `ord_schema/orm`, whose fixtures need a local Postgres.
- 29 new tests across the artifact and the script. Each guard is mutation-checked: disabling the mismatched-path refusal, the every-artifact-empty warning, the directory escape, or the explicit mirror root fails exactly its own test. The metacharacter test derives from `pivots[1]` beside a decoy `pivots1` holding one shard instead of two, so the pre-fix behavior is a run that succeeds against the wrong tree rather than one that crashes.
- Over the full local corpus: the tree is **242 MB**, derives in about ten seconds from existing pivots, and agrees with the built index **tuple for tuple** — 18,847,978 rows, 0 in either `EXCEPT ALL`, per-path counts equal.
- Semi-join cost, five rounds, medians: **1.28×** the built table summed over every path and pattern; 0.31 s against 0.15 s for pyridine over `inputs.components`, and the smallest path gets *faster* (0.004 s against 0.015 s) because reading one path's files beats filtering `path = ?` across 18.8M rows.

## Notes

`ARTIFACT_VERSION` is unchanged at `"1"` — nothing has been published, so there is nothing to invalidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds dataset-local occurrence artifacts derived from pivots, plus derivation, auditing, discovery, and documentation support. The previous unescaped pivot-directory glob issue is fixed by escaping the directory when constructing the pattern and passing its literal root separately for output mirroring.
- Adds occurrence artifact schema, path discovery, derivation, metadata, and tests.
- Adds a CLI for deriving and auditing occurrence trees from required pivots.
- Extends shared artifact output mapping with an explicit mirroring root.
- Pins indexed search paths to the artifact schema walk.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported literal-directory glob issue is addressed by escaping the pivot root and preserving that root separately for destination mapping.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/artifacts/occurrences.py | Defines the occurrence artifact schema, pivot projection, provenance checks, path metadata, and recursive artifact discovery without an accepted blocking issue. |
| ord_schema/artifacts/scripts/derive_occurrences.py | Derives and audits occurrence trees; the escaped pivot-directory pattern and explicit output root resolve the prior glob-handling finding. |
| ord_schema/artifacts/base.py | Adds an optional literal root for artifact output mirroring so escaped input patterns do not distort destination paths. |
| ord_schema/search/execute.py | Aligns indexed search paths with the occurrence artifact’s schema-derived path set. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  D[Source dataset] --> P[Projection]
  P --> V[Pivot per repeated level]
  V --> O[Occurrences per indexed path]
  O -. future integration .-> C[Search Corpus]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Distill the prose added on this branch"](https://github.com/open-reaction-database/ord-schema/commit/40f8b686e0093ec7da6ea02fadf0b38e15737e63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58499439)</sub>

**Context used:**

- Knowledge Base — [Reaction artifacts and projections](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/reaction-artifacts.md)
- Knowledge Base — [Chemical data transformation](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/chemical-data-transformation.md)

<!-- /greptile_comment -->