### PR TITLE
Bound what a search returns unless the caller says otherwise

### DIFF
--- a/ord_schema/search/check.py
+++ b/ord_schema/search/check.py
@@ -930,6 +930,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.structures,
         require_current=True,
         pivot_budget_bytes=args.pivot_budget_bytes,
+        # Unbounded: a baseline is a count and a digest over every matching reaction,
+        # and under the corpus's own default it would be a digest over an arbitrary
+        # page of them -- which compares unequal against the recorded one and reports a
+        # regression in the corpus rather than in the bound that produced it.
+        max_rows=None,
     ) as corpus:
         measured = measure(corpus, timeout_seconds=args.timeout_seconds)
         if args.write_baseline:

--- a/ord_schema/search/check_test.py
+++ b/ord_schema/search/check_test.py
@@ -285,3 +285,24 @@ def test_an_empty_corpus_says_why_its_other_checks_are_worthless(empty_corpus):
     findings = check.check_coverage(empty_corpus, timeout_seconds=60)
     failure = next(f for f in findings if not f.passed)
     assert "vacuously" in failure.detail
+
+
+def test_the_baseline_is_measured_over_every_match(monkeypatch):
+    # A baseline is a count and a digest over every matching reaction. Under the
+    # corpus's own default bound it would be a digest over an arbitrary page, which
+    # compares unequal against the recorded one and reports a regression in the corpus
+    # rather than in the bound that produced it. The fixtures here hold three
+    # reactions, far under any bound, so only the argument itself can say this.
+    seen = {}
+
+    class _RecordedError(Exception):
+        pass
+
+    def _corpus(*args, **kwargs):
+        seen.update(kwargs)
+        raise _RecordedError
+
+    monkeypatch.setattr(check.execute, "Corpus", _corpus)
+    with pytest.raises(_RecordedError):
+        check.main(["--projections=x", "--structures=y"])
+    assert seen["max_rows"] is None

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -134,6 +134,19 @@ _CACHED_MATCHES = 16
 # its size whether or not it is kept.
 _PIVOT_BUDGET_BYTES = 4 * 1024**3
 
+# Most rows a search returns where the caller states no bound. The grammar leaves
+# ``limit`` optional and a question like "reactions above 350 K" matches hundreds of
+# thousands, so an unbounded default builds an Arrow table of them in whatever process
+# asked -- from a query that reads as ordinary. A thousand is a page of reactions to
+# look at rather than a dataset to compute over; a caller that wants the whole match set
+# says so with max_rows=None, and one that wants a different page says so with a number.
+DEFAULT_MAX_ROWS = 1000
+
+# Stamped on a result the corpus's own bound may have cut short. On the table rather
+# than logged alone, because whoever reads the answer is often not whoever reads the
+# log: a summary saying "1000 reactions" is wrong in a way nothing in the rows shows.
+TRUNCATED = "ord.truncated"
+
 
 # What the process holds beside DuckDB's own accounting while the occurrence index
 # builds: about 1.4 GB resident before it starts -- the interpreter, RDKit, the paired
@@ -494,7 +507,7 @@ def _occurrences_from_projection(path: str, expression: str) -> str:
 
 def _warn_when_the_bound_was_reached(
     request: query.Query, compiled: query.Compiled, returned: int
-) -> None:
+) -> bool:
     """Says when this corpus's bound, not the query's, may have cut the answer short.
 
     Said after the query rather than while compiling it, because a bound applied is not
@@ -511,11 +524,14 @@ def _warn_when_the_bound_was_reached(
         request: The query as asked, whose own ``limit`` is not this corpus's doing.
         compiled: What it compiled to, carrying the limit that reached the SQL.
         returned: Rows the query returned.
+
+    Returns:
+        Whether the answer may be short of the matches, for stamping on the table.
     """
     if compiled.limit is None or compiled.limit == request.limit:
-        return
+        return False
     if returned < compiled.limit:
