### PR TITLE
Reduce over the pivot a corpus already holds

### DIFF
--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -401,10 +401,10 @@ of the container's cap, which it does read. The step-by-step breakdown is in
 **A reduction reads the pivot, and what is left is the scan.** Ranking the corpus by a
 reaction's best yield walks three nested lists over every reaction on the projection route
 and costs 2.5s; the same query against the `outcomes.products.measurements` pivot costs
-0.76s, which is what reading `reaction_id` alone costs — the reduction itself becomes free,
-and the pivot's own group-by is 0.023s. Over the 19 canonical queries the slowest fell from
-1.87s to 0.231s, and none is now above a second. The artifact costs no budget, so this is
-latency a corpus holding pivots gets for nothing.
+0.76s, which is what reading `reaction_id` alone costs — the reduction itself is free, and
+the pivot's own group-by is 0.023s. Over the 19 canonical queries the slowest is 0.231s
+with the pivots held and 1.87s without them, and none is above a second. The artifact costs
+no budget, so this is latency a corpus holding pivots gets for nothing.
 
 None of that is optional for substructure search, since the screen and verify are RDKit in
 this process rather than SQL in an engine. Everything above it is latency: a container

--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -97,7 +97,15 @@ is a compile error rather than a wrong answer:
 - A `Reduction` is the one place a repeated path is read without a quantifier: it reduces
   that reaction's own elements to a single value, so `max` over `outcomes.products.measurements.percentage.value`
   is the reaction's best yield rather than the corpus's. Its path must cross a repeated level;
-  a scalar one is refused, since it would give the same query two spellings.
+  a scalar one is refused, since it would give the same query two spellings. It reads the
+  pivot over the deepest level the path crosses where the corpus holds one, and the
+  projection's lists otherwise; the answer is the same either way, and the measurement is
+  below.
+- `count` answers zero for a reaction holding no elements under the path, whichever route
+  reads them. The projection spells an absent repeated level NULL rather than empty --
+  788,334 reactions record no workups this way -- so the list route coalesces, because
+  "how many does this reaction have" is answered by none rather than by unknown. The
+  arithmetic reducers yield NULL there, which is what an average over nothing is.
 - `min`, `max`, `avg`, and `sum` need a numeric column, whether they reduce a repeated path
   or aggregate a scalar one; `count` takes any. Arithmetic over text is refused where the
   query is compiled rather than left to fail where it runs.
@@ -175,7 +183,7 @@ in what they read. Worked examples, with the route each clause takes:
 | solvent-free: no component is a solvent | `forall inputs.components` | pivot — the index shows which elements match, never that all of them do |
 | pyridine **and** a boronic acid in one component | `exists inputs.components` | pivot — two structure predicates is one more than an occurrence row can carry |
 | a desired product with a yield above 50% | `exists outcomes.products`, nested `exists measurements` | both levels' pivots, joined on the ordinal prefix |
-| the ten highest-yielding reactions | `order_by` a `reduce` over `outcomes.products.measurements` | no quantifier: a list aggregate over the projection |
+| the ten highest-yielding reactions | `order_by` a `reduce` over `outcomes.products.measurements` | no quantifier: the level's pivot, or the projection's lists without one |
 
 Every pivot row above falls to the elements when no pivot is available — a level the
 budget refused, or one with neither an artifact nor room to build. The answer does not
@@ -389,6 +397,14 @@ container against rather than a floor a later query raises it to. `Corpus`
 takes that limit as an argument; left unset, DuckDB claims about 80% of the machine — or
 of the container's cap, which it does read. The step-by-step breakdown is in
 [the logbook entry][cache-entry], finding 16.
+
+**A reduction reads the pivot, and what is left is the scan.** Ranking the corpus by a
+reaction's best yield walks three nested lists over every reaction on the projection route
+and costs 2.5s; the same query against the `outcomes.products.measurements` pivot costs
+0.76s, which is what reading `reaction_id` alone costs — the reduction itself becomes free,
+and the pivot's own group-by is 0.023s. Over the 19 canonical queries the slowest fell from
+1.87s to 0.231s, and none is now above a second. The artifact costs no budget, so this is
+latency a corpus holding pivots gets for nothing.
 
 None of that is optional for substructure search, since the screen and verify are RDKit in
 this process rather than SQL in an engine. Everything above it is latency: a container

