### PR TITLE
Let an aggregate group the elements of a repeated level

### DIFF
--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -55,7 +55,7 @@ Predicate  = { op: "and" | "or", clauses: [Predicate] }
 
 Value      = { literal: <scalar> } | { compound: <name> }
 
-Aggregate  = { group_by: [Path],
+Aggregate  = { over?: Path, where?: Predicate, group_by: [Path],
                measures: [{ fn: "count"|"count_distinct"|"sum"|"avg"|"min"|"max",
                             path?: Path | Reduction, name: string }] }
 
@@ -85,6 +85,15 @@ is a compile error rather than a wrong answer:
 - Operators must suit the leaf type — `contains` is text-only, ordering is numeric-only.
 - `group_by` paths must be scalar, so the number of groups is bounded by the values a column
   holds rather than by an explosion over a repeated level.
+- `aggregate.over` names a repeated level and makes the rows its elements rather than
+  reactions, which is the only way to group by something a reaction has many of — "the most
+  common solvent" is not a column of a reaction. Paths inside are relative to the element,
+  `aggregate.where` selects the elements grouped and the query's own `where` selects the
+  reactions whose elements are counted, and `count_distinct` over `reaction_id` is what
+  answers about reactions rather than occurrences. One level, never nested, so the rows are
+  that level's own cardinality and the query stays one pass and a sort. It reads the pivot
+  artifact for the level and is refused without one: reaching the elements otherwise means
+  the `UNNEST` this grammar exists to make unwritable.
 - A `Reduction` is the one place a repeated path is read without a quantifier: it reduces
   that reaction's own elements to a single value, so `max` over `outcomes.products.measurements.percentage.value`
   is the reaction's best yield rather than the corpus's. Its path must cross a repeated level;

--- a/ord_schema/search/nl.py
+++ b/ord_schema/search/nl.py
@@ -55,6 +55,7 @@ from anthropic.types import (
     ToolUseBlock,
 )
 
+from ord_schema.artifacts import pivot as pivot_levels
 from ord_schema.logging import get_logger
 from ord_schema.search import execute, nl_log, query, schema
 
@@ -327,7 +328,16 @@ def _validated(coerced: Any) -> query.Query:
             "the query asks nothing: it has no where, no aggregate, and no limit, so "
             "it would return every reaction in the corpus"
         )
-    query.compile_query(parsed)
+    # Every level offered as pivoted, because this asks whether the query is
+    # well-formed, not how it would be planned. Which levels a corpus actually holds is
+    # a property of that corpus, and refusing here on this process's answer would reject
+    # a query the corpus about to run it can serve.
+    query.compile_query(
+        parsed,
+        pivot=lambda path: (
+            pivot_levels.table_name(path) if path in pivot_levels.LEVELS else None
+        ),
+    )
     return parsed
 
 

--- a/ord_schema/search/nl_prompt.md
+++ b/ord_schema/search/nl_prompt.md
@@ -50,6 +50,23 @@ Rules that keep a query answerable:
   reaction's best yield. A plain path there is refused.
 - Enum columns compare against the spellings listed beside them, which are the value
   names rather than numbers.
+- "The most common X", "how many of each X", and anything else that groups by something
+  under a repeated level needs `aggregate.over`, which makes the rows the elements of
+  that level rather than reactions. `group_by` and measure paths are then relative to
+  the element, `aggregate.where` selects which elements are counted, and the query's own
+  `where` still selects reactions. Count `reaction_id` distinctly to answer about
+  reactions, since one reaction can hold the same solvent twice:
+
+  ```json
+  {"aggregate": {"over": "inputs.components",
+                 "where": {"op": "eq", "path": "reaction_role",
+                           "value": {"literal": "SOLVENT"}},
+                 "group_by": ["smiles"],
+                 "measures": [{"fn": "count_distinct", "path": "reaction_id",
+                               "name": "reactions"}]},
+   "order_by": [{"key": "reactions", "descending": true}], "limit": 3}
+  ```
+
 - Prefer the smallest query that answers the question, and set `limit` when the user asks
   for a particular number of results.
 

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -630,10 +630,39 @@ class Aggregate(_Node):
 
     ``group_by`` paths must be scalar, so the number of groups is bounded by the values
     a column holds rather than by an explosion over a repeated level.
