### PR TITLE
Give every projected date a parsed timestamp

### DIFF
--- a/ord_schema/artifacts/base.py
+++ b/ord_schema/artifacts/base.py
@@ -269,6 +269,37 @@ def load_stamps(path: str | os.PathLike[str]) -> Stamps:
     )
 
 
+def _declared_paths(schema: pa.Schema | pa.DataType, prefix: str = "") -> list[str]:
+    """Returns every field a schema declares, dotted, in declaration order.
+
+    A list's or map's own name is not a field a reader binds; what it holds is, so the
+    descent passes through them without adding a segment of its own.
+
+    Args:
+        schema: A schema, or a nested type within one.
+        prefix: What the walk has already named, for the recursion.
+
+    Returns:
+        The dotted paths, outermost first.
+    """
+    if isinstance(schema, pa.Schema):
+        fields: list[pa.Field] = list(schema)
+    elif pa.types.is_struct(schema):
+        fields = [schema.field(index) for index in range(schema.num_fields)]
+    elif pa.types.is_list(schema) or pa.types.is_large_list(schema):
+        return _declared_paths(schema.value_type, prefix)
+    elif pa.types.is_map(schema):
+        return _declared_paths(schema.item_type, prefix)
+    else:
+        return []
+    paths = []
+    for field in fields:
+        name = f"{prefix}.{field.name}" if prefix else field.name
+        paths.append(name)
+        paths.extend(_declared_paths(field.type, name))
+    return paths
+
+
 def missing_columns(path: str | os.PathLike[str], schema: pa.Schema) -> list[str]:
     """Returns the columns ``schema`` declares that ``path`` does not carry.
 
@@ -276,20 +307,30 @@ def missing_columns(path: str | os.PathLike[str], schema: pa.Schema) -> list[str
     an artifact's definition: a file written before it stamps exactly as a file written
     after it, and the difference shows up only in the schema.
 
+    Compared down through structs, lists and maps, not across the top level alone. The
+    projection is one struct per message and nearly every field it has is nested, so a
+    top-level comparison would call a file current that is missing everything added
+    since it was written -- and a reader binding the new column would fail on a file
+    nothing marked stale.
+
     Args:
         path: Path to check. Need not exist.
         schema: The columns this library's version of the artifact carries.
 
     Returns:
-        The declared names the file lacks, in declaration order. A file that cannot be
-        read at all lacks all of them.
+        The declared paths the file lacks, dotted from the top level and in declaration
+        order. A file that cannot be read at all lacks all of them.
     """
     try:
         with pq.ParquetFile(path) as parquet_file:
-            names = set(parquet_file.schema_arrow.names)
+            found = parquet_file.schema_arrow
     except (OSError, ValueError, pa.ArrowInvalid):
-        return list(schema.names)
-    return [name for name in schema.names if name not in names]
+        return _declared_paths(schema)
+    return [
+        path
+        for path in _declared_paths(schema)
+        if path not in set(_declared_paths(found))
+    ]
 
 
 def is_current(

--- a/ord_schema/artifacts/base.py
+++ b/ord_schema/artifacts/base.py
@@ -269,8 +269,20 @@ def load_stamps(path: str | os.PathLike[str]) -> Stamps:
     )
 
 
-def _declared_paths(schema: pa.Schema | pa.DataType, prefix: str = "") -> list[str]:
-    """Returns every field a schema declares, dotted, in declaration order.
+def _is_nested(dtype: pa.DataType) -> bool:
+    """Returns whether ``dtype`` holds other fields rather than values of its own."""
+    return (
+        pa.types.is_struct(dtype)
+        or pa.types.is_list(dtype)
+        or pa.types.is_large_list(dtype)
+        or pa.types.is_map(dtype)
+    )
+
+
+def _declared_paths(
+    schema: pa.Schema | pa.DataType, prefix: str = ""
+) -> list[tuple[str, pa.DataType | None]]:
+    """Returns every field a schema declares, dotted and typed, in declaration order.
 
     A list's or map's own name is not a field a reader binds; what it holds is, so the
     descent passes through them without adding a segment of its own.
@@ -280,7 +292,9 @@ def _declared_paths(schema: pa.Schema | pa.DataType, prefix: str = "") -> list[s
         prefix: What the walk has already named, for the recursion.
 
     Returns:
-        The dotted paths, outermost first.
+        Pairs of dotted path and leaf type, outermost first. The type is None for a
+        field that holds other fields, whose own type is decided by the leaves beneath
+        it and would otherwise report a change twice.
     """
     if isinstance(schema, pa.Schema):
         fields: list[pa.Field] = list(schema)
@@ -292,10 +306,10 @@ def _declared_paths(schema: pa.Schema | pa.DataType, prefix: str = "") -> list[s
         return _declared_paths(schema.item_type, prefix)
     else:
         return []
-    paths = []
+    paths: list[tuple[str, pa.DataType | None]] = []
     for field in fields:
         name = f"{prefix}.{field.name}" if prefix else field.name
-        paths.append(name)
+        paths.append((name, None if _is_nested(field.type) else field.type))
         paths.extend(_declared_paths(field.type, name))
     return paths
 
@@ -313,24 +327,34 @@ def missing_columns(path: str | os.PathLike[str], schema: pa.Schema) -> list[str
     since it was written -- and a reader binding the new column would fail on a file
     nothing marked stale.
 
+    A leaf whose type changed counts as missing too, because a path comparison alone
+    cannot see it: widening a column or moving a timestamp from seconds to microseconds
+    leaves every name where it was, so a file holding the old type would read as current
+    and keep serving values the current definition does not describe.
+
     Args:
         path: Path to check. Need not exist.
         schema: The columns this library's version of the artifact carries.
 
     Returns:
         The declared paths the file lacks, dotted from the top level and in declaration
-        order. A file that cannot be read at all lacks all of them.
+        order. A path present with the wrong type carries the type it should hold, so
+        the message says what changed rather than naming a column the file visibly has.
+        A file that cannot be read at all lacks all of them.
     """
+    declared = _declared_paths(schema)
     try:
         with pq.ParquetFile(path) as parquet_file:
-            found = parquet_file.schema_arrow
+            found = dict(_declared_paths(parquet_file.schema_arrow))
     except (OSError, ValueError, pa.ArrowInvalid):
-        return _declared_paths(schema)
-    return [
-        path
-        for path in _declared_paths(schema)
-        if path not in set(_declared_paths(found))
-    ]
+        return [name for name, _ in declared]
+    missing = []
+    for name, leaf in declared:
+        if name not in found:
+            missing.append(name)
+        elif leaf is not None and found[name] != leaf:
+            missing.append(f"{name}: {leaf}")
+    return missing
 
 
 def is_current(

--- a/ord_schema/artifacts/base_test.py
+++ b/ord_schema/artifacts/base_test.py
@@ -633,3 +633,50 @@ def test_a_grandparent_bump_makes_a_grandchild_stale(tmp_path, monkeypatch):
         base, "ARTIFACT_VERSIONS", base.ARTIFACT_VERSIONS | {"projection": "2"}
     )
     assert not base.is_current(path, "occurrences", "0" * 32)
+
+
+def test_missing_columns_sees_a_field_added_inside_a_struct(tmp_path):
+    # Nearly every field the projection has is nested, so a top-level comparison would
+    # call a file current that is missing everything added since it was written -- and a
+    # reader binding the new column would fail on a file nothing marked stale.
+    path = tmp_path / "artifact.parquet"
+    inner = pa.struct([pa.field("value", pa.string())])
+    pq.write_table(pa.table({"provenance": pa.array([{"value": "x"}], inner)}), path)
+    widened = pa.schema(
+        [
+            pa.field(
+                "provenance",
+                pa.struct(
+                    [
+                        pa.field("value", pa.string()),
+                        pa.field("timestamp", pa.timestamp("us")),
+                    ]
+                ),
+            )
+        ]
+    )
+    assert base.missing_columns(path, widened) == ["provenance.timestamp"]
+
+
+def test_missing_columns_descends_through_lists_and_maps(tmp_path):
+    # A list's own name is not a field a reader binds; what it holds is.
+    path = tmp_path / "artifact.parquet"
+    held = pa.list_(pa.struct([pa.field("a", pa.string())]))
+    pq.write_table(pa.table({"items": pa.array([[{"a": "x"}]], held)}), path)
+    widened = pa.schema(
+        [
+            pa.field(
+                "items",
+                pa.list_(
+                    pa.struct([pa.field("a", pa.string()), pa.field("b", pa.int64())])
+                ),
+            )
+        ]
+    )
+    assert base.missing_columns(path, widened) == ["items.b"]
+
+
+def test_a_file_carrying_every_nested_field_lacks_nothing(tmp_path):
+    path = tmp_path / "artifact.parquet"
+    _write(path, _valid_metadata())
+    assert base.missing_columns(path, pa.schema([pa.field("x", pa.int32())])) == []

--- a/ord_schema/artifacts/base_test.py
+++ b/ord_schema/artifacts/base_test.py
@@ -25,7 +25,7 @@ import pytest
 from rdkit import rdBase
 
 from ord_schema import parquet
-from ord_schema.artifacts import base
+from ord_schema.artifacts import base, projection, structures
 from ord_schema.proto import dataset_pb2, reaction_pb2
 
 
@@ -656,6 +656,48 @@ def test_missing_columns_sees_a_field_added_inside_a_struct(tmp_path):
         ]
     )
     assert base.missing_columns(path, widened) == ["provenance.timestamp"]
