### PR TITLE
Bound the whole search, not the final query alone

### DIFF
--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -771,8 +771,15 @@ reader learns to skip the line that matters. On an **aggregated** query the boun
 groups rather than reactions — part of a distribution read as the whole of it, and an
 arbitrary part where the query ordered by nothing — so that one says more.
 
-`search(timeout_seconds=)` bounds the SQL and only the SQL: name resolution, the library
-and index builds, screening, and verification all run before that timer starts.
+`search(timeout_seconds=)` bounds the whole call. What it can interrupt it interrupts —
+the final query, which runs on the search's own cursor — and the query is given what the
+earlier phases left rather than the whole bound. What it cannot interrupt it checks as the
+phase finishes: screening and verification are RDKit with the GIL released, name
+resolution is an external service, and the index, the library, and a pivot are built once
+for the corpus under a lock, where a timer that killed one would fail every search queued
+behind it, callers that asked for no bound included. So a search can outlast its bound and
+report the overrun rather than being stopped at it, and the `TimeoutError` names the phase
+that ran long.
 
 ## Not yet solved
 

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -69,11 +69,9 @@ Reading the projection at all costs a re-parse of every file's footer, and over 
 it goes on to read. The corpus keeps the parsed footers instead; see ``_cache_footers``.
 
 The grammar bounds what a query can cost (one pass and a sort), and ``search``
-takes a wall-clock timeout over the whole call. It bounds when the caller is answered
-rather than when work stops: the final query is interrupted, while name resolution, the
-one-time library and index builds, screening, and verification are checked as they
-finish, since none of them can be stopped partway and the builds are shared with
-whatever else is waiting on them. Both builds happen
+takes a wall-clock timeout over the whole call, bounding when the caller is answered
+rather than when work stops; see ``_Deadline`` for which phases can be interrupted and
+which are only checked. Both builds happen
 at open unless the corpus was given ``warm=False``, which leaves the index to the first
 query taking a clause of it and the library to the first substructure predicate. A
 search that pays for either pays upwards of a minute over the whole corpus, on top of
