### PR TITLE
Version each artifact separately, and stamp the whole chain

### DIFF
--- a/ord_schema/artifacts/README.md
+++ b/ord_schema/artifacts/README.md
@@ -63,8 +63,8 @@ A chain is invisible to a consumer checking currency.
 **Versions are per artifact, and the stamp carries the whole chain.** The derivations
 cost wildly different amounts — measured over the source that is 96% of ORD, a projection
 is 34.6 minutes and its structures 29.6, while the occurrences at every indexed path are
-1.9 seconds — so one shared version charged the 81-minute rebuild for a change to the
-1.9-second artifact.
+1.9 seconds — so one shared version would charge the 81-minute rebuild for a change to
+the 1.9-second artifact.
 
 Splitting it alone would break the thing the shared version was doing, which is real: a
 change to how projections are derived has to invalidate everything built *from* a

--- a/ord_schema/artifacts/README.md
+++ b/ord_schema/artifacts/README.md
@@ -47,7 +47,7 @@ current:
 | key | why it can invalidate |
 | --- | --- |
 | `ord.artifact` | tells one artifact from another without inspecting the schema |
-| `ord.artifact_version` | one version across **all** artifacts, so two artifacts of one dataset cannot disagree while both look current |
+| `ord.artifact_lineage` | this artifact's version and every ancestor's, so a redefinition anywhere up the chain makes the file stale |
 | `ord.source_md5` | the content of the source dataset this restates |
 | `ord.ord_schema_version` | what derived it |
 | `ord.rdkit_version` | RDKit releases have changed both canonicalization and pattern fingerprints, either of which silently breaks a file whose consumers run the newer one |
@@ -60,9 +60,23 @@ hashing its parent, so every artifact names the dataset it reflects however many
 derivations away it sits, and one comparison answers "is this current for that dataset?"
 A chain is invisible to a consumer checking currency.
 
-The version is shared rather than per-artifact because a derivation change usually
-touches shared helpers, and a reader comparing two artifacts to each other needs to know
-they were built by the same definition.
+**Versions are per artifact, and the stamp carries the whole chain.** The derivations
+cost wildly different amounts — measured over the source that is 96% of ORD, a projection
+is 34.6 minutes and its structures 29.6, while the occurrences at every indexed path are
+1.9 seconds — so one shared version charged the 81-minute rebuild for a change to the
+1.9-second artifact.
+
+Splitting it alone would break the thing the shared version was doing, which is real: a
+change to how projections are derived has to invalidate everything built *from* a
+projection, and an artifact stamps its **source dataset's** hash rather than its parent's,
+so a child cannot otherwise see that its parent's definition moved. So the stamp is the
+chain — `occurrences=1,pivot=1,projection=1` — and the currency check compares it to what
+the library would write today. A projection bump reaches the occurrences three derivations
+down; an occurrences bump reaches nothing above it.
+
+The direct parent alone is not enough, which is the part worth stating: occurrences record
+the pivot they came from, and a projection bump moves neither the occurrences' own version
+nor the pivot's. Only the full chain says so.
 
 ## Deriving a tree
 

--- a/ord_schema/artifacts/base.py
+++ b/ord_schema/artifacts/base.py
@@ -35,11 +35,13 @@ already uses for source datasets:
 
 * ``ord.artifact`` -- which artifact this is, so a reader can tell one from another
   without inspecting the schema.
-* ``ord.artifact_version`` -- one version across *all* artifacts, deliberately. A
-  derivation change usually touches shared helpers, and a reader comparing artifacts to
-  each other needs to know they were built by the same definition. Per-artifact versions
-  would let a structures artifact and a projection of the same dataset disagree while
-  both looked current.
+* ``ord.artifact_lineage`` -- this artifact's version and every ancestor's, as one
+  string. Per artifact, because the derivations cost wildly different amounts and a
+  shared version charged the most expensive rebuild for a change to the cheapest. The
+  whole chain rather than the artifact's own version, because what a version has to
+  invalidate is everything built *from* it: occurrences derived from a pivot derived
+  from a projection go stale when any of the three is redefined, and a stamp naming only
+  one of them cannot say so.
 * ``ord.source_md5`` -- the content of the source dataset it restates. An artifact
   derived from another artifact passes this through rather than hashing its parent, so
   every artifact names the dataset it reflects however many derivations away it sits,
