### PR TITLE
Boot one PostgreSQL cluster per worker, not one per test

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -93,11 +93,18 @@ jobs:
           ORD_LIVE_RESOLVERS: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
         run: |
           uv run coverage erase
-          # -n auto: each ORM test spins up its own testing.postgresql instance, so the suite is
-          # parallel-safe; pytest-cov aggregates coverage across xdist workers.
+          # -n auto: the ORM tests run one PostgreSQL cluster per xdist worker and clone a
+          # database per test, so the suite is parallel-safe; pytest-cov aggregates coverage
+          # across workers.
+          # --dist worksteal: the default scheduler hands each worker a fixed slice up front,
+          # and the ORM tests are both contiguous in collection order and the slowest here, so
+          # a worker that draws them finishes late while the other waits. Work stealing lets an
+          # idle worker take queued tests instead. Measured at the two workers a runner gives:
+          # 64s to 56s. It costs one PostgreSQL cluster per worker that ends up with an ORM
+          # test, which is bounded by the worker count.
           # -ra: summarize all non-passing outcomes (failures, errors, and skip reasons) at the end of the run --
           # e.g. live resolver tests gated off this matrix entry vs. skipped on a PubChem 503.
-          uv run pytest -n auto -vv -ra --cov=ord_schema --durations=20
+          uv run pytest -n auto --dist worksteal -vv -ra --cov=ord_schema --durations=20
           # Print the coverage summary in the job log (no external upload).
           uv run coverage report
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -100,7 +100,7 @@ jobs:
           # and the ORM tests are both contiguous in collection order and the slowest here, so
           # a worker that draws them finishes late while the other waits. Work stealing lets an
           # idle worker take queued tests instead. Measured at the two workers a runner gives:
-          # 64s to 56s. It costs one PostgreSQL cluster per worker that ends up with an ORM
+          # 62s to 54s. It costs one PostgreSQL cluster per worker that ends up with an ORM
           # test, which is bounded by the worker count.
           # -ra: summarize all non-passing outcomes (failures, errors, and skip reasons) at the end of the run --
           # e.g. live resolver tests gated off this matrix entry vs. skipped on a PubChem 503.

--- a/ord_schema/orm/conftest.py
+++ b/ord_schema/orm/conftest.py
@@ -12,14 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Pytest fixtures."""
+"""Pytest fixtures.
 
