### PR TITLE
Read the occurrence index as a view over artifacts

### DIFF
--- a/ord_schema/artifacts/README.md
+++ b/ord_schema/artifacts/README.md
@@ -18,7 +18,7 @@ flowchart LR
     S -.->|"paired by source dataset"| C["ord_schema.search.Corpus"]
     P -.-> C
     V -.-> C
-    O -. "not yet" .-> C
+    O -.-> C
 ```
 
 | artifact | one file per | holds | read by |
@@ -26,7 +26,7 @@ flowchart LR
 | [`projection`](projection.py) | source dataset | every field of every message reachable from `Reaction`, as `STRUCT` / `LIST` / `MAP` | any query engine; the compiler in [`ord_schema.search`](../search/) |
 | [`structures`](structures.py) | projection | one row per distinct structure: `pattern_fp`, `morgan_fp`, `morgan_popcount`, `mol_binary`, keyed by `structure_id` | the screen and verify steps of substructure search |
 | [`pivot`](pivot.py) | projection × repeated level | one row per element, carrying `reaction_id`, the ordinal of every enclosing level, and the element's own non-repeated fields | quantifiers, as a semi-join |
-| [`occurrences`](occurrences.py) | pivot × indexed path | one row per structure occurrence: `reaction_id`, `structure_id`, `reaction_role` | *nothing yet* — the corpus assembles these rows in process; reading them is a separate change |
+| [`occurrences`](occurrences.py) | pivot × indexed path | one row per structure occurrence: `reaction_id`, `structure_id`, `reaction_role` | the semi-join a structure query is routed to, as a view rather than a table the corpus builds |
 
 The projection leaves **no field out** — a field left out is a question nobody can ask.
 Its schema is generated from the proto descriptors, so a field added upstream appears
@@ -133,8 +133,13 @@ file would stay *in range* while naming another dataset's molecule — passing o
 corpus and failing only on a subset of it, which is the shape of bug that reaches
 production. The corpus assigns offsets at open and joins them on, keyed by the source
 dataset every artifact names. That rule is what lets the occurrence index be an artifact
-at all rather than a relation rebuilt at every startup — which is what
-[`Corpus`](../search/execute.py) does, since nothing reads the artifact yet.
+at all rather than a relation rebuilt at every startup: given an `occurrences_dir`
+covering every indexed path, [`Corpus`](../search/execute.py) publishes it as a view over
+those files and builds nothing. Measured over the full corpus that is 0.13 s and 0.32 GiB
+resident against 2.9 s and 1.92 GiB for the table, and DuckDB holds 28 MiB where it held
+1.66 GiB. A path with no artifact is read from a pivot or unnested from the projection as
+before, and one uncovered path materializes the whole index — a view whose branches unnest
+the projection would repeat that traversal on every query rather than pay it once.
 
 ## Querying a projection
 

--- a/ord_schema/artifacts/README.md
+++ b/ord_schema/artifacts/README.md
@@ -111,8 +111,13 @@ path left out is one whose structures no query can find.
 one dataset**. The projection and its structures artifact are two statements of one
 derivation and are meaningful only together:
 
-- IDs are not stable across builds, so nothing outside the artifacts should record them.
-  The column is marked internal and stays out of what a model is told it may query.
+- IDs are stable for a fixed source and a fixed library — assignment is first-seen order
+  over the reactions, so the same bytes under the same ord-schema and RDKit give the same
+  numbers, which is what lets an artifact pair with a projection by source hash rather
+  than by which build produced it. They are *not* stable across a library upgrade that
+  changes canonicalization, which is what the version stamps are for. Nothing outside the
+  artifacts should record them either way; the column is marked internal and stays out of
+  what a model is told it may query.
 - A projection rewritten in place needs its structures artifact rederived with it. The
   stamps name the *source dataset* rather than the projection file, so the skip check
   cannot see that the pairing changed — which is why

--- a/ord_schema/artifacts/occurrences.py
+++ b/ord_schema/artifacts/occurrences.py
@@ -32,11 +32,12 @@ open, keyed by the source dataset every artifact names; see
 :mod:`ord_schema.search.execute`.
 
 That rule is what lets this be an artifact at all rather than a relation assembled at
-open, which is what :mod:`ord_schema.search.execute` does: over ORD it builds
-18,847,978 rows holding 1.19 GiB, wanting 5-6.5 GB of DuckDB memory and 16-25 GB of
-temporary files to get there, before the first query can be answered. The same rows
-derived here are 242 MB of Parquet. **Nothing reads them yet** -- the corpus that does
-is a separate change, and until it lands a tree derived from this is inert.
+open. Assembled, over ORD it is 18,847,978 rows holding 1.19 GiB, wanting 5-6.5 GB of
+DuckDB memory and 16-25 GB of temporary files to get there, before the first query can
+be answered. The same rows derived here are 253 MB of Parquet, and a corpus given a
+directory covering every indexed path reads them as a view instead of building anything:
+0.13 s and 0.32 GiB resident against 2.9 s and 1.92 GiB, measured over the full corpus.
+See :class:`ord_schema.search.execute.Corpus` and its ``occurrences_dir``.
 
 Derived from the **pivot** over the level an indexed path ranges within, which already
 holds one row per element: this artifact is that projected down to three columns, so the

--- a/ord_schema/artifacts/projection_test.py
+++ b/ord_schema/artifacts/projection_test.py
@@ -601,6 +601,38 @@ def test_write_projection_stamps_one_id_space_per_dataset(tmp_path):
         assert product["structure_id"] == 1
 
 
+def test_rebuilding_a_projection_assigns_the_same_structure_ids(tmp_path):
+    # The invariant every derived artifact rests on. A pivot or occurrences artifact
+    # names its structures by the ID its projection assigned, and pairs with that
+    # projection by source hash rather than by which build produced it -- so if a
+    # rebuild from the same source renumbered, an artifact that is current by every
+    # stamp would point every one of its rows at a different molecule. Nothing
+    # downstream could see it: the count of distinct IDs is unchanged by a permutation,
+    # and every ID stays in range.
+    smiles = ["CCO", "c1ccncc1", "CCOCC", "Cc1ccccc1", "OC(=O)C"]
+    reactions = []
+    for index in range(len(smiles)):
+        reaction = reaction_pb2.Reaction(reaction_id=f"ord-{index:04d}")
+        # Reversed, so first-seen order is not also alphabetical or insertion order:
+        # an assignment that happened to sort would pass a same-order comparison.
+        for structure in reversed(smiles[: index + 1]):
+            component = reaction.inputs["in"].components.add()
+            component.identifiers.add(type="SMILES", value=structure)
+        reactions.append(reaction)
+    source = _source(tmp_path, reactions)
+    assignments = []
+    for run in range(2):
+        output = tmp_path / f"projection-{run}.parquet"
+        projection.write_projection(source, output)
+        seen: dict[int, str] = {}
+        for row in pq.read_table(output, columns=["inputs"]).to_pylist():
+            for component in row["inputs"][0][1]["components"]:
+                seen[component["structure_id"]] = component["smiles"]
+        assignments.append(seen)
+    assert len(assignments[0]) == len(smiles)
+    assert assignments[0] == assignments[1]
+
+
 def test_structure_ids_span_source_row_groups(tmp_path):
     # The ID mapping is created once per dataset, not once per row group: rebuilding
     # it inside the loop would restart the IDs and corrupt every join in a dataset

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -203,11 +203,28 @@ authentic standards — is a level with no elements: nothing satisfies an `exist
 and nothing contradicts a `forall`, so "reactions **without** pyridine in the workup"
 includes every reaction that has no workup at all.
 