@@ -785,15 +783,14 @@ def _warn_when_the_cap_leaves_no_headroom(
 
 
 class _Deadline:
-    """When a search has to be finished, and what it may still spend getting there.
+    """When a search has to be finished, and what it may still spend.
 
     A search is several phases -- compiling, which may build a pivot; the occurrence
     index; name resolution; screening and verifying a structure predicate; and the query
     itself -- and only the last is a DuckDB statement a timer can interrupt. The rest is
-    RDKit with the GIL released, an external resolver, or a build another search is
-    waiting on, none of which can be stopped partway. So this bounds when the caller
-    gets an answer or an error rather than when work stops: each phase is checked as it
-    finishes, and the query is given whatever is left.
+    RDKit with the GIL released, an external resolver, or a build another search waits
+    on. So this bounds when the caller gets an answer or an error rather than when work
+    stops: each phase is checked as it finishes, and the query gets whatever is left.
 
     A shared build is deliberately not interrupted. The occurrence index, the
     substructure library, and a materialized pivot are built once for the corpus under a
@@ -2700,14 +2697,10 @@ class Corpus:
         Args:
             request: The query to run.
             timeout_seconds: Wall-clock bound on the whole call, not on the final
-                query alone. It bounds when the caller gets an answer or an error rather
-                than when work stops: the query is interrupted, but a phase already
-                running is not. Screening and verifying are RDKit with the GIL released,
-                name resolution is an external service, and the index, the library and a
-                pivot are built once for the corpus under a lock -- a timer that killed
-                one of those would fail every search queued behind it, including
-                callers that asked for no bound. So an overrun in one of those phases
-                raises when it finishes, naming it. None runs unbounded.
+                query alone. The query is interrupted; a phase already running is not,
+                and raises when it finishes instead -- so a search can take longer than
+                this and still report the overrun. ``_Deadline`` says which phases those
+                are and why. None runs unbounded.
 
         Returns:
             The selected columns: ``reaction_id`` for a plain query, the group and

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -69,10 +69,11 @@ Reading the projection at all costs a re-parse of every file's footer, and over 
 it goes on to read. The corpus keeps the parsed footers instead; see ``_cache_footers``.
 
 The grammar bounds what a query can cost (one pass and a sort), and ``search``
-takes a wall-clock timeout that interrupts the final query. Name resolution, the
-one-time library and index builds, screening, and verification all run before the timer
-starts: each is bounded by the corpus rather than by the query, so a slow one is slow
-for every caller and shows up in the logs rather than in a timeout. Both builds happen
+takes a wall-clock timeout over the whole call. It bounds when the caller is answered
+rather than when work stops: the final query is interrupted, while name resolution, the
+one-time library and index builds, screening, and verification are checked as they
+finish, since none of them can be stopped partway and the builds are shared with
+whatever else is waiting on them. Both builds happen
 at open unless the corpus was given ``warm=False``, which leaves the index to the first
 query taking a clause of it and the library to the first substructure predicate. A
 search that pays for either pays upwards of a minute over the whole corpus, on top of
@@ -783,6 +784,56 @@ def _warn_when_the_cap_leaves_no_headroom(
     )
 
 
+class _Deadline:
+    """When a search has to be finished, and what it may still spend getting there.
+
+    A search is several phases -- compiling, which may build a pivot; the occurrence
+    index; name resolution; screening and verifying a structure predicate; and the query
+    itself -- and only the last is a DuckDB statement a timer can interrupt. The rest is
+    RDKit with the GIL released, an external resolver, or a build another search is
+    waiting on, none of which can be stopped partway. So this bounds when the caller
+    gets an answer or an error rather than when work stops: each phase is checked as it
+    finishes, and the query is given whatever is left.
+
+    A shared build is deliberately not interrupted. The occurrence index, the
+    substructure library, and a materialized pivot are built once for the corpus under a
+    lock, so a timer that killed one would fail every search queued behind it -- callers
+    that asked for no bound included.
+    """
+
+    def __init__(self, seconds: float | None) -> None:
+        """Starts the clock.
+
+        Args:
+            seconds: Wall-clock bound, or None for no deadline.
+        """
+        self._at = None if seconds is None else time.monotonic() + seconds
+        self._seconds = seconds
+
+    def remaining(self) -> float | None:
+        """Returns the seconds left, or None where there is no deadline."""
+        if self._at is None:
+            return None
+        return self._at - time.monotonic()
+
+    def check(self, phase: str) -> None:
+        """Raises if the deadline has passed.
+
+        Args:
+            phase: What has just finished, named in the error so the caller learns
+                which part of the search was the slow one.
+
+        Raises:
+            TimeoutError: If the deadline has passed.
+        """
+        left = self.remaining()
+        if left is not None and left <= 0:
+            raise TimeoutError(
+                f"the search exceeded {self._seconds} seconds while {phase}; it ran to "
+                "completion because that phase cannot be interrupted"
+            )
+
+
 def _run_with_timeout(
     cursor: duckdb.DuckDBPyConnection,
     sql: str,
@@ -790,6 +841,10 @@ def _run_with_timeout(
     timeout_seconds: float,
 ) -> pa.Table:
     """Runs ``sql``, interrupting it if it outlasts ``timeout_seconds``.
+
+    The one phase of a search that is interruptible, and the only one whose work is this
+    caller's alone: the cursor is the search's own, so interrupting it fails nothing
+    else.
 
     ``Timer.cancel`` only sets a flag, so a timer that has already passed its own
     check fires anyway. The lock makes the interrupt and the teardown exclusive, so
@@ -2644,10 +2699,15 @@ class Corpus:
 
         Args:
             request: The query to run.
-            timeout_seconds: Wall-clock bound on the final query. Name resolution, the
-                library and index builds, screening, and verification run before the
-                timer starts and are not counted, so a first substructure search can
-                take seconds longer than this allows. None runs unbounded.
+            timeout_seconds: Wall-clock bound on the whole call, not on the final
+                query alone. It bounds when the caller gets an answer or an error rather
+                than when work stops: the query is interrupted, but a phase already
+                running is not. Screening and verifying are RDKit with the GIL released,
+                name resolution is an external service, and the index, the library and a
+                pivot are built once for the corpus under a lock -- a timer that killed
+                one of those would fail every search queued behind it, including
+                callers that asked for no bound. So an overrun in one of those phases
+                raises when it finishes, naming it. None runs unbounded.
 
         Returns:
             The selected columns: ``reaction_id`` for a plain query, the group and
@@ -2662,7 +2722,8 @@ class Corpus:
             PairingError: If the corpus IDs do not come out one unbroken run, or the
                 occurrence index refuses the corpus -- a reaction stated by more than
                 one row, or a structure no indexed path reaches.
-            TimeoutError: If the query exceeds ``timeout_seconds``.
+            TimeoutError: If the search exceeds ``timeout_seconds``, naming the phase
+                that was running when the bound passed.
         """
         # Records into this search rather than onto the corpus: two searches share one
         # Corpus, and whether the index answered is a fact about one of them.
@@ -2685,6 +2746,7 @@ class Corpus:
                 resolved[name] = _canonical(self._resolver(name))
             return resolved[name]
 
+        deadline = _Deadline(timeout_seconds)
         with contextlib.ExitStack() as reading:
             pivoted: dict[str, str | None] = {}
 
@@ -2700,6 +2762,9 @@ class Corpus:
             compiled = query.compile_query(
                 request, index=index, pivot=pivot_table, max_rows=self._max_rows
             )
+            # Compiling is cheap, but pivot_table above is not: a level with no artifact
+            # is unnested out of the projection here, which is minutes over a corpus.
+            deadline.check("building a pivot to compile against")
             if compiled.limit != request.limit:
                 logger.info("the corpus bounds this query at %d rows", compiled.limit)
             if indexing:
@@ -2708,6 +2773,7 @@ class Corpus:
                 # after the build, so a build that refuses the corpus does not leave a
                 # line claiming the index answered a query nothing ran.
                 self._occurrences()
+                deadline.check("building the occurrence index")
                 logger.info("the occurrence index answers part of this query")
             else:
                 logger.info("the projection answers this query")
@@ -2716,16 +2782,22 @@ class Corpus:
                 parameters: dict[str, Any] = {
                     name: resolve(name) for name in compiled.compounds
                 }
+                # An external service, so how long it takes is not this corpus's to
+                # predict; a resolver that hangs is the likeliest way a search overruns
+                # without a single slow query in it.
+                deadline.check("resolving compound names")
                 for parameter in compiled.structures:
                     parameters[parameter.name] = self._matches(
                         cursor, parameter, resolve
                     )
-                if timeout_seconds is None:
+                    # Per predicate rather than after all of them, so a query with two
+                    # does not pay for the second once the first has spent the budget.
+                    deadline.check(f"matching {parameter.op} {parameter.name!r}")
+                left = deadline.remaining()
+                if left is None:
                     answered = cursor.execute(compiled.sql, parameters).to_arrow_table()
                 else:
-                    answered = _run_with_timeout(
-                        cursor, compiled.sql, parameters, timeout_seconds
-                    )
+                    answered = _run_with_timeout(cursor, compiled.sql, parameters, left)
                 _warn_when_the_bound_was_reached(request, compiled, answered.num_rows)
                 return answered
             finally:

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -2767,7 +2767,7 @@ class Corpus:
             )
             # Compiling is cheap, but pivot_table above is not: a level with no artifact
             # is unnested out of the projection here, which is minutes over a corpus.
-            deadline.check("building a pivot to compile against")
+            deadline.check("compiling the query")
             if compiled.limit != request.limit:
                 logger.info("the corpus bounds this query at %d rows", compiled.limit)
             if indexing:
@@ -2795,7 +2795,11 @@ class Corpus:
                     )
                     # Per predicate rather than after all of them, so a query with two
                     # does not pay for the second once the first has spent the budget.