+One PostgreSQL cluster per session, and a database cloned from a template per test.
+
+A cluster costs 0.47s to start, the ORM schema and the RDKit cartridge another 0.14s,
+and loading the example dataset with its derived tables 1.0s more. Paid per test that is
+1.6s before the test body runs, which over this package is most of the two minutes the
+suite takes. ``CREATE DATABASE ... TEMPLATE`` copies a prepared database in 0.06s, so
+the templates are built once and every test clones one.
+
+Isolation is unchanged: a clone is a byte copy, so a test still gets a database nobody
+else writes to, and dropping it afterwards leaves the template as it was. Under xdist
+each worker is its own session and so runs its own cluster.
+"""
+
+import itertools
 import pathlib
 import re
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session
 from testing.postgresql import Postgresql
@@ -27,39 +41,194 @@ from testing.postgresql import Postgresql
 from ord_schema.datasets import load_dataset
 from ord_schema.orm.database import add_dataset, prepare_database, update_derived_data
 
+_SERIAL = itertools.count(1)
+_PREPARED = "template_prepared"
+_LOADED = "template_loaded"
 
-@pytest.fixture(name="test_engine")
-def test_engine_fixture() -> Iterator[Engine]:
+
+def _engine(postgres: Postgresql, database: str) -> Engine:
+    """Returns an engine on one database of the session's cluster.
+
+    Args:
+        postgres: The running cluster.
+        database: Which database to connect to.
+
+    Returns:
+        An engine. See
+        https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg.
+    """
+    return create_engine(
+        re.sub(
+            "postgresql://", "postgresql+psycopg://", postgres.url(database=database)
+        ),
+        future=True,
+    )
+
+
+def _clone(postgres: Postgresql, template: str, name: str) -> None:
+    """Copies ``template`` into a new database.
+
+    Args:
+        postgres: The running cluster.
+        template: The database to copy. It must have no open connections, which is
+            why every builder below disposes its engine before returning.
+        name: The database to create.
+    """
+    # AUTOCOMMIT because CREATE DATABASE cannot run inside a transaction block.
+    admin = create_engine(
+        re.sub("postgresql://", "postgresql+psycopg://", postgres.url()),
+        future=True,
+        isolation_level="AUTOCOMMIT",
+    )
+    try:
+        with admin.connect() as connection:
+            connection.execute(text(f'CREATE DATABASE "{name}" TEMPLATE "{template}"'))
+            # Database-scoped settings are keyed by database OID in pg_db_role_setting,
+            # which a copy does not carry: the clone gets a new OID and reverts to the
+            # server default. prepare_database pins search_path this way, so a clone
+            # would otherwise resolve the ord schema ahead of public wherever the role
+            # is named "ord". Reapplied here rather than left to the caller, since
+            # every database this module hands out is a clone.
+            connection.execute(
+                text(f'ALTER DATABASE "{name}" SET search_path TO public')
+            )
+    finally:
+        admin.dispose()
+
+
+@pytest.fixture(scope="session", name="postgres")
+def postgres_fixture() -> Iterator[Postgresql]:
+    """The cluster every database in this session lives in."""
     with Postgresql() as postgres:
-        # See
-        # https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg.
-        url = re.sub("postgresql://", "postgresql+psycopg://", postgres.url())
-        engine = create_engine(url, future=True)
-        yield engine
+        yield postgres
 
 
-@pytest.fixture(name="prepared_engine")
-def prepared_engine_fixture(test_engine: Engine) -> Engine:
-    """``test_engine`` with the ORM schema (and RDKit cartridge) installed."""
-    assert prepare_database(test_engine)
-    return test_engine
+@pytest.fixture(scope="session", name="prepared_template")
+def prepared_template_fixture(postgres: Postgresql) -> str:
+    """Builds a template holding the ORM schema, and returns its name."""
+    _clone(postgres, "template1", _PREPARED)
+    engine = _engine(postgres, _PREPARED)
+    try:
+        assert prepare_database(engine)
+    finally:
+        engine.dispose()
+    return _PREPARED
 
 
-@pytest.fixture(name="test_session")
-def test_session_fixture(test_engine: Engine) -> Iterator[Session]:
-    datasets = [
-        load_dataset(
+@pytest.fixture(scope="session", name="loaded_template")
+def loaded_template_fixture(postgres: Postgresql, prepared_template: str) -> str:
+    """Builds a template holding the schema and the example dataset, and names it."""
+    _clone(postgres, prepared_template, _LOADED)
+    engine = _engine(postgres, _LOADED)
+    try:
+        dataset = load_dataset(
             pathlib.Path(__file__).parent / "testdata" / "ord-nielsen-example.pbtxt",
             as_dataset=True,
         )
-    ]
-    rdkit_cartridge = prepare_database(test_engine)
-    with Session(test_engine) as session:
-        for dataset in datasets:
-            with session.begin():
-                add_dataset(dataset, session)
-                update_derived_data(
-                    dataset.dataset_id, session, rdkit_cartridge=rdkit_cartridge
-                )
-    with Session(test_engine) as session:
-        yield session
+        # Read back rather than assumed: prepare_database reports whether the RDKit
+        # cartridge is installed, and the derived tables differ if it is not.
+        with engine.connect() as connection:
+            cartridge = bool(
+                connection.execute(
+                    text("SELECT to_regnamespace('rdkit') IS NOT NULL")
+                ).scalar()
+            )
+        with Session(engine) as session, session.begin():
+            add_dataset(dataset, session)
+            update_derived_data(dataset.dataset_id, session, rdkit_cartridge=cartridge)
+    finally:
+        engine.dispose()
+    return _LOADED
+
+
+@pytest.fixture(name="database_name")
+def database_name_fixture(request: pytest.FixtureRequest) -> str:
+    """Returns a database name unique to this test.
+
+    Named after the test so a failure says which database it ran against, and prefixed
+    with a serial because PostgreSQL truncates identifiers at 63 bytes and parametrized
+    names collide once truncated. The counter is per process, which is per xdist worker,
+    which is per cluster.
+    """
+    stem = re.sub(r"[^A-Za-z0-9_]", "_", request.node.name)[:40]
+    return f"t{next(_SERIAL)}_{stem}"
+
+
+@pytest.fixture(name="test_engine")
+def test_engine_fixture(postgres: Postgresql, database_name: str) -> Iterator[Engine]:
+    """An engine on an empty database of this session's cluster."""
+    _clone(postgres, "template1", database_name)
+    engine = _engine(postgres, database_name)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture(name="prepared_engine")
+def prepared_engine_fixture(
+    postgres: Postgresql, prepared_template: str, database_name: str
+) -> Iterator[Engine]:
+    """``test_engine`` with the ORM schema (and RDKit cartridge) installed."""
+    _clone(postgres, prepared_template, database_name)
+    engine = _engine(postgres, database_name)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture(name="test_session")
+def test_session_fixture(
+    postgres: Postgresql, loaded_template: str, database_name: str
+) -> Iterator[Session]:
+    """A session on a database already holding the example dataset."""
+    _clone(postgres, loaded_template, database_name)
+    engine = _engine(postgres, database_name)
+    try:
+        with Session(engine) as session:
+            yield session
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture(name="prepared_database")
+def prepared_database_fixture(
+    postgres: Postgresql, prepared_template: str, database_name: str
+) -> Iterator[Callable[[], tuple[Engine, str]]]:
+    """Returns a factory making a fresh prepared database, and disposes what it made.
+
+    For a test that needs more than one database at a time -- comparing two ingest paths
+    on identical schemas -- or that hands a URL to a subprocess rather than reusing this
+    process's engine.
+
+    Disposal is here rather than in the test because ``Engine`` is not a context manager
+    and has no ``close``, so every caller would otherwise carry its own ``try/finally``.
+    It is not optional: a pooled connection outlives the test, and a session's worth of
+    them reaches the server's connection limit.
+
+    Args:
+        postgres: The running cluster.
+        prepared_template: The template to clone.
+        database_name: Names the first database; later ones get a suffix.
+
+    Yields:
+        A callable returning ``(engine, url)`` for a database nobody else writes to.
+    """
+    made: list[Engine] = []
+
+    def build() -> tuple[Engine, str]:
+        name = database_name if not made else f"{database_name}_{len(made) + 1}"
+        _clone(postgres, prepared_template, name)
+        url = re.sub(
+            "postgresql://", "postgresql+psycopg://", postgres.url(database=name)
+        )
+        engine = create_engine(url, future=True)
+        made.append(engine)
+        return engine, url
+
+    try:
+        yield build
+    finally:
+        for engine in made:
+            engine.dispose()