-        return
+        return False
     if request.aggregate is not None:
         logger.warning(
             "this query grouped into at least the %d rows the corpus bounds it at, so "
@@ -530,6 +546,7 @@ def _warn_when_the_bound_was_reached(
             "matches it did not return; raise max_rows to see them",
             compiled.limit,
         )
+    return True
 
 
 def _index_condition(
@@ -945,7 +962,7 @@ class Corpus:
         require_occurrences: bool = False,
         memory_limit: str | None = None,
         warm: bool = True,
-        max_rows: int | None = None,
+        max_rows: int | None = DEFAULT_MAX_ROWS,
     ) -> None:
         """Pairs the artifacts, checks their stamps, and prepares the relations.
 
@@ -1049,9 +1066,12 @@ class Corpus:
                 asked for a limit and clamping one that asks for more. The grammar
                 leaves ``limit`` optional, so a query without one returns every matching
                 reaction -- at ORD's scale millions of rows, built into an Arrow table
-                in this process, from a query that reads as ordinary. A caller serving
-                queries it did not write wants this set. None leaves every query's own
-                limit, or none, exactly as stated.
+                in this process, from a query that reads as ordinary. Defaults to
+                ``DEFAULT_MAX_ROWS``; None leaves every query's own limit, or none,
+                exactly as stated, which is what a caller computing over the whole match
+                set wants. A result this bound may have cut short carries
+                ``TRUNCATED`` in its schema metadata, since nothing in the rows tells a
+                short answer from a complete one.
 
         Raises:
             PairingError: If either pattern matches nothing, a file on one side has no
@@ -2731,9 +2751,10 @@ class Corpus:
         Returns:
             The selected columns: ``reaction_id`` for a plain query, the group and
             measure columns for an aggregated one. At most this corpus's ``max_rows``,
-            where it has one: an answer that reached the bound is logged as possibly
-            cut, and the table itself does not say. ``Compiled.limit`` is what actually
-            reached the SQL, for a caller that wants to check rather than read a log.
+            where it has one: an answer that reached the bound is logged as possibly cut
+            and carries ``TRUNCATED`` in its schema metadata. ``Compiled.limit`` is what
+            actually reached the SQL, for a caller that wants the number rather than the
+            flag.
 
         Raises:
             query.QueryError: If the query does not compile.
@@ -2821,7 +2842,12 @@ class Corpus:
                     answered = cursor.execute(compiled.sql, parameters).to_arrow_table()
                 else:
                     answered = _run_with_timeout(cursor, compiled.sql, parameters, left)
-                _warn_when_the_bound_was_reached(request, compiled, answered.num_rows)
+                if _warn_when_the_bound_was_reached(
+                    request, compiled, answered.num_rows
+                ):
+                    answered = answered.replace_schema_metadata(
+                        (answered.schema.metadata or {}) | {TRUNCATED: b"true"}
+                    )
                 return answered
             finally:
                 cursor.close()

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -1708,7 +1708,8 @@ def test_max_rows_bounds_what_a_search_returns(corpus_dir, caplog):
 
 def test_an_answer_that_reaches_the_bound_says_it_may_be_cut(corpus_dir, caplog):
     # Cut rather than refused: the answer is nearer what the caller wanted than an
-    # error, and nothing in the result says it was cut, so the log has to.
+    # error, so the log says it may be short, and the table carries TRUNCATED for a
+    # reader who never sees the log.
     with (
         caplog.at_level(logging.WARNING, logger="ord_schema.search.execute"),
         execute.Corpus(
@@ -4792,3 +4793,55 @@ def test_an_answer_that_arrives_past_the_bound_is_a_timeout(corpus, monkeypatch)
             )
     finally:
         cursor.close()
+
+
+def test_a_corpus_bounds_what_it_returns_without_being_asked(corpus_dir):
+    # The grammar leaves limit optional, so an unbounded default builds every matching
+    # reaction into an Arrow table in whatever process asked -- millions of them at
+    # corpus scale, from a query that reads as ordinary.
+    assert execute.DEFAULT_MAX_ROWS == 1000
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+    ) as value:
+        assert value._max_rows == execute.DEFAULT_MAX_ROWS
+
+
+def test_a_caller_computing_over_every_match_can_still_ask_for_one(corpus_dir):
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        max_rows=None,
+    ) as value:
+        answer = value.search(query.Query.model_validate({}))
+    assert answer.num_rows == 3
+    assert execute.TRUNCATED.encode() not in (answer.schema.metadata or {})
+
+
+def test_an_answer_the_bound_may_have_cut_says_so_on_the_table(corpus_dir):
+    # On the table rather than logged alone: whoever reads the answer is often not
+    # whoever reads the log, and a summary saying "2 reactions" is wrong in a way
+    # nothing in the rows shows.
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        max_rows=2,
+    ) as value:
+        answer = value.search(query.Query.model_validate({}))
+    assert answer.num_rows == 2
+    assert (answer.schema.metadata or {})[execute.TRUNCATED.encode()] == b"true"
+
+
+def test_an_answer_the_bound_did_not_reach_carries_no_stamp(corpus_dir):
+    with execute.Corpus(
+        str(corpus_dir / "projections" / "*.parquet"),
+        str(corpus_dir / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        max_rows=100,
+    ) as value:
+        answer = value.search(query.Query.model_validate({}))
+    assert answer.num_rows == 3
+    assert execute.TRUNCATED.encode() not in (answer.schema.metadata or {})

--- a/ord_schema/search/nl_eval.py
+++ b/ord_schema/search/nl_eval.py
@@ -400,6 +400,11 @@ def main(argv: Sequence[str] | None = None) -> None:
         require_current=args.require_current,
         pivots_dir=args.pivots_dir,
         pivot_budget_bytes=args.pivot_budget_bytes,
+        # Unbounded: a case is scored by comparing the reactions a translation returns
+        # against the reference's. Bounded, both sides are arbitrary pages of their
+        # match sets -- SQL leaves an unordered LIMIT free to pick any rows -- so two
+        # queries that agree would be scored as disagreeing.
+        max_rows=None,
     ) as corpus:
         results = [
             run_case(

--- a/ord_schema/search/nl_eval_test.py
+++ b/ord_schema/search/nl_eval_test.py
@@ -407,3 +407,25 @@ def test_a_run_without_a_sink_records_nothing(tmp_path):
     result = _run(_CASE, _StubClient("build_query", _BAD_PATH))
     assert not result.passed
     assert not list(tmp_path.iterdir())
+
+
+def test_a_case_is_scored_over_every_match(monkeypatch):
+    # A case is scored by comparing the reactions a translation returns against the
+    # reference's. Bounded, both sides are arbitrary pages of their match sets -- SQL
+    # leaves an unordered LIMIT free to pick any rows -- so two queries that agree would
+    # be scored as disagreeing. The corpora in this file are far under any bound, so
+    # only the argument itself can say this.
+    seen = {}
+
+    class _RecordedError(Exception):
+        pass
+
+    def _corpus(*args, **kwargs):
+        seen.update(kwargs)
+        raise _RecordedError
+
+    monkeypatch.setattr(nl_eval.nl, "get_client", lambda: None)
+    monkeypatch.setattr(nl_eval.execute, "Corpus", _corpus)
+    with pytest.raises(_RecordedError):
+        nl_eval.main(["--projections=x", "--structures=y"])
+    assert seen["max_rows"] is None


### PR DESCRIPTION
## Summary

The grammar leaves `limit` optional, so a query without one returned every matching reaction. At ORD's scale that is hundreds of thousands of rows built into an Arrow table in whatever process asked — "reactions run above 350 K" is 211,457 — from a query that reads as ordinary.

## Changes

- Default `Corpus(max_rows=...)` to `DEFAULT_MAX_ROWS = 1000`: a page of reactions to look at rather than a dataset to compute over. `None` still means unbounded.
- Stamp an answer the bound may have cut with `ord.truncated` in the table's schema metadata. The warning already said so, but whoever reads the answer is often not whoever reads the log, and a summary reporting "1000 reactions" is wrong in a way nothing in the rows shows.
- Opt the two callers that measure rather than display out of the bound. `check.py` digests every matching reaction into the recorded baseline, and `nl_eval` scores a case by comparing the reactions a translation returns against the reference's — bounded, the first reports a corpus regression that is really the bound, and the second compares two arbitrary pages, since SQL leaves an unordered `LIMIT` free to pick any rows.

## Testing

- `uv run pytest -n auto` — 1631 passed.
- Six new tests: the default is applied unasked, `max_rows=None` returns everything unstamped, a cut answer carries the stamp, an answer the bound did not reach does not, and each CLI passes `max_rows=None`.
- Mutation-checked all four guards. Reverting the default fails only `test_a_corpus_bounds_what_it_returns_without_being_asked`; removing the stamp fails only the stamp test; dropping either `max_rows=None` fails only that CLI's test.

## Notes

- Neither CLI's `main` had a test, which is how the default reached them unnoticed: every corpus in the suite holds three reactions, far under any bound, so only the argument itself can say this. The recorded baseline answers for three canonical queries are 211,457, 660,671 and 1,542,319 rows.
- The bound already distinguishes the two cases it must: for an aggregated query it bounds *groups*, where a truncated answer is an arbitrary part of a distribution rather than a sample of the matching reactions. That warning predates this change.
- `test_a_phase_that_outlasts_the_bound_raises_naming_itself` failed once under a filtered `-n auto` run and passes consistently in full runs. It is a timing-sensitive deadline test and looks pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR bounds ordinary corpus searches to 1,000 rows by default while preserving explicitly unbounded operation for completeness-sensitive workflows.
- Adds truncation metadata when the corpus-level bound may have shortened a result.
- Exempts corpus baseline checks and natural-language evaluations from the default bound.
- Adds focused tests for default, unbounded, truncated, and complete-result behavior.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported completeness failure is fixed: corpus checks and natural-language evaluations now use explicitly unbounded corpus instances, and no blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/execute.py | Introduces the default row bound and stamps results that may have been truncated. |
| ord_schema/search/check.py | Keeps corpus baseline measurement unbounded so counts and digests remain complete. |
| ord_schema/search/nl_eval.py | Keeps reference and translated-query comparisons unbounded so evaluation uses complete reaction sets. |
| ord_schema/search/execute_test.py | Covers the default bound, explicit unbounded behavior, and truncation metadata. |
| ord_schema/search/check_test.py | Verifies that corpus validation explicitly disables the default result bound. |
| ord_schema/search/nl_eval_test.py | Verifies that natural-language evaluation explicitly disables the default result bound. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Q[Structured query] --> C[Corpus]
  C --> D{Caller supplies max_rows?}
  D -->|No| B[Apply default 1000-row bound]
  D -->|None| U[Preserve query-authored limit only]
  B --> R[Execute query]
  U --> R
  R --> T{Corpus bound reached?}
  T -->|Yes| M[Attach ord.truncated metadata]
  T -->|No| A[Return unstamped Arrow table]
  M --> A
  X[Baseline checks and NL evaluation] -->|max_rows=None| U
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Keep the whole match set where a caller ..."](https://github.com/open-reaction-database/ord-schema/commit/7a4821caa3c5a3e538bfaaa510f23d3e1a465eb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60284553)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Database access and reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/database-and-search.md)
- Knowledge Base — [Structured reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/structured-reaction-search.md)
- Knowledge Base — [Natural-language reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/natural-language-search.md)
</details>


<!-- /greptile_comment -->