### PR TITLE
Unwrap a query a model nested under the tool's own name

### DIFF
--- a/ord_schema/search/nl.py
+++ b/ord_schema/search/nl.py
@@ -84,7 +84,14 @@ SYSTEM_PROMPT = (
 # miss on every query.
 TOOL: ToolParam = {
     "name": "build_query",
-    "description": "Build an ORD search query from the user's question.",
+    # The input is the query, said explicitly because a model otherwise nests it under
+    # the tool's own name: its top-level keys are the Query fields, not a "query" key
+    # holding them. _unwrapped recovers from that; saying so avoids it.
+    "description": (
+        "Build an ORD search query from the user's question. The input is the query "
+        "itself, whose top-level keys are where, aggregate, order_by, and limit; do "
+        "not nest it under a key of its own."
+    ),
     "input_schema": query.Query.model_json_schema(),
 }
 # Forcing build_query would leave a model with no way to decline, and a model with no
@@ -303,6 +310,31 @@ def _coerce(value: Any) -> Any:
     return value
 
 
+def _unwrapped(value: Any) -> Any:
+    """Returns a tool input without the envelope a model may nest it in.
+
+    A model that puts its arguments under the tool's parameter name sends
+    ``{"query": {...}}`` where the schema asks for the query itself. ``Query`` declares
+    no ``query`` field and refuses undeclared ones, so a payload of exactly that shape
+    can mean nothing else. Unwrapping it costs no round trip, where handing it to the
+    repair turn costs one and does not reliably work: a model that nests once tends to
+    nest again when told the result did not validate.
+
+    Args:
+        value: A tool input, already coerced.
+
+    Returns:
+        What the envelope holds, or ``value`` where it is not one.
+    """
+    if (
+        isinstance(value, dict)
+        and set(value) == {"query"}
+        and isinstance(value["query"], dict)
+    ):
+        return value["query"]
+    return value
+
+
 def _validated(coerced: Any) -> query.Query:
     """Returns the query a tool call carries, proven to compile.
 
@@ -450,7 +482,7 @@ def translate(
     except NLQueryError as error:
         raise failed(error) from error
     spent += usage
-    coerced = _coerce(block.input)
+    coerced = _unwrapped(_coerce(block.input))
     try:
         parsed = _validated(coerced)
     except (ValueError, query.QueryError) as error:
@@ -497,7 +529,7 @@ def translate(
         # by way of a query the compiler refused rather than by reading the question.
         raise failed(error) from error
     spent += usage
-    coerced = _coerce(retry.input)
+    coerced = _unwrapped(_coerce(retry.input))
     try:
         parsed = _validated(coerced)
     except (ValueError, query.QueryError) as error:

--- a/ord_schema/search/nl_test.py
+++ b/ord_schema/search/nl_test.py
@@ -192,6 +192,30 @@ def test_a_tree_returned_as_an_object_is_understood_too():
     assert _where(nl.translate("solvent reactions", client=client)).op == "exists"
 
 
+def test_a_query_nested_under_the_tool_s_own_name_is_unwrapped():
+    # Sonnet nests its arguments under the tool's parameter name on most questions, and
+    # repeats it when the failure is handed back. Query declares no "query" field and
+    # refuses undeclared ones, so this payload can mean nothing else.
+    client = _stub({"query": {"where": _SOLVENT}})
+    assert _where(nl.translate("solvent reactions", client=client)).op == "exists"
+
+
+def test_a_nested_query_encoded_as_a_string_is_unwrapped_too():
+    # The two model habits compose: the envelope arrives with the tree inside it still
+    # JSON-encoded.
+    client = _stub({"query": json.dumps({"where": _SOLVENT})})
+    assert _where(nl.translate("solvent reactions", client=client)).op == "exists"
+
+
+def test_a_key_named_query_beside_others_is_not_an_envelope():
+    # Only a payload that is exactly the envelope is unwrapped. Anything else is the
+    # model having gone wrong in a way this cannot read, and belongs in the repair turn
+    # where it is told what failed.
+    client = _stub({"query": {"where": _SOLVENT}, "limit": 5})
+    with pytest.raises(nl.MalformedQueryError):
+        nl.translate("solvent reactions", client=client, repair=False)
+
+
 def test_the_prefix_is_marked_cacheable():
     # Cache reads are most of what a query costs; an uncached prefix is a tenfold bill.
     client = _stub({"where": _SOLVENT})


### PR DESCRIPTION
## Summary

Measured against the eval set on the full corpus, Sonnet wraps its arguments in `{"query": {...}}` on **14 of 25** questions where the schema asks for the query itself — one payload even leaked a literal `"$PARAMETER_NAME": "query"`. The chemistry inside those envelopes is mostly right; the harness threw it away, scoring 11/25.

The repair turn ran on all 14 and Sonnet re-emitted the same envelope, so this belongs in the layer rather than in the retry.

## Changes

- Unwrap a payload that is exactly `{"query": {...}}`. `Query` declares no `query` field and refuses undeclared ones, so that shape can mean nothing else, and unwrapping costs no round trip where the repair turn costs one.
- Say in the tool description that the input is the query rather than a wrapper around it.
- Anything less tidy than the bare envelope still goes to the repair turn, where the model is told what failed.

## Testing

- `uv run pytest -n auto` — 1628 passed.
- Three new tests: the bare envelope, the envelope with the tree still JSON-encoded inside it (the two model habits compose), and a `query` key beside other fields, which is *not* unwrapped and must reach the repair turn.
- Mutation-checked: removing the unwrap fails exactly the two tests that assert it and nothing else.
- With this in place Sonnet scores 22/25 on the eval set, tying Haiku at roughly 3x the per-token rate.

## Notes

- The description names the top-level `Query` fields by hand, so it can drift if one is added. Nothing enforces the match today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR accepts model-generated query arguments wrapped exactly as `{"query": {...}}` while retaining the existing validation and repair path for all other malformed shapes.
- Clarifies in the tool description that arguments are the query fields themselves.
- Normalizes the exact redundant envelope on initial and repaired model responses.
- Adds tests for object and JSON-encoded envelopes and confirms mixed-key payloads remain invalid.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the new normalization restricted to a shape that cannot represent a valid unwrapped `Query`.

The exact-envelope check preserves all other payloads, and the resulting inner value still passes through the existing schema validation and query compilation boundaries.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/nl.py | Adds narrowly scoped envelope normalization before existing query validation and aligns the model-facing description with all current `Query` fields. |
| ord_schema/search/nl_test.py | Covers both supported envelope forms and verifies that ambiguous payloads with sibling fields are not unwrapped. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Unwrap a query a model nested under the ..."](https://github.com/open-reaction-database/ord-schema/commit/88b695cb5011c576210b12d4f997e7af74982b36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60284563)</sub>

<!-- /greptile_comment -->