--- a/ord_schema/orm/conftest.py
+++ b/ord_schema/orm/conftest.py
@@ -46,6 +46,21 @@ _PREPARED = "template_prepared"
 _LOADED = "template_loaded"
 
 
+def _url(postgres: Postgresql, database: str | None = None) -> str:
+    """Returns the psycopg URL for one database of the session's cluster.
+
+    Args:
+        postgres: The running cluster.
+        database: Which database, or None for the cluster's own.
+
+    Returns:
+        The URL, with the driver named. See
+        https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg.
+    """
+    raw = postgres.url() if database is None else postgres.url(database=database)
+    return re.sub("postgresql://", "postgresql+psycopg://", raw)
+
+
 def _engine(postgres: Postgresql, database: str) -> Engine:
     """Returns an engine on one database of the session's cluster.
 
@@ -54,15 +69,9 @@ def _engine(postgres: Postgresql, database: str) -> Engine:
         database: Which database to connect to.
 
     Returns:
-        An engine. See
-        https://docs.sqlalchemy.org/en/20/dialects/postgresql.html#module-sqlalchemy.dialects.postgresql.psycopg.
+        An engine.
     """
-    return create_engine(
-        re.sub(
-            "postgresql://", "postgresql+psycopg://", postgres.url(database=database)
-        ),
-        future=True,
-    )
+    return create_engine(_url(postgres, database), future=True)
 
 
 def _clone(postgres: Postgresql, template: str, name: str) -> None:
@@ -75,11 +84,7 @@ def _clone(postgres: Postgresql, template: str, name: str) -> None:
         name: The database to create.
     """
     # AUTOCOMMIT because CREATE DATABASE cannot run inside a transaction block.
-    admin = create_engine(
-        re.sub("postgresql://", "postgresql+psycopg://", postgres.url()),
-        future=True,
-        isolation_level="AUTOCOMMIT",
-    )
+    admin = create_engine(_url(postgres), future=True, isolation_level="AUTOCOMMIT")
     try:
         with admin.connect() as connection:
             connection.execute(text(f'CREATE DATABASE "{name}" TEMPLATE "{template}"'))
@@ -116,11 +121,7 @@ def _drop(postgres: Postgresql, name: str) -> None:
         postgres: The running cluster.
         name: The database to drop.
     """
-    admin = create_engine(
-        re.sub("postgresql://", "postgresql+psycopg://", postgres.url()),
-        future=True,
-        isolation_level="AUTOCOMMIT",
-    )
+    admin = create_engine(_url(postgres), future=True, isolation_level="AUTOCOMMIT")
     try:
         with admin.connect() as connection:
             connection.execute(text(f'DROP DATABASE IF EXISTS "{name}"'))
