### PR TITLE
Ask the eval set what an empty count averages to

### DIFF
--- a/ord_schema/search/nl_cases.json
+++ b/ord_schema/search/nl_cases.json
@@ -439,7 +439,7 @@
     }
   },
   {
-    "question": "on average, how many yield measurements does a reaction have?",
+    "question": "on average, how many percentage measurements does a reaction have?",
     "why": "counting a repeated level gives zero where the reaction has none, so every reaction belongs in the average; restricting to the ones that have any answers a different question",
     "reference": {
       "aggregate": {
@@ -457,7 +457,7 @@
     }
   },
   {
-    "question": "among reactions that have at least one yield measurement, how many do they have on average?",
+    "question": "among reactions that have at least one percentage measurement, how many do they have on average?",
     "why": "the same average behind an exists, which is the only thing separating it from the question over every reaction",
     "reference": {
       "where": {

--- a/ord_schema/search/nl_cases.json
+++ b/ord_schema/search/nl_cases.json
@@ -439,8 +439,8 @@
     }
   },
   {
-    "question": "on average, how many percentage measurements does a reaction have?",
-    "why": "counting a repeated level gives zero where the reaction has none, so every reaction belongs in the average; restricting to the ones that have any answers a different question",
+    "question": "on average, how many yield measurements does a reaction have?",
+    "why": "counting a repeated level gives zero where the reaction has none, so every reaction belongs in the average; a percentage is also recorded for selectivity and purity, so the count needs the reduction's own where",
     "reference": {
       "aggregate": {
         "measures": [
@@ -448,24 +448,43 @@
             "fn": "avg",
             "path": {
               "reduce": "count",
-              "path": "outcomes.products.measurements.percentage.value"
+              "path": "outcomes.products.measurements.percentage.value",
+              "where": {
+                "op": "eq",
+                "path": "type",
+                "value": {
+                  "literal": "YIELD"
+                }
+              }
             },
-            "name": "measurements_per_reaction"
+            "name": "yields_per_reaction"
           }
         ]
       }
     }
   },
   {
-    "question": "among reactions that have at least one percentage measurement, how many do they have on average?",
+    "question": "among reactions that have at least one yield measurement, how many do they have on average?",
     "why": "the same average behind an exists, which is the only thing separating it from the question over every reaction",
     "reference": {
       "where": {
         "op": "exists",
         "path": "outcomes.products.measurements",
         "where": {
-          "op": "not_null",
-          "path": "percentage.value"
+          "op": "and",
+          "clauses": [
+            {
+              "op": "eq",
+              "path": "type",
+              "value": {
+                "literal": "YIELD"
+              }
+            },
+            {
+              "op": "not_null",
+              "path": "percentage.value"
+            }
+          ]
         }
       },
       "aggregate": {
@@ -474,9 +493,16 @@
             "fn": "avg",
             "path": {
               "reduce": "count",
-              "path": "outcomes.products.measurements.percentage.value"
+              "path": "outcomes.products.measurements.percentage.value",
+              "where": {
+                "op": "eq",
+                "path": "type",
+                "value": {
+                  "literal": "YIELD"
+                }
+              }
             },
-            "name": "measurements_per_reaction"
+            "name": "yields_per_reaction"
           }
         ]
       }

--- a/ord_schema/search/nl_cases.json
+++ b/ord_schema/search/nl_cases.json
@@ -439,6 +439,50 @@
     }
   },
   {
+    "question": "on average, how many yield measurements does a reaction have?",
+    "why": "counting a repeated level gives zero where the reaction has none, so every reaction belongs in the average; restricting to the ones that have any answers a different question",
+    "reference": {
+      "aggregate": {
+        "measures": [
+          {
+            "fn": "avg",
+            "path": {
+              "reduce": "count",
+              "path": "outcomes.products.measurements.percentage.value"
+            },
+            "name": "measurements_per_reaction"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "question": "among reactions that have at least one yield measurement, how many do they have on average?",
+    "why": "the same average behind an exists, which is the only thing separating it from the question over every reaction",
+    "reference": {
+      "where": {
+        "op": "exists",
+        "path": "outcomes.products.measurements",
+        "where": {
+          "op": "not_null",
+          "path": "percentage.value"
+        }
+      },
+      "aggregate": {
+        "measures": [
+          {
+            "fn": "avg",
+            "path": {
+              "reduce": "count",
+              "path": "outcomes.products.measurements.percentage.value"
+            },
+            "name": "measurements_per_reaction"
+          }
+        ]
+      }
+    }
+  },
+  {
     "question": "what is the average setpoint temperature, for automated and manual reactions separately?",
     "why": "an average crossing two regions, where a count of rows and an average of values look alike in the answer",
     "reference": {


### PR DESCRIPTION
## Summary

`{"reduce": "count"}` is the one reducer whose empty case is a zero rather than a null, so "on average, how many yield measurements does a reaction have?" is an average over every reaction, and "among reactions that have at least one" is a different question with a different answer. Both are expressible and nothing measured whether a model keeps them apart — the distinction is one `exists`, which is exactly the kind of clause a translation drops without looking wrong.

Stacked on #1028: both references need the reduction's own `where` to count yields rather than every percentage.

## Changes

- Two eval cases, next to the existing reduce case: the average over every reaction, and the same average behind an `exists` on the counted path.

## Testing

- `pytest -n auto` on `ord_schema/search` — 570 passed.
- `test_every_shipped_reference_compiles` covers both. Mutation-checked: pointing one reference at `percentage.nonesuch` fails that test and nothing else, and reverting it passes.
- Both references run on the full corpus with all 39 pivots: **0.670** over all 2,428,291 reactions, **1.489** over the 1,135,174 recording a yield percentage.

## Notes

- The gap between the readings is not the obvious one. Restricting to reactions holding any measurement *row* gives a third population — 1,257,843 reactions, because 122,669 carry measurements with no percentage at all. That is what a pivot-backed `GROUP BY` would produce, which is why #1027 routes a reduction through a correlated subquery rather than a join.
- Greptile caught the first version of these cases counting every percentage while asking about yields. That was true, and unfixable at the time: a `Reduction` took a bare path. #1028 gives it a `where`, and the questions ask about yields again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds two natural-language evaluation cases that distinguish averaging yield counts across all reactions from averaging only across reactions containing a yield measurement.
- Uses a filtered count reduction so non-yield percentages are excluded.
- Keeps the conditional population predicate aligned with the quantity being counted.
- The previously reported mismatch between the questions and references is fully resolved.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the evaluation questions and references consistently distinguish the two intended reaction populations.

No actionable new defects remain, and the previous finding is fully fixed by filtering both count reductions to yield measurements while applying the corresponding non-null yield condition to the conditional population.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/nl_cases.json | Adds two aligned evaluation fixtures for unconditional and existence-filtered averages of yield-measurement counts. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;agent/reduce-filter&#39; into ..."](https://github.com/open-reaction-database/ord-schema/commit/12fdd2da0f0c99c982f85ed4af42d55754e35eb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60841032)</sub>

<!-- /greptile_comment -->