-The index is built at open, which `Corpus(warm=False)` defers to the first query that
-spends it. Where a pivot artifact covers an indexed path the build reads that level
-instead of unnesting the projection — over ORD **3.3s against 59.4s** for the same
-18,847,978 occurrences — and every path no artifact covers still costs its own pass over
-the projections.
+Three ways to reach those rows, cheapest first, decided per path.
+
+`Corpus(..., occurrences_dir=...)` reads an **occurrences artifact**, which is the rows
+themselves: the read adds only the corpus-wide offset. Where the directory covers every
+indexed path the index is published as a **view over Parquet** and nothing is built —
+0.13s and 0.32 GiB resident over ORD, against 2.9s and 1.92 GiB for the table, with
+DuckDB holding 28 MiB where it held 1.66 GiB — at about the same per-query cost, and less
+on the narrow paths, where reading one path's files beats filtering `path = ?` across
+every occurrence in the corpus. `require_occurrences=True` refuses a directory that does
+not cover every path, which is worth setting wherever the container was sized for the
+view.
+
+Failing that, a **pivot artifact** over the path's level holds one row per element, which
+is what the build would otherwise unnest the projection to produce — over ORD **3.3s
+against 59.4s** for the same 18,847,978 occurrences. Failing both, the projection is
+unnested.
+
+One uncovered path materializes the whole index rather than leaving a view whose branches
+unnest the projection, which would repeat that traversal on every query rather than pay it
+once. Either way the index is built at open, which `Corpus(warm=False)` defers to the
+first query that spends it — and with a covering `occurrences_dir` there is little left
+for `warm` to do but check that the index reaches every structure the corpus holds.
 
 ## Pivoted levels
 
@@ -290,9 +307,9 @@ answers against rows this corpus does not hold, confidently and wrongly. A level
 artifacts is still built in process, so a partial set is a partial speedup rather than a
 missing answer.
 
-The occurrence index reads them too, one indexed path at a time: an artifact holds one
-row per element of the nearest repeated level, which is what the build would otherwise
-unnest the projection to produce.
+The occurrence index reads them too, one indexed path at a time, where no occurrences
+artifact covers that path: a pivot holds one row per element of the nearest repeated
+level, which is what the build would otherwise unnest the projection to produce.
 
 `Corpus(..., pivots_dir=..., derive_pivots=True)` writes the missing ones instead of
 building them: the same pass, spent where it outlives the process and costs no budget,

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -76,7 +76,8 @@ for every caller and shows up in the logs rather than in a timeout. Both builds 
 at open unless the corpus was given ``warm=False``, which leaves the index to the first
 query taking a clause of it and the library to the first substructure predicate. A
 search that pays for either pays upwards of a minute over the whole corpus, on top of
-whatever timeout it was given.
+whatever timeout it was given -- unless an ``occurrences_dir`` covers every indexed
+path, where the index is a view over those files and there is nothing to build.
 """
 
 import array
@@ -862,6 +863,8 @@ class Corpus:
         pivots_dir: str | None = None,
         derive_pivots: bool = False,
         require_pivots: bool = False,
+        occurrences_dir: str | None = None,
+        require_occurrences: bool = False,
         memory_limit: str | None = None,
         warm: bool = True,
         max_rows: int | None = None,
@@ -919,6 +922,26 @@ class Corpus:
                 ``ord_schema.artifacts.scripts.derive_pivots``. Needs ``warm`` off,
                 since warming reads the levels the occurrence index covers and a
                 derivation has to precede the read of the level it completes.
+            occurrences_dir: Directory holding derived occurrence artifacts, one
+                subdirectory per indexed path. Given one covering every path, the
+                occurrence index is a view over those files rather than a table built
+                at open: the corpus stops holding the 1.19 GB the table costs over ORD,
+                stops wanting the 5-6.5 GB of DuckDB memory and 16-25 GB of temporary
+                files to build it, and pays instead about 1.28x per query -- less on
+                the narrow paths, where reading one path's files beats filtering across
+                every occurrence in the corpus. A path with no artifacts is read from a
+                pivot or unnested from the projection as before, and one uncovered path
+                materializes the whole index, since a view would repeat that traversal
+                on every query; ``require_occurrences`` refuses that rather than
+                falling back to it. Derived by
+                ``ord_schema.artifacts.scripts.derive_occurrences``.
+            require_occurrences: Refuse a corpus whose ``occurrences_dir`` does not
+                cover every indexed path, rather than materializing the index because
+                one path was missing. Needs an ``occurrences_dir``. What it costs is a
+                footer read per artifact at startup; what it buys is that a deployment
+                sized for the view is not handed the table, which wants several
+                gigabytes it was not given and takes the container down rather than
+                answering slowly.
             memory_limit: What DuckDB may hold, spelled as it spells sizes: ``6500MiB``,
                 ``8GB``. Left unset, DuckDB takes about 80% of the machine, or of the
                 container's cap, which it does read. That default suits a process that
@@ -931,8 +954,11 @@ class Corpus:
                 killed partway.
             warm: Build at open what a structure query would otherwise build on the
                 query itself, on by default: the occurrence index, then the substructure
-                library. The index costs a read of the pivot artifacts covering the
-                indexed paths and a pass over the projections for every path they do not
+                library. An ``occurrences_dir`` covering every indexed path leaves the
+                index nothing to build, so what this then pays for it is the scan that
+                checks it reaches every structure the corpus holds. Built, the index
+                costs a read of the pivot artifacts covering the indexed paths and a
+                pass over the projections for every path they do not
                 cover -- over ORD the difference between a second and a minute -- and it
                 wants 5-6.5 GB of DuckDB memory to build and holds 1.19 GB afterwards.
                 The library is about 8s and 2.2 GB on top. Together they are most of
@@ -968,8 +994,9 @@ class Corpus:
                 derivation can complete them. If ``max_rows`` is less than one, which is
                 a bound no query can satisfy rather than a small one. If
                 ``pivot_budget_bytes`` is negative, which no amount of memory is; zero
-                is allowed, and materializes nothing; or if ``derive_pivots`` or
-                ``require_pivots`` is set without a ``pivots_dir``.
+                is allowed, and materializes nothing; if ``derive_pivots`` or
+                ``require_pivots`` is set without a ``pivots_dir``; or if
+                ``require_occurrences`` is set without an ``occurrences_dir``.
         """
         self._resolver = resolver if resolver is not None else _resolve_with_resolvers
         if max_rows is not None and max_rows <= 0:
@@ -1055,6 +1082,11 @@ class Corpus:
                 "require_pivots was set without a pivots_dir, so there is nowhere to "
                 "look for what it would require"
             )
+        if require_occurrences and occurrences_dir is None:
+            raise ValueError(
+                "require_occurrences was set without an occurrences_dir, so there is "
+                "nowhere to look for what it would require"
+            )
         if derive_pivots and warm:
             # The index reads the artifacts over the levels it indexes as files, so
             # warming checks a level derive_pivots means to complete before the
@@ -1072,6 +1104,7 @@ class Corpus:
             projection_pattern, structures_pattern, require_current
         )
         self._pivots_dir = pivots_dir
+        self._occurrences_dir = occurrences_dir
         self._derive_pivots = derive_pivots
         self._require_current = require_current
         # The pattern the derivation reads, which is what mirrors the projections'
@@ -1088,6 +1121,9 @@ class Corpus:
         # same level as a view, and the lock holds a footer read per artifact, which is
         # not something to hold the lock a published view is looked up under.
         self._pivot_artifacts_found: dict[str, dict[str, str] | None] = {}
+        # The occurrence artifacts found for each indexed path, under the same lock and
+        # for the same reason.
+        self._occurrence_artifacts_found: dict[str, dict[str, str] | None] = {}
         self._artifacts_lock = threading.Lock()
         # What a dataset's structure IDs add to reach a corpus-wide one, keyed by the
         # source every artifact derived from it names; filled by _prepare.
@@ -1101,6 +1137,8 @@ class Corpus:
             self._total, self._searchable = self._prepare(pairs)
             if require_pivots:
                 self._require_every_pivot()
+            if require_occurrences:
+                self._require_every_occurrence()
             if warm:
                 self._warm()
         except Exception:
@@ -1317,10 +1355,16 @@ class Corpus:
         holding DuckDB to 6500MiB finishes at 9.3 GB resident. ``Corpus`` warns at open
         when a cap it can read leaves too little.
 
-        A corpus opened with ``warm`` has paid the build already, and the call is then
-        its counts. Leaving it cold suits one asked only for scalar or similarity
-        queries, which never spends what the index costs: about a minute over ORD where
-        no pivot artifact covers a path, and 1.19 GB resident however it was built.
+        None of that applies to an index published as a view, which an
+        ``occurrences_dir`` covering every indexed path gets: there is nothing to
+        materialize, so the floor is the scan this call makes rather than a build. Over
+        ORD that is 0.13s and 0.32 GiB resident, against 2.9s and 1.92 GiB for the table
+        read from pivots.
+
+        A corpus opened with ``warm`` has paid whichever of those it owes already, and
+        the call is then its counts. Leaving it cold suits one asked only for scalar or
+        similarity queries, which never spends what a built index costs: about a minute
+        over ORD where no artifact covers a path, and 1.19 GB resident once built.
 
         Returns:
             The number of occurrences found per indexed path, including the paths that
@@ -1545,7 +1589,9 @@ class Corpus:
         sources = self._pivot_artifacts(level.path)
         if sources is None:
             return None
-        offsets = self._pivot_offsets(level.path, sources)
+        offsets = self._artifact_offsets(
+            f"{pivot.table_name(level.path)}_offsets", sources
+        )
         element = ".".join(["x", pivot.ELEMENT, *remainder])
         # S608: the level and its remainder come from this module's walk of the schema,
         # and the paths from this process's own glob, quoted with their single quotes
@@ -1556,39 +1602,38 @@ class Corpus:
                        AS global_id,
                    {element}.{_INDEXED_FIELD} AS {_INDEXED_FIELD}
             FROM read_parquet({_sql_paths(sources)}, filename=true) x
-            JOIN {offsets} o ON x.filename = o.pivot_filename
+            JOIN {offsets} o ON x.filename = o.artifact_filename
             WHERE {element}.structure_id IS NOT NULL
             """  # noqa: S608
 
-    def _pivot_offsets(self, level: str, sources: dict[str, str]) -> str:
-        """Publishes what each pivot artifact's rows add to reach a corpus-wide ID.
+    def _artifact_offsets(self, published: str, sources: dict[str, str]) -> str:
+        """Publishes what each artifact's rows add to reach a corpus-wide ID.
 
-        A pivot and the projection it was derived from restate one source dataset, so
+        An artifact and the projection it descends from restate one source dataset, so
         they carry the same ``source_md5`` however many derivations apart they sit, and
         that hash is what pairs an artifact with the offset its projection was given.
         Pairing on the filename instead would rest on the two trees being laid out
         alike, which nothing enforces.
 
         Args:
-            level: The repeated level the artifacts hold, which names the relation.
-            sources: The source each artifact names, from ``_pivot_artifacts``.
+            published: The relation to create, named for the level or path it serves so
+                that a retry after a refusal replaces these rows rather than leaving a
+                relation behind per attempt.
+            sources: The source each artifact names, from the check that accepted them.
 
         Returns:
-            The relation's name.
+            ``published``.
         """
         rows = []
         for name, source in sources.items():
-            offset = self._offset_of_source.get(source)
-            # _check_pivots requires these artifacts' sources to be exactly the
+            # The checks require these artifacts' sources to be exactly the
             # projections', and the offsets are keyed by those same hashes.
+            offset = self._offset_of_source.get(source)
             assert offset is not None, f"{name} names a source the corpus does not hold"
             rows.append((name, offset))