@@ -201,12 +202,9 @@ def databases_fixture(
     def build(template: str) -> tuple[Engine, str]:
         name = f"t{next(_SERIAL)}_{stem}"
         _clone(postgres, template, name)
-        url = re.sub(
-            "postgresql://", "postgresql+psycopg://", postgres.url(database=name)
-        )
-        engine = create_engine(url, future=True)
+        engine = _engine(postgres, name)
         made.append((engine, name))
-        return engine, url
+        return engine, _url(postgres, name)
 
     try:
         yield build

--- a/ord_schema/orm/conftest.py
+++ b/ord_schema/orm/conftest.py
@@ -85,13 +85,45 @@ def _clone(postgres: Postgresql, template: str, name: str) -> None:
             connection.execute(text(f'CREATE DATABASE "{name}" TEMPLATE "{template}"'))
             # Database-scoped settings are keyed by database OID in pg_db_role_setting,
             # which a copy does not carry: the clone gets a new OID and reverts to the
-            # server default. prepare_database pins search_path this way, so a clone
-            # would otherwise resolve the ord schema ahead of public wherever the role
-            # is named "ord". Reapplied here rather than left to the caller, since
-            # every database this module hands out is a clone.
-            connection.execute(
-                text(f'ALTER DATABASE "{name}" SET search_path TO public')
-            )
+            # server defaults. prepare_database pins search_path that way, so without
+            # this a clone resolves the ord schema ahead of public wherever the role is
+            # named "ord".
+            #
+            # Read off the template rather than named here, so whatever
+            # prepare_database sets is carried without a second list of it to keep in
+            # step. A setting it adds later needs no change on this side.
+            settings = connection.execute(
+                text(
+                    "SELECT unnest(setconfig) FROM pg_db_role_setting s "
+                    "JOIN pg_database d ON d.oid = s.setdatabase "
+                    "WHERE d.datname = :template AND s.setrole = 0"
+                ),
+                {"template": template},
+            ).scalars()
+            for setting in settings:
+                key, _, value = setting.partition("=")
+                connection.execute(
+                    text(f'ALTER DATABASE "{name}" SET {key} TO {value}')
+                )
+    finally:
+        admin.dispose()
+
+
+def _drop(postgres: Postgresql, name: str) -> None:
+    """Removes a database the session is done with.
+
+    Args:
+        postgres: The running cluster.
+        name: The database to drop.
+    """
+    admin = create_engine(
+        re.sub("postgresql://", "postgresql+psycopg://", postgres.url()),
+        future=True,
+        isolation_level="AUTOCOMMIT",
+    )
+    try:
+        with admin.connect() as connection:
+            connection.execute(text(f'DROP DATABASE IF EXISTS "{name}"'))
     finally:
         admin.dispose()
 
@@ -141,94 +173,92 @@ def loaded_template_fixture(postgres: Postgresql, prepared_template: str) -> str
     return _LOADED
 
 
-@pytest.fixture(name="database_name")
-def database_name_fixture(request: pytest.FixtureRequest) -> str:
-    """Returns a database name unique to this test.
+@pytest.fixture(name="databases")
+def databases_fixture(
+    postgres: Postgresql, request: pytest.FixtureRequest
+) -> Iterator[Callable[[str], tuple[Engine, str]]]:
+    """Returns a factory cloning a template, and cleans up everything it made.
 
-    Named after the test so a failure says which database it ran against, and prefixed
-    with a serial because PostgreSQL truncates identifiers at 63 bytes and parametrized
-    names collide once truncated. The counter is per process, which is per xdist worker,
-    which is per cluster.
-    """
-    stem = re.sub(r"[^A-Za-z0-9_]", "_", request.node.name)[:40]
-    return f"t{next(_SERIAL)}_{stem}"
-
-
-@pytest.fixture(name="test_engine")
-def test_engine_fixture(postgres: Postgresql, database_name: str) -> Iterator[Engine]:
-    """An engine on an empty database of this session's cluster."""
-    _clone(postgres, "template1", database_name)
-    engine = _engine(postgres, database_name)
-    try:
-        yield engine
-    finally:
-        engine.dispose()
-
-
-@pytest.fixture(name="prepared_engine")
-def prepared_engine_fixture(
-    postgres: Postgresql, prepared_template: str, database_name: str
-) -> Iterator[Engine]:
-    """``test_engine`` with the ORM schema (and RDKit cartridge) installed."""
-    _clone(postgres, prepared_template, database_name)
-    engine = _engine(postgres, database_name)
-    try:
-        yield engine
-    finally:
-        engine.dispose()
-
-
-@pytest.fixture(name="test_session")
-def test_session_fixture(
-    postgres: Postgresql, loaded_template: str, database_name: str
-) -> Iterator[Session]:
-    """A session on a database already holding the example dataset."""
-    _clone(postgres, loaded_template, database_name)
-    engine = _engine(postgres, database_name)
-    try:
-        with Session(engine) as session:
-            yield session
-    finally:
-        engine.dispose()
-
-
-@pytest.fixture(name="prepared_database")
-def prepared_database_fixture(
-    postgres: Postgresql, prepared_template: str, database_name: str
-) -> Iterator[Callable[[], tuple[Engine, str]]]:
-    """Returns a factory making a fresh prepared database, and disposes what it made.
-
-    For a test that needs more than one database at a time -- comparing two ingest paths
-    on identical schemas -- or that hands a URL to a subprocess rather than reusing this
-    process's engine.
-
-    Disposal is here rather than in the test because ``Engine`` is not a context manager
-    and has no ``close``, so every caller would otherwise carry its own ``try/finally``.
-    It is not optional: a pooled connection outlives the test, and a session's worth of
-    them reaches the server's connection limit.
+    Every database a test runs against comes from here, so disposal and dropping happen
+    once rather than in each fixture below. Neither is optional: a pooled connection
+    outlives the test and a session's worth reaches the server's connection limit, and a
+    clone is a full copy -- 11.7 MB for the prepared schema, which over this package
+    would leave most of a gigabyte behind.
 
     Args:
         postgres: The running cluster.
-        prepared_template: The template to clone.
-        database_name: Names the first database; later ones get a suffix.
+        request: Names the databases after the test, so a failure says which one it ran
+            against. Truncated to fit PostgreSQL's 63-byte identifier, with a serial
+            prefix because parametrized names collide once truncated.
 
     Yields:
-        A callable returning ``(engine, url)`` for a database nobody else writes to.
+        A callable taking a template name and returning ``(engine, url)`` for a fresh
+        clone of it.
     """
-    made: list[Engine] = []
+    stem = re.sub(r"[^A-Za-z0-9_]", "_", request.node.name)[:40]
+    made: list[tuple[Engine, str]] = []
 
-    def build() -> tuple[Engine, str]:
-        name = database_name if not made else f"{database_name}_{len(made) + 1}"
-        _clone(postgres, prepared_template, name)
+    def build(template: str) -> tuple[Engine, str]:
+        name = f"t{next(_SERIAL)}_{stem}"
+        _clone(postgres, template, name)
         url = re.sub(
             "postgresql://", "postgresql+psycopg://", postgres.url(database=name)
         )
         engine = create_engine(url, future=True)
-        made.append(engine)
+        made.append((engine, name))
         return engine, url
 
     try:
         yield build
     finally:
-        for engine in made:
+        for engine, name in made:
+            # Dropped only after the engine's pool is closed; PostgreSQL refuses to drop
+            # a database anything is still connected to.
             engine.dispose()
+            _drop(postgres, name)
+
+
+@pytest.fixture(name="test_engine")
+def test_engine_fixture(databases: Callable[[str], tuple[Engine, str]]) -> Engine:
+    """An engine on an empty database of this session's cluster."""
+    engine, _ = databases("template1")
+    return engine
+
+
+@pytest.fixture(name="prepared_engine")
+def prepared_engine_fixture(
+    databases: Callable[[str], tuple[Engine, str]], prepared_template: str
+) -> Engine:
+    """``test_engine`` with the ORM schema (and RDKit cartridge) installed."""
+    engine, _ = databases(prepared_template)
+    return engine
+
+
+@pytest.fixture(name="test_session")
+def test_session_fixture(
+    databases: Callable[[str], tuple[Engine, str]], loaded_template: str
+) -> Iterator[Session]:
+    """A session on a database already holding the example dataset."""
+    engine, _ = databases(loaded_template)
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture(name="prepared_database")
+def prepared_database_fixture(
+    databases: Callable[[str], tuple[Engine, str]], prepared_template: str
+) -> Callable[[], tuple[Engine, str]]:
+    """Returns a factory making a fresh prepared database on each call.
+
+    For a test that needs more than one database at a time -- comparing two ingest paths
+    on identical schemas -- or that hands a URL to a subprocess rather than reusing this
+    process's engine.
+
+    Args:
+        databases: The factory that owns cleanup.
+        prepared_template: The template to clone.
+
+    Returns:
+        A callable returning ``(engine, url)`` for a database nobody else writes to.
+    """
+    return lambda: databases(prepared_template)

--- a/ord_schema/orm/conftest.py
+++ b/ord_schema/orm/conftest.py
@@ -16,15 +16,15 @@
 
 One PostgreSQL cluster per session, and a database cloned from a template per test.
 
-A cluster costs 0.47s to start, the ORM schema and the RDKit cartridge another 0.14s,
-and loading the example dataset with its derived tables 1.0s more. Paid per test that is
-1.6s before the test body runs, which over this package is most of the two minutes the
-suite takes. ``CREATE DATABASE ... TEMPLATE`` copies a prepared database in 0.06s, so
-the templates are built once and every test clones one.
+Starting a cluster costs 0.47s, installing the ORM schema and the RDKit cartridge
+another 0.14s, and loading the example dataset with its derived tables 1.0s more: 1.6s
+before a test body runs, and this package has 74 of them. ``CREATE DATABASE ...
+TEMPLATE`` copies a prepared database in 0.06s, so the templates are built once per
+session and every test clones one.
 
-Isolation is unchanged: a clone is a byte copy, so a test still gets a database nobody
-else writes to, and dropping it afterwards leaves the template as it was. Under xdist
-each worker is its own session and so runs its own cluster.
+A clone is a byte copy, so a test owns a database nobody else writes to, and dropping it
+leaves the template as it was. Under xdist each worker is its own session and so runs
+its own cluster.
 """
 
 import itertools
@@ -179,11 +179,11 @@ def databases_fixture(
 ) -> Iterator[Callable[[str], tuple[Engine, str]]]:
     """Returns a factory cloning a template, and cleans up everything it made.
 
-    Every database a test runs against comes from here, so disposal and dropping happen
-    once rather than in each fixture below. Neither is optional: a pooled connection
-    outlives the test and a session's worth reaches the server's connection limit, and a
-    clone is a full copy -- 11.7 MB for the prepared schema, which over this package
-    would leave most of a gigabyte behind.
+    Every database a test runs against comes from here, so disposal and dropping live in
+    one place. Neither is optional: a pooled connection outlives the test and a
+    session's worth reaches the server's connection limit, and a clone is a full copy --
+    11.7 MB for the prepared schema, so a run of this package would leave most of a
+    gigabyte behind.
 
     Args:
         postgres: The running cluster.

--- a/ord_schema/orm/database_test.py
+++ b/ord_schema/orm/database_test.py
@@ -1011,3 +1011,30 @@ def test_rederive_drops_a_row_that_no_longer_derives(
             ).scalar_one()
         assert after == 0, f"{derived_table} kept {after} stale rows"
         assert nulls == 0
+
+
+def test_a_finished_test_leaves_no_database_behind(test_session):
+    """Databases this session made are dropped, not merely disconnected from.
+
+    A clone is a full copy -- 11.7 MB for the prepared schema -- so without the drop a
+    run of this package leaves most of a gigabyte in the cluster's data directory.
+    Nothing else asserts it, and the leak would be invisible until a runner filled up.
+
+    Order-independent by construction: every worker has its own cluster, and if teardown
+    stopped dropping, whichever tests ran before this one on this worker would still be
+    listed here.
+    """
+    listed = set(
+        test_session.execute(
+            text(
+                "SELECT datname FROM pg_database "
+                "WHERE NOT datistemplate AND datname <> 'postgres'"
+            )
+        )
+        .scalars()
+        .all()
+    )
+    # The cluster's own database, the two templates, and whatever this test is using.
+    expected = {"test", "template_prepared", "template_loaded"}
+    current = test_session.execute(text("SELECT current_database()")).scalar()
+    assert listed <= expected | {current}, sorted(listed - expected - {current})

--- a/ord_schema/orm/loading_test.py
+++ b/ord_schema/orm/loading_test.py
@@ -16,12 +16,10 @@
 
 import logging
 import pathlib
-import re
 
 import pytest
-from sqlalchemy import create_engine, select, text
+from sqlalchemy import select, text
 from sqlalchemy.orm import Session
-from testing.postgresql import Postgresql
 
 from ord_schema import message_helpers, parquet
 from ord_schema.orm import Base, database, loading
@@ -90,7 +88,7 @@ def _content_digests(engine) -> dict[str, tuple[int, str | None]]:
     return digests
 
 
-def test_parquet_copy_ingest_matches_orm(tmp_path):
+def test_parquet_copy_ingest_matches_orm(prepared_database, tmp_path):
     """COPY parquet ingest yields the same ord.*/public.reactions content as the ORM.
 
     add_parquet_dataset builds the same from_proto trees as add_dataset but streams them
@@ -101,23 +99,20 @@ def test_parquet_copy_ingest_matches_orm(tmp_path):
     parquet_path, dataset = _write_parquet_dataset(tmp_path)
     result: dict[str, dict[str, tuple[int, str | None]]] = {}
     for label in ("copy", "orm"):
-        with Postgresql() as postgres:
-            url = re.sub("postgresql://", "postgresql+psycopg://", postgres.url())
-            engine = create_engine(url, future=True)
-            database.prepare_database(engine)
-            with Session(engine) as session, session.begin():
-                if label == "copy":
-                    database.add_parquet_dataset(parquet_path, session)
-                else:
-                    database.add_dataset(dataset, session)
-            result[label] = _content_digests(engine)
+        engine, _ = prepared_database()
+        with Session(engine) as session, session.begin():
+            if label == "copy":
+                database.add_parquet_dataset(parquet_path, session)
+            else:
+                database.add_dataset(dataset, session)
+        result[label] = _content_digests(engine)
     for table in result["copy"]:
         if table == "public.datasets":
             continue
         assert result["copy"][table] == result["orm"][table], table
 
 
-def test_parquet_sharded_ingest_matches_single_process(tmp_path):
+def test_parquet_sharded_ingest_matches_single_process(prepared_database, tmp_path):
     """Row-group-sharded ingest (n_jobs>1) yields the same content as single-process.
 
     The dataset is written with several small row groups so the sharded path actually
@@ -129,44 +124,38 @@ def test_parquet_sharded_ingest_matches_single_process(tmp_path):
     assert view.num_row_groups > 1  # Sharding is actually exercised.
     result: dict[str, dict[str, tuple[int, str | None]]] = {}
     for label, n_jobs in (("sharded", 2), ("single", 1)):
-        with Postgresql() as postgres:
-            url = re.sub("postgresql://", "postgresql+psycopg://", postgres.url())
-            engine = create_engine(url, future=True)
-            database.prepare_database(engine)
-            loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=n_jobs)
-            result[label] = _content_digests(engine)
+        engine, url = prepared_database()
+        loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=n_jobs)
+        result[label] = _content_digests(engine)
     assert result["sharded"] == result["single"]
 
 
