### PR TITLE
Let a run refresh artifacts an older library stamped

### DIFF
--- a/ord_schema/artifacts/README.md
+++ b/ord_schema/artifacts/README.md
@@ -55,6 +55,12 @@ current:
 A sixth, `ord.source_dataset_id`, is written only when the source records one, and is the
 only key not required to read stamps back.
 
+`ord.artifact` has a second job that the others do not share: nothing outside this library
+writes it, so its presence alone says a file is ours to replace. That is what
+`derive_tree` asks before writing over anything, rather than asking for the whole stamp
+set — a file written before a key was added or renamed reads as no artifact at all, and a
+guard wanting all five would refuse the very re-derive that brings such a tree up to date.
+
 An artifact derived from another artifact **passes `source_md5` through** rather than
 hashing its parent, so every artifact names the dataset it reflects however many
 derivations away it sits, and one comparison answers "is this current for that dataset?"

--- a/ord_schema/artifacts/README.md
+++ b/ord_schema/artifacts/README.md
@@ -55,7 +55,7 @@ current:
 A sixth, `ord.source_dataset_id`, is written only when the source records one, and is the
 only key not required to read stamps back.
 
-`ord.artifact` has a second job that the others do not share: nothing outside this library
+`ord.artifact` carries a second job the other keys do not: nothing outside this library
 writes it, so its presence alone says a file is ours to replace. That is what
 `derive_tree` asks before writing over anything, rather than asking for the whole stamp
 set — a file written before a key was added or renamed reads as no artifact at all, and a

--- a/ord_schema/artifacts/base.py
+++ b/ord_schema/artifacts/base.py
@@ -631,9 +631,9 @@ def derive_tree(
         for source in sources
     }
     # Two different mistakes, reported apart: a destination that is one of this run's
-    # own inputs, and one holding a file from outside this library. Naming both "inputs"
-    # sends the reader looking for the input that landed there, and for the second kind
-    # there is none -- the file was already sitting at the destination.
+    # own inputs, and one holding a file from outside this library. One message for both
+    # would send the reader looking for the input that landed there, and for the second
+    # kind there is none -- the file was already sitting at the destination.
     resolved_sources = {pathlib.Path(source).resolve() for source in sources}
     over_inputs, over_strangers = [], []
     for destination in destinations.values():

--- a/ord_schema/artifacts/base.py
+++ b/ord_schema/artifacts/base.py
@@ -490,19 +490,28 @@ def _is_irreplaceable(destination: pathlib.Path) -> bool:
     a mistyped ``output_dir`` aimed at them would replace a corpus that cannot be
     regenerated with artifacts that can.
 
+    The question is who wrote the file, not whether it is current, so ``ord.artifact``
+    alone decides it: nothing but this library writes that key, and a file carrying it
+    is one of ours whatever else its footer says. Requiring the whole stamp set would
+    answer a different question -- whether the file matches *today's* format -- and so
+    would read every artifact written before a key was added or renamed as a stranger's,
+    refusing the very re-derive that would bring it up to date.
+
     Args:
         destination: Path an artifact would be written to.
 
     Returns:
-        True if something is already there and it is not a derived artifact.
+        True if something is already there and this library did not write it.
     """
     if not destination.exists():
         return False
     try:
-        return not is_artifact(destination)
-    except ValueError:
+        with pq.ParquetFile(destination) as parquet_file:
+            raw = parquet_file.schema_arrow.metadata or {}
+    except (OSError, ValueError, pa.ArrowInvalid):
         # Not readable as Parquet at all, so certainly not an artifact this run wrote.
         return True
+    return _META_ARTIFACT.encode() not in raw
 
 
 def _parent_provenance(

--- a/ord_schema/artifacts/base.py
+++ b/ord_schema/artifacts/base.py
@@ -601,7 +601,8 @@ def derive_tree(
 
     Raises:
         ValueError: If the input pattern matches nothing, if any match cannot be read as
-            Parquet, or if any destination would land on a parent.
+            Parquet, if any destination would land on a parent, or if any destination
+            already holds a file this library did not write.
     """
     # Deduplicated: a pattern with more than one ** reaches the same file by more than
     # one route, and a source derived twice is written twice -- the second pass reading
@@ -629,15 +630,25 @@ def derive_tree(
         source: output_path(source, input_pattern, output_dir, root=root)
         for source in sources
     }
+    # Two different mistakes, reported apart: a destination that is one of this run's
+    # own inputs, and one holding a file from outside this library. Naming both "inputs"
+    # sends the reader looking for the input that landed there, and for the second kind
+    # there is none -- the file was already sitting at the destination.
     resolved_sources = {pathlib.Path(source).resolve() for source in sources}