-                    deadline.check(f"matching {parameter.op} {parameter.name!r}")
+                    # Named by what the caller wrote rather than by parameter.name,
+                    # which is the compiler's own placeholder and identifies nothing
+                    # outside the SQL it was allocated for.
+                    asked = parameter.pattern or parameter.compound
+                    deadline.check(f"matching {parameter.op} {asked!r}")
                 left = deadline.remaining()
                 if left is None:
                     answered = cursor.execute(compiled.sql, parameters).to_arrow_table()

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -858,8 +858,18 @@ def _run_with_timeout(
         The result as an Arrow table.
 
     Raises:
-        TimeoutError: If the query is interrupted by the timer.
+        TimeoutError: If the query is interrupted by the timer, or if
+            ``timeout_seconds`` has already run out before it starts.
     """
+    # Refused rather than armed. A timer set for a bound already spent fires while the
+    # cursor is still idle, and DuckDB clears an interrupt nothing was running when it
+    # arrived -- so the query would then run unbounded and answer after the deadline it
+    # was given. Decided from the same value that would arm the timer, so no time passes
+    # between the test and the arming for the bound to expire in.
+    if timeout_seconds <= 0:
+        raise TimeoutError(
+            "the search spent its whole bound before the query could start"
+        )
     lock = threading.Lock()
     running = True
 

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -858,8 +858,9 @@ def _run_with_timeout(
         The result as an Arrow table.
 
     Raises:
-        TimeoutError: If the query is interrupted by the timer, or if
-            ``timeout_seconds`` has already run out before it starts.
+        TimeoutError: If the query is interrupted by the timer, if ``timeout_seconds``
+            has already run out before it starts, or if the query answers after the
+            bound because its interrupt was lost.
     """
     # Refused rather than armed. A timer set for a bound already spent fires while the
     # cursor is still idle, and DuckDB clears an interrupt nothing was running when it
@@ -879,15 +880,30 @@ def _run_with_timeout(
                 cursor.interrupt()
 
     timer = threading.Timer(timeout_seconds, interrupt)
+    started = time.monotonic()
     timer.start()
     try:
-        return cursor.execute(sql, parameters).to_arrow_table()
+        answered = cursor.execute(sql, parameters).to_arrow_table()
     except duckdb.InterruptException as error:
         raise TimeoutError(f"query exceeded {timeout_seconds} seconds") from error
     finally:
         timer.cancel()
         with lock:
             running = False
+    # The interrupt is not guaranteed to land. A timer armed for a very short bound can
+    # fire while the cursor is still idle, and DuckDB clears an interrupt that arrived
+    # with nothing running -- measured, a bound of a nanosecond loses it about one run
+    # in five -- after which the query goes on unbounded. So the answer is checked
+    # against the clock rather than trusted because no interrupt arrived: the bound is a
+    # promise about when the caller is answered, and one kept only when a race goes the
+    # right way is not a promise.
+    elapsed = time.monotonic() - started
+    if elapsed > timeout_seconds:
+        raise TimeoutError(
+            f"the query answered after {elapsed:.3f} seconds, past the "
+            f"{timeout_seconds} it was given; its interrupt did not land"
+        )
+    return answered
 
 
 @dataclasses.dataclass

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -4749,3 +4749,46 @@ def test_a_bound_spent_before_the_query_starts_does_not_run_it(corpus, spent):
             execute._run_with_timeout(cursor, "SELECT * FROM no_such_table", {}, spent)
     finally:
         cursor.close()
+
+
+class _LostTimer:
+    """A timer that never fires, standing in for an interrupt DuckDB dropped."""
+
+    def __init__(self, seconds: float, function) -> None:
+        """Accepts and discards what ``threading.Timer`` would act on.
+
+        Args:
+            seconds: Ignored.
+            function: Ignored; never called, which is the point.
+        """
+        del seconds, function
+
+    def start(self) -> None:
+        """Does nothing."""
+
+    def cancel(self) -> None:
+        """Does nothing."""
+
+
+def test_an_answer_that_arrives_past_the_bound_is_a_timeout(corpus, monkeypatch):
+    # The interrupt is not guaranteed to land: a timer armed for a very short bound can
+    # fire while the cursor is still idle, and DuckDB clears an interrupt that arrived
+    # with nothing running -- measured, a bound of a nanosecond loses it about one run
+    # in five, after which the query runs unbounded. So the answer is checked against
+    # the clock rather than trusted because no interrupt arrived.
+    #
+    # The lost interrupt is simulated rather than raced for: a timer that never fires
+    # is what the caller sees either way, and a test that waited for the real race
+    # would pass four times in five while the bug was present.
+    monkeypatch.setattr(execute.threading, "Timer", _LostTimer)
+    cursor = corpus._connection.cursor()
+    try:
+        with pytest.raises(TimeoutError, match=r"past the .* it was given"):
+            execute._run_with_timeout(
+                cursor,
+                "SELECT count(*) FROM range(30_000_000) t(i) WHERE i % 7 = 0",
+                {},
+                0.001,
+            )
+    finally:
+        cursor.close()

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -2054,7 +2054,10 @@ def test_a_routed_query_is_bounded_by_the_timeout(corpus, monkeypatch):
     assert _index_spent(body), "expected the index to take the clause"
     request = query.Query.model_validate(body)
     assert _reactions(corpus.search(request, timeout_seconds=60)) == {"ord-aa01"}
-    assert [timeout for _, timeout in seen] == [60]
+    # What reaches the query is what the earlier phases left, not the whole bound: the
+    # screen and the index build come out of the same budget.
+    (spent,) = [timeout for _, timeout in seen]
+    assert 0 < spent <= 60
     assert "FROM occurrences" in seen[0][0]
 
 
@@ -4651,3 +4654,76 @@ def test_requiring_occurrences_accepts_a_covered_directory(corpus_dir, occurrenc
 def test_requiring_occurrences_without_a_directory_is_refused(corpus_dir):
     with pytest.raises(ValueError, match="require_occurrences was set without"):
         _indexed_corpus(corpus_dir, None, require_occurrences=True)
+
+
+# What the timeout covers
+
+
+def test_the_query_is_given_what_the_earlier_phases_left(corpus, monkeypatch):
+    # The bound is over the whole call, so a phase that spends half of it leaves the
+    # query the other half. Passing the full bound down would let a search take twice
+    # what it was allowed and report no error.
+    seen: list[float] = []
+    original = execute._run_with_timeout
+
+    def recording(cursor, sql, parameters, timeout_seconds):
+        seen.append(timeout_seconds)
+        return original(cursor, sql, parameters, timeout_seconds)
+
+    monkeypatch.setattr(execute, "_run_with_timeout", recording)
+    slow = execute.Corpus._matches
+
+    def dawdle(self, cursor, parameter, resolve):
+        time.sleep(0.2)
+        return slow(self, cursor, parameter, resolve)
+
+    monkeypatch.setattr(execute.Corpus, "_matches", dawdle)
+    request = query.Query.model_validate(
+        {
+            "where": _exists(
+                {"op": "substructure", "path": "smiles", "compound": "pyridine"}
+            )
+        }
+    )
+    corpus.search(request, timeout_seconds=10)
+    (left,) = seen
+    assert 0 < left < 10 - 0.2
+
+
+def test_a_phase_that_outlasts_the_bound_raises_naming_itself(corpus, monkeypatch):
+    # The phases that cannot be interrupted -- an external resolver, RDKit with the GIL
+    # released, a build another search is waiting on -- are checked as they finish. The
+    # error says which one, because "the search timed out" over a corpus that answers in
+    # milliseconds is a question rather than an answer.
+    def dawdle(self, cursor, parameter, resolve):
+        time.sleep(0.05)
+        return self._bitmap([])
+
+    monkeypatch.setattr(execute.Corpus, "_matches", dawdle)
+    request = query.Query.model_validate(
+        {
+            "where": _exists(
+                {"op": "substructure", "path": "smiles", "compound": "pyridine"}
+            )
+        }
+    )
+    with pytest.raises(TimeoutError, match="matching substructure"):
+        corpus.search(request, timeout_seconds=0.01)
+
+
+def test_no_timeout_leaves_every_phase_unbounded(corpus, monkeypatch):
+    # None has to stay a real "no bound" rather than a very large one: a phase that
+    # checked a deadline of None would raise on a corpus that is merely slow.
+    def dawdle(self, cursor, parameter, resolve):
+        time.sleep(0.05)
+        return self._bitmap([])
+
+    monkeypatch.setattr(execute.Corpus, "_matches", dawdle)
+    request = query.Query.model_validate(
+        {
+            "where": _exists(
+                {"op": "substructure", "path": "smiles", "compound": "pyridine"}
+            )
+        }
+    )
+    assert corpus.search(request) is not None

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -4727,3 +4727,20 @@ def test_no_timeout_leaves_every_phase_unbounded(corpus, monkeypatch):
         }
     )
     assert corpus.search(request) is not None
+
+
+@pytest.mark.parametrize("spent", [0, -0.5])
+def test_a_bound_spent_before_the_query_starts_does_not_run_it(corpus, spent):
+    # A timer armed for a bound already spent fires while the cursor is idle, and DuckDB
+    # clears an interrupt that arrived with nothing running -- so the query would go on
+    # to run unbounded and answer after the deadline it was given. Refused instead, from
+    # the same value that would have armed the timer, so nothing can expire in between.
+    #
+    # The SQL names a table that does not exist: if it ran at all, what comes back is a
+    # DuckDB binder error rather than the TimeoutError this asserts.
+    cursor = corpus._connection.cursor()
+    try:
+        with pytest.raises(TimeoutError, match="whole bound before the query"):
+            execute._run_with_timeout(cursor, "SELECT * FROM no_such_table", {}, spent)
+    finally:
+        cursor.close()

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -4707,13 +4707,16 @@ def test_a_phase_that_outlasts_the_bound_raises_naming_itself(corpus, monkeypatc
             )
         }
     )