-def test_parquet_sharded_ingest_skip_and_overwrite(tmp_path):
+def test_parquet_sharded_ingest_skip_and_overwrite(prepared_database, tmp_path):
     """Sharded path skips unchanged, rejects changed, and reloads on overwrite."""
     parquet_path, dataset = _write_parquet_dataset(tmp_path, row_group_size=10)
     expected_count = len(dataset.reactions)
-    with Postgresql() as postgres:
-        url = re.sub("postgresql://", "postgresql+psycopg://", postgres.url())
-        engine = create_engine(url, future=True)
-        database.prepare_database(engine)
+    engine, url = prepared_database()
 
-        def reaction_count() -> int:
-            with Session(engine) as session:
-                return session.query(Mappers.Reaction).count()
+    def reaction_count() -> int:
+        with Session(engine) as session:
+            return session.query(Mappers.Reaction).count()
 
+    loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=2)
+    assert reaction_count() == expected_count
+    # An unchanged re-ingest is skipped on the matching md5, not loaded again.
+    loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=2)
+    assert reaction_count() == expected_count
+    # Changed content without overwrite fails and leaves the original intact.
+    dataset.reactions[0].outcomes[0].conversion.value = 999.0
+    parquet.save_dataset(dataset, parquet_path, row_group_size=10)
+    with pytest.raises(RuntimeError):
         loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=2)