@@ -55,8 +57,8 @@ already uses for source datasets:
   one, and so the only key not required to read stamps back.
 
 ``is_current`` requires the artifact name, the source content, the library version, the
-artifact version, and the RDKit version to all match, since any of the five changing
-can change a value or mean the file answers a different question.
+artifact lineage, and the RDKit version to all match, since any of the five changing can
+change a value or mean the file answers a different question.
 """
 
 import dataclasses
@@ -75,12 +77,62 @@ from ord_schema.logging import get_logger
 
 logger = get_logger(__name__)
 
-# Bumped when any artifact's definition changes -- a column's meaning, how it is
-# populated, or a shared helper that feeds one. Existing artifacts then read as stale.
-ARTIFACT_VERSION = "1"
+# Bumped when an artifact's definition changes -- a column's meaning, how it is
+# populated, or a shared helper that feeds it. Per artifact, because a re-derive is not
+# one price: measured over the source that is 96% of ORD, a projection is 34.6 minutes
+# and its structures 29.6, while the occurrences at every indexed path are 1.9 seconds.
+# One version for all of them charged the 81-minute rebuild for a change to the
+# 1.9-second artifact.
+ARTIFACT_VERSIONS = {
+    "projection": "1",
+    "structures": "1",
+    "pivot": "1",
+    "occurrences": "1",
+}
+
+# What each artifact is derived from, or None where it is derived from a source dataset.
+# Here rather than in the artifact modules because a version has to invalidate what was
+# built *from* it, which is a fact about the chain rather than about either end: a
+# projection bump has to reach the occurrences three derivations down, and neither
+# module knows the other exists.
+DERIVED_FROM: dict[str, str | None] = {
+    "projection": None,
+    "structures": "projection",
+    "pivot": "projection",
+    "occurrences": "pivot",
+}
+
+
+def lineage(artifact: str) -> str:
+    """Returns an artifact's version and every ancestor's, as one comparable string.
+
+    What is stamped, so that a bump anywhere up the chain makes a file stale. Stamping
+    only the artifact's own version would leave the occurrences current when the pivot
+    they came from was redefined; stamping only the parent's would leave them current
+    when the *projection* under that pivot was, which is the case a chain of three makes
+    reachable.
+
+    Args:
+        artifact: Artifact name, a key of ``ARTIFACT_VERSIONS``.
+
+    Returns:
+        The chain from this artifact to its root, e.g. ``occurrences=1,pivot=1,
+        projection=1``.
+
+    Raises:
+        KeyError: If ``artifact`` is not one this library derives, which is a typo
+            rather than a condition to handle.
+    """
+    parts = []
+    name: str | None = artifact
+    while name is not None:
+        parts.append(f"{name}={ARTIFACT_VERSIONS[name]}")
+        name = DERIVED_FROM[name]
+    return ",".join(parts)
+
 
 _META_ARTIFACT = "ord.artifact"
-_META_ARTIFACT_VERSION = "ord.artifact_version"
+_META_ARTIFACT_LINEAGE = "ord.artifact_lineage"
 _META_RDKIT_VERSION = "ord.rdkit_version"
 _META_SOURCE_DATASET_ID = "ord.source_dataset_id"
 _META_SOURCE_MD5 = "ord.source_md5"
@@ -88,7 +140,7 @@ _META_ORD_SCHEMA_VERSION = "ord.ord_schema_version"
 
 _REQUIRED = (
     _META_ARTIFACT,
-    _META_ARTIFACT_VERSION,
+    _META_ARTIFACT_LINEAGE,
     _META_SOURCE_MD5,
     _META_ORD_SCHEMA_VERSION,
 )
@@ -106,7 +158,7 @@ class Stamps:
     source_dataset_id: str | None
     source_md5: str
     ord_schema_version: str
-    artifact_version: str
+    artifact_lineage: str
     rdkit_version: str | None = None
 
 
@@ -144,14 +196,14 @@ def current_stamps(
         source_md5: Hash of the source, from ``parquet.DatasetView.md5``.
 
     Returns:
-        Stamps carrying the current library and artifact versions.
+        Stamps carrying the current library version and the artifact's lineage.
     """
     return Stamps(
         artifact=artifact,
         source_dataset_id=source_dataset_id,
         source_md5=source_md5,
         ord_schema_version=metadata.version("ord-schema"),
-        artifact_version=ARTIFACT_VERSION,
+        artifact_lineage=lineage(artifact),
         rdkit_version=rdBase.rdkitVersion,
     )
 