-    clobbered = sorted(
-        str(destination)
-        for destination in destinations.values()
-        if destination.resolve() in resolved_sources or _is_irreplaceable(destination)
-    )
-    if clobbered:
+    over_inputs, over_strangers = [], []
+    for destination in destinations.values():
+        if destination.resolve() in resolved_sources:
+            over_inputs.append(str(destination))
+        elif _is_irreplaceable(destination):
+            over_strangers.append(str(destination))
+    refused = []
+    if over_inputs:
+        refused.append(f"its own inputs: {sorted(over_inputs)}")
+    if over_strangers:
+        refused.append(f"files this library did not write: {sorted(over_strangers)}")
+    if refused:
         raise ValueError(
-            f"output_dir {output_dir!r} would write over its inputs: {clobbered}"
+            f"output_dir {output_dir!r} would write over {' and '.join(refused)}"
         )
     written = skipped = 0
     for source in sources:

--- a/ord_schema/artifacts/base_test.py
+++ b/ord_schema/artifacts/base_test.py
@@ -505,6 +505,32 @@ def test_derive_tree_still_rewrites_its_own_artifacts(tmp_path):
     assert (written, skipped, ignored) == (1, 0, 0)
 
 
+def test_derive_tree_rewrites_an_artifact_stamped_by_an_older_library(tmp_path):
+    # The one case the guard must not refuse and cannot see from the stamp set: a tree
+    # written before a required key existed. Adding or renaming one leaves every file on
+    # disk unreadable as stamps, and a guard that asks for the whole set then reads a
+    # corpus this driver wrote as a stranger's -- refusing the re-derive that is the
+    # only way to bring it up to date, with no --force to override it.
+    (tmp_path / "projections").mkdir()
+    _write(
+        tmp_path / "projections" / "ds.parquet",
+        _current_metadata(**{"ord.artifact": "projection"}),
+    )
+    (tmp_path / "structures").mkdir()
+    superseded = _valid_metadata()
+    del superseded["ord.artifact_lineage"]
+    superseded["ord.artifact_version"] = "1"
+    _write(tmp_path / "structures" / "ds.parquet", superseded)
+    written, skipped, ignored = base.derive_tree(
+        str(tmp_path / "projections" / "*.parquet"),
+        str(tmp_path / "structures"),
+        artifact="structures",
+        write=lambda *args, **kwargs: 1,
+        parent_artifact="projection",
+    )
+    assert (written, skipped, ignored) == (1, 0, 0)
+
+
 def test_stamps_record_the_rdkit_version():
     value = base.current_stamps("structures", "ord_dataset-1", "abc")
     assert value.rdkit_version == rdBase.rdkitVersion

--- a/ord_schema/artifacts/base_test.py
+++ b/ord_schema/artifacts/base_test.py
@@ -293,7 +293,7 @@ def test_derive_tree_refuses_to_write_over_its_own_sources(tmp_path):
     (tmp_path / "aa").mkdir()
     _fake_source(tmp_path / "aa" / "source.parquet")
     calls = []