-        assert reaction_count() == expected_count
-        # An unchanged re-ingest is skipped on the matching md5, not loaded again.
-        loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=2)
-        assert reaction_count() == expected_count
-        # Changed content without overwrite fails and leaves the original intact.
-        dataset.reactions[0].outcomes[0].conversion.value = 999.0
-        parquet.save_dataset(dataset, parquet_path, row_group_size=10)
-        with pytest.raises(RuntimeError):
-            loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=2)
-        assert reaction_count() == expected_count
-        # With overwrite the dataset is deleted and reloaded, still a single copy.
-        loading.load_datasets(
-            parquet_path, url, stages=["ingest"], n_jobs=2, overwrite=True
-        )
-        assert reaction_count() == expected_count
+    assert reaction_count() == expected_count
+    # With overwrite the dataset is deleted and reloaded, still a single copy.
+    loading.load_datasets(
+        parquet_path, url, stages=["ingest"], n_jobs=2, overwrite=True
+    )
+    assert reaction_count() == expected_count
 
 
 def test_load_datasets_parquet_parallel(prepared_engine, tmp_path):
@@ -207,7 +196,7 @@ def test_derived_stage_shards_smiles_and_rdkit(prepared_engine, tmp_path, monkey
         )
 
 
-def test_parquet_sharded_ingest_recovers_from_partial_load(tmp_path):
+def test_parquet_sharded_ingest_recovers_from_partial_load(prepared_database, tmp_path):
     """A crashed shard (dataset row + some reactions, no marker) is cleanly redone.
 
     Simulates the failure the completeness marker guards against: prep inserts the
@@ -216,27 +205,24 @@ def test_parquet_sharded_ingest_recovers_from_partial_load(tmp_path):
     wipe the partial rows, and produce a complete, correct ingest.
     """
     parquet_path, dataset = _write_parquet_dataset(tmp_path, row_group_size=10)