+
+    ``over`` changes what a row is. Without it the rows are reactions, and "how many
+    reactions are automated" is a count of them. With it the rows are the elements of
+    one repeated level, which is what "the most common solvent" asks for: solvents are
+    not a column of a reaction, and no grouping of reactions can name one. Paths inside
+    are then relative to the element, as they are inside a quantifier.
+
+    Two filters, because there are two things to filter. This ``where`` selects the
+    elements grouped -- the components that are solvents. The *query's* ``where``
+    selects reactions, and says which reactions' elements are counted at all. "The most
+    common solvents in reactions run above 350 K" needs both, and neither can say what
+    the other says.
+
+    One level, never nested, so the rows are that level's own cardinality rather than a
+    product: the query stays one pass and a sort, over the pivot instead of over the
+    projection. ``reaction_id`` is reachable as a measure path and is how a question
+    about reactions is answered from a relation of elements -- a reaction using THF
+    twice is one reaction and two rows.
     """
 
+    over: str | None = None
+    where: "Predicate | None" = None
     group_by: list[str] = Field(default_factory=list)
     measures: list[Measure] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _element_filter_needs_elements(self) -> "Aggregate":
+        if self.where is not None and self.over is None:
+            raise ValueError(
+                "aggregate.where selects the elements being grouped, so it needs an "
+                "over; a condition on reactions is the query's own where"
+            )
+        return self
 
 
 class Order(_Node):
@@ -1132,9 +1161,11 @@ def _predicate(
     return _leaf(node, resolved, compounds)
 
 
-def _scalar(path: str, schema: pa.Schema, what: str) -> _Resolved:
+def _scalar(
+    path: str, schema: pa.Schema, what: str, root: str | None = None
+) -> _Resolved:
     """Returns where a path that has to be scalar landed."""
-    resolved = resolve(path, schema=schema)
+    resolved = resolve(path, schema=schema, root=root)
     if resolved.repeated:
         raise QueryError(f"{path}: {what} needs a scalar column, not a repeated level")
     return resolved
@@ -1183,12 +1214,17 @@ def _reduced(reduction: Reduction, schema: pa.Schema) -> str:
     return _REDUCERS[reduction.reduce].format(expression=resolved.expression)
 
 
-def _measure_argument(measure: Measure, schema: pa.Schema) -> str:
+def _measure_argument(
+    measure: Measure, schema: pa.Schema, element: str | None = None
+) -> str:
     """Returns the expression a measure aggregates over.
 
     Args:
         measure: The measure being compiled.
         schema: Schema its path resolves against.
+        element: The bound element paths are relative to, for an aggregate over a
+            repeated level; None where the rows are reactions. A ``Reduction`` needs
+            none, since a level's elements hold no list to reduce.
 
     Returns:
         ``*`` for a bare count, a reduced expression where the path crosses a repeated
@@ -1201,13 +1237,75 @@ def _measure_argument(measure: Measure, schema: pa.Schema) -> str:
     if measure.path is None:
         return "*"
     if isinstance(measure.path, Reduction):
+        if element is not None:
+            raise QueryError(
+                f"{measure.path.path}: a reduction reads a reaction's own elements, "
+                "and this aggregate's rows are already elements"
+            )
         argument = _reduced(measure.path, schema)
+    elif element is not None and measure.path == pivot_levels.REACTION_ID:
+        # The one path a pivot row carries outside its element, and what makes a count
+        # of elements answerable as a count of reactions.
+        argument = f"{element}.{pivot_levels.REACTION_ID}"
     else:
-        resolved = _scalar(measure.path, schema, measure.fn)
+        resolved = _scalar(
+            measure.path,
+            schema,
+            measure.fn,
+            None if element is None else f"{element}.{pivot_levels.ELEMENT}",
+        )
         if measure.fn in _ARITHMETIC:
             _check_numeric(measure.path, resolved.type, measure.fn)
         argument = resolved.expression
     return f"DISTINCT {argument}" if measure.fn == "count_distinct" else argument
+
+
+def _element_relation(
+    query: Query, table: str, pivot: PivotIndex | None
+) -> tuple[str, str, pa.DataType] | None:
+    """Returns the relation an aggregate's rows come from, where they are not reactions.
+
+    Args:
+        query: The query being compiled.
+        table: The relation of reactions, named in the message where the level is not
+            one this grammar can group over.
+        pivot: Pivoted levels; the only relation of elements there is.
+
+    Returns:
+        ``(alias, relation, element type)`` for an ``aggregate.over``, or None where the
+        rows are reactions.
+
+    Raises:
+        QueryError: If the path names no repeated level, or no pivot covers it. There
+            is no fallback: reaching the elements without one means ``UNNEST`` in a
+            ``FROM`` clause, measured at 27-200x for the same answer and the one
+            spelling this grammar exists to make unwritable.
+    """
+    if query.aggregate is None or query.aggregate.over is None:
+        return None
+    over = query.aggregate.over
+    reached = pivot_levels.reach(over)
+    if reached is None:
+        raise QueryError(
+            f"{over}: aggregate.over names a repeated level to group the elements of, "
+            f"and this reaches no such level of {table}"
+        )
+    level, remainder, element_type = reached
+    if remainder:
+        # reach() descends singular fields past a level, which a quantifier wants and
+        # this cannot use: the rows would be that struct, and group_by paths relative to
+        # it would silently mean something narrower than the level named.
+        raise QueryError(
+            f"{over}: aggregate.over names the level itself, and this descends past "
+            f"{level.path} into {'.'.join(remainder)}"
+        )
+    relation = None if pivot is None else pivot(level.path)
+    if relation is None:
+        raise QueryError(
+            f"{over}: grouping elements reads the pivot artifact for {level.path}, "
+            "which this corpus does not hold"
+        )
+    return "x0", relation, element_type
 
 
 def compile_query(
@@ -1266,14 +1364,22 @@ def compile_query(
         )
     compounds: list[str] = []
     structures: list[StructureParameter] = []
+    element = _element_relation(query, table, pivot)
     if query.aggregate:
+        alias = None if element is None else element[0]
+        element_schema = schema if element is None else element[2]
         groups = [
-            _scalar(path, schema, "group_by").expression
+            _scalar(
+                path,
+                element_schema,
+                "group_by",
+                None if alias is None else f"{alias}.{pivot_levels.ELEMENT}",
+            ).expression
             for path in query.aggregate.group_by
         ]
         selected = list(groups)
         for measure in query.aggregate.measures:
-            argument = _measure_argument(measure, schema)
+            argument = _measure_argument(measure, element_schema, alias)
             selected.append(f"{_AGGREGATES[measure.fn]}({argument}) AS {measure.name}")
         names = {measure.name for measure in query.aggregate.measures}
         orderable = names | set(query.aggregate.group_by)
@@ -1284,17 +1390,47 @@ def compile_query(
     # either an expression resolved against the schema or a measure name already held to
     # an identifier shape, `table` is this module's constant, and every model-supplied
     # value reached the string as a bound parameter or a quoted literal.
-    sql = f"SELECT {', '.join(selected)} FROM {table}"  # noqa: S608
+    source = table if element is None else f"{element[1]} AS {element[0]}"
+    sql = f"SELECT {', '.join(selected)} FROM {source}"  # noqa: S608
+    conditions = []
+    if element is not None and query.aggregate is not None:
+        if query.aggregate.where is not None:
+            conditions.append(
+                _predicate(
+                    query.aggregate.where,
+                    f"{element[0]}.{pivot_levels.ELEMENT}",
+                    element[2],
+                    compounds,
+                    structures,
+                    1,
+                    _Routing(table, index, pivot),
+                )
+            )
     if query.where is not None:
-        sql += " WHERE " + _predicate(
+        condition = _predicate(
             query.where,
             None,
             schema,
             compounds,
             structures,
-            0,
+            # Past the alias this aggregate's own relation took, so a quantifier inside
+            # does not bind its variable to the elements being grouped.
+            0 if element is None else 1,
             _Routing(table, index, pivot),
         )
+        if element is not None:
+            # ``where`` selects reactions whatever the rows are, so over a relation of
+            # elements it is a semi-join back to them rather than a filter here: the
+            # predicate is written against reaction columns, which a pivot row does not
+            # carry.
+            condition = (
+                f"EXISTS (SELECT 1 FROM {table} WHERE "  # noqa: S608
+                f"{table}.{pivot_levels.REACTION_ID} = "
+                f"{element[0]}.{pivot_levels.REACTION_ID} AND {condition})"
+            )
+        conditions.append(condition)
+    if conditions:
+        sql += " WHERE " + " AND ".join(conditions)
     taken = {parameter.name for parameter in structures}
     collisions = sorted(taken & set(compounds))
     if collisions:

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -1260,6 +1260,35 @@ def _measure_argument(
     return f"DISTINCT {argument}" if measure.fn == "count_distinct" else argument
 
 
+def _refuse_quantified(node: "Predicate", over: str | None) -> None:
+    """Raises where an aggregate's element filter tries to bind elements of its own.
+
+    A pivot carries an element's non-repeated fields and drops the rest, so a quantifier
+    here resolves against a type missing the level it names and fails saying the field
+    does not exist -- which is confusing where the field plainly does, one level up in
+    the projection. Said once, here, in terms of what the rows are.
+
+    Args:
+        node: The element filter, or a clause within it.
+        over: The level being grouped, named in the message.
+
+    Raises:
+        QueryError: If the filter quantifies over anything.
+    """
+    if isinstance(node, Quantifier):
+        raise QueryError(
+            f"{node.path}: aggregate.where selects among the elements of {over}, and "
+            "a pivot carries their non-repeated fields only, so there is no level "
+            "here to quantify over; a condition on the reaction is the query's own "
+            "where"
+        )
+    for clause in getattr(node, "clauses", []):
+        _refuse_quantified(clause, over)
+    inner = getattr(node, "clause", None)
+    if inner is not None:
+        _refuse_quantified(inner, over)
+
+
 def _element_relation(
     query: Query, table: str, pivot: PivotIndex | None
 ) -> tuple[str, str, pa.DataType] | None:
@@ -1395,6 +1424,7 @@ def compile_query(
     conditions = []
     if element is not None and query.aggregate is not None:
         if query.aggregate.where is not None:
+            _refuse_quantified(query.aggregate.where, query.aggregate.over)
             conditions.append(
                 _predicate(
                     query.aggregate.where,

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -1524,7 +1524,7 @@ def test_the_elements_being_grouped_cannot_be_quantified_over():
     # Load-bearing, not incidental: a pivot prunes the repeated fields from its element
     # type, so an aggregate's own filter can never bind a variable. That is what lets it
     # and the reaction filter compile at the same depth without their aliases colliding.
-    with pytest.raises(query.QueryError, match="no field named"):
+    with pytest.raises(query.QueryError, match="no level here to quantify over"):
         _over(
             {
                 "aggregate": {
@@ -1576,3 +1576,29 @@ def test_both_filters_allocate_structure_parameters_apart():
     names = [parameter.name for parameter in compiled.structures]
     assert len(names) == 2
     assert len(set(names)) == 2
+
+
+def test_a_quantifier_buried_in_the_element_filter_is_found_too():
+    # Reached through a not, an and, or an or, so the message does not depend on where
+    # in the clause tree the quantifier sits.
+    with pytest.raises(query.QueryError, match="no level here to quantify over"):
+        _over(
+            {
+                "aggregate": {
+                    "over": "outcomes.products",
+                    "where": {
+                        "op": "not",
+                        "clause": {
+                            "op": "exists",
+                            "path": "measurements",
+                            "where": {
+                                "op": "eq",
+                                "path": "type",
+                                "value": {"literal": "YIELD"},
+                            },
+                        },
+                    },
+                    "measures": [{"fn": "count", "name": "n"}],
+                }
+            }
+        )

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -1518,3 +1518,61 @@ def test_a_reduction_is_refused_where_the_rows_are_already_elements():
                 }
             }
         )
+
+
+def test_the_elements_being_grouped_cannot_be_quantified_over():
+    # Load-bearing, not incidental: a pivot prunes the repeated fields from its element
+    # type, so an aggregate's own filter can never bind a variable. That is what lets it
+    # and the reaction filter compile at the same depth without their aliases colliding.
+    with pytest.raises(query.QueryError, match="no field named"):
+        _over(
+            {
+                "aggregate": {
+                    "over": "outcomes.products",
+                    "where": {
+                        "op": "exists",
+                        "path": "measurements",
+                        "where": {
+                            "op": "eq",
+                            "path": "type",
+                            "value": {"literal": "YIELD"},
+                        },
+                    },
+                    "measures": [{"fn": "count", "name": "n"}],
+                }
+            }
+        )
+
+
+def test_both_filters_allocate_structure_parameters_apart():
+    # They append to one list, so a name taken by the element filter is not offered to
+    # the reaction filter -- two bitmaps bound under one name would silently be one.
+    compiled = query.compile_query(
+        query.Query.model_validate(
+            {
+                "aggregate": {
+                    "over": "inputs.components",
+                    "where": {
+                        "op": "substructure",
+                        "path": "smiles",
+                        "smarts": "c1ccccc1",
+                    },
+                    "group_by": ["smiles"],
+                    "measures": [{"fn": "count", "name": "n"}],
+                },
+                "where": {
+                    "op": "exists",
+                    "path": "inputs.components",
+                    "where": {
+                        "op": "substructure",
+                        "path": "smiles",
+                        "smarts": "[Pd]",
+                    },
+                },
+            }
+        ),
+        pivot=_every_level,
+    )
+    names = [parameter.name for parameter in compiled.structures]
+    assert len(names) == 2
+    assert len(set(names)) == 2

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -1371,3 +1371,150 @@ def test_same_parent_needs_a_compound_smiles_column():
                 }
             }
         )
+
+
+# Aggregating over a repeated level
+
+
+def _over(body, pivot=_every_level):
+    return _pivot_sql(body, pivot=pivot)
+
+
+_SOLVENT_COUNTS = {
+    "aggregate": {
+        "over": "inputs.components",
+        "where": {"op": "eq", "path": "reaction_role", "value": {"literal": "SOLVENT"}},
+        "group_by": ["smiles"],
+        "measures": [{"fn": "count_distinct", "path": "reaction_id", "name": "n"}],
+    },
+    "order_by": [{"key": "n", "descending": True}],
+    "limit": 3,
+}
+
+
+def test_an_aggregate_over_a_level_reads_the_pivot_rather_than_the_reactions():
+    # The rows are elements, so the relation is the pivot and the group_by path is
+    # relative to the element -- the shape "the most common solvent" needs, which no
+    # grouping of reactions can express.
+    sql = _over(_SOLVENT_COUNTS)
+    assert "FROM pivot_inputs_components AS x0" in sql
+    assert "x0.element.smiles" in sql
+    assert "count(DISTINCT x0.reaction_id) AS n" in sql
+    assert "FROM reactions" not in sql
+
+
+def test_the_aggregate_s_where_filters_the_elements_not_the_reactions():
+    sql = _over(_SOLVENT_COUNTS)
+    assert "WHERE x0.element.reaction_role = 'SOLVENT'" in sql
+    assert "EXISTS" not in sql
+
+
+def test_the_query_s_where_still_selects_reactions():
+    # Two filters because there are two things to filter, and neither can say what the
+    # other says: the elements grouped, and whose elements are counted.
+    sql = _over(
+        _SOLVENT_COUNTS
+        | {
+            "where": {
+                "op": "gt",
+                "path": "conditions.temperature.setpoint_kelvin",
+                "value": {"literal": 350},
+            }
+        }
+    )
+    assert "x0.element.reaction_role = 'SOLVENT'" in sql
+    assert (
+        "EXISTS (SELECT 1 FROM reactions WHERE reactions.reaction_id = x0.reaction_id"
+        in sql
+    )
+    assert "setpoint_kelvin > 350" in sql
+
+
+def test_a_quantifier_in_the_reaction_filter_does_not_take_the_grouped_alias():
+    # Both relations are the same pivot, so a shared alias would leave the inner
+    # correlation binding to the rows being grouped.
+    sql = _over(
+        _SOLVENT_COUNTS
+        | {
+            "where": {
+                "op": "exists",
+                "path": "inputs.components",
+                "where": {
+                    "op": "eq",
+                    "path": "reaction_role",
+                    "value": {"literal": "CATALYST"},
+                },
+            }
+        }
+    )
+    assert "AS x1 WHERE x1.reaction_id = reactions.reaction_id" in sql
+    assert "AS x0" in sql
+
+
+def test_grouping_elements_needs_a_pivot_for_the_level():
+    # No fallback: reaching the elements without one is UNNEST in a FROM clause, which
+    # is the spelling this grammar exists to make unwritable.
+    with pytest.raises(query.QueryError, match="does not hold"):
+        _over(_SOLVENT_COUNTS, pivot=lambda path: None)
+
+
+def test_over_must_name_a_repeated_level():
+    with pytest.raises(query.QueryError, match="no such level"):
+        _over(
+            {
+                "aggregate": {
+                    "over": "conditions.temperature.setpoint_kelvin",
+                    "measures": [{"fn": "count", "name": "n"}],
+                }
+            }
+        )
+
+
+def test_over_names_the_level_itself_not_a_field_below_it():
+    # reach() descends singular fields past a level, which a quantifier wants and this
+    # cannot use: the rows would be that struct rather than the level named.
+    with pytest.raises(query.QueryError, match="descends past"):
+        _over(
+            {
+                "aggregate": {
+                    "over": "outcomes.products.measurements.authentic_standard",
+                    "measures": [{"fn": "count", "name": "n"}],
+                }
+            }
+        )
+
+
+def test_an_element_filter_without_a_level_is_refused():
+    with pytest.raises(ValidationError, match="needs an over"):
+        query.Query.model_validate(
+            {
+                "aggregate": {
+                    "where": {"op": "not_null", "path": "reaction_id"},
+                    "measures": [{"fn": "count", "name": "n"}],
+                }
+            }
+        )
+
+
+def test_a_reduction_is_refused_where_the_rows_are_already_elements():
+    # A reduction folds a reaction's own list to one value; a row that is already one
+    # element has no list to fold.
+    with pytest.raises(query.QueryError, match="already elements"):
+        _over(
+            {
+                "aggregate": {
+                    "over": "outcomes.products",
+                    "measures": [
+                        {
+                            "fn": "max",
+                            "path": {
+                                "reduce": "max",
+                                "path": "outcomes.products.measurements."
+                                "percentage.value",
+                            },
+                            "name": "n",
+                        }
+                    ],
+                }
+            }
+        )


### PR DESCRIPTION
## Summary

"What are the three most common solvents?" is a question the grammar could not ask. A solvent is not a column of a reaction, `group_by` paths must be scalar, and no grouping of reactions can name one — so the compiler refused the query both Haiku and Sonnet wrote for it, which was otherwise exactly right: `group_by: ["inputs.components.smiles"]`, count, order descending, limit 3.

The relation it needs already exists. The pivot artifact for a level *is* that level unnested and materialized.

## Changes

- Add `aggregate.over`, naming a repeated level and making the rows its elements. Paths inside are relative to the element, as they are inside a quantifier.
- Add `aggregate.where`, because there are two things to filter: it selects the elements grouped, while the query's own `where` selects the reactions whose elements are counted. "The most common solvents in reactions run above 350 K" needs both, and neither can say what the other says.
- `count_distinct` over `reaction_id` is what answers about reactions rather than occurrences — a reaction using THF twice is one reaction and two rows.
- Refuse `over` where no pivot artifact covers the level. There is no fallback: reaching the elements otherwise means the `UNNEST` in a `FROM` clause this grammar exists to make unwritable, measured at 27-200x for the same answer.
- Refuse a quantifier inside `aggregate.where` in terms of what the rows are. A pivot carries an element's non-repeated fields and drops the rest, so it used to fail with "no field named 'measurements'" — confusing, when the field plainly exists one level up.
- `nl._validated` offers every level as pivoted when it checks a query compiles — that asks whether the query is well-formed, not how a corpus would plan it.

## Testing

- `uv run pytest -n auto` — 1637 passed.
- Thirteen new tests: the pivot relation and element-relative paths, each filter separately and together, alias separation, the missing-pivot refusal, `over` naming a non-level or descending past one, an element filter without a level, a reduction refused where the rows are already elements, and the quantifier refusal both bare and buried under a `not`.
- Mutation-checked the alias separation, which is the subtle one: both relations are the same pivot, so a shared alias leaves the inner correlation binding to the rows being grouped. Sharing it fails exactly the test that asserts it.
- Measured on the real corpus: the solvents question answers in **0.10 s** over the 11.5M-row components pivot — water 229,054, DMF 226,046, THF 222,482 — matching a hand-written DuckDB query exactly. With a reaction filter as well, 0.91 s.

## Notes

- The pruning that makes an element filter unable to quantify is load-bearing rather than incidental: it is what lets the two filters compile at the same depth without their aliases colliding. Pinned by a test, since a pivot that kept repeated fields would make the collision real without failing anything.
- No canonical `check.py` query exercises this path yet. Adding one needs the recorded baseline regenerated against the real corpus, and a baseline run that supplies a `pivots_dir`; both are worth doing together.
- Grouping by a high-cardinality SMILES column is a new cost shape for this grammar. It is fast on the pivot, but worth a bound before a deployment serves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends aggregate queries to group elements from a repeated level through an available pivot artifact.
- Adds element-relative grouping and filtering with `aggregate.over` and `aggregate.where`.
- Keeps reaction-level filtering separate through a correlated semi-join.
- Updates natural-language validation, prompting, documentation, and focused compiler tests.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/query.py | Adds pivot-backed element aggregation, separate element and reaction filters, path resolution, and explicit unsupported-case validation. |
| ord_schema/search/query_test.py | Covers pivot selection, relative paths, filter separation, alias and parameter isolation, and validation failures. |
| ord_schema/search/nl.py | Validates generated queries with all recognized repeated levels represented as available pivots. |
| ord_schema/search/nl_prompt.md | Teaches the natural-language translator how to construct repeated-element aggregate queries. |
| ord_schema/search/README.md | Documents the new aggregate grammar and its pivot-backed execution contract. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Q[Aggregate query] --> O{aggregate.over?}
    O -->|No| R[Reaction relation]
    O -->|Yes| P[Repeated-level pivot]
    P --> E[Element filter]
    P --> J[Reaction-filter semi-join]
    R --> G[Group and measure]
    E --> G
    J --> G
    G --> S[Ordered aggregate results]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Say why an element filter cannot quantif..."](https://github.com/open-reaction-database/ord-schema/commit/d8508b25b350627bd276c3dbbf1c5aec5fdaecef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60284611)</sub>

<!-- /greptile_comment -->