@@ -160,7 +212,7 @@ def to_metadata(value: Stamps) -> dict[str, str]:
     """Returns ``value`` as Parquet footer key-value metadata."""
     result = {
         _META_ARTIFACT: value.artifact,
-        _META_ARTIFACT_VERSION: value.artifact_version,
+        _META_ARTIFACT_LINEAGE: value.artifact_lineage,
         _META_SOURCE_MD5: value.source_md5,
         _META_ORD_SCHEMA_VERSION: value.ord_schema_version,
     }
@@ -204,7 +256,7 @@ def load_stamps(path: str | os.PathLike[str]) -> Stamps:
         ),
         source_md5=values[_META_SOURCE_MD5],
         ord_schema_version=values[_META_ORD_SCHEMA_VERSION],
-        artifact_version=values[_META_ARTIFACT_VERSION],
+        artifact_lineage=values[_META_ARTIFACT_LINEAGE],
         rdkit_version=rdkit_version.decode() if rdkit_version is not None else None,
     )
 
@@ -240,9 +292,9 @@ def is_current(
 ) -> bool:
     """Returns whether ``path`` holds ``artifact`` derived from ``source_md5`` by us.
 
-    All of the source content, the library version, the artifact version, and the RDKit
-    version must match; any of them changing can change a value. A missing, unreadable,
-    or wrong-artifact file is not current.
+    All of the source content, the library version, the artifact lineage, and the
+    RDKit version must match; any of them changing can change a value. A missing,
+    unreadable, or wrong-artifact file is not current.
 
     Args:
         path: Path to check. Need not exist.
@@ -278,13 +330,15 @@ def stamps_are_current(value: Stamps, artifact: str) -> bool:
         artifact: Artifact name the file is expected to hold.
 
     Returns:
-        Whether the artifact name, the library version, the artifact version, and the
-        RDKit version all match. A file with no RDKit stamp is not current.
+        Whether the artifact name, the library version, the artifact lineage, and the
+        RDKit version all match. A file with no RDKit stamp is not current -- and a
+        lineage mismatch covers a redefinition of this artifact or of anything it was
+        derived from.
     """
     return (
         value.artifact == artifact
         and value.ord_schema_version == metadata.version("ord-schema")
-        and value.artifact_version == ARTIFACT_VERSION
+        and value.artifact_lineage == lineage(artifact)
         and value.rdkit_version == rdBase.rdkitVersion
     )
 

--- a/ord_schema/artifacts/base.py
+++ b/ord_schema/artifacts/base.py
@@ -81,7 +81,7 @@ logger = get_logger(__name__)
 # populated, or a shared helper that feeds it. Per artifact, because a re-derive is not
 # one price: measured over the source that is 96% of ORD, a projection is 34.6 minutes
 # and its structures 29.6, while the occurrences at every indexed path are 1.9 seconds.