-        # Named for the level, so a retry after a refusal replaces these rows instead of
-        # leaving a relation behind per attempt.
-        published = f"{pivot.table_name(level)}_offsets"
         registered = pa.table(
             {
-                "pivot_filename": [row[0] for row in rows],
+                "artifact_filename": [row[0] for row in rows],
                 query.STRUCTURE_OFFSET: pa.array(
                     [row[1] for row in rows], type=pa.int64()
                 ),
@@ -1598,13 +1643,185 @@ class Corpus:
         # its table with two memory readings taken across everyone. S608: the name comes
         # from this module's walk of the schema.
         with self._build_lock:
-            self._connection.register("registered_pivot_offsets", registered)
+            self._connection.register("registered_artifact_offsets", registered)
             self._connection.execute(
                 f"CREATE OR REPLACE TABLE {published} AS "  # noqa: S608
-                "SELECT * FROM registered_pivot_offsets"
+                "SELECT * FROM registered_artifact_offsets"
             )
-            self._connection.unregister("registered_pivot_offsets")
+            self._connection.unregister("registered_artifact_offsets")
         return published
+
+    def _occurrence_artifacts(self, path: str) -> dict[str, str] | None:
+        """Returns the artifacts holding ``path``'s occurrences, checked, or None.
+
+        Globbed and checked once per path and remembered, including the answer that
+        there are none, so a corpus without artifacts reads the directory once rather
+        than on every query.
+
+        Args:
+            path: The indexed path, as the query grammar names it.
+
+        Returns:
+            The source dataset each artifact was derived from, keyed by its path, or
+            None where the corpus has no directory or the directory holds none for this
+            path.
+
+        Raises:
+            PairingError: If the artifacts do not belong to this corpus; see
+                ``_check_occurrences``.
+        """
+        if self._occurrences_dir is None:
+            return None
+        with self._artifacts_lock:
+            if path in self._occurrence_artifacts_found:
+                return self._occurrence_artifacts_found[path]
+            files = [
+                str(found)
+                for found in occurrences.artifact_paths(self._occurrences_dir, path)
+            ]
+            if not files:
+                self._occurrence_artifacts_found[path] = None
+                return None
+            sources = self._check_occurrences(path, files)
+            self._occurrence_artifacts_found[path] = sources
+            return sources
+
+    def _check_occurrences(self, path: str, files: list[str]) -> dict[str, str]:
+        """Refuses occurrence artifacts that do not belong to this corpus.
+
+        The check ``_check_pivots`` makes, for the same reason: an occurrence names its
+        reaction by ID and its structure by a dataset-local ``structure_id``, and both
+        resolve against whatever this corpus holds. Artifacts derived from another
+        corpus therefore answer a quantifier confidently and wrongly rather than
+        failing.
+
+        Every indexed path writes the same three columns, so where a file sits says
+        nothing about what it holds and the stamped path is the only thing that does. A
+        file under the wrong one would answer that path's quantifiers with another
+        level's elements.
+
+        Args:
+            path: The indexed path the files claim to hold.
+            files: The artifacts found for it.
+
+        Returns:
+            The source dataset each artifact was derived from, keyed by its path, which
+            is what pairs an artifact with the offset its projection was given; see
+            ``_artifact_offsets``.
+
+        Raises:
+            PairingError: If a file is not an occurrences artifact, if it is stamped
+                with another path, if two artifacts restate one source dataset, if the
+                set of source datasets differs from the projections', or -- with
+                ``require_current`` -- if any artifact is stale.
+        """
+        wanted = {base.load_stamps(name).source_md5 for name in self._projections}
+        sources: dict[str, str] = {}
+        derived_from: dict[str, str] = {}
+        for name in files:
+            stamps = base.load_stamps(name)
+            if stamps.artifact != occurrences.ARTIFACT:
+                raise PairingError(
+                    f"{name} is a {stamps.artifact}, not an {occurrences.ARTIFACT} "
+                    "artifact"
+                )
+            held = occurrences.occurrence_path(name)
+            if held != path:
+                raise PairingError(
+                    f"{name} holds the occurrences at {held}, but sits where {path} is "
+                    "read from, so a quantifier over it would be answered by another "
+                    "path's elements"
+                )
+            if self._require_current and not base.stamps_are_current(
+                stamps, occurrences.ARTIFACT
+            ):
+                raise PairingError(f"{name} is a stale {occurrences.ARTIFACT} artifact")
+            # Two artifacts of one dataset pass the set comparison below and are both
+            # read, so every occurrence at the path is stated twice. A quantifier cannot
+            # see it -- a semi-join returns a reaction once however many rows name it --
+            # but the structure count that decides whether the index reaches the corpus
+            # is taken over distinct IDs, so it cannot see it either, and check_index
+            # reports the doubled count as the corpus's own.
+            if stamps.source_md5 in derived_from:
+                raise PairingError(
+                    f"{name} and {derived_from[stamps.source_md5]} are both "
+                    f"{occurrences.ARTIFACT} artifacts at {path} of the same source "
+                    "dataset, so its occurrences would each be read twice"
+                )
+            derived_from[stamps.source_md5] = name
+            sources[name] = stamps.source_md5
+        if set(sources.values()) != wanted:
+            found = set(sources.values())
+            raise PairingError(
+                f"the {occurrences.ARTIFACT} artifacts at {path} were derived from "
+                f"{len(found)} source datasets and the projections from {len(wanted)}, "
+                f"and {len(wanted - found)} of the projections' are missing; an "
+                "artifact of another corpus names reactions this one does not hold"
+            )
+        return sources
+
+    def _occurrences_from_artifact(self, path: str) -> str | None:
+        """Returns the SELECT reading ``path``'s occurrences from artifacts, or None.
+
+        The artifact is already one row per occurrence, so the read adds only the
+        corpus-wide ID: the element's own plus its dataset's offset, which is a running
+        total over the corpus's pairs and so belongs to no artifact. It is joined here
+        from the file each row came from, keyed by the source that file and its
+        projection both name.
+
+        Args:
+            path: The indexed path.
+
+        Returns:
+            The SELECT, or None where the corpus has no artifacts for the path.
+
+        Raises:
+            PairingError: If the artifacts do not belong to this corpus; see
+                ``_check_occurrences``.
+        """
+        sources = self._occurrence_artifacts(path)
+        if sources is None:
+            return None
+        offsets = self._artifact_offsets(
+            f"occurrences_{path.replace('.', '_')}_offsets", sources
+        )
+        # The artifact holds no row for an element carrying no structure, so nothing
+        # here filters: what a pivot needs a WHERE for, the derivation already did.
+        # S608: the path is a key of INDEXED_PATHS and the filenames come from this
+        # process's own glob, quoted with their single quotes escaped.
+        return f"""
+            SELECT x.reaction_id, {sql_string(path)} AS path,
+                   (x.structure_id + o.{query.STRUCTURE_OFFSET})::UINTEGER AS global_id,
+                   x.{_INDEXED_FIELD}
+            FROM read_parquet({_sql_paths(sources)}, filename=true) x
+            JOIN {offsets} o ON x.filename = o.artifact_filename
+            """  # noqa: S608
+
+    def _require_every_occurrence(self) -> None:
+        """Refuses a corpus whose occurrences_dir does not hold every indexed path.
+
+        A path with no artifact is otherwise read from a pivot or unnested out of the
+        projection, and either leaves the index a materialized table -- 1.19 GB held
+        over ORD, and 5-6.5 GB of DuckDB memory wanted to build it. A deployment sized
+        for the view is sized for neither, so the fallback that keeps a corpus
+        answering is the one that gets the container killed, which is the failure a
+        caller naming an occurrences_dir is least likely to be expecting.
+
+        Raises:
+            PairingError: If any indexed path has no artifacts. Wrong provenance, a
+                path filed under another, and staleness are raised by the check itself.
+        """
+        missing = [
+            path
+            for path in sorted(INDEXED_PATHS)
+            if self._occurrence_artifacts(path) is None
+        ]
+        if missing:
+            raise PairingError(
+                f"{self._occurrences_dir} holds no {occurrences.ARTIFACT} artifacts "
+                f"for {missing}, which this corpus was opened requiring; derive them "
+                "first with ord_schema.artifacts.scripts.derive_occurrences"
+            )
 
     def _occurrences(self) -> None:
         """Builds the occurrence index, once.
@@ -1635,20 +1852,34 @@ class Corpus:
             if self._occurrences_built:
                 return
             start = time.perf_counter()
-            # A level's pivot already holds one row per element, which is what this
-            # build would otherwise unnest the projection to produce. Reading it is a
-            # scan of a few hundred megabytes against a traversal of every reaction.
-            # Decided per path, so a directory holding some levels and not others is a
-            # partial speedup rather than a missing index.
-            reads, from_pivots = [], []
+            # Three ways to reach a path's occurrences, cheapest first. An occurrences
+            # artifact is the rows themselves and needs only the offset joined on. A
+            # level's pivot holds one row per element, which is a scan of a few hundred
+            # megabytes against a traversal of every reaction. Failing both, the
+            # projection is unnested. Decided per path, so a directory holding some and
+            # not others is a partial speedup rather than a missing index.
+            reads, from_artifacts, from_pivots = [], [], []
             for path, expression in INDEXED_PATHS.items():
-                reading = self._occurrences_from_pivot(path)
-                if reading is None:
-                    reads.append(_occurrences_from_projection(path, expression))
+                reading = self._occurrences_from_artifact(path)
+                if reading is not None:
+                    from_artifacts.append(path)
                 else:
-                    reads.append(reading)
-                    from_pivots.append(path)
+                    reading = self._occurrences_from_pivot(path)
+                    if reading is not None:
+                        from_pivots.append(path)
+                    else:
+                        reading = _occurrences_from_projection(path, expression)
+                reads.append(reading)
             selects = "\nUNION ALL\n".join(reads)
+            # A view where every path is an artifact, and a table otherwise. Read per
+            # query the artifacts cost 1.28x the built table summed over every path and
+            # pattern -- and less on the narrow paths, where reading one path's files
+            # beats filtering path = ? across every occurrence in the corpus -- against
+            # the 1.19 GB the table holds and the 5-6.5 GB it wants to build. A path
+            # read from a pivot or unnested out of the projection is the traversal this
+            # index exists to avoid, and a view would repeat it on every query rather
+            # than pay it once, so one uncovered path materializes all of them.
+            held = "VIEW" if len(from_artifacts) == len(INDEXED_PATHS) else "TABLE"
             # Its own cursor: this runs while searches are in flight, and the shared
             # connection holds their results.
             cursor = self._connection.cursor()
@@ -1672,16 +1903,18 @@ class Corpus:
                         "glob one artifact per reaction"
                     )
                     raise PairingError(self._refused)
-                # Under the build lock, which every statement that puts a table in this
-                # database takes, so none of them lands while a materialization is
+                # Under the build lock, which every statement that puts a relation in
+                # this database takes, so none of them lands while a materialization is
                 # measuring what one costs -- a difference of two readings taken across
                 # everyone.
-                # OR REPLACE, so a build interrupted after the table exists is a build
-                # the next query repeats rather than one that collides with itself
-                # forever. S608: the fragments are this module's own schema walk and
-                # the compiler's traversals, not anything a query supplies.
+                # OR REPLACE, so a build interrupted after the relation exists is a
+                # build the next query repeats rather than one that collides with
+                # itself forever. The kind cannot change under an open corpus, since
+                # what it turns on is which artifacts the directory held at open.
+                # S608: the fragments are this module's own schema walk and the
+                # compiler's traversals, not anything a query supplies.
                 with self._build_lock:
-                    cursor.execute(f"CREATE OR REPLACE TABLE occurrences AS {selects}")
+                    cursor.execute(f"CREATE OR REPLACE {held} occurrences AS {selects}")
                 counts = dict(
                     cursor.execute(
                         "SELECT path, count(*) FROM occurrences GROUP BY path"
@@ -1713,12 +1946,14 @@ class Corpus:
             # authentic standards -- which is why the refusal above counts structures
             # rather than paths.
             logger.info(
-                "indexed %d structure occurrences in %.1fs, %d of %d paths read from "
-                "pivot artifacts: %s",
+                "indexed %d structure occurrences in %.1fs as a %s, %d of %d paths "
+                "read from occurrence artifacts and %d from pivot artifacts: %s",
                 sum(counts.values()),
                 time.perf_counter() - start,
-                len(from_pivots),
+                held.lower(),
+                len(from_artifacts),
                 len(INDEXED_PATHS),
+                len(from_pivots),
                 ", ".join(f"{path} {counts.get(path, 0)}" for path in INDEXED_PATHS),
             )
 

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -4395,7 +4395,6 @@ def test_a_corpus_fingerprint_moves_when_only_the_structures_are_rebuilt(
 
 
 def _write_occurrences(
-    root: pathlib.Path,
     pivots: pathlib.Path,
     into: pathlib.Path,
     paths: Sequence[str] = tuple(execute.INDEXED_PATHS),
@@ -4406,8 +4405,6 @@ def _write_occurrences(
     them, mirroring the pivots it descends from.
 
     Args:
-        root: Unused by the derivation, and taken so this reads like ``_write_pivots``
-            at the call site.
         pivots: Holds the pivot artifacts to derive from.
         into: Where to write.
         paths: Which indexed paths to write, every one by default.
@@ -4415,7 +4412,6 @@ def _write_occurrences(
     Returns:
         ``into``.
     """
-    del root
     for path in paths:
         level = occurrences.PATHS[path][0].path
         for pivoted in sorted((pivots / level).glob("*/*.parquet")):
@@ -4429,7 +4425,7 @@ def _write_occurrences(
 def occurrence_dirs(tmp_path, corpus_dir) -> tuple[pathlib.Path, pathlib.Path]:
     """The pivots the occurrences descend from, and the occurrences themselves."""
     pivots = _write_pivots(corpus_dir, _OCCURRENCE_LEVELS, into=tmp_path / "pivots")
-    return pivots, _write_occurrences(corpus_dir, pivots, tmp_path / "occurrences")
+    return pivots, _write_occurrences(pivots, tmp_path / "occurrences")
 
 
 @pytest.mark.parametrize("smarts", ["c1ccncc1", "[OX2H]", "c1ccccc1", "[#6]"])
@@ -4504,10 +4500,7 @@ def test_one_uncovered_path_materializes_the_whole_index(
     # query rather than pay it once, so partial coverage is a table.
     pivots, _ = occurrence_dirs
     partial = _write_occurrences(
-        corpus_dir,
-        pivots,
-        pathlib.Path(str(pivots) + "-partial"),
-        ("outcomes.products",),
+        pivots, pathlib.Path(str(pivots) + "-partial"), ("outcomes.products",)
     )
     with (
         caplog.at_level(logging.INFO, logger="ord_schema.search.execute"),
@@ -4527,7 +4520,7 @@ def test_an_uncovered_path_still_answers(corpus_dir, occurrence_dirs):
     # artifact are read the way they were before there were any.
     pivots, _ = occurrence_dirs
     partial = _write_occurrences(
-        corpus_dir, pivots, pathlib.Path(str(pivots) + "-one"), ("outcomes.products",)
+        pivots, pathlib.Path(str(pivots) + "-one"), ("outcomes.products",)
     )
     where = _exists({"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"})
     with _indexed_corpus(corpus_dir, None) as unnested:
@@ -4637,9 +4630,7 @@ def test_requiring_occurrences_refuses_a_partial_directory(
     # A deployment sized for the view is not sized for the table, so the fallback that
     # keeps a corpus answering is the one that gets the container killed.
     pivots, _ = occurrence_dirs
-    partial = _write_occurrences(
-        corpus_dir, pivots, tmp_path / "partial", ("outcomes.products",)
-    )
+    partial = _write_occurrences(pivots, tmp_path / "partial", ("outcomes.products",))
     with pytest.raises(execute.PairingError, match="holds no occurrences artifacts"):
         _indexed_corpus(
             corpus_dir, None, occurrences_dir=str(partial), require_occurrences=True

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -3598,8 +3598,7 @@ def test_an_index_reads_the_pivots_rather_than_unnesting_the_projection(
             corpus, _exists({"op": "substructure", "path": "smiles", "smarts": "[Pt]"})
         )
     assert any(
-        f"{len(execute.INDEXED_PATHS)} of {len(execute.INDEXED_PATHS)} "
-        "paths read from pivot artifacts" in record.message
+        f"and {len(execute.INDEXED_PATHS)} from pivot artifacts" in record.message
         for record in caplog.records
     )
 
@@ -3619,9 +3618,7 @@ def test_a_path_whose_level_has_no_pivot_is_still_unnested(
     ):
         assert _search(corpus, where) == expected
     assert any(
-        f"1 of {len(execute.INDEXED_PATHS)} paths read from pivot artifacts"
-        in record.message
-        for record in caplog.records
+        "and 1 from pivot artifacts" in record.message for record in caplog.records
     )
 
 
@@ -4392,3 +4389,274 @@ def test_a_corpus_fingerprint_moves_when_only_the_structures_are_rebuilt(
         ) as after,
     ):
         assert before.fingerprint != after.fingerprint
+
+
+# Reading the occurrence index from artifacts
+
+
+def _write_occurrences(
+    root: pathlib.Path,
+    pivots: pathlib.Path,
+    into: pathlib.Path,
+    paths: Sequence[str] = tuple(execute.INDEXED_PATHS),
+) -> pathlib.Path:
+    """Derives occurrence artifacts for ``paths`` from the pivots under ``pivots``.
+
+    Written under ``<path>/<shard>/`` because that is where ``derive_occurrences`` puts
+    them, mirroring the pivots it descends from.
+
+    Args:
+        root: Unused by the derivation, and taken so this reads like ``_write_pivots``
+            at the call site.
+        pivots: Holds the pivot artifacts to derive from.
+        into: Where to write.
+        paths: Which indexed paths to write, every one by default.
+
+    Returns:
+        ``into``.
+    """
+    del root
+    for path in paths:
+        level = occurrences.PATHS[path][0].path
+        for pivoted in sorted((pivots / level).glob("*/*.parquet")):
+            shard = into / path / pivoted.parent.name
+            shard.mkdir(parents=True, exist_ok=True)
+            occurrences.write_occurrences(pivoted, shard / pivoted.name, path=path)
+    return into
+
+
+@pytest.fixture
+def occurrence_dirs(tmp_path, corpus_dir) -> tuple[pathlib.Path, pathlib.Path]:
+    """The pivots the occurrences descend from, and the occurrences themselves."""
+    pivots = _write_pivots(corpus_dir, _OCCURRENCE_LEVELS, into=tmp_path / "pivots")
+    return pivots, _write_occurrences(corpus_dir, pivots, tmp_path / "occurrences")
+
+
+@pytest.mark.parametrize("smarts", ["c1ccncc1", "[OX2H]", "c1ccccc1", "[#6]"])
+def test_an_index_read_from_artifacts_answers_what_unnesting_answers(
+    corpus_dir, occurrence_dirs, smarts
+):
+    # The artifact is the same occurrences by a third route, so it cannot answer
+    # differently from either of the two that build them. Over both datasets, because
+    # an occurrence's ID is its element's plus its own dataset's offset and a corpus of
+    # one dataset has an offset of zero to get wrong.
+    _, occurrence_dir = occurrence_dirs
+    where = _exists({"op": "substructure", "path": "smiles", "smarts": smarts})
+    with _indexed_corpus(corpus_dir, None) as unnested:
+        expected = _search(unnested, where)
+    assert expected
+    with _indexed_corpus(corpus_dir, None, occurrences_dir=str(occurrence_dir)) as read:
+        assert _search(read, where) == expected
+
+
+def test_an_index_read_from_artifacts_binds_the_role_to_the_element(
+    corpus_dir, occurrence_dirs
+):
+    # The role travels on the occurrence row, which is what keeps "pyridine as the
+    # solvent" a condition on one row rather than an intersection of two reaction sets.
+    _, occurrence_dir = occurrence_dirs
+    where = _role_and_structure("c1ccncc1", "SOLVENT")
+    with _indexed_corpus(corpus_dir, None) as unnested:
+        expected = _search(unnested, where)
+    with _indexed_corpus(corpus_dir, None, occurrences_dir=str(occurrence_dir)) as read:
+        assert _search(read, where) == expected
+
+
+def test_an_index_read_from_artifacts_keeps_a_structure_in_its_own_dataset(
+    corpus_dir, occurrence_dirs
+):
+    # An offset dropped or taken from the wrong dataset still lands inside the corpus's
+    # structures, so it returns a reaction rather than raising -- the wrong one.
+    _, occurrence_dir = occurrence_dirs
+    with (
+        _indexed_corpus(corpus_dir, None) as unnested,
+        _indexed_corpus(corpus_dir, None, occurrences_dir=str(occurrence_dir)) as read,
+    ):
+        where = _exists({"op": "substructure", "path": "smiles", "smarts": "[OX2H]"})
+        expected = _search(unnested, where)
+        assert expected
+        assert _search(read, where) == expected
+
+
+def test_a_covered_corpus_publishes_the_index_as_a_view(
+    corpus_dir, occurrence_dirs, caplog
+):
+    # The whole point of the artifact: the rows stay on disk. Over ORD the table holds
+    # 1.19 GB and wants several more to build, and the view holds none of it.
+    _, occurrence_dir = occurrence_dirs
+    with (
+        caplog.at_level(logging.INFO, logger="ord_schema.search.execute"),
+        _indexed_corpus(corpus_dir, None, occurrences_dir=str(occurrence_dir)) as read,
+    ):
+        read.check_index()
+    assert any("as a view" in record.message for record in caplog.records)
+    assert any(
+        f"{len(execute.INDEXED_PATHS)} of {len(execute.INDEXED_PATHS)} paths read "
+        "from occurrence artifacts" in record.message
+        for record in caplog.records
+    )
+
+
+def test_one_uncovered_path_materializes_the_whole_index(
+    corpus_dir, occurrence_dirs, caplog
+):
+    # A view whose branches unnest the projection would repeat that traversal on every
+    # query rather than pay it once, so partial coverage is a table.
+    pivots, _ = occurrence_dirs
+    partial = _write_occurrences(
+        corpus_dir,
+        pivots,
+        pathlib.Path(str(pivots) + "-partial"),
+        ("outcomes.products",),
+    )
+    with (
+        caplog.at_level(logging.INFO, logger="ord_schema.search.execute"),
+        _indexed_corpus(corpus_dir, None, occurrences_dir=str(partial)) as read,
+    ):
+        read.check_index()
+    assert any("as a table" in record.message for record in caplog.records)
+    assert any(
+        f"1 of {len(execute.INDEXED_PATHS)} paths read from occurrence artifacts"
+        in record.message
+        for record in caplog.records
+    )
+
+
+def test_an_uncovered_path_still_answers(corpus_dir, occurrence_dirs):
+    # Partial coverage is a partial speedup, never a missing answer: the paths with no
+    # artifact are read the way they were before there were any.
+    pivots, _ = occurrence_dirs
+    partial = _write_occurrences(
+        corpus_dir, pivots, pathlib.Path(str(pivots) + "-one"), ("outcomes.products",)
+    )
+    where = _exists({"op": "substructure", "path": "smiles", "smarts": "c1ccncc1"})
+    with _indexed_corpus(corpus_dir, None) as unnested:
+        expected = _search(unnested, where)
+    assert expected
+    with _indexed_corpus(corpus_dir, None, occurrences_dir=str(partial)) as read:
+        assert _search(read, where) == expected
+
+
+def test_a_directory_with_no_artifacts_is_not_an_error(corpus_dir, tmp_path):
+    # Naming an empty directory reads as a corpus that has not derived them yet, which
+    # is the state every corpus starts in.
+    empty = tmp_path / "none"
+    empty.mkdir()
+    with _indexed_corpus(corpus_dir, None, occurrences_dir=str(empty)) as read:
+        assert sum(read.check_index().values()) > 0
+
+
+# What the reader refuses
+
+
+def test_occurrence_artifacts_of_another_corpus_are_refused(
+    tmp_path, corpus_dir, occurrence_dirs
+):
+    # An occurrence names its reaction by ID and its structure by a dataset-local one,
+    # and both resolve against whatever this corpus holds -- so artifacts from another
+    # answer a quantifier confidently and wrongly rather than failing.
+    _, occurrence_dir = occurrence_dirs
+    one = tmp_path / "one"
+    for path in execute.INDEXED_PATHS:
+        found = occurrences.artifact_paths(occurrence_dir, path)
+        target = one / path / found[0].parent.name
+        target.mkdir(parents=True)
+        shutil.copy(found[0], target / found[0].name)
+    with pytest.raises(execute.PairingError, match="another corpus names reactions"):
+        _indexed_corpus(corpus_dir, None, occurrences_dir=str(one)).check_index()
+
+
+def test_an_artifact_stamped_with_another_path_is_refused(
+    tmp_path, corpus_dir, occurrence_dirs
+):
+    # Every indexed path writes the same three columns, so where a file sits says
+    # nothing about what it holds and the stamped path is the only thing that does.
+    _, occurrence_dir = occurrence_dirs
+    misfiled = tmp_path / "misfiled"
+    shutil.copytree(occurrence_dir, misfiled)
+    stranger = occurrences.artifact_paths(misfiled, "inputs.components")[0]
+    into = occurrences.artifact_paths(misfiled, "outcomes.products")[0]
+    shutil.copy(stranger, into)
+    with pytest.raises(execute.PairingError, match="holds the occurrences at"):
+        _indexed_corpus(corpus_dir, None, occurrences_dir=str(misfiled)).check_index()
+
+
+def test_two_artifacts_of_one_source_dataset_are_refused(
+    tmp_path, corpus_dir, occurrence_dirs
+):
+    # Both are read, so every occurrence at the path is stated twice. A semi-join
+    # returns a reaction once however many rows name it, and the reached-structure
+    # count is over distinct IDs, so nothing downstream can see it -- but check_index
+    # reports the doubled count as the corpus's own.
+    _, occurrence_dir = occurrence_dirs
+    doubled = tmp_path / "doubled"
+    shutil.copytree(occurrence_dir, doubled)
+    found = occurrences.artifact_paths(doubled, "inputs.components")[0]
+    shutil.copy(found, found.parent / f"copy-{found.name}")
+    with pytest.raises(execute.PairingError, match="of the same source dataset"):
+        _indexed_corpus(corpus_dir, None, occurrences_dir=str(doubled)).check_index()
+
+
+def test_a_file_that_is_not_an_occurrences_artifact_is_refused(
+    tmp_path, corpus_dir, occurrence_dirs
+):
+    _, occurrence_dir = occurrence_dirs
+    mixed = tmp_path / "mixed"
+    shutil.copytree(occurrence_dir, mixed)
+    projected = sorted((corpus_dir / "projections").glob("*.parquet"))[0]
+    shutil.copy(projected, mixed / "inputs.components" / projected.name)
+    with pytest.raises(execute.PairingError, match="is a projection, not an"):
+        _indexed_corpus(corpus_dir, None, occurrences_dir=str(mixed)).check_index()
+
+
+def test_a_stale_occurrence_artifact_is_refused(tmp_path, corpus_dir, occurrence_dirs):
+    # The stamps are the only thing saying an artifact was written by the library
+    # reading it, and an RDKit that has changed canonicalization changes which
+    # structure a row names.
+    _, occurrence_dir = occurrence_dirs
+    staled = tmp_path / "stale"
+    shutil.copytree(occurrence_dir, staled)
+    found = occurrences.artifact_paths(staled, "inputs.components")[0]
+    table = pq.read_table(found)
+    metadata = dict(table.schema.metadata)
+    metadata[b"ord.rdkit_version"] = b"0000.00.0"
+    pq.write_table(table.replace_schema_metadata(metadata), found)
+    with pytest.raises(execute.PairingError, match="is a stale occurrences artifact"):
+        _indexed_corpus(corpus_dir, None, occurrences_dir=str(staled)).check_index()
+    # Read anyway where the caller has said staleness is theirs to judge, which is the
+    # same latitude require_current gives every other artifact.
+    with _indexed_corpus(
+        corpus_dir, None, occurrences_dir=str(staled), require_current=False
+    ) as read:
+        assert sum(read.check_index().values()) > 0
+
+
+def test_requiring_occurrences_refuses_a_partial_directory(
+    corpus_dir, occurrence_dirs, tmp_path
+):
+    # A deployment sized for the view is not sized for the table, so the fallback that
+    # keeps a corpus answering is the one that gets the container killed.
+    pivots, _ = occurrence_dirs
+    partial = _write_occurrences(
+        corpus_dir, pivots, tmp_path / "partial", ("outcomes.products",)
+    )
+    with pytest.raises(execute.PairingError, match="holds no occurrences artifacts"):
+        _indexed_corpus(
+            corpus_dir, None, occurrences_dir=str(partial), require_occurrences=True
+        )
+
+
+def test_requiring_occurrences_accepts_a_covered_directory(corpus_dir, occurrence_dirs):
+    _, occurrence_dir = occurrence_dirs
+    with _indexed_corpus(
+        corpus_dir,
+        None,
+        occurrences_dir=str(occurrence_dir),
+        require_occurrences=True,
+    ) as read:
+        assert sum(read.check_index().values()) > 0
+
+
+def test_requiring_occurrences_without_a_directory_is_refused(corpus_dir):
+    with pytest.raises(ValueError, match="require_occurrences was set without"):
+        _indexed_corpus(corpus_dir, None, require_occurrences=True)


### PR DESCRIPTION
## Summary

[#1006](https://github.com/open-reaction-database/ord-schema/pull/1006) derived the occurrences artifact and nothing read it, so none of what it was for had been collected. This reads it.

`Corpus` gains `occurrences_dir`. Where it covers every indexed path the index is published as a **view over Parquet** rather than materialized, which is the half that actually drops the memory.

## Changes

- `occurrences_dir`: three ways to reach a path's occurrences, cheapest first — the occurrences artifact, then a pivot over its level, then unnesting the projection. Decided per path.
- The relation is a `VIEW` only when every path came from an artifact. One uncovered path materializes all of them: a view whose branches unnest the projection would repeat that traversal on every query rather than pay it once.
- `require_occurrences=True` refuses a directory that does not cover every path, rather than silently materializing. A container sized for the view is not sized for the table, so the fallback that keeps a corpus answering is the one that gets it killed.
- Artifacts are checked the way pivots are: derived from this corpus's own projections, stamped with the path they sit under, current, and no two of one source dataset. The offsets publisher is now shared between pivots and occurrences rather than duplicated.

## Testing

- `uv run pytest`: 1530 passed outside `ord_schema/orm`, whose fixtures need a local Postgres.
- 16 new tests. Seven guards mutation-checked: forcing a table, never reading the artifact, dropping the stamped-path, duplicate-source, staleness, or `require_occurrences` refusals, and making `structure_id` assignment non-deterministic — each fails exactly its own test.
- `test_rebuilding_a_projection_assigns_the_same_structure_ids` pins the invariant the whole artifact chain rests on: an artifact names its structures by the ID its projection assigned and pairs by source hash rather than by build, so a rebuild that renumbered would repoint every row while staying current by every stamp. A permutation leaves the distinct-ID count unchanged, so nothing downstream could see it.
- Over the full local corpus (53 pairs, 2,428,291 reactions, 18,847,978 occurrences), with the substructure library left unbuilt so the index is the only thing measured:

  | | table (from pivots) | view |
  | --- | --- | --- |
  | index build | 2.86 s | **0.13 s** |
  | resident added | 1.92 GiB | **0.32 GiB** |
  | DuckDB holds | +1.66 GiB | **+28 MiB** |
  | peak RSS | 5.61 GiB | **4.58 GiB** |

- Identical `check_index` counts on all four paths and identical row totals for `c1ccncc1`, `[OX2H]`, `C(=O)O`, and `[#6]`; per-query semi-join times are comparable in both directions (0.10 s vs 0.06 s for pyridine, 0.15 s vs 0.11 s for `[#6]`).

## Notes

`ARTIFACT_VERSION` is unchanged at `"1"` — nothing has been published, so there is nothing to invalidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR lets `Corpus` consume occurrence artifacts and publish a fully covered occurrence index as a DuckDB view, while retaining pivot or projection fallbacks for incomplete coverage.
- Adds occurrence-artifact discovery, provenance and freshness checks, dataset-specific offset joins, and duplicate-source rejection.
- Adds strict `require_occurrences` handling for deployments that cannot safely materialize the fallback table.
- Adds differential, coverage, validation, and deterministic-ID regression tests.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/execute.py | Adds validated occurrence-artifact loading, corpus-wide offset joins, strict coverage checks, and view-versus-table publication. |
| ord_schema/search/execute_test.py | Adds coverage for artifact-backed query equivalence, element-role binding, offsets, fallback behavior, and artifact refusal conditions. |
| ord_schema/artifacts/projection_test.py | Adds regression coverage for stable structure-ID assignments when rebuilding a projection. |
| ord_schema/artifacts/occurrences.py | Updates occurrence-artifact documentation to describe its new `Corpus` integration. |
| ord_schema/search/README.md | Documents artifact, pivot, and projection occurrence-index routes and deployment sizing behavior. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    C[Corpus opens] --> A{Occurrence artifact covers path?}
    A -- Yes --> O[Read occurrence Parquet and join dataset offset]
    A -- No --> P{Pivot artifact covers level?}
    P -- Yes --> V[Derive occurrences from pivot]
    P -- No --> U[Unnest projection]
    O --> F{All indexed paths use artifacts?}
    V --> F
    U --> F
    F -- Yes --> VIEW[Publish occurrences as VIEW]
    F -- No --> TABLE[Materialize occurrences as TABLE]
    R[require_occurrences] --> Q{Every path covered?}
    Q -- No --> E[Refuse corpus]
    Q -- Yes --> VIEW
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Say what structure ID stability actually..."](https://github.com/open-reaction-database/ord-schema/commit/8e8c671a3e72980afe7cb093f5f87555e18976ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59334663)</sub>

<!-- /greptile_comment -->