--- a/ord_schema/search/check.py
+++ b/ord_schema/search/check.py
@@ -910,6 +910,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         default=0,
         help="What pivots built in process may hold; zero builds none",
     )
+    parser.add_argument(
+        "--pivots",
+        default=None,
+        help=(
+            "Directory holding pivot artifacts. Without it a reduction reads the "
+            "projection's lists, which answers the same but leaves the pivoted route "
+            "unmeasured"
+        ),
+    )
     args = parser.parse_args(argv)
     # Re-projecting a sampled reaction runs the same RDKit the derivation did, and it
     # says the same things about atom maps it said then.
@@ -930,6 +939,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         args.structures,
         require_current=True,
         pivot_budget_bytes=args.pivot_budget_bytes,
+        pivots_dir=args.pivots,
         # Unbounded: a baseline is a count and a digest over every matching reaction,
         # and under the corpus's own default it would be a digest over an arbitrary
         # page of them -- which compares unequal against the recorded one and reports a

--- a/ord_schema/search/check_test.py
+++ b/ord_schema/search/check_test.py
@@ -306,3 +306,26 @@ def test_the_baseline_is_measured_over_every_match(monkeypatch):
     with pytest.raises(_RecordedError):
         check.main(["--projections=x", "--structures=y"])
     assert seen["max_rows"] is None
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [([], None), (["--pivots=/artifacts/pivots"], "/artifacts/pivots")],
+)
+def test_the_pivots_directory_reaches_the_corpus(monkeypatch, argv, expected):
+    # A reduction routes to a pivot only where the corpus holds one, so a baseline
+    # recorded without this argument measures the list spelling and says nothing about
+    # the pivoted route -- for either the answers or the coverage counts.
+    seen = {}
+
+    class _RecordedError(Exception):
+        pass
+
+    def _corpus(*args, **kwargs):
+        seen.update(kwargs)
+        raise _RecordedError
+
+    monkeypatch.setattr(check.execute, "Corpus", _corpus)
+    with pytest.raises(_RecordedError):
+        check.main(["--projections=x", "--structures=y", *argv])
+    assert seen["pivots_dir"] == expected

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -3494,6 +3494,79 @@ def test_a_pivot_artifact_is_read_rather_than_built(wide_root, caplog):
     assert not any("building the pivot" in message for message in messages)
 
 
