### PR TITLE
Walk map fields in key order when projecting

### DIFF
--- a/ord_schema/artifacts/projection.py
+++ b/ord_schema/artifacts/projection.py
@@ -493,7 +493,13 @@ def message_row(
         message_type = field.message_type
         if message_type is not None and message_type.GetOptions().map_entry:
             value_field = message_type.fields_by_name["value"]
-            items = getattr(message, field.name).items()
+            # Sorted by key, because protobuf leaves a map's iteration order undefined
+            # and structure IDs are assigned in the order this walk reaches a SMILES.
+            # Taking protobuf's order would make the IDs a function of the protobuf
+            # build as well as of the source and the stamped library versions -- and
+            # that build is not stamped, so an upgrade that reordered a map would
+            # renumber a corpus whose artifacts all read as current, silently.
+            items = sorted(getattr(message, field.name).items())
             if value_field.message_type is not None:
                 row[name] = [
                     (key, message_row(value, structure_ids)) for key, value in items

--- a/ord_schema/artifacts/projection_test.py
+++ b/ord_schema/artifacts/projection_test.py
@@ -601,6 +601,31 @@ def test_write_projection_stamps_one_id_space_per_dataset(tmp_path):
         assert product["structure_id"] == 1
 
 
+def test_map_fields_are_walked_in_key_order(tmp_path):
+    # Structure IDs are assigned in the order this walk reaches a SMILES, and protobuf
+    # leaves a map's iteration order undefined. Taking protobuf's order would make the
+    # IDs a function of the protobuf build as well as of the source and the stamped
+    # library versions -- and that build is stamped nowhere, so an upgrade that
+    # reordered a map would renumber a corpus whose artifacts all read as current.
+    keys = ["zeta", "alpha", "mike", "bravo", "yankee", "delta", "oscar", "kilo"]
+    reaction = reaction_pb2.Reaction(reaction_id="ord-0001")
+    for index, key in enumerate(keys):
+        component = reaction.inputs[key].components.add()
+        component.identifiers.add(type="SMILES", value="C" * (index + 1) + "O")
+    assert list(reaction.inputs.keys()) != sorted(keys), (
+        "protobuf now iterates this map in key order, so this test proves nothing; "
+        "choose keys it orders differently or drop it"
+    )
+    source = _source(tmp_path, [reaction])
+    output = tmp_path / "projection.parquet"
+    projection.write_projection(source, output)
+    (row,) = pq.read_table(output, columns=["inputs"]).to_pylist()
+    assigned = {
+        key: value["components"][0]["structure_id"] for key, value in row["inputs"]
+    }
+    assert assigned == {key: rank for rank, key in enumerate(sorted(keys))}
+
+
 def test_rebuilding_a_projection_assigns_the_same_structure_ids(tmp_path):
     # The invariant every derived artifact rests on. A pivot or occurrences artifact
     # names its structures by the ID its projection assigned, and pairs with that


### PR DESCRIPTION
## Summary

`structure_id` is assigned in the order the projection walk reaches a SMILES, and that walk iterated protobuf map fields in protobuf's own order — which protobuf specifies as **undefined**.

So the IDs were a function of the protobuf build as well as of the source and the stamped library versions. That build is stamped nowhere, so a protobuf upgrade that reordered a map would renumber a corpus whose artifacts all read as current, with no `Corpus.fingerprint` change to warn anything holding an ID.

Found by the Greptile review of [#1010](https://github.com/open-reaction-database/ord-schema/pull/1010), which was right after I had rebutted the same concern reached by a different route.

## Changes

- `projection.message_row` sorts a map field's items by key, making the order the derivation's own rather than a property of a dependency nothing records.

## Testing

- `uv run pytest`: 1531 passed outside `ord_schema/orm`, whose fixtures need a local Postgres.
- `test_map_fields_are_walked_in_key_order` uses eight keys `upb` orders differently from sorted, and asserts that too — so if protobuf ever starts sorting maps, the test says it has become vacuous rather than passing quietly. Mutation-checked: dropping the sort fails it.
- Every existing test passed both with and without the sort, which is the point: measured across five `PYTHONHASHSEED` values, `upb` orders a given serialization identically every time, so nothing that runs against one protobuf build could have caught this.

## Notes

**This changes what a projection contains**, so artifacts derived before it are stale in content while still current by every stamp. `ARTIFACT_VERSION` is unchanged at `"1"` — nothing is published, so there is nothing to invalidate publicly, but a local corpus needs re-deriving. The natural moment is the `ARTIFACT_VERSION` split, which re-derives anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes projection traversal deterministic by sorting protobuf map entries before assigning dataset-local structure IDs.
- Sorts map fields by key during recursive projection.
- Adds regression coverage verifying key-ordered structure-ID assignment and detecting a vacuous protobuf-order test.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the artifact compatibility consequence explicitly documented and deferred to the planned artifact-version split.

The changed traversal deterministically orders all Reaction-reachable maps, whose keys are strings, and the accompanying test directly verifies the resulting structure-ID assignment.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/artifacts/projection.py | Sorts protobuf map entries before recursive projection so structure-ID assignment no longer depends on protobuf map iteration order. |
| ord_schema/artifacts/projection_test.py | Verifies deterministic key-ordered ID assignment and explicitly guards against the fixture becoming vacuous. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Walk map fields in key order when projec..."](https://github.com/open-reaction-database/ord-schema/commit/59c931d1e1c96eec512be9b53c7d6cbb2d49ab1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59759717)</sub>

**Context used:**

- Knowledge Base — [Chemical data transformation](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/chemical-data-transformation.md)
- Knowledge Base — [Reaction artifacts and projections](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/reaction-artifacts.md)

<!-- /greptile_comment -->