+
+
+def test_missing_columns_sees_a_leaf_whose_type_changed(tmp_path):
+    # A path comparison alone cannot see this: moving a timestamp from milliseconds to
+    # microseconds leaves every name where it was, so the file would read as current
+    # and keep serving values truncated against the current definition.
+    path = tmp_path / "old.parquet"
+    millis = pa.schema(
+        [
+            pa.field("reaction_id", pa.string()),
+            pa.field(
+                "provenance", pa.struct([pa.field("recorded", pa.timestamp("ms"))])
+            ),
+        ]
+    )
+    pq.write_table(millis.empty_table(), path)
+    micros = pa.schema(
+        [
+            pa.field("reaction_id", pa.string()),
+            pa.field(
+                "provenance", pa.struct([pa.field("recorded", pa.timestamp("us"))])
+            ),
+        ]
+    )
+    assert base.missing_columns(path, micros) == ["provenance.recorded: timestamp[us]"]
+    # The same file against its own schema is current, so the check is about the type
+    # rather than about a nested field being reported twice.
+    assert base.missing_columns(path, millis) == []
+
+
+@pytest.mark.parametrize(
+    ("name", "schema"),
+    [("projection", projection.SCHEMA), ("structures", structures.SCHEMA)],
+)
+def test_every_declared_type_survives_a_parquet_round_trip(tmp_path, name, schema):
+    # missing_columns compares leaf types, and Parquet does not store every Arrow type
+    # it is given -- a second-resolution timestamp comes back as milliseconds. A type
+    # the writer coerces would make every file of that artifact read as stale forever,
+    # which is a re-derive that never converges rather than a wrong answer.
+    path = tmp_path / f"{name}.parquet"
+    pq.write_table(schema.empty_table(), path)
+    assert base.missing_columns(path, schema) == []
 
 
 def test_missing_columns_descends_through_lists_and_maps(tmp_path):

--- a/ord_schema/artifacts/projection.py
+++ b/ord_schema/artifacts/projection.py
@@ -189,7 +189,7 @@ TIMESTAMP_COLUMN = "timestamp"
 # 1.77 million from a dataset whose stamps merely begin with it.
 #
 # Slash dates are listed month-first here and read day-first where the dataset says so;
