### PR TITLE
Let a reduction say which elements it reduces

### DIFF
--- a/ord_schema/search/README.md
+++ b/ord_schema/search/README.md
@@ -59,7 +59,7 @@ Aggregate  = { over?: Path, where?: Predicate, group_by: [Path],
                measures: [{ fn: "count"|"count_distinct"|"sum"|"avg"|"min"|"max",
                             path?: Path | Reduction, name: string }] }
 
-Reduction  = { reduce: "min"|"max"|"avg"|"sum"|"count", path: Path }
+Reduction  = { reduce: "min"|"max"|"avg"|"sum"|"count", path: Path, where?: Predicate }
 
 Order      = { key: string | Reduction, descending?: bool }
 ```
@@ -101,6 +101,13 @@ is a compile error rather than a wrong answer:
   pivot over the deepest level the path crosses where the corpus holds one, and the
   projection's lists otherwise; the answer is the same either way, and the measurement is
   below.
+- A `Reduction`'s `where` selects which elements are reduced, with paths relative to the
+  element as inside a quantifier. It is what separates "the highest yield" from "the
+  highest percentage anything was measured at": 42,909 of the corpus's percentage-valued
+  measurements are selectivity, purity, area, or custom, so the bare path answers a
+  broader question than the one asked. Quantifying inside it is refused on both routes,
+  since the pivot carries an element's non-repeated fields only and whether a filter
+  compiles should not depend on which artifacts a corpus holds.
 - `count` answers zero for a reaction holding no elements under the path, whichever route
   reads them. The projection spells an absent repeated level NULL rather than empty --
   788,334 reactions record no workups this way -- so the list route coalesces, because

--- a/ord_schema/search/check.py
+++ b/ord_schema/search/check.py
@@ -190,6 +190,33 @@ QUERIES: list[dict[str, Any]] = [
         },
     },
     {
+        # Averaged rather than ordered, because every ordering over this path answers
+        # the same 25 reactions whatever the reducer and whatever the filter: the top
+        # is held by a handful of percentages recorded as 9.0e19, which are yields. A
+        # query whose digest cannot move is coverage in name only.
+        "name": "filtered_reduction",
+        "covers": "a reduction narrowed to the elements its where keeps",
+        "query": {
+            "aggregate": {
+                "measures": [
+                    {
+                        "fn": "avg",
+                        "path": {
+                            "reduce": "count",
+                            "path": "outcomes.products.measurements.percentage.value",
+                            "where": {
+                                "op": "eq",
+                                "path": "type",
+                                "value": {"literal": "YIELD"},
+                            },
+                        },
+                        "name": "yields_per_reaction",
+                    }
+                ]
+            }
+        },
+    },
+    {
         "name": "aggregate_grouping",
         "covers": "GROUP BY with a measure",
         "query": {

--- a/ord_schema/search/check_test.py
+++ b/ord_schema/search/check_test.py
@@ -227,6 +227,18 @@ def _operators_used(node) -> set[str]:
     return set()
 
 
+def _reductions_used(node) -> list[dict]:
+    """Returns every reduction appearing anywhere in a query payload."""
+    if isinstance(node, dict):
+        found = [node] if "reduce" in node else []
+        for value in node.values():
+            found += _reductions_used(value)
+        return found
+    if isinstance(node, list):
+        return [found for item in node for found in _reductions_used(item)]
+    return []
+
+
 def test_every_grammar_operator_is_covered_by_a_canonical_query():
     # The baseline is only as good as what it asks. An operator nothing asks about can
     # break without moving a single digest, and the day that matters is the day someone
@@ -246,6 +258,17 @@ def test_every_reducer_is_covered_by_a_canonical_query():
     # One is enough to prove the list-aggregate path compiles and runs; the rest differ
     # only in which DuckDB function the same expression wraps, which query_test pins.
     assert covered
+
+
+def test_every_field_of_a_reduction_is_covered_by_a_canonical_query():
+    # A reduction compiles differently for each field it carries -- a where narrows the
+    # elements on both routes -- so a field nothing asks about can break without moving
+    # a digest. The same argument as the operator list above, for the same reason.
+    covered = set()
+    for entry in check.QUERIES:
+        for reduction in _reductions_used(entry["query"]):
+            covered |= set(reduction)
+    assert set(query.Reduction.model_fields) - covered == set()
 
 
 @pytest.fixture(scope="module")

--- a/ord_schema/search/corpus_baseline.json
+++ b/ord_schema/search/corpus_baseline.json
@@ -25,6 +25,10 @@
       "rows": 25,
       "digest": "b50a316f9ed7fcbfaeb7f7bed8971afdc31144bcc2f52220264a1e6012c97d5e"
     },
+    "filtered_reduction": {
+      "rows": 1,
+      "digest": "2285e18e5ceb1a2bfac3e6efc2ba05a4fbf738108df18e3a6124328668e90f60"
+    },
     "aggregate_grouping": {
       "rows": 6,
       "digest": "c72bf61cee8eb30484583a814e816c5cb3c6775f835a3a359ab22dca5d27f84a"

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -3202,6 +3202,15 @@ def _wide_reactions() -> list[reaction_pb2.Reaction]:
     other.measurements.add(type="YIELD").percentage.value = 90
     reactions.append(sibling)
 
+    # A percentage that is not a yield, beside one that is. Selectivity, purity, and
+    # area are recorded as percentages too -- 42,909 measurements across the corpus --
+    # so a reduction over the bare path answers a broader question than "yield" asks.
+    mixed = reaction_pb2.Reaction(reaction_id="ord-wd08")
+    only = mixed.outcomes.add().products.add(is_desired_product=True)
+    only.measurements.add(type="YIELD").percentage.value = 40
+    only.measurements.add(type="SELECTIVITY").percentage.value = 95
+    reactions.append(mixed)
+
     return reactions
 
 
@@ -3494,25 +3503,20 @@ def test_a_pivot_artifact_is_read_rather_than_built(wide_root, caplog):
     assert not any("building the pivot" in message for message in messages)
 
 
-def _reduced_per_reaction(corpus, reducer):
+def _reduced_per_reaction(corpus, reducer, where=None):
     """Returns the reduction each reaction answers, keyed by reaction."""
+    key = {
+        "reduce": reducer,
+        "path": "outcomes.products.measurements.percentage.value",
+    }
+    if where is not None:
+        key["where"] = where
     table = corpus.search(
         query.Query.model_validate(
             {
                 "aggregate": {
                     "group_by": ["reaction_id"],
-                    "measures": [
-                        {
-                            "fn": "min",
-                            "path": {
-                                "reduce": reducer,
-                                "path": (
-                                    "outcomes.products.measurements.percentage.value"
-                                ),
-                            },
-                            "name": "reduced",
-                        }
-                    ],
+                    "measures": [{"fn": "min", "path": key, "name": "reduced"}],
                 }
             }
         )
@@ -3542,6 +3546,54 @@ def test_a_pivoted_reduction_answers_what_the_projection_answers(
         projected, structured, resolver={}.__getitem__, pivots_dir=str(pivots)
     ) as pivoted:
         assert _reduced_per_reaction(pivoted, reducer) == expected
+
+
+@pytest.mark.parametrize("reducer", ["min", "max", "avg", "sum", "count"])
+def test_a_filtered_reduction_answers_the_same_on_either_route(
+    wide_root, tmp_path, reducer
+):
+    # The filter narrows the same elements whichever relation holds them, and the
+    # wide corpus records measurements that are not yields for exactly this.
+    pivots = _write_pivots(
+        wide_root, ("outcomes.products.measurements",), into=tmp_path / "pivots"
+    )
+    projected = str(wide_root / "projections" / "*.parquet")
+    structured = str(wide_root / "structures" / "*.parquet")
+    where = {"op": "eq", "path": "type", "value": {"literal": "YIELD"}}
+    with execute.Corpus(
+        projected, structured, resolver={}.__getitem__, pivot_budget_bytes=0
+    ) as lists:
+        expected = _reduced_per_reaction(lists, reducer, where)
+    with execute.Corpus(
+        projected,
+        structured,
+        resolver={}.__getitem__,
+        pivots_dir=str(pivots),
+        pivot_budget_bytes=0,
+    ) as pivoted:
+        assert _reduced_per_reaction(pivoted, reducer, where) == expected
+
+
+@pytest.mark.parametrize("pivoted", [False, True])
+def test_a_filter_changes_which_elements_are_reduced(wide_root, tmp_path, pivoted):
+    # The point of the filter, and the reason the bare path is the wrong question:
+    # ord-wd08 records a selectivity percentage beside its yield, so counting every
+    # percentage counts two where the yield is one, and the highest is the selectivity.
+    pivots = _write_pivots(
+        wide_root, ("outcomes.products.measurements",), into=tmp_path / "pivots"
+    )
+    yields = {"op": "eq", "path": "type", "value": {"literal": "YIELD"}}
+    with execute.Corpus(
+        str(wide_root / "projections" / "*.parquet"),
+        str(wide_root / "structures" / "*.parquet"),
+        resolver={}.__getitem__,
+        pivots_dir=str(pivots) if pivoted else None,
+        pivot_budget_bytes=0,
+    ) as corpus:
+        assert _reduced_per_reaction(corpus, "count")["ord-wd08"] == 2
+        assert _reduced_per_reaction(corpus, "count", yields)["ord-wd08"] == 1
+        assert _reduced_per_reaction(corpus, "max")["ord-wd08"] == 95
+        assert _reduced_per_reaction(corpus, "max", yields)["ord-wd08"] == 40
 
 
 @pytest.mark.parametrize("pivoted", [False, True])
@@ -3777,7 +3829,7 @@ def test_a_level_without_artifacts_is_still_built(wide_root, caplog):
                 },
             },
         )
-    assert found == {"ord-wd01", "ord-wd02", "ord-wd07"}
+    assert found == {"ord-wd01", "ord-wd02", "ord-wd07", "ord-wd08"}
     assert any(
         "building the pivot over outcomes.products.measurements" in record.message
         for record in caplog.records

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -3574,6 +3574,57 @@ def test_a_filtered_reduction_answers_the_same_on_either_route(
         assert _reduced_per_reaction(pivoted, reducer, where) == expected
 
 
+def test_a_reduction_filter_may_screen_structures(deep_root, tmp_path):
+    # A structure test reads structure_offset, which the reactions carry and a pivot
+    # row does not. Inside the correlated subquery the unqualified name resolves to the
+    # outer relation, which is the offset that makes the element's dataset-local
+    # structure_id corpus-wide; getting that wrong screens against another file's
+    # molecules and answers plausibly.
+    pivots = _write_pivots(deep_root, ("inputs.components",), into=tmp_path / "pivots")
+    counted = {
+        "aggregate": {
+            "group_by": ["reaction_id"],
+            "measures": [
+                {
+                    "fn": "min",
+                    "path": {
+                        "reduce": "count",
+                        "path": "inputs.components.reaction_role",
+                        "where": {
+                            "op": "substructure",
+                            "path": "smiles",
+                            "smarts": "[OX2H]",
+                        },
+                    },
+                    "name": "alcohols",
+                }
+            ],
+        }
+    }
+    answers = {}
+    for pivots_dir in (None, str(pivots)):
+        with execute.Corpus(
+            str(deep_root / "projections" / "*.parquet"),
+            str(deep_root / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=pivots_dir,
+            pivot_budget_bytes=0,
+        ) as corpus:
+            for smarts in ("[OX2H]", "[n]"):
+                counted["aggregate"]["measures"][0]["path"]["where"]["smarts"] = smarts
+                table = corpus.search(query.Query.model_validate(counted))
+                answers[pivots_dir is not None, smarts] = {
+                    row["reaction_id"]: row["alcohols"] for row in table.to_pylist()
+                }
+    # Every input here is ethanol, and the pyridine is a workup's. So the alcohol
+    # screen keeps both -- an agreement on zeros would say nothing about the offset --
+    # and the aromatic-nitrogen screen keeps neither, which is what a dropped filter
+    # could not produce.
+    for pivoted in (False, True):
+        assert answers[pivoted, "[OX2H]"] == {"ord-cc01": 1, "ord-cc02": 1}
+        assert answers[pivoted, "[n]"] == {"ord-cc01": 0, "ord-cc02": 0}
+
+
 @pytest.mark.parametrize("pivoted", [False, True])
 def test_a_filter_changes_which_elements_are_reduced(wide_root, tmp_path, pivoted):
     # The point of the filter, and the reason the bare path is the wrong question:

--- a/ord_schema/search/nl_prompt.md
+++ b/ord_schema/search/nl_prompt.md
@@ -75,9 +75,21 @@ Rules that keep a query answerable:
   A metal named as a catalyst is a `substructure` on the element — `[Pd]`, `[Ni]` —
   rather than a compound identity, since the catalyst is a complex and not the bare
   metal.
-- To rank or aggregate by a value under a repeated level, reduce it:
-  `{"reduce": "max", "path": "outcomes.products.measurements.percentage.value"}` is a
-  reaction's best yield. A plain path there is refused.
+- To rank or aggregate by a value under a repeated level, reduce it. A plain path there
+  is refused. `where` inside the reduction says which elements count, and its paths are
+  relative to the element, as they are inside a quantifier. Reach for it whenever the
+  column is shared by things the question does not mean: a percentage is recorded for
+  selectivity and purity as well as yield, so the bare path is "the highest percentage"
+  and only the filter makes it "the highest yield".
+
+  ```json
+  {"reduce": "max", "path": "outcomes.products.measurements.percentage.value",
+   "where": {"op": "eq", "path": "type", "value": {"literal": "YIELD"}}}
+  ```
+
+  Counting one reduces to zero for a reaction with no such element, so an average over
+  reductions includes those zeros. "Among reactions that have at least one" is a
+  different question, and it wants the query's own `where` to say so.
 - Enum columns compare against the spellings listed beside them, which are the value
   names rather than numbers.
 - "The most common X", "how many of each X", and anything else that groups by something

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -609,13 +609,24 @@ class Reduction(_Node):
     that list to the one value the reaction is judged by, leaving the aggregate to
     combine those across reactions.
 
+    ``where`` selects which elements are reduced, and is what separates "the highest
+    yield" from "the highest percentage anything was measured at": a percentage is
+    recorded for selectivity and purity too, so a reduction over the bare path answers
+    a broader question than the one asked. Its paths are relative to the element, as
+    they are inside a quantifier, and the element is the deepest repeated level the
+    path crosses -- for
+    ``outcomes.products.measurements.percentage.value`` that is a measurement, so
+    ``type`` there means the measurement's own.
+
     Attributes:
         reduce: How to reduce the list. ``count`` counts the values that are present.
         path: A dotted path crossing at least one repeated level.
+        where: Selects the elements to reduce; all of them when absent.
     """
 
     reduce: Literal["min", "max", "avg", "sum", "count"]
     path: str
+    where: "Predicate | None" = None
 
 
 class Measure(_Node):
@@ -1195,8 +1206,36 @@ def _check_numeric(path: str, leaf: pa.DataType, what: str) -> None:
         raise QueryError(f"{path}: {what} needs a numeric column, not {leaf}")
 
 
+def _reduced_element(reduction: Reduction) -> tuple[Any, tuple[str, ...], Any]:
+    """Returns the level a reduction's elements come from, and the descent past it.
+
+    Args:
+        reduction: What to reduce, and how.
+
+    Returns:
+        The level, the segments from its element down to the reduced value, and that
+        element's type.
+
+    Raises:
+        QueryError: If no repeated level covers the path, which leaves a ``where``
+            nothing to bind its paths to.
+    """
+    reached = pivot_levels.reach(reduction.path)
+    if reached is None:
+        raise QueryError(
+            f"{reduction.path}: a reduction's where selects among the elements of a "
+            "repeated level, and this path crosses none this grammar names"
+        )
+    level, remainder, _ = reached
+    return level, remainder, level.element_type
+
+
 def _pivoted_reduction(
-    reduction: Reduction, table: str, pivot: PivotIndex | None
+    reduction: Reduction,
+    table: str,
+    compounds: list[str],
+    structures: list["StructureParameter"],
+    routing: "_Routing",
 ) -> str | None:
     """Returns the reduction as an aggregate over a pivot, where one covers the path.
 
@@ -1208,44 +1247,98 @@ def _pivoted_reduction(
     Args:
         reduction: What to reduce, and how.
         table: The relation of reactions the subquery correlates to.
-        pivot: Pivoted levels, or None where the caller holds none.
+        compounds: Compound names collected so far, appended to as they are met.
+        structures: Structure parameters collected so far, appended to as they are met.
+        routing: Where a filter's own clauses may be answered. See ``_Routing``.
 
     Returns:
         A correlated scalar subquery over the pivot, or None where no pivot covers the
         path and the projection has to answer it.
     """
-    if pivot is None:
+    if routing.pivot is None:
         return None
     reached = pivot_levels.reach(reduction.path)
     if reached is None:
         return None
     level, remainder, _ = reached
-    relation = pivot(level.path)
+    relation = routing.pivot(level.path)
     if relation is None:
         return None
     column = ".".join([_REDUCTION_ALIAS, pivot_levels.ELEMENT, *remainder])
+    condition = (
+        f"{_REDUCTION_ALIAS}.{pivot_levels.REACTION_ID} = "
+        f"{table}.{pivot_levels.REACTION_ID}"
+    )
+    if reduction.where is not None:
+        condition += " AND " + _predicate(
+            reduction.where,
+            f"{_REDUCTION_ALIAS}.{pivot_levels.ELEMENT}",
+            level.element_type,
+            compounds,
+            structures,
+            1,
+            routing,
+        )
     return (
         f"(SELECT {_AGGREGATES[reduction.reduce]}({column}) "  # noqa: S608
-        f"FROM {relation} AS {_REDUCTION_ALIAS} WHERE "
-        f"{_REDUCTION_ALIAS}.{pivot_levels.REACTION_ID} = "
-        f"{table}.{pivot_levels.REACTION_ID})"
+        f"FROM {relation} AS {_REDUCTION_ALIAS} WHERE {condition})"
     )
+
+
+def _filtered_elements(
+    reduction: Reduction,
+    schema: pa.Schema,
+    compounds: list[str],
+    structures: list["StructureParameter"],
+    routing: "_Routing",
+) -> str:
+    """Returns the projection's list of reduced values, narrowed to matching elements.
+
+    Args:
+        reduction: What to reduce, and how. Its ``where`` is compiled here.
+        schema: Schema the level's own path resolves against.
+        compounds: Compound names collected so far, appended to as they are met.
+        structures: Structure parameters collected so far, appended to as they are met.
+        routing: Where a filter's own clauses may be answered. See ``_Routing``.
+
+    Returns:
+        A DuckDB list expression holding the values the reducer combines.
+    """
+    level, remainder, element_type = _reduced_element(reduction)
+    elements = resolve(level.path, schema=schema)
+    body = _predicate(
+        reduction.where,
+        _REDUCTION_ALIAS,
+        element_type,
+        compounds,
+        structures,
+        1,
+        routing,
+    )
+    expression = f"list_filter({elements.expression}, {_REDUCTION_ALIAS} -> {body})"
+    for segment in remainder:
+        expression = f"list_transform({expression}, x -> x.{segment})"
+    return expression
 
 
 def _reduced(
     reduction: Reduction,
     schema: pa.Schema,
     *,
-    table: str = TABLE,
-    pivot: PivotIndex | None = None,
+    compounds: list[str] | None = None,
+    structures: list["StructureParameter"] | None = None,
+    routing: "_Routing | None" = None,
 ) -> str:
     """Returns the expression reducing a repeated path to one value per reaction.
 
     Args:
         reduction: What to reduce, and how.
         schema: Schema the path resolves against.
-        table: The relation of reactions, which a pivoted reduction correlates to.
-        pivot: Pivoted levels to read the elements from, where one covers the path.
+        compounds: Compound names collected so far, appended to as a ``where`` meets
+            them; a fresh list where the caller compiles no filter.
+        structures: Structure parameters, collected the same way.
+        routing: Where the elements may be read besides the projection's lists, and
+            the relation a pivoted reduction correlates to. See ``_Routing``.
 
     Returns:
         A DuckDB expression yielding one scalar per reaction. An arithmetic reducer
@@ -1254,9 +1347,13 @@ def _reduced(
 
     Raises:
         QueryError: If the path is already scalar, which needs no reduction (accepting
-            one would give the same query two spellings), or if an arithmetic reducer
-            reaches a leaf that does not hold numbers.
+            one would give the same query two spellings), if an arithmetic reducer
+            reaches a leaf that does not hold numbers, or if a ``where`` quantifies
+            over a level of its own.
     """
+    collected_compounds = [] if compounds is None else compounds
+    collected_structures = [] if structures is None else structures
+    where_to_look = _Routing(TABLE) if routing is None else routing
     resolved = resolve(reduction.path, schema=schema)
     if not resolved.repeated:
         raise QueryError(
@@ -1265,10 +1362,30 @@ def _reduced(
         )
     if reduction.reduce in _ARITHMETIC:
         _check_numeric(reduction.path, resolved.type, reduction.reduce)
-    pivoted = _pivoted_reduction(reduction, table, pivot)
+    if reduction.where is not None:
+        level, _, _ = _reduced_element(reduction)
+        _refuse_quantified(reduction.where, level.path, "a reduction's where")
+    pivoted = _pivoted_reduction(
+        reduction,
+        where_to_look.table,
+        collected_compounds,
+        collected_structures,
+        where_to_look,
+    )
     if pivoted is not None:
         return pivoted
-    return _REDUCERS[reduction.reduce].format(expression=resolved.expression)
+    expression = (
+        resolved.expression
+        if reduction.where is None
+        else _filtered_elements(
+            reduction,
+            schema,
+            collected_compounds,
+            collected_structures,
+            where_to_look,
+        )
+    )
+    return _REDUCERS[reduction.reduce].format(expression=expression)
 
 
 def _measure_argument(
@@ -1276,8 +1393,9 @@ def _measure_argument(
     schema: pa.Schema,
     element: str | None = None,
     *,
-    table: str = TABLE,
-    pivot: PivotIndex | None = None,
+    compounds: list[str] | None = None,
+    structures: list["StructureParameter"] | None = None,
+    routing: "_Routing | None" = None,
 ) -> str:
     """Returns the expression a measure aggregates over.
 
@@ -1287,8 +1405,11 @@ def _measure_argument(
         element: The bound element paths are relative to, for an aggregate over a
             repeated level; None where the rows are reactions. A ``Reduction`` needs
             none, since a level's elements hold no list to reduce.
-        table: The relation of reactions, which a pivoted reduction correlates to.
-        pivot: Pivoted levels to read a reduction's elements from.
+        compounds: Compound names collected so far, appended to as a reduction's
+            ``where`` meets them.
+        structures: Structure parameters, collected the same way.
+        routing: Where a reduction's elements may be read besides the projection's
+            lists. See ``_Routing``.
 
     Returns:
         ``*`` for a bare count, a reduced expression where the path crosses a repeated
@@ -1306,7 +1427,13 @@ def _measure_argument(
                 f"{measure.path.path}: a reduction reads a reaction's own elements, "
                 "and this aggregate's rows are already elements"
             )
-        argument = _reduced(measure.path, schema, table=table, pivot=pivot)
+        argument = _reduced(
+            measure.path,
+            schema,
+            compounds=compounds,
+            structures=structures,
+            routing=routing,
+        )
     elif element is not None and measure.path == pivot_levels.REACTION_ID:
         # The one path a pivot row carries outside its element, and what makes a count
         # of elements answerable as a count of reactions.
@@ -1324,33 +1451,38 @@ def _measure_argument(
     return f"DISTINCT {argument}" if measure.fn == "count_distinct" else argument
 
 
-def _refuse_quantified(node: "Predicate", over: str | None) -> None:
-    """Raises where an aggregate's element filter tries to bind elements of its own.
+def _refuse_quantified(
+    node: "Predicate", over: str | None, what: str = "aggregate.where"
+) -> None:
+    """Raises where an element filter tries to bind elements of its own.
 
     A pivot carries an element's non-repeated fields and drops the rest, so a quantifier
     here resolves against a type missing the level it names and fails saying the field
     does not exist -- which is confusing where the field plainly does, one level up in
-    the projection. Said once, here, in terms of what the rows are.
+    the projection. Said once, here, in terms of what the rows are. Refused whichever
+    route reads the elements, so that a filter compiling at all does not depend on
+    whether the corpus holds the pivot.
 
     Args:
         node: The element filter, or a clause within it.
-        over: The level being grouped, named in the message.
+        over: The level whose elements are filtered, named in the message.
+        what: The clause doing the filtering, named in the message.
 
     Raises:
         QueryError: If the filter quantifies over anything.
     """
     if isinstance(node, Quantifier):
         raise QueryError(
-            f"{node.path}: aggregate.where selects among the elements of {over}, and "
+            f"{node.path}: {what} selects among the elements of {over}, and "
             "a pivot carries their non-repeated fields only, so there is no level "
             "here to quantify over; a condition on the reaction is the query's own "
             "where"
         )
     for clause in getattr(node, "clauses", []):
-        _refuse_quantified(clause, over)
+        _refuse_quantified(clause, over, what)
     inner = getattr(node, "clause", None)
     if inner is not None:
-        _refuse_quantified(inner, over)
+        _refuse_quantified(inner, over, what)
 
 
 def _element_relation(
@@ -1473,7 +1605,12 @@ def compile_query(
         selected = list(groups)
         for measure in query.aggregate.measures:
             argument = _measure_argument(
-                measure, element_schema, alias, table=table, pivot=pivot
+                measure,
+                element_schema,
+                alias,
+                compounds=compounds,
+                structures=structures,
+                routing=_Routing(table, index, pivot),
             )
             selected.append(f"{_AGGREGATES[measure.fn]}({argument}) AS {measure.name}")
         names = {measure.name for measure in query.aggregate.measures}
@@ -1548,7 +1685,13 @@ def compile_query(
                         "an aggregated query orders by a measure name or a group_by "
                         "path; reduce inside a measure instead"
                     )
-                key = _reduced(order.key, schema, table=table, pivot=pivot)
+                key = _reduced(
+                    order.key,
+                    schema,
+                    compounds=compounds,
+                    structures=structures,
+                    routing=_Routing(table, index, pivot),
+                )
             elif orderable is None:
                 key = _scalar(order.key, schema, "order_by").expression
             elif order.key in orderable:

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -17,6 +17,7 @@
 import warnings
 
 import duckdb
+import pyarrow as pa
 import pytest
 from pydantic import ValidationError
 from rdkit import Chem
@@ -1291,6 +1292,117 @@ def test_a_measure_reduces_over_the_pivot_too():
         pivot=_every_level,
     )
     assert "avg((SELECT count(r0.element.percentage.value)" in sql
+
+
+# Reducing only the elements a filter keeps
+
+_YIELD = {"op": "eq", "path": "type", "value": {"literal": "YIELD"}}
+
+
+def _filtered(where=None, reducer="count"):
+    key = {
+        "reduce": reducer,
+        "path": "outcomes.products.measurements.percentage.value",
+    }
+    if where is not None:
+        key["where"] = where
+    return {"order_by": [{"key": key}]}
+
+
+def test_a_filtered_reduction_narrows_the_pivot_subquery():
+    sql = _pivot_sql(_filtered(_YIELD), pivot=_every_level)
+    assert (
+        "WHERE r0.reaction_id = reactions.reaction_id AND r0.element.type = 'YIELD'"
+    ) in sql
+
+
+def test_a_filtered_reduction_narrows_the_list_before_reducing():
+    # The filter binds the element, so it has to apply before the descent to the leaf:
+    # filtering percentages could not see the type the question asks about.
+    sql = _pivot_sql(_filtered(_YIELD))
+    assert "list_filter(flatten(" in sql
+    assert "r0 -> r0.type = 'YIELD'" in sql
+    assert sql.index("list_filter(flatten(") < sql.index("x -> x.percentage")
+
+
+def test_an_unfiltered_reduction_reduces_every_element():
+    # count filters the nulls whether or not a where narrows the elements, so the tell
+    # is the bound variable rather than the presence of a list_filter.
+    assert "r0 ->" not in _pivot_sql(_filtered())
+
+
+def test_a_reduction_filter_may_name_a_compound():
+    # The filter's own clauses collect parameters like any other predicate; a name
+    # reaching the SQL unbound is an error rather than a wasted parameter.
+    compiled = query.compile_query(
+        query.Query.model_validate(
+            {
+                "order_by": [
+                    {
+                        "key": {
+                            "reduce": "count",
+                            "path": "inputs.components.amount.moles_moles",
+                            "where": {
+                                "op": "eq",
+                                "path": "smiles",
+                                "value": {"compound": "thf"},
+                            },
+                        }
+                    }
+                ]
+            }
+        )
+    )
+    assert compiled.compounds == ("thf",)
+    assert "$thf" in compiled.sql
+
+
+@pytest.mark.parametrize("pivoted", [False, True])
+def test_a_reduction_filter_cannot_quantify(pivoted):
+    # Refused on both routes, so whether a filter compiles at all does not depend on
+    # what artifacts the corpus happens to hold.
+    with pytest.raises(query.QueryError, match="no level here to quantify over"):
+        _pivot_sql(
+            _filtered(
+                {
+                    "op": "exists",
+                    "path": "identifiers",
+                    "where": {"op": "not_null", "path": "value"},
+                }
+            ),
+            pivot=_every_level if pivoted else None,
+        )
+
+
+def test_a_reduction_filter_needs_a_level_to_bind_to():
+    # Every repeated path the projection holds reaches a named level, so this is only
+    # reachable through a caller-supplied schema -- but a filter with nothing to bind
+    # its paths to has to say so rather than resolve them against the row.
+    schema = pa.schema(
+        [
+            pa.field("reaction_id", pa.string()),
+            pa.field(
+                "readings", pa.list_(pa.struct([pa.field("value", pa.float64())]))
+            ),
+        ]
+    )
+    with pytest.raises(query.QueryError, match="crosses none this grammar names"):
+        query.compile_query(
+            query.Query.model_validate(
+                {
+                    "order_by": [
+                        {
+                            "key": {
+                                "reduce": "count",
+                                "path": "readings.value",
+                                "where": {"op": "not_null", "path": "value"},
+                            }
+                        }
+                    ]
+                }
+            ),
+            schema=schema,
+        )
 
 
 # Comparing compounds rather than spellings


### PR DESCRIPTION
## Summary

A `Reduction` took a bare path, which made "the highest yield" unwritable. A percentage is recorded for selectivity, purity, and area as well, and 42,909 of the corpus's 1,671,639 percentage-valued measurements are not yields — so the bare path answered "the highest percentage anything was measured at" while reading exactly like the question asked. `where` now selects which elements are reduced, with paths relative to the element as inside a quantifier.

Stacked on #1027, which is where the pivot route came from.

## Changes

- `Reduction.where`, compiled on both routes: the pivot subquery gains a conjunct, the list route filters the elements before descending to the leaf — filtering percentages could not see the `type` the question asks about.
- Quantifying inside it is refused on both routes. The pivot carries an element's non-repeated fields only, and whether a filter compiles at all should not depend on which artifacts a corpus holds. `_refuse_quantified` is the same guard `aggregate.where` uses, generalized to name the clause.
- The prompt's reduction rule taught the bare path as "a reaction's best yield", which is the mistake this fixes; it now says when to reach for the filter and what a `count` of nothing means.
- A `filtered_reduction` canonical query and its baseline entry, plus a coverage test holding the canonical set to every field of a `Reduction` the way the operator list is already held.

## Testing

- `pytest -n auto` — 1685 passed.
- Measured on the full corpus, both routes agreeing to the last digit: **0.670** yield measurements per reaction over every reaction, **1.489** over the reactions that record at least one, and the same highest yield. The pivot route runs them in 0.15s, 0.13s, and 0.08s against 5.83s, 2.16s, and 1.79s for the lists.
- A differential test derives the pivot and asserts all five reducers answer identically filtered, per reaction, with and without it.
- The wide fixture gains `ord-wd08`, which records a selectivity percentage beside its yield — the shape the whole feature exists for. Counting every percentage there gives 2 where the yield is 1, and the maximum is 95 against the yield's 40.
- A structure predicate inside the filter reads `structure_offset`, which the reactions carry and a pivot row does not; both routes agree on the deep corpus, asserting a SMARTS that keeps every input and one that keeps none.
- Mutation-checked, every guard: dropping the filter from the pivot route fails 6 tests, dropping it from the list route fails 7, removing the quantifier refusal fails exactly the two that assert it, and removing `where` from the canonical query fails the coverage test. Against the full corpus with the pivot conjunct disabled, `check` reports `FAIL answers unchanged: filtered_reduction` and 26/27; restored, 27/27.

## Notes

- `Reduction.where` needs a named repeated level to bind its paths to. Every repeated path the projection holds reaches one, so that refusal is only reachable through a caller-supplied `schema` — which is how it is tested.
- The first `filtered_reduction` canonical query ordered by a filtered `max` and produced a digest identical to `reduction_ordering`'s: every ordering over that path answers the same 25 reactions whatever the reducer and whatever the filter, because the top is held by percentages recorded as 9.0e19 that are already yields. It is an average of a filtered count instead, which moves.
- #1026's two eval cases are what this unblocks; they go back to asking about yields once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends reductions with an element-relative `where` predicate so callers can reduce only matching repeated elements, such as yield measurements rather than every percentage-valued measurement.

- Compiles filtered reductions consistently over nested projection lists and pivot relations.
- Rejects nested quantifiers inside reduction filters to keep behavior independent of available artifacts.
- Propagates compound and structure parameters discovered by reduction predicates.
- Updates the structured-query documentation and natural-language prompt.
- Adds canonical corpus coverage and route-equivalence tests, including structure filtering with corpus-wide structure offsets.
- The previous canonical-validation coverage finding is fully addressed by the new filtered reduction query, baseline digest, and reduction-field coverage assertion.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; no actionable new failures remain, and the previous validation-coverage concern is fully fixed.

The filtered reduction is now represented in canonical corpus validation and its baseline, while tests exercise both projection and pivot compilation, all reducers, structure-offset handling, and route-independent rejection behavior. No outstanding previous finding or accepted new issue remains.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/query.py | Adds element-filtered reductions on both execution routes, parameter propagation, and route-independent quantifier validation. |
| ord_schema/search/execute_test.py | Adds differential coverage for every reducer, mixed percentage types, and structure filtering across projection and pivot routes. |
| ord_schema/search/check.py | Adds a canonical filtered-reduction query whose digest exercises the new behavior. |
| ord_schema/search/check_test.py | Ensures every Reduction model field appears in the canonical validation queries. |
| ord_schema/search/corpus_baseline.json | Records the expected result digest for the canonical filtered-reduction query. |
| ord_schema/search/query_test.py | Covers SQL generation, parameter collection, filtering order, and invalid reduction-filter forms. |
| ord_schema/search/nl_prompt.md | Teaches natural-language translation to distinguish filtered yield reductions from unfiltered percentage reductions. |
| ord_schema/search/README.md | Documents Reduction.where semantics, restrictions, and clarified route-performance measurements. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Q[Reduction with optional where] --> V[Validate path and filter]
    V --> R{Matching pivot available?}
    R -->|Yes| P[Correlated pivot subquery]
    R -->|No| L[Projection list expression]
    P --> PF[Apply where to pivot elements]
    L --> LF[Filter repeated elements before leaf descent]
    PF --> A[Apply reduction aggregate]
    LF --> A
    A --> S[One scalar value per reaction]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Screen structures inside a reduction&#39;s f..."](https://github.com/open-reaction-database/ord-schema/commit/eb1fb2665a295939f67aca7f696b54a4c14eb266) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60848767)</sub>

**Context used:**

- Knowledge Base — [Structured reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/structured-reaction-search.md)
- Knowledge Base — [Database access and reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/database-and-search.md)

<!-- /greptile_comment -->