-    with pytest.raises(TimeoutError, match="matching substructure"):
+    # Named by the pattern the caller asked for, not by the compiler's placeholder.
+    with pytest.raises(TimeoutError, match="matching substructure 'pyridine'"):
         corpus.search(request, timeout_seconds=0.01)
 
 
 def test_no_timeout_leaves_every_phase_unbounded(corpus, monkeypatch):
     # None has to stay a real "no bound" rather than a very large one: a phase that
-    # checked a deadline of None would raise on a corpus that is merely slow.
+    # checked a deadline of None would raise on a corpus that is merely slow. The
+    # contrast is the assertion -- the same slow phase under a bound does raise, so a
+    # passing unbounded search says something about None rather than about the fixture.
     def dawdle(self, cursor, parameter, resolve):
         time.sleep(0.05)
         return self._bitmap([])
@@ -4726,7 +4729,9 @@ def test_no_timeout_leaves_every_phase_unbounded(corpus, monkeypatch):
             )
         }
     )
-    assert corpus.search(request) is not None
+    with pytest.raises(TimeoutError):
+        corpus.search(request, timeout_seconds=0.01)
+    assert corpus.search(request).num_rows == 0
 
 
 @pytest.mark.parametrize("spent", [0, -0.5])


### PR DESCRIPTION
## Summary

