### PR TITLE
Refuse query keys the models do not declare

### DIFF
--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -68,6 +68,11 @@ A `Path` is a dotted column path such as `conditions.temperature.setpoint_kelvin
 `exists` or `forall` it is **relative to the bound element**, which is what lets one component
 be required to satisfy several conditions at once.
 
+A key the grammar does not name is refused rather than dropped. Every field that narrows a
+query is optional, so an ignored key would leave a query missing the clause it was meant to
+carry — and a `Query` with no `where` is every reaction in the corpus, returned as an answer
+rather than as a failure.
+
 Every rule below is enforced against `projection.SCHEMA` before any SQL exists, so a bad query
 is a compile error rather than a wrong answer:
 

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -65,7 +65,7 @@ from collections.abc import Callable
 from typing import Annotated, Any, Literal
 
 import pyarrow as pa
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from rdkit import Chem
 
 # Aliased because ``pivot`` is the parameter name a caller passes an index under, and a
@@ -304,7 +304,21 @@ def resolve(
     return _Resolved(expression or "", repeated, current)
 
 
-class Value(BaseModel):
+class _Node(BaseModel):
+    """Base of every model below, refusing keys the model does not declare.
+
+    Dropping an unknown key is the wrong default here because these models are how a
+    query arrives from outside -- a dict, a JSON body, a tool call. Every field that
+    narrows a query is optional or lives under a discriminated union, so a misspelled
+    key does not fail: it validates to a query missing the clause the caller wrote,
+    which for a top-level ``where`` is every reaction in the corpus. The caller sees a
+    plausible answer to a question they did not ask, with nothing logged.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class Value(_Node):
     """A comparison operand: a literal, or a compound to resolve and bind."""
 
     literal: bool | int | float | str | None = None
@@ -319,28 +333,28 @@ class Value(BaseModel):
         return self
 
 
-class And(BaseModel):
+class And(_Node):
     """Every clause holds."""
 
     op: Literal["and"]
     clauses: list["Predicate"] = Field(min_length=1)
 
 
-class Or(BaseModel):
+class Or(_Node):
     """At least one clause holds."""
 
     op: Literal["or"]
     clauses: list["Predicate"] = Field(min_length=1)
 
 
-class Not(BaseModel):
+class Not(_Node):
     """The clause does not hold."""
 
     op: Literal["not"]
     clause: "Predicate"
 
 
-class Quantifier(BaseModel):
+class Quantifier(_Node):
     """Some, or every, element at a repeated level satisfies ``where``.
 
     Paths inside ``where`` are relative to the element bound here, which is what lets a
@@ -352,7 +366,7 @@ class Quantifier(BaseModel):
     where: "Predicate"
 
 
-class Comparison(BaseModel):
+class Comparison(_Node):
     """A leaf compared against a literal or a resolved compound."""
 
     op: Literal[
@@ -362,14 +376,14 @@ class Comparison(BaseModel):
     value: Value
 
 
-class NullCheck(BaseModel):
+class NullCheck(_Node):
     """Whether the source recorded the leaf at all."""
 
     op: Literal["is_null", "not_null"]
     path: str
 
 
-class Substructure(BaseModel):
+class Substructure(_Node):
     """The element's structure contains the query as a subgraph.
 
     ``path`` names a compound's ``smiles``. The query is a SMARTS pattern, or a
@@ -422,7 +436,7 @@ class Substructure(BaseModel):
         return self
 
 
-class Similarity(BaseModel):
+class Similarity(_Node):
     """The element's structure is Tanimoto-similar to the query molecule.
 
     Similarity is defined on the Morgan fingerprints in the structures artifact, so
@@ -478,7 +492,7 @@ def _check_molecule_query(node: "SameCompound | SameParent") -> None:
             raise ValueError(f"SMILES has no atoms: {node.smiles!r}")
 
 
-class SameCompound(BaseModel):
+class SameCompound(_Node):
     """The element's structure is the same compound, however either was drawn.
 
     An ``eq`` on a ``smiles`` compares spellings, and two drawings of one reagent are
@@ -503,7 +517,7 @@ class SameCompound(BaseModel):
         return self
 
 
-class SameParent(BaseModel):
+class SameParent(_Node):
     """The element's structure is the same compound once counterions are set aside.
 
     What ``same_compound`` ignores, this ignores too, and the salt a reagent was sold
@@ -577,7 +591,7 @@ _REDUCERS = {
 _ARITHMETIC = frozenset({"min", "max", "avg", "sum"})
 
 
-class Reduction(BaseModel):
+class Reduction(_Node):
     """One value per reaction, reduced from a path that crosses a repeated level.
 
     An ordering key and an aggregate's argument both have to be scalar, which leaves
@@ -595,7 +609,7 @@ class Reduction(BaseModel):
     path: str
 
 
-class Measure(BaseModel):
+class Measure(_Node):
     """One aggregate over the matching rows."""
 
     fn: Literal["count", "count_distinct", "sum", "avg", "min", "max"]
@@ -611,7 +625,7 @@ class Measure(BaseModel):
         return self
 
 
-class Aggregate(BaseModel):
+class Aggregate(_Node):
     """Group the matching rows and measure each group.
 
     ``group_by`` paths must be scalar, so the number of groups is bounded by the values
@@ -622,14 +636,14 @@ class Aggregate(BaseModel):
     measures: list[Measure] = Field(min_length=1)
 
 
-class Order(BaseModel):
+class Order(_Node):
     """How to sort the result."""
 
     key: str | Reduction
     descending: bool = False
 
 
-class Query(BaseModel):
+class Query(_Node):
     """A whole query: which reactions, optionally grouped and measured."""
 
     where: Predicate | None = None

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -422,9 +422,9 @@ def test_an_unknown_key_is_refused_rather_than_dropped(payload):
         query.Query.model_validate(payload)
 
 
-def test_a_dropped_top_level_key_would_have_matched_everything():
-    # Why the test above is about more than typo-catching: this is what the refused
-    # payload compiles to when the key is dropped instead.
+def test_a_query_with_no_where_matches_everything():
+    # What the payloads above validate to once their unknown key is dropped, and why
+    # refusing them is more than typo-catching: no predicate compiles to no WHERE.
     assert "WHERE" not in query.compile_query(query.Query()).sql
 
 

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -393,6 +393,41 @@ def test_rejected_before_compilation(payload):
         query.Query.model_validate(payload)
 
 
+@pytest.mark.parametrize(
+    "payload",
+    [
+        # A misspelled top-level key: dropped, this is Query() and matches everything.
+        {"structure": {"path": "inputs.components.smiles", "smarts": "c1ccccc1"}},
+        {"wehre": {"op": "is_null", "path": "reaction_id"}},
+        # Misspelled inside a predicate, where the surviving model is still valid: the
+        # quantifier keeps its body but loses the pattern, and the substructure node
+        # then has neither smarts nor compound.
+        {
+            "where": {
+                "op": "exists",
+                "path": "inputs.components",
+                "where": {"op": "substructure", "path": "smiles", "smart": "c1ccccc1"},
+            }
+        },
+        {"where": {"op": "eq", "path": "reaction_id", "value": {"literl": "a"}}},
+        {"limit": 10, "ordr_by": []},
+    ],
+)
+def test_an_unknown_key_is_refused_rather_than_dropped(payload):
+    # Dropping one does not fail here, it widens: every narrowing field is optional or
+    # sits under a discriminated union, so the survivor is a valid query missing the
+    # clause the caller wrote -- and a Query with no ``where`` is every reaction in the
+    # corpus, returned without a warning.
+    with pytest.raises(ValidationError, match=r"[Ee]xtra"):
+        query.Query.model_validate(payload)
+
+
+def test_a_dropped_top_level_key_would_have_matched_everything():
+    # Why the test above is about more than typo-catching: this is what the refused
+    # payload compiles to when the key is dropped instead.
+    assert "WHERE" not in query.compile_query(query.Query()).sql
+
+
 # Reductions over a repeated level
 
 


### PR DESCRIPTION
## Summary

Every model in the query grammar took pydantic's default and silently dropped an unknown key. Dropping one does not fail here, it *widens*: every field that narrows a query is optional or sits under a discriminated union, so the survivor is a valid query missing the clause the caller wrote.

A misspelled top-level key leaves `Query(where=None)` — every reaction in the corpus, returned with nothing logged. Found by writing `{"structure": {...}}` instead of `{"where": {"op": "substructure", ...}}` against the local corpus and getting all 2,428,291 reactions back from three different searches before noticing they were identical.

## Changes

- Give the 16 query models a shared `_Node` base carrying `extra="forbid"`, so a key a model does not declare is a `ValidationError` rather than a dropped one. Applied to the whole family, not just `Query`: the same trap sits one level down, where `{"op": "substructure", "path": "smiles", "smart": "..."}` would validate to a node with neither `smarts` nor `compound`.
- Say the rule in the README where the grammar is written down, above the compile-time rules rather than among them — it is settled at validation, before `projection.SCHEMA` is consulted.
- `additionalProperties: false` now appears 16 times in the generated JSON schema, which is what `nl.py` hands the model as a tool `input_schema` and what a tool-calling client validates against. The schema grows to 14.5 KB.

## Testing

- `PATH=<conda ord env>/bin:$PATH uv run pytest -n auto` — 1625 passed. (Without the conda `bin` on PATH the 61 ORM tests error on `initdb`; unrelated to this change.)
- New `test_an_unknown_key_is_refused_rather_than_dropped` covers five payloads: a misspelled top-level key, a misspelled `where`, a typo inside a nested `substructure`, one inside a `value`, and one beside a valid `limit`. Mutation-checked — reverting to `extra="ignore"` fails all five and nothing else.
- `test_a_query_with_no_where_matches_everything` pins why this matters rather than just that it validates: `Query()` compiles to SQL with no `WHERE`.
- Checked every query fixture on disk against the new rule: all 19 canonical `check.QUERIES` validate and compile, and all four `nl_cases.json` cases carrying a `reference` validate. `corpus_baseline.json` holds only expected row counts and digests, no queries.

## Notes

- The NL path is unaffected in shape: `pydantic.ValidationError` subclasses `ValueError`, and `nl._validated` is called under `except (ValueError, QueryError)` at both sites, so a stray key from the model reaches the repair turn as before — now with the offending key named.
- `nl.py` already refuses a query with no `where`, no `aggregate`, and no `limit`. That guard is narrower than this one: a dropped `where` beside a valid `limit` passed it.
- A bare `Query()` still compiles and still matches everything. That is a legitimate request with a `limit`, and the NL layer is where "asks nothing" is judged; not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR makes structured-search query models reject undeclared keys, preventing misspelled filters from silently widening searches.
- Introduces a shared strict Pydantic base for all query grammar nodes.
- Exposes the restriction through generated JSON Schema.
- Adds validation and semantic regression coverage and documents the behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/query.py | Adds a shared Pydantic configuration that forbids undeclared fields across every structured-query model. |
| ord_schema/search/query_test.py | Covers unknown keys at top-level and nested grammar positions and confirms an unfiltered query compiles without a WHERE clause. |
| ord_schema/search/README.md | Documents why undeclared query keys are rejected instead of silently discarded. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Query payload] --> B[Pydantic schema validation]
  B -->|Declared keys| C[Query model]
  B -->|Unknown key| D[ValidationError]
  C --> E[SQL compilation]
  E --> F[Corpus search]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Say the unknown-key rule where the gramm..."](https://github.com/open-reaction-database/ord-schema/commit/431b340802add8f4b30809b99f14f79b0e70557e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60249957)</sub>

**Context used:**

- Knowledge Base — [Database access and reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/database-and-search.md)
- Knowledge Base — [Structured reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/structured-reaction-search.md)

<!-- /greptile_comment -->