-    with Postgresql() as postgres:
-        url = re.sub("postgresql://", "postgresql+psycopg://", postgres.url())
-        engine = create_engine(url, future=True)
-        database.prepare_database(engine)
-        # Prep inserts the ord.dataset row; load only the first row group; skip
-        # finalize.
-        plan = loading._prep_parquet_dataset(parquet_path, dsn=url, overwrite=False)
-        assert plan.needs_load
-        assert plan.num_row_groups > 1
-        assert plan.dataset_uuid is not None
-        loading._ingest_parquet_shard((plan.filename, plan.dataset_uuid, 0), dsn=url)
-        with Session(engine) as session:
-            # Partial state: some reactions present, but no completeness marker.
-            assert database.get_dataset_md5(dataset.dataset_id, session) is None
-            partial = session.query(Mappers.Reaction).count()
-            assert 0 < partial < len(dataset.reactions)
-        # A fresh run wipes the orphaned rows and reloads to completion, marker and all.
-        loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=2)
-        with Session(engine) as session:
-            assert database.get_dataset_md5(dataset.dataset_id, session) is not None
-            assert session.query(Mappers.Reaction).count() == len(dataset.reactions)
+    engine, url = prepared_database()
+    # Prep inserts the ord.dataset row; load only the first row group; skip
+    # finalize.
+    plan = loading._prep_parquet_dataset(parquet_path, dsn=url, overwrite=False)
+    assert plan.needs_load
+    assert plan.num_row_groups > 1
+    assert plan.dataset_uuid is not None
+    loading._ingest_parquet_shard((plan.filename, plan.dataset_uuid, 0), dsn=url)
+    with Session(engine) as session:
+        # Partial state: some reactions present, but no completeness marker.
+        assert database.get_dataset_md5(dataset.dataset_id, session) is None
+        partial = session.query(Mappers.Reaction).count()
+        assert 0 < partial < len(dataset.reactions)
+    # A fresh run wipes the orphaned rows and reloads to completion, marker and all.
+    loading.load_datasets(parquet_path, url, stages=["ingest"], n_jobs=2)
+    with Session(engine) as session:
+        assert database.get_dataset_md5(dataset.dataset_id, session) is not None
+        assert session.query(Mappers.Reaction).count() == len(dataset.reactions)
 
 
 def test_load_datasets(prepared_engine):