-# see ``day_first_dates``.
+# see ``slash_orientation``.
 _DATE_FORMATS = (
     "%Y-%m-%d %H:%M:%S.%f",
     "%Y-%m-%dT%H:%M:%S.%f",
@@ -912,9 +912,10 @@ def write_projection(
     # Which way this dataset writes slash dates, settled before any row is projected.
     # The convention belongs to the depositor rather than to a value, so it cannot be
     # read off the rows as they stream past and a row group's worth of them is not the
-    # dataset. Where the answer is not already recorded this costs a pass that parses
-    # the protos without projecting them: measured at ~7 seconds over the source that is
-    # 96% of ORD, against the 34.6 minutes the projection itself takes.
+    # dataset. Every dataset but an undecided one costs a pass that parses the protos
+    # without projecting them, though it stops at the first value that settles the
+    # question: measured at ~7 seconds over the source that is 96% of ORD, against the
+    # 34.6 minutes the projection itself takes.
     day_first = slash_orientation(source_dataset_id, _recorded_dates(view))
     with (
         atomic_io.atomic_path(output) as temp_path,

--- a/ord_schema/artifacts/projection.py
+++ b/ord_schema/artifacts/projection.py
@@ -29,7 +29,8 @@ That works only because the message graph is acyclic: no message reaches itself,
 recursion terminates. ``build_schema`` enforces this rather than assuming it -- a
 recursive message added upstream would otherwise recurse forever at import time.
 
-Two normalizations are applied, and only two. Both cost no query and remove a real trap:
+Three normalizations are applied, and only three. Each costs no query and removes a
+real trap:
 
 * **United messages become canonical floats.** A ``{value, precision, units}`` triple
   projected verbatim means ``WHERE temperature > 350`` silently misses every row
@@ -38,6 +39,21 @@ Two normalizations are applied, and only two. Both cost no query and remove a re
   stays expressible while the mixed-unit comparison that would quietly return the wrong
   rows does not. The source records precision in the same units as the value, so it
   converts with the value and is null under the same conditions.
+* **Dates become instants.** ``DateTime`` is a bare string the depositor wrote, and the
+  corpus holds fifteen shapes of it in nine families, so comparing the text answers
+  arbitrarily: over ORD a prefix match on ``2021`` finds none of that year's 490,412
+  records while one on ``2022`` matches 1.77 million from a dataset whose stamps merely
+  begin with it. Each ``DateTime`` gains a ``timestamp`` beside the recorded string,
+  which stays: the projection adds a reading rather than replacing what the source says,
+  and a shape none of the formats cover is a visible null.
+
+  ``NN/NN/NNNN`` is the part that needs more than a format list, since the string never
+  says which field is the month. It is settled per dataset and before any row is
+  written -- the convention belongs to the depositor, not to a value -- from
+  ``_SLASH_ORIENTATION`` where the question has been answered and from the dataset's own
+  unambiguous values otherwise. Where neither settles it the timestamp is null, because
+  a guess written here is indistinguishable afterwards from a date the source recorded.
+
 * **Structural identifiers collapse to one ``smiles``.** ``SMILES``, ``CXSMILES``,
   ``INCHI``, and ``MOLBLOCK`` all answer "what is this molecule," so the projection
   answers it once, through ``message_helpers.smiles_from_compound`` -- the same
@@ -97,7 +113,9 @@ reproducible from the projection alone.
 """
 
 import os
-from collections.abc import Iterator, MutableMapping
+import re
+from collections.abc import Iterable, Iterator, MutableMapping
+from datetime import datetime
 from typing import Any, cast, get_args
 
 import pyarrow as pa
@@ -154,6 +172,91 @@ _STRUCTURAL_TYPES: dict[str, frozenset[int]] = {
 # ``structure_id``. Reaction is structural but its smiles is a reaction;
 # reaction-level structure search is a different operation and no ID is assigned there.
 _STRUCTURE_ID_TYPES = frozenset({"Compound", "ProductCompound"})
+
+# Messages whose free-text date gains a parsed ``timestamp`` beside it.
+_TIMESTAMP_TYPES = frozenset({"DateTime"})
+TIMESTAMP_COLUMN = "timestamp"
+
+# The shapes ORD's dates are recorded in, tried in order. DateTime.value is a string the
+# depositor wrote, so there is no format to rely on: seven appear across the corpus, and
+# a reader comparing the text instead answers arbitrarily -- over ORD, a prefix match on
+# "2021" finds none of the 490,412 records from that year while one on "2022" matches
+# 1.77 million from a dataset whose stamps merely begin with it.
+#
+# Slash dates are listed month-first here and read day-first where the dataset says so;
+# see ``day_first_dates``.
+_DATE_FORMATS = (
+    "%Y-%m-%d %H:%M:%S.%f",
+    "%Y-%m-%dT%H:%M:%S.%f",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%d",
+    "%m/%d/%Y, %I:%M:%S %p",
+    "%m/%d/%Y, %H:%M:%S",
+    "%m/%d/%Y %H:%M:%S",
+    "%m/%d/%Y",
+    "%a %b %d %H:%M:%S %Y",
+)
+# Written day-first for a dataset that records dates that way; same order, so a value
+# matches the same shape either way and only the two leading numbers swap meaning.
+_DAY_FIRST_FORMATS = tuple(shape.replace("%m/%d/", "%d/%m/") for shape in _DATE_FORMATS)
+_SLASH_DATE = re.compile(r"^(\d{1,2})/(\d{1,2})/")
+
+# Which way each dataset writes its slash dates, where something settles it. A value
+# alone settles only 28 of the 41 datasets that write one -- those holding a number
+# above twelve -- and the rest need evidence outside any single value: an upper bound
+# from the reaction's own record_modified events, a co-submitted sibling in the same
+# shape, the en-US 12-hour rendering no day-first locale produces, and the supplemental
+# data on two submission pull requests. That work is the ord-logbook entry "Date and
+# time formats across the corpus" (2026-09-03), where the reasoning per dataset lives.
+#
+# Two datasets are deliberately absent: 5c9a1032 and 5e8318f0, which no evidence settles
+# and whose submitters have been asked. Absent means their ambiguous dates project as
+# null, which is the point -- writing a guess would freeze it into the artifact and
+# destroy the record that it was ever a guess.
+_SLASH_ORIENTATION: dict[str, bool] = {
+    "ord_dataset-172039a759a440219a68af62d203b79b": True,  # witness
+    "ord_dataset-2be11f57f3304e678ea8469baf6dd1bc": True,  # sibling
+    "ord_dataset-3b8a2ef300e145468579027f206a3ac8": True,  # witness
+    "ord_dataset-c5b00523487a4211a194160edf45e9ab": True,  # witness
+    "ord_dataset-00005539a1e04c809a9a78647bea649c": False,  # witness
+    "ord_dataset-0316886541d9435489859c2ad7edc863": False,  # witness
+    "ord_dataset-0c75d67751634f0594b24b9f498b77c2": False,  # bound
+    "ord_dataset-10b940e7982c4622b1e1ac879394aba6": False,  # witness
+    "ord_dataset-1d3a1a6fb70d46c084602d0688967afc": False,  # witness
+    # ord-data#86 supplemental data
+    "ord_dataset-35a5a513f1dd44a3a97c88da99f81a00": False,
+    "ord_dataset-3b5db90e337942ea886b8f5bc5e3aa72": False,  # bound
+    "ord_dataset-46ff9a32d9e04016b9380b1b1ef949c3": False,  # format
+    "ord_dataset-488402f6ec0d441ca2f7d6fabea7c220": False,  # witness
+    "ord_dataset-4d431564f3ef4e9c91d8da5836f4eae6": False,  # format
+    "ord_dataset-52bd3b0ec72c443aab113bcea09bf3f4": False,  # witness
+    "ord_dataset-5481550056a14935b76e031fb94b88be": False,  # witness
+    "ord_dataset-5540e162c09f4c04905ddc8ba9c931c6": False,  # witness
+    "ord_dataset-55de08a995554f558c25fc43eac62359": False,  # witness
+    "ord_dataset-5eb7f2689f4a42eba63ad9e37e49a5cd": False,  # witness
+    "ord_dataset-675eddcaa6674ce3ae61e79bbc1e1c08": False,  # bound
+    "ord_dataset-68cb8b4b2b384e3d85b5b1efae58b203": False,  # witness
+    "ord_dataset-6a0bfcdf53a64c07987822162ae591e2": False,  # witness
+    "ord_dataset-7acd6ad2bf4d4cff841cad008ab726d5": False,  # witness
+    "ord_dataset-7d8f5fd922d4497d91cb81489b052746": False,  # witness
+    "ord_dataset-805ad863feef48579d95d86a728035f4": False,  # witness
+    "ord_dataset-89b083710e2d441aa0040c361d63359f": False,  # bound
+    "ord_dataset-8d1e28ec1f6b4ee8ad372e0b5ed7a62e": False,  # witness
+    "ord_dataset-9b8aa9a7835143ef8ce3f70abfab7545": False,  # witness
+    "ord_dataset-a12fa15d036d489c971b0b514caeae52": False,  # witness
+    "ord_dataset-ac78456835404910b3a4c840248b6ac9": False,  # witness
+    "ord_dataset-b440f8c90b6343189093770060fc4098": False,  # witness
+    "ord_dataset-cbcc4048add7468e850b6ec42549c70d": False,  # format
+    "ord_dataset-ce5045aceb214cfc8bfd0ef3031e2737": False,  # witness
+    "ord_dataset-d26118acda314269becc35db5c22dc59": False,  # bound
+    "ord_dataset-d319c2a22ecf4ce59db1a18ae71d529c": False,  # witness
+    # ord-data#188 supplemental data
+    "ord_dataset-d92976309c3a48a3a64a4cf5e7048086": False,
+    "ord_dataset-e7830cd6b11158b43994ccfb5ee9acb3": False,  # witness
+    "ord_dataset-eeba974d3c284aed86d1c1d442260a1e": False,  # witness
+    "ord_dataset-fc83743b978f4deea7d6856deacbfe53": False,  # witness
+}
 
 # An ID rides beside the collapsed smiles and cannot exist without it: the schema
 # would gain a structure_id with no sibling smiles, and message_row would KeyError.
@@ -247,6 +350,114 @@ def _reachable_fields() -> Iterator[FieldDescriptor]:
             yield field
             if field.message_type is not None:
                 stack.append(field.message_type)
+
+
+def day_first_dates(values: Iterable[str | None]) -> bool | None:
+    """Returns whether a dataset writes slash dates day first, or None if it cannot say.
+
+    The convention is a property of the depositor rather than of a value, and a value
+    only reveals it where one of the two leading numbers exceeds twelve. Measured over
+    ORD no dataset carries evidence both ways, so one answer per dataset is the right
+    shape -- and thirteen carry none at all, which is what None is for: those hold one
+    bulk-import stamp repeated across every row, so a date guessed for them would be
+    guessed for tens of thousands of reactions at once.
+
+    Args:
+        values: Every date string the dataset records, in any order. Nones and values in
+            other formats are ignored, since only a slash date is ambiguous.
+
+    Returns:
+        True where the dataset writes day/month, False where it writes month/day, and
+        None where no value settles it.
+    """
+    for value in values:
+        if value is None:
+            continue
+        matched = _SLASH_DATE.match(value)
+        if matched is None:
+            continue
+        first, second = int(matched.group(1)), int(matched.group(2))
+        if first > 12:
+            return True
+        if second > 12:
+            return False
+    return None
+
+
+def slash_orientation(
+    dataset_id: str | None, values: Iterable[str | None]
+) -> bool | None:
+    """Returns whether a dataset writes slash dates day first, preferring what is known.
+
+    ``_SLASH_ORIENTATION`` wins where it names the dataset, because it holds evidence a
+    value cannot carry -- a bound, a sibling submission, a locale's rendering, a
+    submission's supplemental data. The scan is what answers for a dataset nobody has
+    looked at yet, which is every dataset added after that table was written.
+
+    Args:
+        dataset_id: The source's ``ord_dataset-`` ID, or None where it records none.
+        values: Every date string the dataset records, for the fallback scan. Read only
+            where the table does not name the dataset, and lazily even then.
+
+    Returns:
+        True for day first, False for month first, and None where neither settles it --
+        which leaves an ambiguous date unparsed rather than guessed.
+
+    Raises:
+        ValueError: If a witness in the data contradicts the recorded verdict. One of
+            the two is then wrong about the dataset, and projecting either reading would
+            record a date this library has evidence against.
+    """
+    recorded = _SLASH_ORIENTATION.get(dataset_id or "")
+    if recorded is None:
+        return day_first_dates(values)
+    witnessed = day_first_dates(values)
+    if witnessed is not None and witnessed != recorded:
+        raise ValueError(
+            f"{dataset_id} is recorded as "
+            f"{'day' if recorded else 'month'}-first, but its own values witness "
+            f"{'day' if witnessed else 'month'}-first"
+        )
+    return recorded
+
+
+def parse_timestamp(value: str, *, day_first: bool | None = None) -> datetime | None:
+    """Returns the instant a recorded date names, or None where none of the shapes fit.
+
+    Args:
+        value: The string a depositor wrote.
+        day_first: Whether this dataset writes slash dates day first, from
+            ``day_first_dates``. None leaves an ambiguous slash date unparsed rather
+            than guessing, which is the difference between a null a reader can see and
+            a date that is silently the wrong month.
+
+    Returns:
+        The parsed instant, or None where no format matched or the value is ambiguous
+        and the dataset does not say which way to read it.
+    """
+    matched = _SLASH_DATE.match(value)
+    if matched is not None:
+        first, second = int(matched.group(1)), int(matched.group(2))
+        if first <= 12 and second <= 12 and day_first is None:
+            return None
+        formats = _DAY_FIRST_FORMATS if day_first else _DATE_FORMATS
+        # An unambiguous value reads the same under either table, so the dataset's
+        # convention decides only the values that need it.
+        if first > 12:
+            formats = _DAY_FIRST_FORMATS
+        elif second > 12:
+            formats = _DATE_FORMATS
+    else:
+        formats = _DATE_FORMATS
+    for shape in formats:
+        try:
+            # DTZ007: naive on purpose. None of the recorded shapes carries an offset,
+            # so the zone is not in the data; attaching one would state a fact the
+            # source never recorded, and shift every instant by it.
+            return datetime.strptime(value, shape)  # noqa: DTZ007
+        except ValueError:
+            continue
+    return None
 
 
 def _canonical_unit(field: FieldDescriptor) -> tuple[str, str] | None:
@@ -353,6 +564,8 @@ def _struct_fields(descriptor: Descriptor, stack: frozenset[str]) -> list[pa.Fie
     fields = []
     if descriptor.name in _STRUCTURAL_TYPES:
         fields.append(pa.field("smiles", pa.string()))
+    if descriptor.name in _TIMESTAMP_TYPES:
+        fields.append(pa.field(TIMESTAMP_COLUMN, pa.timestamp("s")))
     if descriptor.name in _STRUCTURE_ID_TYPES:
         fields.append(
             pa.field(
@@ -446,7 +659,10 @@ def _enum_name(field: FieldDescriptor, number: int) -> str:
 
 
 def message_row(
-    message: Message, structure_ids: MutableMapping[str, int] | None = None
+    message: Message,
+    structure_ids: MutableMapping[str, int] | None = None,
+    *,
+    day_first: bool | None = None,
 ) -> dict[str, Any]:
     """Projects ``message`` to a dict matching its struct type in ``SCHEMA``.
 
@@ -459,6 +675,9 @@ def message_row(
             order as compounds are projected. None -- the default, for a message
             projected outside a dataset -- leaves every ``structure_id`` null, since an
             ID is meaningful only against the artifact that shares the mapping.
+        day_first: Whether this dataset writes slash dates day first, from
+            ``day_first_dates``. None leaves an ambiguous one unparsed; see
+            ``parse_timestamp``.
 
     Returns:
         A dict keyed by projected column name.
@@ -473,6 +692,11 @@ def message_row(
         row["smiles"] = smiles
         if smiles is not None:
             collapsed = _STRUCTURAL_TYPES[descriptor.name]
+    if descriptor.name in _TIMESTAMP_TYPES:
+        recorded = getattr(message, "value", "")
+        row[TIMESTAMP_COLUMN] = (
+            parse_timestamp(recorded, day_first=day_first) if recorded else None
+        )
     if descriptor.name in _STRUCTURE_ID_TYPES:
         if row["smiles"] is not None and structure_ids is not None:
             row["structure_id"] = structure_ids.setdefault(
@@ -502,7 +726,8 @@ def message_row(
             items = sorted(getattr(message, field.name).items())
             if value_field.message_type is not None:
                 row[name] = [
-                    (key, message_row(value, structure_ids)) for key, value in items
+                    (key, message_row(value, structure_ids, day_first=day_first))
+                    for key, value in items
                 ] or None
             else:
                 row[name] = list(items) or None
@@ -513,7 +738,8 @@ def message_row(
                 values = _kept_identifiers(values, collapsed)
             if message_type is not None:
                 row[name] = [
-                    message_row(value, structure_ids) for value in values
+                    message_row(value, structure_ids, day_first=day_first)
+                    for value in values
                 ] or None
             elif field.type == FieldDescriptor.TYPE_ENUM:
                 row[name] = [_enum_name(field, value) for value in values] or None
@@ -522,7 +748,9 @@ def message_row(
             continue
         if message_type is not None:
             row[name] = (
-                message_row(getattr(message, field.name), structure_ids)
+                message_row(
+                    getattr(message, field.name), structure_ids, day_first=day_first
+                )
                 if message.HasField(field.name)
                 else None
             )
@@ -546,6 +774,8 @@ def reaction_row(
     reaction: reaction_pb2.Reaction,
     reaction_id: str | None,
     structure_ids: MutableMapping[str, int] | None = None,
+    *,
+    day_first: bool | None = None,
 ) -> dict[str, Any]:
     """Projects one row of a source dataset to a dict matching ``SCHEMA``.
 
@@ -565,6 +795,9 @@ def reaction_row(
         structure_ids: Mapping from SMILES to ``structure_id``, shared across a
             dataset's rows and extended in first-seen order. None leaves every
             ``structure_id`` null.
+        day_first: Whether this dataset writes slash dates day first, from
+            ``day_first_dates``. None leaves an ambiguous one unparsed; see
+            ``parse_timestamp``.
 
     Returns:
         A dict keyed by projected column name.
@@ -583,12 +816,30 @@ def reaction_row(
             f"reaction_id column {reaction_id!r} disagrees with the reaction's own "
             f"{reaction.reaction_id!r}"
         )
-    return message_row(reaction, structure_ids)
+    return message_row(reaction, structure_ids, day_first=day_first)
 
 
 def is_current(path: str | os.PathLike[str], source_md5: str) -> bool:
     """Returns whether ``path`` is a projection of ``source_md5`` by this library."""
     return base.is_current(path, ARTIFACT, source_md5)
+
+
+def _recorded_dates(view: parquet.DatasetView) -> Iterator[str | None]:
+    """Yields every date string a dataset records, for inferring its convention.
+
+    Args:
+        view: The source dataset.
+
+    Yields:
+        The recorded value of each DateTime a reaction reaches, unparsed. Lazily, so a
+        dataset that settles the question in its first reaction reads no further.
+    """
+    for _, reaction in view.iter_reactions():
+        provenance = reaction.provenance
+        yield provenance.experiment_start.value
+        yield provenance.record_created.time.value
+        for modified in provenance.record_modified:
+            yield modified.time.value
 
 
 def write_projection(
@@ -638,6 +889,13 @@ def write_projection(
     # artifact derived from this file. The order follows protobuf map iteration, which
     # is unspecified, so IDs are a fact about this file rather than about the dataset.
     structure_ids: dict[str, int] = {}
+    # Which way this dataset writes slash dates, settled before any row is projected.
+    # The convention belongs to the depositor rather than to a value, so it cannot be
+    # read off the rows as they stream past and a row group's worth of them is not the
+    # dataset. Where the answer is not already recorded this costs a pass that parses
+    # the protos without projecting them: measured at ~7 seconds over the source that is
+    # 96% of ORD, against the 34.6 minutes the projection itself takes.
+    day_first = slash_orientation(source_dataset_id, _recorded_dates(view))
     with (
         atomic_io.atomic_path(output) as temp_path,
         pq.ParquetWriter(temp_path, schema, compression=compression) as writer,
@@ -646,7 +904,9 @@ def write_projection(
             batch = []
             for reaction_id, reaction in view.iter_reactions(row_group=row_group):
                 try:
-                    row = reaction_row(reaction, reaction_id, structure_ids)
+                    row = reaction_row(
+                        reaction, reaction_id, structure_ids, day_first=day_first
+                    )
                 except ValueError as error:
                     raise ValueError(f"{view.path}: {error}") from error
                 unreadable += _unreadable_structures(row)

--- a/ord_schema/artifacts/projection.py
+++ b/ord_schema/artifacts/projection.py
@@ -50,9 +50,14 @@ real trap:
   ``NN/NN/NNNN`` is the part that needs more than a format list, since the string never
   says which field is the month. It is settled per dataset and before any row is
   written -- the convention belongs to the depositor, not to a value -- from
-  ``_SLASH_ORIENTATION`` where the question has been answered and from the dataset's own
-  unambiguous values otherwise. Where neither settles it the timestamp is null, because
-  a guess written here is indistinguishable afterwards from a date the source recorded.
+  ``_DAY_FIRST``, from the dataset's own unambiguous values, and from month first
+  otherwise. The two datasets ``_UNDECIDED`` names are the exception: nothing settles
+  them, so their timestamps are null, because a guess written here is indistinguishable
+  afterwards from a date the source recorded.
+
+  The string the depositor wrote stays beside the timestamp, and is internal. Keeping it
+  is what lets those nulls be read back once their submitters answer; hiding it is what
+  keeps a date question off a column the corpus spells ten ways.
 
 * **Structural identifiers collapse to one ``smiles``.** ``SMILES``, ``CXSMILES``,
   ``INCHI``, and ``MOLBLOCK`` all answer "what is this molecule," so the projection
@@ -202,61 +207,33 @@ _DATE_FORMATS = (
 _DAY_FIRST_FORMATS = tuple(shape.replace("%m/%d/", "%d/%m/") for shape in _DATE_FORMATS)
 _SLASH_DATE = re.compile(r"^(\d{1,2})/(\d{1,2})/")
 
-# Which way each dataset writes its slash dates, where something settles it. A value
-# alone settles only 28 of the 41 datasets that write one -- those holding a number
-# above twelve -- and the rest need evidence outside any single value: an upper bound
-# from the reaction's own record_modified events, a co-submitted sibling in the same
-# shape, the en-US 12-hour rendering no day-first locale produces, and the supplemental
-# data on two submission pull requests. That work is the ord-logbook entry "Date and
-# time formats across the corpus" (2026-09-03), where the reasoning per dataset lives.
-#
-# Two datasets are deliberately absent: 5c9a1032 and 5e8318f0, which no evidence settles
-# and whose submitters have been asked. Absent means their ambiguous dates project as
-# null, which is the point -- writing a guess would freeze it into the artifact and
-# destroy the record that it was ever a guess.
-_SLASH_ORIENTATION: dict[str, bool] = {
-    "ord_dataset-172039a759a440219a68af62d203b79b": True,  # witness
-    "ord_dataset-2be11f57f3304e678ea8469baf6dd1bc": True,  # sibling
-    "ord_dataset-3b8a2ef300e145468579027f206a3ac8": True,  # witness
-    "ord_dataset-c5b00523487a4211a194160edf45e9ab": True,  # witness
-    "ord_dataset-00005539a1e04c809a9a78647bea649c": False,  # witness
-    "ord_dataset-0316886541d9435489859c2ad7edc863": False,  # witness
-    "ord_dataset-0c75d67751634f0594b24b9f498b77c2": False,  # bound
-    "ord_dataset-10b940e7982c4622b1e1ac879394aba6": False,  # witness
-    "ord_dataset-1d3a1a6fb70d46c084602d0688967afc": False,  # witness
-    # ord-data#86 supplemental data
-    "ord_dataset-35a5a513f1dd44a3a97c88da99f81a00": False,
-    "ord_dataset-3b5db90e337942ea886b8f5bc5e3aa72": False,  # bound
-    "ord_dataset-46ff9a32d9e04016b9380b1b1ef949c3": False,  # format
-    "ord_dataset-488402f6ec0d441ca2f7d6fabea7c220": False,  # witness
-    "ord_dataset-4d431564f3ef4e9c91d8da5836f4eae6": False,  # format
-    "ord_dataset-52bd3b0ec72c443aab113bcea09bf3f4": False,  # witness
-    "ord_dataset-5481550056a14935b76e031fb94b88be": False,  # witness
-    "ord_dataset-5540e162c09f4c04905ddc8ba9c931c6": False,  # witness
-    "ord_dataset-55de08a995554f558c25fc43eac62359": False,  # witness
-    "ord_dataset-5eb7f2689f4a42eba63ad9e37e49a5cd": False,  # witness
-    "ord_dataset-675eddcaa6674ce3ae61e79bbc1e1c08": False,  # bound
-    "ord_dataset-68cb8b4b2b384e3d85b5b1efae58b203": False,  # witness
-    "ord_dataset-6a0bfcdf53a64c07987822162ae591e2": False,  # witness
-    "ord_dataset-7acd6ad2bf4d4cff841cad008ab726d5": False,  # witness
-    "ord_dataset-7d8f5fd922d4497d91cb81489b052746": False,  # witness
-    "ord_dataset-805ad863feef48579d95d86a728035f4": False,  # witness
-    "ord_dataset-89b083710e2d441aa0040c361d63359f": False,  # bound
-    "ord_dataset-8d1e28ec1f6b4ee8ad372e0b5ed7a62e": False,  # witness
-    "ord_dataset-9b8aa9a7835143ef8ce3f70abfab7545": False,  # witness
-    "ord_dataset-a12fa15d036d489c971b0b514caeae52": False,  # witness
-    "ord_dataset-ac78456835404910b3a4c840248b6ac9": False,  # witness
-    "ord_dataset-b440f8c90b6343189093770060fc4098": False,  # witness
-    "ord_dataset-cbcc4048add7468e850b6ec42549c70d": False,  # format
-    "ord_dataset-ce5045aceb214cfc8bfd0ef3031e2737": False,  # witness
-    "ord_dataset-d26118acda314269becc35db5c22dc59": False,  # bound
-    "ord_dataset-d319c2a22ecf4ce59db1a18ae71d529c": False,  # witness
-    # ord-data#188 supplemental data
-    "ord_dataset-d92976309c3a48a3a64a4cf5e7048086": False,
-    "ord_dataset-e7830cd6b11158b43994ccfb5ee9acb3": False,  # witness
-    "ord_dataset-eeba974d3c284aed86d1c1d442260a1e": False,  # witness
-    "ord_dataset-fc83743b978f4deea7d6856deacbfe53": False,  # witness
-}
+# Datasets that write their slash dates day first. Everything else reads month first:
+# that is what a dataset's own values witness wherever one holds a number above twelve,
+# and what the corpus's other evidence settles for the rest -- an upper bound from the
+# reaction's own record_modified events, a co-submitted sibling in the same shape, the
+# en-US 12-hour rendering no day-first locale produces, and the supplemental data on two
+# submission pull requests. The reasoning per dataset is the ord-logbook entry "Date and
+# time formats across the corpus" (2026-09-03).
+_DAY_FIRST = frozenset(
+    {
+        "ord_dataset-172039a759a440219a68af62d203b79b",
+        "ord_dataset-2be11f57f3304e678ea8469baf6dd1bc",
+        "ord_dataset-3b8a2ef300e145468579027f206a3ac8",
+        "ord_dataset-c5b00523487a4211a194160edf45e9ab",
+    }
+)
+
+# Datasets no evidence settles, whose submitters have been asked. Their ambiguous dates
+# project as null, which is the point: writing a guess would freeze it into the artifact
+# and destroy the record that it was ever a guess. Between them they hold every
+# ambiguous slash date the corpus records outside ``_DAY_FIRST`` -- 9,656 values, 0.40%
+# of the 2,430,268 dates it records.
+_UNDECIDED = frozenset(
+    {
+        "ord_dataset-5c9a10329a8a48968d18879a48bb8ab2",
+        "ord_dataset-5e8318f0dda04b398c14f4c3adfeb32c",
+    }
+)
 
 # An ID rides beside the collapsed smiles and cannot exist without it: the schema
 # would gain a structure_id with no sibling smiles, and message_row would KeyError.
@@ -389,40 +366,42 @@ def slash_orientation(
 ) -> bool | None:
     """Returns whether a dataset writes slash dates day first, preferring what is known.
 
-    ``_SLASH_ORIENTATION`` wins where it names the dataset, because it holds evidence a
-    value cannot carry -- a bound, a sibling submission, a locale's rendering, a
-    submission's supplemental data. The scan is what answers for a dataset nobody has
-    looked at yet, which is every dataset added after that table was written.
+    ``_UNDECIDED`` answers first, because a dataset nothing settles has to stay unparsed
+    rather than take the default. ``_DAY_FIRST`` answers next, holding evidence a value
+    cannot carry -- a sibling submission alongside the datasets that witness themselves.
+    The scan then answers for a dataset nobody has looked at yet, which is what keeps a
+    day-first dataset added later from silently reading month first. Month first is what
+    is left, and what every settled dataset outside ``_DAY_FIRST`` reads.
 
     Args:
         dataset_id: The source's ``ord_dataset-`` ID, or None where it records none.
-        values: Every date string the dataset records. Read whether or not the table
-            names the dataset, since a recorded verdict is checked against any witness
-            among them -- but read lazily, so a dataset that produces one stops there.
-            A dataset the table settles by something other than a witness has none to
-            find, and that scan runs to the end: ~7 seconds over the source that is 96%
-            of ORD, against the 34.6 minutes the projection itself takes.
+        values: Every date string the dataset records. Read whether or not a list names
+            the dataset, since a listed verdict is checked against any witness among
+            them -- but read lazily, so a dataset that produces one stops there. A
+            dataset settled by something other than a witness has none to find, and that
+            scan runs to the end: ~7 seconds over the source that is 96% of ORD, against
+            the 34.6 minutes the projection itself takes.
 
     Returns:
-        True for day first, False for month first, and None where neither settles it --
-        which leaves an ambiguous date unparsed rather than guessed.
+        True for day first, False for month first, and None for a dataset ``_UNDECIDED``
+        names -- which leaves its ambiguous dates unparsed rather than guessed.
 
     Raises:
-        ValueError: If a witness in the data contradicts the recorded verdict. One of
-            the two is then wrong about the dataset, and projecting either reading would
-            record a date this library has evidence against.
+        ValueError: If a witness in the data contradicts ``_DAY_FIRST``. One of the two
+            is then wrong about the dataset, and projecting either reading would record
+            a date this library has evidence against.
     """
-    recorded = _SLASH_ORIENTATION.get(dataset_id or "")
-    if recorded is None:
-        return day_first_dates(values)
+    if dataset_id in _UNDECIDED:
+        return None
     witnessed = day_first_dates(values)
-    if witnessed is not None and witnessed != recorded:
-        raise ValueError(
-            f"{dataset_id} is recorded as "
-            f"{'day' if recorded else 'month'}-first, but its own values witness "
-            f"{'day' if witnessed else 'month'}-first"
-        )
-    return recorded
+    if dataset_id in _DAY_FIRST:
+        if witnessed is False:
+            raise ValueError(
+                f"{dataset_id} is recorded as day-first, but its own values witness "
+                "month-first"
+            )
+        return True
+    return False if witnessed is None else witnessed
 
 
 def parse_timestamp(value: str, *, day_first: bool | None = None) -> datetime | None:
@@ -583,11 +562,24 @@ def _struct_fields(descriptor: Descriptor, stack: frozenset[str]) -> list[pa.Fie
         )
     for field in descriptor.fields:
         if _canonical_unit(field) is None:
+            metadata = _enum_metadata(field)
+            if descriptor.name in _TIMESTAMP_TYPES and field.name == "value":
+                # The depositor's own spelling, kept because the timestamp beside it is
+                # an interpretation and cannot be turned back into it -- and is null for
+                # the 9,656 ambiguous dates no evidence settles, which would otherwise
+                # have no representation at all. Internal because a date question is
+                # answered by the timestamp: matching text against a date the corpus
+                # spells ten ways finds a fraction of what it asks for and reads as if
+                # it found all of it.
+                metadata = {
+                    **(metadata or {}),
+                    _META_INTERNAL: "the recorded spelling; query the timestamp",
+                }
             fields.append(
                 pa.field(
                     column_name(field),
                     _field_type(field, stack),
-                    metadata=_enum_metadata(field),
+                    metadata=metadata,
                 )
             )
             continue

--- a/ord_schema/artifacts/projection.py
+++ b/ord_schema/artifacts/projection.py
@@ -235,6 +235,14 @@ _UNDECIDED = frozenset(
     }
 )
 
+# A dataset in both lists reads as undecided, silently: nothing else says that the
+# evidence naming it day first and the evidence settling nothing are the same claim.
+if _DAY_FIRST & _UNDECIDED:
+    raise ValueError(
+        "a dataset cannot be both day-first and undecided: "
+        f"{sorted(_DAY_FIRST & _UNDECIDED)}"
+    )
+
 # An ID rides beside the collapsed smiles and cannot exist without it: the schema
 # would gain a structure_id with no sibling smiles, and message_row would KeyError.
 if not set(_STRUCTURAL_TYPES) >= _STRUCTURE_ID_TYPES:
@@ -384,7 +392,8 @@ def slash_orientation(
 
     Returns:
         True for day first, False for month first, and None for a dataset ``_UNDECIDED``
-        names -- which leaves its ambiguous dates unparsed rather than guessed.
+        names or a source recording no ID at all -- which leaves ambiguous dates
+        unparsed rather than guessed.
 
     Raises:
         ValueError: If a witness in the data contradicts ``_DAY_FIRST``. One of the two
@@ -393,6 +402,12 @@ def slash_orientation(
     """
     if dataset_id in _UNDECIDED:
         return None
+    if dataset_id is None:
+        # The default is a claim about a dataset someone could name in _DAY_FIRST after
+        # reading its submission. A source recording no ID can never be named, so the
+        # guess would be permanent and there would be nothing to correct it against;
+        # only its own values may speak for it.
+        return day_first_dates(values)
     witnessed = day_first_dates(values)
     if dataset_id in _DAY_FIRST:
         if witnessed is False:

--- a/ord_schema/artifacts/projection.py
+++ b/ord_schema/artifacts/projection.py
@@ -569,7 +569,10 @@ def _struct_fields(descriptor: Descriptor, stack: frozenset[str]) -> list[pa.Fie
     if descriptor.name in _STRUCTURAL_TYPES:
         fields.append(pa.field("smiles", pa.string()))
     if descriptor.name in _TIMESTAMP_TYPES:
-        fields.append(pa.field(TIMESTAMP_COLUMN, pa.timestamp("s")))
+        # Microseconds, because the source records them: 1.77M values in the corpus
+        # are str(datetime) output carrying a fractional part, and a second-resolution
+        # column would drop it while still reading as the instant the source wrote.
+        fields.append(pa.field(TIMESTAMP_COLUMN, pa.timestamp("us")))
     if descriptor.name in _STRUCTURE_ID_TYPES:
         fields.append(
             pa.field(
@@ -829,14 +832,20 @@ def is_current(path: str | os.PathLike[str], source_md5: str) -> bool:
 
 
 def _recorded_dates(view: parquet.DatasetView) -> Iterator[str | None]:
-    """Yields every date string a dataset records, for inferring its convention.
+    """Yields the date strings a dataset records, for inferring its convention.
+
+    The three provenance positions, not all seven the schema reaches: measured over the
+    corpus, ``instrument_last_calibrated`` is unset in all 226,316 Analysis messages,
+    and the other three sit behind repeated and map fields deep in inputs, workups and
+    outcomes. Walking them would cost that descent on every reaction to find evidence
+    the corpus does not hold. A dataset that populates one is where to look again.
 
     Args:
         view: The source dataset.
 
     Yields:
-        The recorded value of each DateTime a reaction reaches, unparsed. Lazily, so a
-        dataset that settles the question in its first reaction reads no further.
+        The recorded value of each provenance DateTime, unparsed. Lazily, so a dataset
+        that settles the question in its first reaction reads no further.
     """
     for _, reaction in view.iter_reactions():
         provenance = reaction.provenance

--- a/ord_schema/artifacts/projection.py
+++ b/ord_schema/artifacts/projection.py
@@ -396,8 +396,12 @@ def slash_orientation(
 
     Args:
         dataset_id: The source's ``ord_dataset-`` ID, or None where it records none.
-        values: Every date string the dataset records, for the fallback scan. Read only
-            where the table does not name the dataset, and lazily even then.
+        values: Every date string the dataset records. Read whether or not the table
+            names the dataset, since a recorded verdict is checked against any witness
+            among them -- but read lazily, so a dataset that produces one stops there.
+            A dataset the table settles by something other than a witness has none to
+            find, and that scan runs to the end: ~7 seconds over the source that is 96%
+            of ORD, against the 34.6 minutes the projection itself takes.
 
     Returns:
         True for day first, False for month first, and None where neither settles it --

--- a/ord_schema/artifacts/projection_test.py
+++ b/ord_schema/artifacts/projection_test.py
@@ -792,9 +792,16 @@ def test_a_recorded_verdict_beats_what_the_values_alone_witness():
 
 
 def test_a_dataset_nobody_has_looked_at_falls_back_to_its_own_values():
+    # A witness still wins for an unlisted dataset, which is what keeps a day-first
+    # dataset added later from silently taking the month-first default.
     assert projection.slash_orientation("ord_dataset-new", ["15/11/2023"]) is True
     assert projection.slash_orientation(None, ["2/25/2021"]) is False
-    assert projection.slash_orientation("ord_dataset-new", ["07/06/2024"]) is None
+
+
+def test_an_unlisted_dataset_with_no_witness_reads_month_first():
+    # Month first is what every settled dataset outside _DAY_FIRST reads, and the two
+    # that nothing settles are named by _UNDECIDED rather than left to this.
+    assert projection.slash_orientation("ord_dataset-new", ["07/06/2024"]) is False
 
 
 def test_a_witness_contradicting_the_recorded_verdict_is_an_error():
@@ -802,7 +809,7 @@ def test_a_witness_contradicting_the_recorded_verdict_is_an_error():
     # this library has evidence against.
     with pytest.raises(ValueError, match="witness"):
         projection.slash_orientation(
-            "ord_dataset-d92976309c3a48a3a64a4cf5e7048086", ["15/11/2023"]
+            "ord_dataset-172039a759a440219a68af62d203b79b", ["2/25/2021"]
         )
 
 
@@ -813,7 +820,7 @@ def test_the_datasets_no_evidence_settles_are_left_out():
         "ord_dataset-5c9a10329a8a48968d18879a48bb8ab2",
         "ord_dataset-5e8318f0dda04b398c14f4c3adfeb32c",
     ):
-        assert open_dataset not in projection._SLASH_ORIENTATION
+        assert open_dataset not in projection._DAY_FIRST
         assert (
             projection.slash_orientation(open_dataset, ["08/05/2024, 11:33:06"]) is None
         )

--- a/ord_schema/artifacts/projection_test.py
+++ b/ord_schema/artifacts/projection_test.py
@@ -15,6 +15,7 @@
 """Tests for ord_schema.artifacts.projection."""
 
 import pathlib
+from datetime import datetime
 from types import SimpleNamespace
 from typing import cast
 
@@ -683,3 +684,136 @@ def test_structure_ids_span_source_row_groups(tmp_path):
                 (product,) = row["outcomes"][0]["products"]
                 assert component["structure_id"] == 0
                 assert product["structure_id"] == 1
+
+
+# Dates
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # Every shape the corpus records, with its share of ORD beside it.
+        ("2022-01-01 00:00:00.0", datetime(2022, 1, 1)),  # 1,771,416
+        ("2025-06-30T05:22:18", datetime(2025, 6, 30, 5, 22, 18)),  # 48,498
+        ("2/25/2021, 1:05:42 PM", datetime(2021, 2, 25, 13, 5, 42)),  # 20,745
+        ("18/08/2024 02:10:09", datetime(2024, 8, 18, 2, 10, 9)),  # 1,430
+        ("2024-07-30", datetime(2024, 7, 30)),  # 1,241
+        ("Thu Jul 18 18:22:17 2024", datetime(2024, 7, 18, 18, 22, 17)),  # 48
+        ("not a date", None),
+        ("", None),
+    ],
+)
+def test_every_recorded_date_shape_parses(value, expected):
+    assert projection.parse_timestamp(value) == (expected if value else None)
+
+
+def test_an_unambiguous_slash_date_needs_no_convention():
+    # A number above twelve can only be the day, so the dataset's habit decides nothing.
+    for day_first in (None, True, False):
+        assert projection.parse_timestamp(
+            "18/08/2024 02:10:09", day_first=day_first
+        ) == datetime(2024, 8, 18, 2, 10, 9)
+        assert projection.parse_timestamp(
+            "2/25/2021, 1:05:42 PM", day_first=day_first
+        ) == datetime(2021, 2, 25, 13, 5, 42)
+
+
+def test_an_ambiguous_slash_date_follows_the_dataset():
+    value = "07/06/2024, 23:25:41"
+    assert projection.parse_timestamp(value, day_first=False) == datetime(
+        2024, 7, 6, 23, 25, 41
+    )
+    assert projection.parse_timestamp(value, day_first=True) == datetime(
+        2024, 6, 7, 23, 25, 41
+    )
+
+
+def test_an_ambiguous_date_with_no_convention_is_left_unparsed():
+    # A null a reader can see, rather than a date that is silently the wrong month.
+    assert projection.parse_timestamp("07/06/2024, 23:25:41") is None
+
+
+@pytest.mark.parametrize(
+    ("values", "expected"),
+    [
+        (["07/06/2024", "15/11/2023"], True),
+        (["07/06/2024", "2/25/2021"], False),
+        (["07/06/2024", "01/02/2020"], None),
+        (["2025-06-30T05:22:18", None, ""], None),
+        ([], None),
+    ],
+)
+def test_a_dataset_s_convention_is_read_from_its_unambiguous_dates(values, expected):
+    assert projection.day_first_dates(values) is expected
+
+
+def test_the_convention_is_settled_without_reading_every_value():
+    # Lazily, so a dataset that answers on its first date does not pay for the rest.
+    seen = []
+
+    def _values():
+        for value in ["15/11/2023", "07/06/2024"]:
+            seen.append(value)
+            yield value
+
+    assert projection.day_first_dates(_values()) is True
+    assert seen == ["15/11/2023"]
+
+
+def test_a_projected_date_carries_both_the_text_and_the_instant():
+    reaction = reaction_pb2.Reaction()
+    reaction.provenance.record_created.time.value = "2025-06-30T05:22:18"
+    row = projection.message_row(reaction)
+    recorded = row["provenance"]["record_created"]["time"]
+    assert recorded["value"] == "2025-06-30T05:22:18"
+    assert recorded[projection.TIMESTAMP_COLUMN] == datetime(2025, 6, 30, 5, 22, 18)
+
+
+def test_a_projected_date_the_shapes_do_not_cover_is_null():
+    reaction = reaction_pb2.Reaction()
+    reaction.provenance.record_created.time.value = "sometime last spring"
+    row = projection.message_row(reaction)
+    recorded = row["provenance"]["record_created"]["time"]
+    assert recorded["value"] == "sometime last spring"
+    assert recorded[projection.TIMESTAMP_COLUMN] is None
+
+
+def test_a_recorded_verdict_beats_what_the_values_alone_witness():
+    # The table holds evidence a value cannot carry, so it decides where it names the
+    # dataset -- and 11 of the 13 datasets no value settles are in it.
+    ambiguous = ["07/06/2024, 23:25:41"]
+    assert projection.day_first_dates(ambiguous) is None
+    assert (
+        projection.slash_orientation(
+            "ord_dataset-d92976309c3a48a3a64a4cf5e7048086", ambiguous
+        )
+        is False
+    )
+
+
+def test_a_dataset_nobody_has_looked_at_falls_back_to_its_own_values():
+    assert projection.slash_orientation("ord_dataset-new", ["15/11/2023"]) is True
+    assert projection.slash_orientation(None, ["2/25/2021"]) is False
+    assert projection.slash_orientation("ord_dataset-new", ["07/06/2024"]) is None
+
+
+def test_a_witness_contradicting_the_recorded_verdict_is_an_error():
+    # One of the two is wrong about the dataset, and either reading would record a date
+    # this library has evidence against.
+    with pytest.raises(ValueError, match="witness"):
+        projection.slash_orientation(
+            "ord_dataset-d92976309c3a48a3a64a4cf5e7048086", ["15/11/2023"]
+        )
+
+
+def test_the_datasets_no_evidence_settles_are_left_out():
+    # Their submitters have been asked; until they answer, an ambiguous date projects
+    # null rather than freezing a guess into the artifact.
+    for open_dataset in (
+        "ord_dataset-5c9a10329a8a48968d18879a48bb8ab2",
+        "ord_dataset-5e8318f0dda04b398c14f4c3adfeb32c",
+    ):
+        assert open_dataset not in projection._SLASH_ORIENTATION
+        assert (
+            projection.slash_orientation(open_dataset, ["08/05/2024, 11:33:06"]) is None
+        )

--- a/ord_schema/artifacts/projection_test.py
+++ b/ord_schema/artifacts/projection_test.py
@@ -804,6 +804,19 @@ def test_an_unlisted_dataset_with_no_witness_reads_month_first():
     assert projection.slash_orientation("ord_dataset-new", ["07/06/2024"]) is False
 
 
+def test_a_source_with_no_dataset_id_is_never_given_the_default():
+    # The default is a claim about a dataset someone could name in _DAY_FIRST later. A
+    # source recording no ID can never be named, so its guess would be permanent.
+    assert projection.slash_orientation(None, ["07/06/2024"]) is None
+    assert projection.slash_orientation(None, ["2/25/2021"]) is False
+
+
+def test_the_two_dataset_lists_are_disjoint():
+    # A dataset in both would read as undecided, and nothing else would say that the
+    # evidence naming it day first and the evidence settling nothing disagree.
+    assert not projection._DAY_FIRST & projection._UNDECIDED
+
+
 def test_a_witness_contradicting_the_recorded_verdict_is_an_error():
     # One of the two is wrong about the dataset, and either reading would record a date
     # this library has evidence against.

--- a/ord_schema/search/projection_schema.txt
+++ b/ord_schema/search/projection_schema.txt
@@ -56,7 +56,6 @@ inputs: MAP<VARCHAR, STRUCT>
       instrument_manufacturer: VARCHAR
       instrument_last_calibrated: STRUCT
         timestamp: TIMESTAMP
-        value: VARCHAR
     texture: STRUCT
       type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
       details: VARCHAR
@@ -286,7 +285,6 @@ workups: LIST<STRUCT>
         instrument_manufacturer: VARCHAR
         instrument_last_calibrated: STRUCT
           timestamp: TIMESTAMP
-          value: VARCHAR
       texture: STRUCT
         type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
         details: VARCHAR
@@ -431,7 +429,6 @@ outcomes: LIST<STRUCT>
           instrument_manufacturer: VARCHAR
           instrument_last_calibrated: STRUCT
             timestamp: TIMESTAMP
-            value: VARCHAR
         texture: STRUCT
           type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
           details: VARCHAR
@@ -495,7 +492,6 @@ outcomes: LIST<STRUCT>
     instrument_manufacturer: VARCHAR
     instrument_last_calibrated: STRUCT
       timestamp: TIMESTAMP
-      value: VARCHAR
 provenance: STRUCT
   experimenter: STRUCT
     username: VARCHAR
@@ -506,14 +502,12 @@ provenance: STRUCT
   city: VARCHAR
   experiment_start: STRUCT
     timestamp: TIMESTAMP
-    value: VARCHAR
   doi: VARCHAR
   patent: VARCHAR
   publication_url: VARCHAR
   record_created: STRUCT
     time: STRUCT
       timestamp: TIMESTAMP
-      value: VARCHAR
     person: STRUCT
       username: VARCHAR
       name: VARCHAR
@@ -524,7 +518,6 @@ provenance: STRUCT
   record_modified: LIST<STRUCT>
     time: STRUCT
       timestamp: TIMESTAMP
-      value: VARCHAR
     person: STRUCT
       username: VARCHAR
       name: VARCHAR

--- a/ord_schema/search/projection_schema.txt
+++ b/ord_schema/search/projection_schema.txt
@@ -55,6 +55,7 @@ inputs: MAP<VARCHAR, STRUCT>
         format: VARCHAR
       instrument_manufacturer: VARCHAR
       instrument_last_calibrated: STRUCT
+        timestamp: TIMESTAMP
         value: VARCHAR
     texture: STRUCT
       type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
@@ -284,6 +285,7 @@ workups: LIST<STRUCT>
           format: VARCHAR
         instrument_manufacturer: VARCHAR
         instrument_last_calibrated: STRUCT
+          timestamp: TIMESTAMP
           value: VARCHAR
       texture: STRUCT
         type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
@@ -428,6 +430,7 @@ outcomes: LIST<STRUCT>
             format: VARCHAR
           instrument_manufacturer: VARCHAR
           instrument_last_calibrated: STRUCT
+            timestamp: TIMESTAMP
             value: VARCHAR
         texture: STRUCT
           type: VARCHAR  (UNSPECIFIED | CUSTOM | POWDER | CRYSTAL | OIL | AMORPHOUS_SOLID | FOAM | WAX | SEMI_SOLID | SOLID | LIQUID | GAS)
@@ -491,6 +494,7 @@ outcomes: LIST<STRUCT>
       format: VARCHAR
     instrument_manufacturer: VARCHAR
     instrument_last_calibrated: STRUCT
+      timestamp: TIMESTAMP
       value: VARCHAR
 provenance: STRUCT
   experimenter: STRUCT
@@ -501,12 +505,14 @@ provenance: STRUCT
     email: VARCHAR
   city: VARCHAR
   experiment_start: STRUCT
+    timestamp: TIMESTAMP
     value: VARCHAR
   doi: VARCHAR
   patent: VARCHAR
   publication_url: VARCHAR
   record_created: STRUCT
     time: STRUCT
+      timestamp: TIMESTAMP
       value: VARCHAR
     person: STRUCT
       username: VARCHAR
@@ -517,6 +523,7 @@ provenance: STRUCT
     details: VARCHAR
   record_modified: LIST<STRUCT>
     time: STRUCT
+      timestamp: TIMESTAMP
       value: VARCHAR
     person: STRUCT
       username: VARCHAR

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -738,6 +738,25 @@ def test_an_internal_column_is_refused():
         query.resolve("inputs.components.structure_id")
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "provenance.record_created.time.value",
+        "provenance.experiment_start.value",
+    ],
+)
+def test_a_recorded_date_is_answered_by_its_timestamp_not_its_spelling(path):
+    # The string a depositor wrote is kept, because the timestamp is an interpretation
+    # and is null for the dates no evidence settles. It is not what a date question is
+    # asked against: the corpus spells dates ten ways, so matching text finds a fraction
+    # of what it asks for and reads as if it found all of it.
+    with pytest.raises(query.QueryError, match="internal"):
+        query.resolve(path)
+    assert query.resolve(path.replace(".value", ".timestamp")).type == pa.timestamp(
+        "us"
+    )
+
+
 def test_suggestions_do_not_name_internal_columns():
     # A near-miss like 'structure' is exactly what a model gropes for when asked a
     # structure question; the suggestion must not teach it the withheld name.

--- a/ord_schema/search/schema.py
+++ b/ord_schema/search/schema.py
@@ -53,6 +53,7 @@ _SCALARS: dict[pa.DataType, str] = {
     pa.int64(): "BIGINT",
     pa.uint32(): "UINTEGER",
     pa.uint64(): "UBIGINT",
+    pa.timestamp("s"): "TIMESTAMP",
 }
 
 _INDENT = "  "

--- a/ord_schema/search/schema.py
+++ b/ord_schema/search/schema.py
@@ -53,7 +53,7 @@ _SCALARS: dict[pa.DataType, str] = {
     pa.int64(): "BIGINT",
     pa.uint32(): "UINTEGER",
     pa.uint64(): "UBIGINT",
-    pa.timestamp("s"): "TIMESTAMP",
+    pa.timestamp("us"): "TIMESTAMP",
 }
 
 _INDENT = "  "

--- a/ord_schema/search/schema_test.py
+++ b/ord_schema/search/schema_test.py
@@ -109,7 +109,7 @@ def test_unnamed_leaf_type_raises():
     # A leaf the projection cannot currently hold, so the description would silently
     # hand a model an Arrow spelling no DuckDB query can use.
     with pytest.raises(KeyError):
-        schema.describe(pa.schema([pa.field("when", pa.timestamp("s"))]))
+        schema.describe(pa.schema([pa.field("when", pa.duration("s"))]))
 
 
 def test_projection_schema_renders():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,8 +242,10 @@ convention = "google"
 # Tests trip a couple of flake8-bugbear (the "B" rules) checks -- B011 (`assert False`)
 # and B017 (overly broad `pytest.raises(Exception)`); type annotations (ANN) also add
 # little value on test functions/fixtures, and SLF001 (private-member access)
-# is fine in tests. Skip these in tests.
-"**/*_test.py" = ["B011", "B017", "ANN", "SLF001", "S603", "S607", "D"]
+# is fine in tests. DTZ001 wants a tzinfo on every datetime, but the dates ORD records
+# carry no offset and project as naive, so a test asserting what one parses to has to
+# build a naive one. Skip these in tests.
+"**/*_test.py" = ["B011", "B017", "ANN", "SLF001", "S603", "S607", "D", "DTZ001"]
 # conftest.py holds pytest fixtures/hooks; docstrings add little there.
 "**/conftest.py" = ["D"]
 # Tutorial notebooks legitimately show commented-out alternative code.


### PR DESCRIPTION
## Summary

`DateTime` is a bare string the depositor wrote, and nothing normalizes it on the way in, so the corpus holds fifteen shapes of it in nine families. Comparing that text answers arbitrarily rather than imprecisely: a prefix match on `2021` finds **none** of that year's 490,412 records, while one on `2022` matches **1.77 million** from a dataset whose stamps merely begin with it.

Every `DateTime` gains a typed `timestamp`. The recorded string stays beside it, marked internal: it is what lets an unsettled date be read back once its submitter answers, and hiding it keeps a date question off a column the corpus spells ten ways.

## Changes

- Add `timestamp: TIMESTAMP` (microsecond resolution, since 1.77M values carry a fractional part) to every `DateTime` struct. The string is kept and marked internal, so the source stays authoritative, a shape no format covers is a visible null rather than a lost value, and a query naming it is refused.
- Parse all seven shapes the corpus records, from `2022-12-02 17:42:01.780701` through `Thu Jul 18 18:22:17 2024`.
- Settle `NN/NN/NNNN` per dataset, before any row is written — the convention belongs to the depositor, not to a value. `_DAY_FIRST` names the four datasets that write day first; the value scan answers for anything unlisted that witnesses itself; month first is the rest. The evidence per dataset is the ord-logbook entry *Date and time formats across the corpus* (2026-09-03).
- Leave a timestamp null for the two `_UNDECIDED` datasets, whose submitters have been asked. A guess written here could not afterwards be told from a date the source recorded, and between them they hold every ambiguous slash date outside `_DAY_FIRST`.
- Raise when a value witnesses the opposite of the recorded verdict, rather than silently preferring one.
- **Fix `missing_columns` to see a leaf whose type changed.** Comparing paths cannot: moving a timestamp from seconds to microseconds leaves every name where it was, so a file holding the old type read as current. The declared type rides with the path, and a mismatch carries the type it should hold.
- **Fix `missing_columns` to descend through structs, lists and maps.** It compared top-level names, so this change was invisible to it — an existing projection would have stamped identically, read as current, and failed a reader binding the new column. Nearly every projection field is nested, so the check has been catching almost nothing: it now finds 548 declared paths where it saw 33.

## Testing

- `uv run pytest -n auto` — 1721 passed.
- Every corpus shape is a parametrized case, with its share of ORD beside it. Ambiguity is covered in both directions, plus the no-evidence null and the contradiction error.
- Parquet does not store every Arrow type it is given — a second-resolution timestamp comes back as milliseconds — so a declared type the writer coerces would make every file of that artifact read as stale forever. A test per artifact schema pins that they round-trip.
- Three new tests for the nested column check. Mutation-checked: restoring the top-level comparison fails exactly those and nothing else; ignoring `_UNDECIDED` fails the null test; and un-marking the string fails both the resolution test and the schema snapshot.
- The two lists reproduce **all 39** verdicts the per-dataset table gave, checked against the corpus rather than argued: 28 the scan derives identically, 11 that fall to the month-first default, 0 contradictions.
- Derived three real ORD datasets end to end: `c5b00523` (day-first by witness) → 2024-08-18, `488402f6` (month-first) → 2021-02-17, and `d9297630` → 2024-07-06, which the table settles from ord-data#188 and which witness-only inference leaves null for all 39,347 of its reactions.
- The evidence pass costs ~7 s on the source that is 96% of ORD, against the 34.6 minutes the projection itself takes.

## Notes

- A typed column is not yet searchable: the grammar refuses ordered comparisons on anything non-numeric, so `ge` on a `TIMESTAMP` is rejected the same way it is on a `DATE`. That is a `query.py` change, tracked separately, and a second date column would not have helped.
- This is read-side only. It makes the corpus as it stands queryable; it does not change what new values look like. The logbook entry's other conclusions — normalizing on write at validation, `updates.py`'s 4.68M `ctime` values, ord-app's dropped `Z` — are separate.
- A value carrying a `Z` parses as null rather than as UTC-in-a-naive-column. The corpus has none today; if the logbook's conclusion #4 lands and ord-app's `Z` survives, that shape needs a deliberate decision here rather than a silent format entry.
- Timestamps are naive: no recorded shape carries an offset, so attaching a zone would state a fact the source never recorded. `DTZ007` is suppressed at that line with the reason.
- Existing projections go stale by the corrected column check, so a corpus needs re-deriving. `ARTIFACT_VERSIONS` is untouched — the column check is the mechanism for exactly this, once it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)














<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds parsed microsecond-resolution timestamps to projected `DateTime` values while retaining their original text internally. It also makes artifact freshness checks compare nested paths and leaf types so older projections are regenerated when their schema is incomplete or incompatible.
- Parses recorded date formats with dataset-level slash-date orientation.
- Adds `timestamp[us]` fields throughout the nested projection schema.
- Recursively detects missing or type-changed fields through structs, lists, and maps.
- Updates query schema rendering, snapshots, and regression tests.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/artifacts/base.py | Recursively compares nested schema paths and leaf types, resolving the previously reported freshness-check gaps. |
| ord_schema/artifacts/projection.py | Adds dataset-aware DateTime parsing, propagates orientation through nested projection rows, and stores timestamps at microsecond resolution. |
| ord_schema/artifacts/base_test.py | Covers nested additions, changed timestamp units, container descent, and complete-schema Parquet round trips. |
| ord_schema/artifacts/projection_test.py | Exercises supported date formats, ambiguity handling, orientation inference, and projected DateTime values. |
| ord_schema/search/schema.py | Adds microsecond timestamp rendering to the searchable projection schema. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Read source dataset] --> B[Scan recorded provenance dates]
  B --> C[Resolve dataset slash orientation]
  C --> D[Project each DateTime]
  D --> E[Keep original value internally]
  D --> F[Parse timestamp at microsecond resolution]
  E --> G[Write Parquet projection]
  F --> G
  H[Check existing artifact] --> I[Walk nested declared paths and leaf types]
  I --> J{Schema complete and compatible?}
  J -->|Yes| K[Reuse artifact]
  J -->|No| A
```
</details>

<sub>Reviews (8): Last reviewed commit: ["Let the column check see a leaf whose ty..."](https://github.com/open-reaction-database/ord-schema/commit/c494fac3bad021552eb28af5167c5d1b6d11e014) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60284503)</sub>

<!-- /greptile_comment -->