-    with pytest.raises(ValueError, match="would write over its inputs"):
+    with pytest.raises(ValueError, match="would write over its own inputs"):
         base.derive_tree(
             str(tmp_path / "*" / "*.parquet"),
             str(tmp_path),
@@ -311,7 +311,7 @@ def test_derive_tree_refuses_to_write_over_a_different_source(tmp_path):
     victim = tmp_path / "aa" / "source.parquet"
     _fake_source(victim)
     original = victim.read_bytes()
-    with pytest.raises(ValueError, match="would write over its inputs"):
+    with pytest.raises(ValueError, match="would write over its own inputs"):
         base.derive_tree(
             str(tmp_path / "**" / "*.parquet"),
             str(tmp_path / "aa"),
@@ -473,7 +473,7 @@ def test_derive_tree_refuses_to_write_over_a_file_it_did_not_derive(tmp_path):
     source = tmp_path / "data" / "ds.parquet"
     _fake_source(source)
     before = source.read_bytes()
-    with pytest.raises(ValueError, match="would write over its inputs"):
+    with pytest.raises(ValueError, match="files this library did not write"):
         base.derive_tree(
             str(tmp_path / "projections" / "*.parquet"),
             str(tmp_path / "data"),

--- a/ord_schema/artifacts/scripts/derive_projection_test.py
+++ b/ord_schema/artifacts/scripts/derive_projection_test.py
@@ -117,7 +117,7 @@ def test_an_exact_filename_writes_a_file_not_a_directory(tmp_path):
 
 def test_writing_into_the_source_tree_is_an_error(tmp_path):
     _dataset(tmp_path, "aa", "ord_dataset-a")
-    with pytest.raises(ValueError, match="would write over its inputs"):
+    with pytest.raises(ValueError, match="would write over its own inputs"):
         derive_projection.main(
             derive_projection.parse_args(
                 [


### PR DESCRIPTION
## Summary

`derive_tree` refuses to write over anything at a destination that is not a derived artifact, so a mistyped `--output_dir` cannot replace source datasets with files that can be regenerated. It decided that by reading the full stamp set, which answers whether a file matches *today's* format rather than who wrote it.

Renaming `ord.artifact_version` to `ord.artifact_lineage` in #1013 therefore made every artifact already on disk unreadable as stamps, so the guard read a corpus this driver wrote as a stranger's and refused the re-derive that was the only way to bring it up to date. `--force` does not help; the clobber check runs before it is consulted. Any existing corpus is wedged until its trees are deleted by hand.

## Changes

- Decide `_is_irreplaceable` on the presence of `ord.artifact` rather than on a complete stamp set. Nothing else writes that key, so a file carrying it is ours whatever the rest of its footer says.
- A source dataset carries `ord.dataset_id` and `ord.schema_version` but no `ord.artifact`, so it is still refused — verified against the local ord-data checkout.
- Report the guard's two refusals apart. A destination that is one of the run's own inputs and one holding a foreign file were both reported as "would write over its inputs"; the second kind involves no input at all, and the refusal that motivated this PR listed 53 destinations and called them inputs. Both now appear in one message so a caller hitting both sees both.
- Record in the artifacts README that `ord.artifact` alone marks a file as this library's, since that is what the guard reads.

## Testing

- `uv run pytest ord_schema/artifacts ord_schema/search -n auto` — 838 passed.
- New `test_derive_tree_rewrites_an_artifact_stamped_by_an_older_library` writes a structures artifact carrying the superseded `ord.artifact_version` and no `ord.artifact_lineage`, and asserts the run rewrites it.
- Mutation-checked three ways, each producing exactly one failure and the right one: the old full-stamp guard restored (the new test fails), `_is_irreplaceable` forced to `False` (`test_derive_tree_refuses_to_write_over_a_file_it_did_not_derive` fails, so the guard is still load-bearing), and the two refusal buckets merged back into one (the same test fails, so the split is what the message now discriminates on).
- `test_derive_tree_refuses_to_write_over_a_file_it_did_not_derive` was matching the input wording for a case that is not about inputs, so it passed for the wrong reason; it now matches its own message.
- Found by running the real re-derive of a 53-dataset local corpus, which failed at the first step before the fix and proceeds after it.

## Notes

- `base.is_artifact` now has no callers in the library or in any sibling repository at `origin/main`. Left in place; removing a public predicate is a separate call.
- No test covers a run that hits both refusals at once, only the `' and '.join` of two independently covered branches. The two live in different topologies — a destination equal to one of the run's own sources, and one holding a foreign file — and constructing both in a single glob needs a symlink or a contrived mirror root. Skipped deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR allows `derive_tree` to refresh artifacts written with older stamp formats while preserving protection for source and unrelated files.
- Determines replaceability from the presence of the `ord.artifact` metadata key rather than the complete current stamp set.
- Separates errors for destinations overlapping inputs from errors for unrelated destination files.
- Adds regression coverage for rewriting an artifact carrying the superseded version stamp and documents the ownership-marker contract.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/artifacts/base.py | Changes destination ownership detection and reports input-overlap and foreign-file refusals separately; no eligible blocking failure remains. |
| ord_schema/artifacts/base_test.py | Adds regression coverage for refreshing artifacts stamped by an older library and updates refusal-message assertions. |
| ord_schema/artifacts/README.md | Documents `ord.artifact` as the stable ownership marker used by the overwrite guard. |
| ord_schema/artifacts/scripts/derive_projection_test.py | Updates the projection command test to match the more precise input-overlap error. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    D[Planned destination exists] --> P{Readable Parquet?}
    P -- No --> R[Refuse overwrite]
    P -- Yes --> A{ord.artifact key present?}
    A -- No --> R
    A -- Yes --> W[Allow artifact refresh]
    W --> C{Current and not forced?}
    C -- Yes --> S[Skip]
    C -- No --> O[Rewrite artifact]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Distill the prose the refusal split adde..."](https://github.com/open-reaction-database/ord-schema/commit/c46f9d46b7c1f60424cb00e213337700b40dd8b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59797829)</sub>

<!-- /greptile_comment -->