`search(timeout_seconds=)` started its timer after name resolution, the library and index builds, screening, and verification — so a caller setting ten seconds got no protection from a sixty-second screen. The docstring was explicit about it; the behavior was still a trap (finding 7 of the [review](https://github.com/open-reaction-database/ord-logbook/tree/main/entries/2026-08-30-artifact-and-search-path-review)).

The bound is now over the whole call.

## Changes

- `_Deadline` starts at entry, and each phase is checked as it finishes: compiling, the occurrence index, name resolution, and each structure predicate's screen.
- **What can be interrupted, is.** The final query runs on the search's own cursor and is given whatever the earlier phases left, not the full bound.
- **What cannot, is checked rather than killed.** Screening and verification are RDKit with the GIL released; name resolution is an external service; and the index, the library, and a pivot are built once for the corpus under a lock — a timer that killed one would fail every search queued behind it, *including callers that asked for no bound*.
- **A bound already spent is refused rather than armed.** A timer set for a non-positive remainder fires while the cursor is idle, and DuckDB clears an interrupt that arrived with nothing running, so the query then ran unbounded. The remainder can go non-positive between the last phase check and the arming, so the guard is inside `_run_with_timeout`, decided from the same value that would arm the timer.
- The error names the phase and the predicate the caller wrote: `the search exceeded 10 seconds while matching substructure 'pyridine'`. "The search timed out" over a corpus that answers in milliseconds is a question rather than an answer.

## Testing

- `uv run pytest`: 1536 passed outside `ord_schema/orm`, whose fixtures need a local Postgres.
- Five new tests. Mutation-checked: dropping the spent-bound guard, and naming a predicate by the compiler's placeholder instead of the caller's pattern, each fail exactly their own test.
- The spent-bound test takes two values and they behave differently without the guard — a remainder of exactly `0` still interrupts in time, `-0.5` loses the interrupt and the query completes. Its SQL names a table that does not exist, so a query that ran at all returns a binder error rather than the `TimeoutError` asserted.
- `test_a_routed_query_is_bounded_by_the_timeout` previously pinned that the query got the *full* bound, which is what changed; it now asserts a positive remainder.

## Notes

This is not a hard wall-clock bound. A 10 s timeout against a 60 s screen returns a `TimeoutError` after 60 s rather than a result after 60 s and no error. A hard bound would mean abandoning work in a worker thread while it holds a corpus-wide lock, which trades a trap for a deadlock.

A consequence worth knowing: a corpus opened with `warm=False` builds the index and library inside the first search's deadline, so a short bound on a cold corpus now raises where it used to return slowly. That is the intended report, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes `search(timeout_seconds=)` from a final-query timeout into a deadline covering the entire search lifecycle.
- Starts deadline accounting when `Corpus.search()` begins and checks it after non-interruptible preparation phases.
- Gives the final DuckDB query only the remaining budget.
- Rejects an exhausted query budget before timer setup and checks successful results for lost interrupts.
- Updates the public timeout documentation and adds focused regression tests.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/execute.py | Implements whole-search deadline accounting, remaining-budget query execution, and guards for exhausted or lost query interrupts. |
| ord_schema/search/execute_test.py | Adds regression coverage for phase accounting, exhausted bounds, unbounded searches, and successful queries whose interrupts were lost. |
| ord_schema/search/README.md | Updates the documented timeout contract to match whole-call deadline behavior. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Search as Corpus.search
    participant Prep as Preparation phases
    participant Query as DuckDB query
    Caller->>Search: search(request, timeout_seconds)
    Search->>Search: Start deadline
    Search->>Prep: Compile, index, resolve, match
    Prep-->>Search: Phase completes
    Search->>Search: Check deadline
    alt Budget exhausted
        Search-->>Caller: TimeoutError naming phase
    else Budget remains
        Search->>Query: Execute with remaining time
        Query-->>Search: Result or interrupt
        Search->>Search: Check elapsed query time
        Search-->>Caller: Result or TimeoutError
    end
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Check the answer against the clock rathe..."](https://github.com/open-reaction-database/ord-schema/commit/dcc8ca5042930e8906a524fc2644b57211c34c8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59757317)</sub>

<!-- /greptile_comment -->