-# One version for all of them charged the 81-minute rebuild for a change to the
+# Sharing one version across them would charge the 81-minute rebuild for a change to the
 # 1.9-second artifact.
 ARTIFACT_VERSIONS = {
     "projection": "1",
@@ -122,13 +122,21 @@ def lineage(artifact: str) -> str:
     Raises:
         KeyError: If ``artifact`` is not one this library derives, which is a typo
             rather than a condition to handle.
+        ValueError: If ``DERIVED_FROM`` describes a cycle. Bounded rather than walked to
+            exhaustion because this runs on every artifact written and every currency
+            check made, and a typo in a four-line literal should not hang all of them.
     """
     parts = []
     name: str | None = artifact
-    while name is not None:
+    for _ in range(len(ARTIFACT_VERSIONS)):
+        if name is None:
+            return ",".join(parts)
         parts.append(f"{name}={ARTIFACT_VERSIONS[name]}")
         name = DERIVED_FROM[name]
-    return ",".join(parts)
+    raise ValueError(
+        f"the chain from {artifact} visits {len(parts)} artifacts without reaching a "
+        f"source dataset, so DERIVED_FROM has a cycle: {' -> '.join(parts)}"
+    )
 
 
 _META_ARTIFACT = "ord.artifact"

--- a/ord_schema/artifacts/base_test.py
+++ b/ord_schema/artifacts/base_test.py
@@ -44,13 +44,15 @@ def _current_metadata(**overrides):
 def _valid_metadata(**overrides):
     metadata = {
         "ord.artifact": "structures",
-        "ord.artifact_version": base.ARTIFACT_VERSION,
         "ord.source_md5": "0" * 32,
         "ord.ord_schema_version": "9.9.9",
         "ord.rdkit_version": rdBase.rdkitVersion,
         "ord.source_dataset_id": "ord_dataset-1",
     }
     metadata.update(overrides)
+    # Derived from whichever artifact the caller asked for, so a test that overrides one
+    # does not silently get another's chain and pass for the wrong reason.
+    metadata.setdefault("ord.artifact_lineage", base.lineage(metadata["ord.artifact"]))
     return metadata
 
 
@@ -60,7 +62,7 @@ def _valid_metadata(**overrides):
 def test_stamps_carries_the_current_versions():
     value = base.current_stamps("structures", "ord_dataset-1", "abc")
     assert value.artifact == "structures"
-    assert value.artifact_version == base.ARTIFACT_VERSION
+    assert value.artifact_lineage == base.lineage("structures")
     assert value.ord_schema_version
 
 
@@ -91,7 +93,7 @@ def test_load_stamps_tolerates_a_missing_dataset_id(tmp_path):
     "missing",
     [
         "ord.artifact",
-        "ord.artifact_version",
+        "ord.artifact_lineage",
         "ord.source_md5",
         "ord.ord_schema_version",
     ],
@@ -140,7 +142,9 @@ def test_is_current_requires_every_stamp_to_match(tmp_path, monkeypatch):
     monkeypatch.setattr(base.metadata, "version", lambda _: "9.9.10")
     assert not base.is_current(path, "structures", "0" * 32)
     monkeypatch.setattr(base.metadata, "version", lambda _: "9.9.9")
-    monkeypatch.setattr(base, "ARTIFACT_VERSION", "99")
+    monkeypatch.setattr(
+        base, "ARTIFACT_VERSIONS", base.ARTIFACT_VERSIONS | {"structures": "99"}
+    )
     assert not base.is_current(path, "structures", "0" * 32)
 
 
@@ -442,7 +446,9 @@ def test_derive_tree_refuses_a_stale_parent(tmp_path, monkeypatch):
     (tmp_path / "aa").mkdir()
     parent = tmp_path / "aa" / "projected.parquet"
     _write(parent, _current_metadata(**{"ord.artifact": "projection"}))
-    monkeypatch.setattr(base, "ARTIFACT_VERSION", "next")
+    monkeypatch.setattr(
+        base, "ARTIFACT_VERSIONS", base.ARTIFACT_VERSIONS | {"projection": "next"}
+    )
     with pytest.raises(ValueError, match="stale projection"):
         base.derive_tree(
             str(tmp_path / "*" / "*.parquet"),
@@ -524,3 +530,61 @@ def test_an_artifact_with_no_rdkit_stamp_reads_stale():
         rdkit_version=None,
     )
     assert not base.stamps_are_current(value, "structures")
+
+
+# Per-artifact versions
+
+
+def test_a_lineage_names_the_artifact_and_every_ancestor():
+    assert base.lineage("projection") == "projection=1"
+    assert base.lineage("structures") == "structures=1,projection=1"
+    assert base.lineage("occurrences") == "occurrences=1,pivot=1,projection=1"
+
+
+def test_every_artifact_reaches_a_source_dataset():
+    # A cycle or a missing parent would hang or raise inside lineage, which is called
+    # for every artifact written and every currency check made.
+    for artifact in base.ARTIFACT_VERSIONS:
+        assert base.lineage(artifact).endswith("projection=1")
+    assert set(base.DERIVED_FROM) == set(base.ARTIFACT_VERSIONS)
+    assert {
+        parent for parent in base.DERIVED_FROM.values() if parent is not None
+    } <= set(base.ARTIFACT_VERSIONS)
+
+
+def test_bumping_an_artifact_leaves_what_it_was_derived_from_alone(monkeypatch):
+    # The whole point of splitting the version. Occurrences are 1.9 seconds to derive
+    # and the projection under them 34.6 minutes, so a change to the cheap one must not
+    # charge the expensive one.
+    before = base.lineage("projection")
+    monkeypatch.setattr(
+        base, "ARTIFACT_VERSIONS", base.ARTIFACT_VERSIONS | {"occurrences": "2"}
+    )
+    assert base.lineage("projection") == before
+    assert base.lineage("pivot") == "pivot=1,projection=1"
+    assert base.lineage("occurrences") == "occurrences=2,pivot=1,projection=1"
+
+
+def test_bumping_an_artifact_reaches_everything_derived_from_it(monkeypatch):
+    # And the other half: a projection redefined has to invalidate the occurrences three
+    # derivations down, which a stamp naming only the artifact's own version cannot say
+    # and one naming only its parent's cannot either.
+    monkeypatch.setattr(
+        base, "ARTIFACT_VERSIONS", base.ARTIFACT_VERSIONS | {"projection": "2"}
+    )
+    assert base.lineage("occurrences") == "occurrences=1,pivot=1,projection=2"
+    assert base.lineage("structures") == "structures=1,projection=2"
+
+
+def test_a_grandparent_bump_makes_a_grandchild_stale(tmp_path, monkeypatch):
+    # The case a direct-parent stamp misses: occurrences record the pivot they came
+    # from, and a projection bump moves neither the occurrences' own version nor the
+    # pivot's, so nothing but the lineage can see it.
+    path = tmp_path / "artifact.parquet"
+    _write(path, _valid_metadata(**{"ord.artifact": "occurrences"}))
+    monkeypatch.setattr(base.metadata, "version", lambda _: "9.9.9")
+    assert base.is_current(path, "occurrences", "0" * 32)
+    monkeypatch.setattr(
+        base, "ARTIFACT_VERSIONS", base.ARTIFACT_VERSIONS | {"projection": "2"}
+    )
+    assert not base.is_current(path, "occurrences", "0" * 32)

--- a/ord_schema/artifacts/base_test.py
+++ b/ord_schema/artifacts/base_test.py
@@ -556,9 +556,14 @@ def test_every_artifact_reaches_a_source_dataset():
         assert last in roots, artifact
 
 
+@pytest.mark.timeout(15)
 def test_a_cycle_is_refused_rather_than_walked_forever(monkeypatch):
     # An infinite loop where an error belongs: a typo in a four-line literal would
     # otherwise hang every write and every currency check rather than saying so.
+    #
+    # Bounded by the marker, because the failure this guards against is a hang: without
+    # it a regression stops CI rather than failing it, and the run has to be killed by
+    # hand to find out which test never came back.
     monkeypatch.setattr(
         base, "DERIVED_FROM", base.DERIVED_FROM | {"projection": "occurrences"}
     )

--- a/ord_schema/artifacts/base_test.py
+++ b/ord_schema/artifacts/base_test.py
@@ -542,14 +542,28 @@ def test_a_lineage_names_the_artifact_and_every_ancestor():
 
 
 def test_every_artifact_reaches_a_source_dataset():
-    # A cycle or a missing parent would hang or raise inside lineage, which is called
-    # for every artifact written and every currency check made.
-    for artifact in base.ARTIFACT_VERSIONS:
-        assert base.lineage(artifact).endswith("projection=1")
+    # The two tables have to agree about which artifacts exist, and every chain has to
+    # terminate: lineage runs for every artifact written and every currency check made.
     assert set(base.DERIVED_FROM) == set(base.ARTIFACT_VERSIONS)
     assert {
         parent for parent in base.DERIVED_FROM.values() if parent is not None
     } <= set(base.ARTIFACT_VERSIONS)
+    roots = {name for name, parent in base.DERIVED_FROM.items() if parent is None}
+    for artifact in base.ARTIFACT_VERSIONS:
+        # Named by the root rather than by its version, which would make this fail on
+        # the next bump of an artifact it is not about.
+        last = base.lineage(artifact).split(",")[-1].split("=")[0]
+        assert last in roots, artifact
+
+
+def test_a_cycle_is_refused_rather_than_walked_forever(monkeypatch):
+    # An infinite loop where an error belongs: a typo in a four-line literal would
+    # otherwise hang every write and every currency check rather than saying so.
+    monkeypatch.setattr(
+        base, "DERIVED_FROM", base.DERIVED_FROM | {"projection": "occurrences"}
+    )
+    with pytest.raises(ValueError, match="has a cycle"):
+        base.lineage("occurrences")
 
 
 def test_bumping_an_artifact_leaves_what_it_was_derived_from_alone(monkeypatch):

--- a/ord_schema/artifacts/pivot_test.py
+++ b/ord_schema/artifacts/pivot_test.py
@@ -802,7 +802,9 @@ def test_counting_a_level_twice_is_refused(populated):
 def test_counting_a_stale_projection_is_refused(populated, tmp_path, monkeypatch):
     # An artifact derived from a stale projection inherits the dataset hash and so
     # claims a provenance it does not have; nothing would mark it stale again.
-    monkeypatch.setattr(base, "ARTIFACT_VERSION", f"{base.ARTIFACT_VERSION}-later")
+    monkeypatch.setattr(
+        base, "ARTIFACT_VERSIONS", base.ARTIFACT_VERSIONS | {"projection": "later"}
+    )
     with pytest.raises(ValueError, match="stale projection"):
         pivot.count_levels(populated, ["workups"])
     with pytest.raises(ValueError, match="stale projection"):

--- a/ord_schema/artifacts/projection_test.py
+++ b/ord_schema/artifacts/projection_test.py
@@ -419,7 +419,7 @@ def test_write_projection_stamps_the_footer(tmp_path):
     projection.write_projection(source, output)
     stamps = base.load_stamps(output)
     assert stamps.artifact == projection.ARTIFACT
-    assert stamps.artifact_version == base.ARTIFACT_VERSION
+    assert stamps.artifact_lineage == base.lineage(projection.ARTIFACT)
     assert stamps.source_dataset_id == "ord_dataset-1"
 
 

--- a/ord_schema/artifacts/structures_test.py
+++ b/ord_schema/artifacts/structures_test.py
@@ -342,7 +342,7 @@ def test_a_stale_projection_is_refused(tmp_path):
         source_dataset_id="ord_dataset-1",
         source_md5="0" * 32,
         ord_schema_version="0.0.0",
-        artifact_version=base.ARTIFACT_VERSION,
+        artifact_lineage=base.lineage(structures.ARTIFACT),
         rdkit_version="0000.00.0",
     )
     schema = projection.SCHEMA.with_metadata(base.to_metadata(stamps))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,9 @@ tests = [
     # to regenerate it; `jupyter execute --inplace` is the command CONTRIBUTING.md points
     # at, and nbval does not pull it in.
     "nbclient>=0.7",
+    # A test whose failure mode is a hang needs a bound, or a regression stops CI
+    # rather than failing it; see test_a_cycle_is_refused_rather_than_walked_forever.
+    "pytest-timeout>=2.4.0",
     # The suite exercises the optional-feature modules, so collecting it needs
     # their extras. Self-reference rather than duplicate the dependencies.
     "ord-schema[search,nl,huggingface,orm]",
@@ -249,7 +252,3 @@ convention = "google"
 [tool.ty.src]
 exclude = ["**/*_pb2.py*"]
 
-[dependency-groups]
-dev = [
-    "pytest-timeout>=2.4.0",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,3 +248,8 @@ convention = "google"
 
 [tool.ty.src]
 exclude = ["**/*_pb2.py*"]
+
+[dependency-groups]
+dev = [
+    "pytest-timeout>=2.4.0",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,26 +106,26 @@ orm = [
     "uuid6>=2023",
 ]
 tests = [
-    "ruff>=0.9.9",
     "coverage>=5.2.1",
-    "pytest>=7.1.1",
-    "pytest-cov>=3.0.0",
-    "pytest-xdist>=3.0.2",
-    "ty>=0.0.28",
-    "testing-postgresql>=1.3.0",
+    # Comparing a notebook's stored output against a fresh run means a contributor who
+    # changes what one prints has to regenerate it; `jupyter execute --inplace` is the
+    # command CONTRIBUTING.md points at, and nbval does not pull it in.
+    "nbclient>=0.7",
     # Notebooks run under pytest, and nbval can compare each cell's output against the
     # one stored in the file rather than only checking that the cell does not raise.
     "nbval>=0.11",
-    # Comparing stored output means a contributor who changes what a notebook prints has
-    # to regenerate it; `jupyter execute --inplace` is the command CONTRIBUTING.md points
-    # at, and nbval does not pull it in.
-    "nbclient>=0.7",
-    # A test whose failure mode is a hang needs a bound, or a regression stops CI
-    # rather than failing it; see test_a_cycle_is_refused_rather_than_walked_forever.
-    "pytest-timeout>=2.4.0",
     # The suite exercises the optional-feature modules, so collecting it needs
     # their extras. Self-reference rather than duplicate the dependencies.
     "ord-schema[search,nl,huggingface,orm]",
+    "pytest>=7.1.1",
+    "pytest-cov>=3.0.0",
+    # A test whose failure mode is a hang needs a bound, or a regression stops CI
+    # rather than failing it; see test_a_cycle_is_refused_rather_than_walked_forever.
+    "pytest-timeout>=2.4.0",
+    "pytest-xdist>=3.0.2",
+    "ruff>=0.9.9",
+    "testing-postgresql>=1.3.0",
+    "ty>=0.0.28",
 ]
 
 [tool.setuptools.packages.find]
@@ -251,4 +251,3 @@ convention = "google"
 
 [tool.ty.src]
 exclude = ["**/*_pb2.py*"]
-

--- a/uv.lock
+++ b/uv.lock
@@ -2036,17 +2036,13 @@ tests = [
     { name = "pydantic" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "sqlalchemy" },
     { name = "testing-postgresql" },
     { name = "ty" },
     { name = "uuid6" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pytest-timeout" },
 ]
 
 [package.metadata]
@@ -2074,6 +2070,7 @@ requires-dist = [
     { name = "pygments", marker = "extra == 'docs'", specifier = ">=2.13.0" },
     { name = "pytest", marker = "extra == 'tests'", specifier = ">=7.1.1" },
     { name = "pytest-cov", marker = "extra == 'tests'", specifier = ">=3.0.0" },
+    { name = "pytest-timeout", marker = "extra == 'tests'", specifier = ">=2.4.0" },
     { name = "pytest-xdist", marker = "extra == 'tests'", specifier = ">=3.0.2" },
     { name = "python-dateutil", specifier = ">=1.10.0" },
     { name = "rdkit", specifier = ">=2025.3.4" },
@@ -2090,9 +2087,6 @@ requires-dist = [
     { name = "uuid6", marker = "extra == 'orm'", specifier = ">=2023" },
 ]
 provides-extras = ["search", "nl", "docs", "examples", "huggingface", "orm", "tests"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "pytest-timeout", specifier = ">=2.4.0" }]
 
 [[package]]
 name = "packaging"

--- a/uv.lock
+++ b/uv.lock
@@ -2044,6 +2044,11 @@ tests = [
     { name = "uuid6" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-timeout" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", marker = "extra == 'nl'", specifier = ">=0.120" },
@@ -2085,6 +2090,9 @@ requires-dist = [
     { name = "uuid6", marker = "extra == 'orm'", specifier = ">=2023" },
 ]
 provides-extras = ["search", "nl", "docs", "examples", "huggingface", "orm", "tests"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-timeout", specifier = ">=2.4.0" }]
 
 [[package]]
 name = "packaging"
@@ -2665,6 +2673,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`ARTIFACT_VERSION` was one version for all four artifacts, so any definition change charged the same rebuild. Finding 3 of the [review](https://github.com/open-reaction-database/ord-logbook/tree/main/entries/2026-08-30-artifact-and-search-path-review), measured over `ord_dataset-1158e351…`, the 1.0 GB source that is 96% of the corpus:

| artifact | re-derive |
| --- | --- |
| projection | 34.6 min |
| structures | 29.6 min |
| pivots, 4 levels | 16.7 min |
| occurrences, 4 paths | **1.9 s** |

So a change to how occurrences are derived invalidated 81 minutes of upstream work that does not depend on it — a factor of about 2,600.

## Changes

- `ARTIFACT_VERSIONS` is per artifact; `DERIVED_FROM` declares the chain.
- **The stamp is the whole lineage**, not the artifact's own version: `occurrences=1,pivot=1,projection=1`. `ord.artifact_version` becomes `ord.artifact_lineage`, and `Stamps.artifact_version` becomes `artifact_lineage`.
- Splitting alone would have dropped what the shared version was doing, and that job is real: an artifact stamps its **source dataset's** hash rather than its parent's, so a child cannot otherwise see that its parent's definition moved. The chain restores exactly that.
- **The direct parent alone is not enough.** Occurrences record the pivot they came from, and a projection bump moves neither the occurrences' own version nor the pivot's — so the obvious "stamp the parent's version" design silently misses a grandparent. Only the full chain sees it.
- **A cycle in the chain is refused rather than walked forever.** `lineage` runs on every artifact written and every currency check made, so a typo in the four-line literal hung all of them instead of saying anything. The walk is bounded and raises past it.

## Testing

- `uv run pytest`: 1543 passed outside `ord_schema/orm`, whose fixtures need a local Postgres.
- Seven new tests: a bump reaches everything derived from it and nothing above it, every chain terminates at a source dataset, and a cycle raises.
- Mutation-checked. A `lineage` returning only the artifact's own version fails, and — the one worth checking — so does one that stops at the direct parent, which is the design that looks sufficient. Restoring the unbounded walk makes the cycle test **hang past 15 s** rather than fail, which is why that test carries a `timeout` marker and this PR adds `pytest-timeout`: a regression there would otherwise stop CI rather than fail it.
- A fixture that hardcoded one artifact's lineage now derives it from the artifact under test, so an override cannot silently get another's chain and pass for the wrong reason. A test asserting the chain ends in `projection=1` now checks it ends at whichever artifact has no parent, so it will not fail on the next bump of an artifact it is not about.

## Notes

Every version stays at `"1"`; this changes the scheme, not any value. Existing artifacts go stale because the stamp key changed, which is the right moment for it — nothing is published, and [#1012](https://github.com/open-reaction-database/ord-schema/pull/1012) already changed what a projection contains with no way to invalidate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces the shared artifact version stamp with per-artifact versions and records each artifact’s complete derivation lineage, allowing targeted rebuilds while propagating ancestor invalidations.
- Adds bounded lineage traversal and cycle detection.
- Migrates artifact footer metadata and freshness checks to `ord.artifact_lineage`.
- Expands tests for ancestor invalidation, independent version bumps, stale parents, and cycles.
- Adds `pytest-timeout` so cycle regressions fail rather than hanging CI.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/artifacts/base.py | Introduces per-artifact versions, bounded ancestry traversal, lineage metadata serialization, and lineage-aware freshness checks. |
| ord_schema/artifacts/base_test.py | Adds direct coverage for lineage composition, descendant invalidation, independent version bumps, complete chains, and cycle rejection. |
| ord_schema/artifacts/README.md | Documents the revised lineage stamp and its targeted-rebuild semantics. |
| pyproject.toml | Adds pytest-timeout to the test extra for bounded cycle-regression testing. |
| uv.lock | Locks pytest-timeout 2.4.0 without changing the unrelated vulnerable dependency versions reported by dependency scanning. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  D["Source dataset"] --> P["Projection<br/>projection version"]
  P --> S["Structures<br/>structures + projection lineage"]
  P --> V["Pivot<br/>pivot + projection lineage"]
  V --> O["Occurrences<br/>occurrences + pivot + projection lineage"]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Sort the tests extra and drop a trailing..."](https://github.com/open-reaction-database/ord-schema/commit/7b4d57f3c6f53619617e161c0d7cbad77551b831) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59765593)</sub>

**Context used:**

- Knowledge Base — [Chemical data transformation](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/chemical-data-transformation.md)
- Knowledge Base — [Reaction artifacts and projections](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/reaction-artifacts.md)

<!-- /greptile_comment -->