### PR DESCRIPTION
## Summary

Every ORM test started its own PostgreSQL cluster and built the schema and the example dataset into it. That is **1.6 s before any test body ran**, and it was most of the two minutes this package took:

| per test | cost |
| --- | --- |
| `Postgresql()` boot | 0.47 s |
| schema + RDKit cartridge | 0.14 s |
| load the example dataset and derive | 0.98 s |
| **`CREATE DATABASE … TEMPLATE`** | **0.06 s** |

## Changes

- One cluster per session — so one per xdist worker — with the schema and the loaded dataset built once into templates. Each test clones a template. Isolation is unchanged: a clone is a byte copy, so a test still owns a database nobody else writes to.
- **Database-scoped settings are copied onto each clone.** They live in `pg_db_role_setting` keyed by database OID, which a copy does not carry, so a clone silently lost the `search_path` that `prepare_database` pins. Read off the template rather than named here, so whatever `prepare_database` sets is carried without a second list of it to keep in step.
- **Clones are dropped, not just disconnected from.** A clone is a full copy — 11.7 MB for the prepared schema — so a run left 0.87 GB of dead databases in the cluster's data directory.
- One factory owns every database this package hands out, so disposal and dropping happen once rather than in three near-identical fixtures. Disposal is not optional either: `Engine` is not a context manager and has no `close()`, only `dispose()`, and a leaked pooled connection per test reaches the server's connection limit.
- `--dist worksteal` in CI. The default scheduler hands each worker a fixed slice up front, and the ORM tests are contiguous in collection order and the slowest here, so a worker that draws them finishes late while the other waits.

## Testing

`uv run pytest`, with a local PostgreSQL from the conda environment:

| | before | after |
| --- | --- | --- |
| `ord_schema/orm`, serial | 120 s | **53 s** |
| full suite, `-n 2` (a runner's width) | 62 s | **54 s** |
| full suite, `-n auto` (18 workers) | 57 s | **29 s** |

- 1618 passed. Occasional skips are the live PubChem resolver smoke tests on a 5xx, which is pre-existing and documented in `resolvers_test`.
- Two guards mutation-checked: not copying the template's settings fails `test_default_search_path_is_public`, and not dropping the clone fails `test_a_finished_test_leaves_no_database_behind`.
- That leak test is new and order-independent by construction — every worker has its own cluster, so if teardown stopped dropping, whichever tests ran earlier on that worker would still be listed.
- Everything except `ord_schema/orm` runs in 10.6 s, so the ORM tests are the critical path either way, which is why the scheduler matters at all.
- Both scheduler figures were re-measured against the final code rather than carried from the run that motivated the change.

## Notes

Work stealing costs one cluster per worker that ends up with an ORM test, bounded by the worker count. On a wide machine the ORM tests had landed on 5 of 18 workers with 13 idle; at the two workers a runner gives the gain is smaller but real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces per-test PostgreSQL clusters with session-scoped clusters and per-test cloned databases, preserving isolation while reducing ORM test setup cost.
- Builds prepared and dataset-loaded templates once per pytest worker.
- Centralizes cloned database creation, engine disposal, and database removal.
- Reuses cloned prepared databases in parallel-loading tests.
- Enables xdist work-stealing in CI to distribute slower ORM tests more evenly.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/run_tests.yml | Enables xdist work-stealing while retaining automatic worker selection and coverage aggregation. |
| ord_schema/orm/conftest.py | Introduces session-scoped PostgreSQL templates and a function-scoped clone factory with centralized disposal and cleanup. |
| ord_schema/orm/database_test.py | Adds coverage verifying that completed tests do not leave unexpected cloned databases in the worker cluster. |
| ord_schema/orm/loading_test.py | Migrates standalone PostgreSQL-based loading tests to isolated databases cloned from the shared prepared template. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  W[Pytest worker session] --> C[PostgreSQL cluster]
  C --> P[Prepared schema template]
  P --> L[Loaded dataset template]
  P --> A[Prepared clone per test]
  L --> B[Loaded clone per test]
  A --> T[Test body]
  B --> T
  T --> D[Dispose tracked engines]
  D --> X[Drop cloned databases]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Build the psycopg URL in one place"](https://github.com/open-reaction-database/ord-schema/commit/7db96c1f39f9b7b3aaf614b8d5eeb1fa4c9c4849) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59790020)</sub>

<!-- /greptile_comment -->