+def _reduced_per_reaction(corpus, reducer):
+    """Returns the reduction each reaction answers, keyed by reaction."""
+    table = corpus.search(
+        query.Query.model_validate(
+            {
+                "aggregate": {
+                    "group_by": ["reaction_id"],
+                    "measures": [
+                        {
+                            "fn": "min",
+                            "path": {
+                                "reduce": reducer,
+                                "path": (
+                                    "outcomes.products.measurements.percentage.value"
+                                ),
+                            },
+                            "name": "reduced",
+                        }
+                    ],
+                }
+            }
+        )
+    )
+    return {row["reaction_id"]: row["reduced"] for row in table.to_pylist()}
+
+
+@pytest.mark.parametrize("reducer", ["min", "max", "avg", "sum", "count"])
+def test_a_pivoted_reduction_answers_what_the_projection_answers(
+    wide_root, tmp_path, reducer
+):
+    # The pivot reaches the same elements by another route, so it cannot answer
+    # differently -- including for the reactions that carry no element at all, which
+    # is where the two spellings of "nothing" diverge if the count is left to len().
+    pivots = _write_pivots(
+        wide_root, ("outcomes.products.measurements",), into=tmp_path / "pivots"
+    )
+    projected = str(wide_root / "projections" / "*.parquet")
+    structured = str(wide_root / "structures" / "*.parquet")
+    # Budgeted to nothing, because a corpus left to its default builds the pivot in
+    # memory and routes through it -- which would compare the pivot against itself.
+    with execute.Corpus(
+        projected, structured, resolver={}.__getitem__, pivot_budget_bytes=0
+    ) as lists:
+        expected = _reduced_per_reaction(lists, reducer)
+    with execute.Corpus(
+        projected, structured, resolver={}.__getitem__, pivots_dir=str(pivots)
+    ) as pivoted:
+        assert _reduced_per_reaction(pivoted, reducer) == expected
+
+
+@pytest.mark.parametrize("pivoted", [False, True])
+def test_counting_a_level_a_reaction_lacks_is_zero(wide_root, tmp_path, pivoted):
+    # ord-wd04 records no outcomes, which the projection writes as NULL rather than as
+    # an empty list, and ord-wd03 an outcome carrying no products. Neither reaction
+    # holds an unknown number of measurements; both hold none.
+    pivots = _write_pivots(
+        wide_root, ("outcomes.products.measurements",), into=tmp_path / "pivots"
+    )
+    with execute.Corpus(
+        str(wide_root / "projections" / "*.parquet"),
+        str(wide_root / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        pivots_dir=str(pivots) if pivoted else None,
+        # Without a budget of zero the unpivoted case builds the level in memory and
+        # takes the pivoted route anyway, leaving the list spelling untested. The
+        # pivoted case reads the artifact, so it needs no budget either.
+        pivot_budget_bytes=0,
+    ) as corpus:
+        counted = _reduced_per_reaction(corpus, "count")
+    assert counted["ord-wd04"] == 0
+    assert counted["ord-wd03"] == 0
+
+
 # The levels the occurrence index's paths range within: three are indexed paths of
 # their own, and the authentic standard is one compound per measurement, so its rows
 # come from the measurements' pivot.

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -576,14 +576,23 @@ Quantifier.model_rebuild()
 
 
 # DuckDB's list aggregates, which ignore the nulls a list may hold. `count` filters
-# rather than taking len(), which would count them.
+# rather than taking len(), which would count them, and coalesces because the
+# projection spells an absent repeated level NULL rather than empty -- 788,334
+# reactions record no workups this way -- and len(NULL) is NULL, which would answer
+# "how many does this reaction have" with "unknown" where the answer is none.
 _REDUCERS = {
     "min": "list_min({expression})",
     "max": "list_max({expression})",
     "avg": "list_avg({expression})",
     "sum": "list_sum({expression})",
-    "count": "len(list_filter({expression}, value -> value IS NOT NULL))",
+    "count": "coalesce(len(list_filter({expression}, value -> value IS NOT NULL)), 0)",
 }
+
+# The relation a pivoted reduction reads its elements from. A reduction is only ever
+# compiled where the rows are reactions, and each subquery scopes its own alias, so one
+# name serves every reduction in a query without shadowing the reactions it correlates
+# to.
+_REDUCTION_ALIAS = "r0"
 
 # Reducers and aggregates that arithmetic has to carry. The grammar already holds
 # ordered comparisons to numbers, and a sum over text is a DuckDB error rather than an
@@ -1186,17 +1195,62 @@ def _check_numeric(path: str, leaf: pa.DataType, what: str) -> None:
         raise QueryError(f"{path}: {what} needs a numeric column, not {leaf}")
 
 
-def _reduced(reduction: Reduction, schema: pa.Schema) -> str:
+def _pivoted_reduction(
+    reduction: Reduction, table: str, pivot: PivotIndex | None
+) -> str | None:
+    """Returns the reduction as an aggregate over a pivot, where one covers the path.
+
+    Reading the elements as rows costs a scan of the narrow pivot rather than a walk of
+    the nested lists the projection holds, measured at 2.5s against 0.76s for a corpus
+    ranking -- which is the cost of reading ``reaction_id`` alone, so the reduction
+    itself becomes free.
+
+    Args:
+        reduction: What to reduce, and how.
+        table: The relation of reactions the subquery correlates to.
+        pivot: Pivoted levels, or None where the caller holds none.
+
+    Returns:
+        A correlated scalar subquery over the pivot, or None where no pivot covers the
+        path and the projection has to answer it.
+    """
+    if pivot is None:
+        return None
+    reached = pivot_levels.reach(reduction.path)
+    if reached is None:
+        return None
+    level, remainder, _ = reached
+    relation = pivot(level.path)
+    if relation is None:
+        return None
+    column = ".".join([_REDUCTION_ALIAS, pivot_levels.ELEMENT, *remainder])
+    return (
+        f"(SELECT {_AGGREGATES[reduction.reduce]}({column}) "  # noqa: S608
+        f"FROM {relation} AS {_REDUCTION_ALIAS} WHERE "
+        f"{_REDUCTION_ALIAS}.{pivot_levels.REACTION_ID} = "
+        f"{table}.{pivot_levels.REACTION_ID})"
+    )
+
+
+def _reduced(
+    reduction: Reduction,
+    schema: pa.Schema,
+    *,
+    table: str = TABLE,
+    pivot: PivotIndex | None = None,
+) -> str:
     """Returns the expression reducing a repeated path to one value per reaction.
 
     Args:
         reduction: What to reduce, and how.
         schema: Schema the path resolves against.
+        table: The relation of reactions, which a pivoted reduction correlates to.
+        pivot: Pivoted levels to read the elements from, where one covers the path.
 
     Returns:
         A DuckDB expression yielding one scalar per reaction. An arithmetic reducer
         yields NULL for a reaction holding no elements under that path; ``count``
-        yields zero there, and NULL only where the repeated level itself is absent.
+        yields zero there.
 
     Raises:
         QueryError: If the path is already scalar, which needs no reduction (accepting
@@ -1211,11 +1265,19 @@ def _reduced(reduction: Reduction, schema: pa.Schema) -> str:
         )
     if reduction.reduce in _ARITHMETIC:
         _check_numeric(reduction.path, resolved.type, reduction.reduce)
+    pivoted = _pivoted_reduction(reduction, table, pivot)
+    if pivoted is not None:
+        return pivoted
     return _REDUCERS[reduction.reduce].format(expression=resolved.expression)
 
 
 def _measure_argument(
-    measure: Measure, schema: pa.Schema, element: str | None = None
+    measure: Measure,
+    schema: pa.Schema,
+    element: str | None = None,
+    *,
+    table: str = TABLE,
+    pivot: PivotIndex | None = None,
 ) -> str:
     """Returns the expression a measure aggregates over.
 
@@ -1225,6 +1287,8 @@ def _measure_argument(
         element: The bound element paths are relative to, for an aggregate over a
             repeated level; None where the rows are reactions. A ``Reduction`` needs
             none, since a level's elements hold no list to reduce.
+        table: The relation of reactions, which a pivoted reduction correlates to.
+        pivot: Pivoted levels to read a reduction's elements from.
 
     Returns:
         ``*`` for a bare count, a reduced expression where the path crosses a repeated
@@ -1242,7 +1306,7 @@ def _measure_argument(
                 f"{measure.path.path}: a reduction reads a reaction's own elements, "
                 "and this aggregate's rows are already elements"
             )
-        argument = _reduced(measure.path, schema)
+        argument = _reduced(measure.path, schema, table=table, pivot=pivot)
     elif element is not None and measure.path == pivot_levels.REACTION_ID:
         # The one path a pivot row carries outside its element, and what makes a count
         # of elements answerable as a count of reactions.
@@ -1408,7 +1472,9 @@ def compile_query(
         ]
         selected = list(groups)
         for measure in query.aggregate.measures:
-            argument = _measure_argument(measure, element_schema, alias)
+            argument = _measure_argument(
+                measure, element_schema, alias, table=table, pivot=pivot
+            )
             selected.append(f"{_AGGREGATES[measure.fn]}({argument}) AS {measure.name}")
         names = {measure.name for measure in query.aggregate.measures}
         orderable = names | set(query.aggregate.group_by)
@@ -1482,7 +1548,7 @@ def compile_query(
                         "an aggregated query orders by a measure name or a group_by "
                         "path; reduce inside a measure instead"
                     )
-                key = _reduced(order.key, schema)
+                key = _reduced(order.key, schema, table=table, pivot=pivot)
             elif orderable is None:
                 key = _scalar(order.key, schema, "order_by").expression
             elif order.key in orderable:

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -1217,6 +1217,82 @@ def test_a_singular_struct_routes_to_its_ancestor_level_s_pivot():
     assert "x0.element.authentic_standard.smiles" in sql
 
 
+# Reducing over a pivot rather than over the projection's lists
+
+
+def _ranking(reducer="max"):
+    return {
+        "order_by": [
+            {
+                "key": {
+                    "reduce": reducer,
+                    "path": "outcomes.products.measurements.percentage.value",
+                }
+            }
+        ]
+    }
+
+
+def test_a_reduction_reads_the_pivot_where_one_covers_its_level():
+    sql = _pivot_sql(_ranking(), pivot=_every_level)
+    assert "list_max(" not in sql
+    assert (
+        "(SELECT max(r0.element.percentage.value) "
+        "FROM pivot_outcomes_products_measurements AS r0 "
+        "WHERE r0.reaction_id = reactions.reaction_id)"
+    ) in sql
+
+
+def test_a_pivoted_reduction_correlates_to_the_reactions_it_reduces():
+    # The pivot carries a reaction_id of its own, so an unqualified outer reference
+    # would bind to the inner one and compare a column to itself, which is true of
+    # every row and reduces the whole corpus for each reaction.
+    sql = _pivot_sql(_ranking(), pivot=_every_level)
+    assert "WHERE r0.reaction_id = reactions.reaction_id" in sql
+
+
+def test_a_reduction_falls_back_to_the_list_aggregate_without_a_pivot():
+    assert _pivot_sql(_ranking()) == _pivot_sql(_ranking(), pivot=lambda path: None)
+    assert "list_max(" in _pivot_sql(_ranking())
+
+
+def test_a_reduction_over_an_unpivoted_level_stays_on_the_projection():
+    sql = _pivot_sql(
+        _ranking(),
+        pivot=lambda path: (
+            None if path == "outcomes.products.measurements" else pivot.table_name(path)
+        ),
+    )
+    assert "list_max(" in sql
+
+
+@pytest.mark.parametrize("reducer", ["min", "max", "avg", "sum", "count"])
+def test_every_reducer_routes_to_the_pivot(reducer):
+    sql = _pivot_sql(_ranking(reducer), pivot=_every_level)
+    assert f"SELECT {reducer}(r0.element.percentage.value)" in sql
+
+
+def test_a_measure_reduces_over_the_pivot_too():
+    sql = _pivot_sql(
+        {
+            "aggregate": {
+                "measures": [
+                    {
+                        "fn": "avg",
+                        "path": {
+                            "reduce": "count",
+                            "path": "outcomes.products.measurements.percentage.value",
+                        },
+                        "name": "measurements",
+                    }
+                ]
+            }
+        },
+        pivot=_every_level,
+    )
+    assert "avg((SELECT count(r0.element.percentage.value)" in sql
+
+
 # Comparing compounds rather than spellings
 
 


### PR DESCRIPTION
## Summary

A `Reduction` walked the projection's nested lists even when the pivot for the level it crosses was already open in the same process. It now compiles to a correlated aggregate over that pivot, falling back to the lists only where no pivot covers the path. The answer is the same either way; what changes is that the reduction stops being the expensive part of the query.

Fixing the route surfaced a second thing: `count` answered NULL for a reaction holding no elements, because the projection spells an absent repeated level `NULL` rather than empty and `len(NULL)` is `NULL`. 788,334 reactions record no workups this way, and none of them holds an unknown number of workup measurements.

## Changes

- `_reduced` consults the pivot index and emits `(SELECT <fn>(r0.element.<rest>) FROM <pivot> AS r0 WHERE r0.reaction_id = reactions.reaction_id)` where one covers the deepest level the path crosses.
- The `count` reducer coalesces on the list route, so both routes answer zero for a level a reaction lacks.
- `check.py --pivots`, without which a recorded baseline measures only the list route and says nothing about the pivoted one.

## Testing

- `pytest -n auto` — 1671 passed.
- Measured on the full corpus, 3 runs each, median: the slowest canonical query falls from **1.87s to 0.231s**, and none is now above a second (total 3.99s → 2.01s). The ranking query alone is 2.5s → 0.76s, against a floor of 0.731s for reading `reaction_id` by itself — the pivot's own group-by is 0.023s, so the reduction is no longer what the query costs.
- All **19 canonical answers match the recorded baseline** byte-for-byte with routing on: same row counts, same digests.
- A differential test derives the measurements pivot and asserts all five reducers answer identically with and without it, per reaction, on a corpus built to hold the absent, empty, and NULL-leaf shapes the ORD corpus barely has.
- Mutation-checked, all three guards: disabling the routing fails 8 tests and nothing else; removing the `coalesce` fails exactly the count differential and the absent-level test; dropping `pivots_dir` from the `Corpus` call fails both new `check.py` cases.

## Notes

- The control corpora in the new tests pass `pivot_budget_bytes=0`. Without it a `Corpus` builds the level in memory and takes the pivoted route anyway, so the first version of these tests compared the pivot against itself and passed with the fix reverted.
- The new tests write their pivot into their own `tmp_path`. `wide_root`'s pivots directory is shared across the module, and an artifact left there makes `test_a_level_without_artifacts_is_still_built` read a level it means to see built.
- A filtered reduction — "count only the YIELD measurements" — is still unwritable, since a `Reduction` takes a path rather than a filtered path. That is the follow-up; it is what #1026's cases are waiting on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR routes reductions through the deepest available pivot while retaining the nested-list fallback and normalizes count reductions over absent repeated levels to zero.
- Adds correlated pivot aggregates for reduction expressions used by measures and ordering.
- Passes pivot artifact directories through the baseline-checking CLI.
- Adds SQL-routing, absent-level, and pivot-versus-projection differential coverage.
- Documents reduction routing, count semantics, and benchmark results.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable new issues or outstanding repository-rule violations were identified.

The correlated aggregate is scoped by the outer reaction identifier, falls back when no pivot is available, and is covered by differential tests across every reducer and absent-level cases. The only change since the previous review clarifies which benchmark measurements use pivots.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/query.py | Adds correlated pivot-backed reduction routing and makes list-backed counts return zero for absent repeated levels. |
| ord_schema/search/execute_test.py | Differentially verifies all reducers across pivot and projection routes, including reactions lacking the reduced level. |
| ord_schema/search/query_test.py | Verifies pivot selection, outer-reaction correlation, fallback behavior, and routing for measures and ordering. |
| ord_schema/search/check.py | Adds a pivots-directory CLI option and forwards it to Corpus so baseline checks exercise artifact-backed routing. |
| ord_schema/search/check_test.py | Confirms the optional pivots directory reaches Corpus unchanged. |
| ord_schema/search/README.md | Documents pivot-backed reductions, absent-level count semantics, and route-specific performance measurements. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Compile reduction path] --> B{Pivot covers deepest repeated level?}
    B -->|Yes| C[Build correlated aggregate over pivot]
    C --> D[Match pivot reaction_id to outer reaction_id]
    B -->|No| E[Reduce nested projection lists]
    E --> F{Reducer is count?}
    F -->|Yes| G[Coalesce absent level to zero]
    F -->|No| H[Preserve arithmetic NULL semantics]
    D --> I[Return one scalar per reaction]
    G --> I
    H --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["State the two routes rather than the imp..."](https://github.com/open-reaction-database/ord-schema/commit/7a463975243eb348800b2c5f5fc0be460883629c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60847090)</sub>

<!-- /greptile_comment -->