### PR TITLE
Compare a date against the column that holds one

### DIFF
--- a/ord_schema/search/check.py
+++ b/ord_schema/search/check.py
@@ -217,6 +217,27 @@ QUERIES: list[dict[str, Any]] = [
         },
     },
     {
+        "name": "temporal_range",
+        "covers": "an ordered comparison against a typed timestamp, at both ends",
+        "query": {
+            "where": {
+                "op": "and",
+                "clauses": [
+                    {
+                        "op": "ge",
+                        "path": "provenance.record_created.time.timestamp",
+                        "value": {"literal": "2020-01-01"},
+                    },
+                    {
+                        "op": "lt",
+                        "path": "provenance.record_created.time.timestamp",
+                        "value": {"literal": "2021-01-01"},
+                    },
+                ],
+            }
+        },
+    },
+    {
         "name": "aggregate_grouping",
         "covers": "GROUP BY with a measure",
         "query": {

--- a/ord_schema/search/check.py
+++ b/ord_schema/search/check.py
@@ -217,27 +217,6 @@ QUERIES: list[dict[str, Any]] = [
         },
     },
     {
-        "name": "temporal_range",
-        "covers": "an ordered comparison against a typed timestamp, at both ends",
-        "query": {
-            "where": {
-                "op": "and",
-                "clauses": [
-                    {
-                        "op": "ge",
-                        "path": "provenance.record_created.time.timestamp",
-                        "value": {"literal": "2020-01-01"},
-                    },
-                    {
-                        "op": "lt",
-                        "path": "provenance.record_created.time.timestamp",
-                        "value": {"literal": "2021-01-01"},
-                    },
-                ],
-            }
-        },
-    },
-    {
         "name": "aggregate_grouping",
         "covers": "GROUP BY with a measure",
         "query": {

--- a/ord_schema/search/nl_cases.json
+++ b/ord_schema/search/nl_cases.json
@@ -560,6 +560,31 @@
     }
   },
   {
+    "question": "reactions recorded in 2025",
+    "why": "a year is a half-open pair of comparisons against the typed timestamp; a single equality, or a text match on the recorded spelling, answers a fraction of it and reads as if it answered all of it",
+    "reference": {
+      "where": {
+        "op": "and",
+        "clauses": [
+          {
+            "op": "ge",
+            "path": "provenance.record_created.time.timestamp",
+            "value": {
+              "literal": "2025-01-01"
+            }
+          },
+          {
+            "op": "lt",
+            "path": "provenance.record_created.time.timestamp",
+            "value": {
+              "literal": "2026-01-01"
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
     "question": "reactions published in the last five years",
     "why": "no date arithmetic and no notion of today: a translation that hardcodes a year looks right and rots",
     "compiles": false

--- a/ord_schema/search/nl_prompt.md
+++ b/ord_schema/search/nl_prompt.md
@@ -92,6 +92,11 @@ Rules that keep a query answerable:
   different question, and it wants the query's own `where` to say so.
 - Enum columns compare against the spellings listed beside them, which are the value
   names rather than numbers.
+- A `TIMESTAMP` column compares against an ISO date or timestamp written as a string:
+  `{"literal": "2025-01-01"}`. A bare date means that day's midnight, so a year is a
+  half-open pair — `ge` its January 1 and `lt` the next year's. The grammar has no date
+  arithmetic and no notion of today, so a question about "the last five years" or
+  "recently" cannot be written; decline it rather than hardcoding a year.
 - "The most common X", "how many of each X", and anything else that groups by something
   under a repeated level needs `aggregate.over`, which makes the rows the elements of
   that level rather than reactions. `group_by` and measure paths are then relative to

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -58,6 +58,7 @@ local and only the executor knows the offsets that make them one corpus-wide spa
 """
 
 import dataclasses
+import datetime
 import difflib
 import re
 import warnings
@@ -144,6 +145,30 @@ def executable_schema(schema: pa.Schema | None = None) -> pa.Schema:
 
 _COMPARISONS = {"eq": "=", "ne": "<>", "lt": "<", "le": "<=", "gt": ">", "ge": ">="}
 _ORDERED = frozenset({"lt", "le", "gt", "ge"})
+
+
+def _is_temporal(leaf: pa.DataType) -> bool:
+    """Returns whether ``leaf`` holds an instant or a day rather than a number."""
+    return pa.types.is_timestamp(leaf) or pa.types.is_date(leaf)
+
+
+def _parsed_instant(literal: str) -> datetime.datetime | None:
+    """Returns the instant an ISO literal names, or None where it is not one.
+
+    Args:
+        literal: The string the query compares a temporal column against.
+
+    Returns:
+        The parsed value, with a bare date reading as that day's midnight so a query
+        for a day compares against the first instant of it. None where the string is
+        not ISO 8601, which the caller refuses where the query is compiled.
+    """
+    try:
+        return datetime.datetime.fromisoformat(literal)
+    except ValueError:
+        return None
+
+
 _TEXT = {"contains": "contains", "starts_with": "starts_with", "ends_with": "ends_with"}
 _AGGREGATES = {
     "count": "count",
@@ -701,13 +726,37 @@ class Query(_Node):
     limit: int | None = Field(default=None, gt=0)
 
 
-def _literal(value: Value, compounds: list[str]) -> str:
-    """Returns the SQL for a value, recording a compound that needs binding."""
+def _literal(
+    value: Value, compounds: list[str], leaf: pa.DataType | None = None
+) -> str:
+    """Returns the SQL for a value, recording a compound that needs binding.
+
+    Args:
+        value: The literal or compound name to compile.
+        compounds: Compound names collected so far, appended to when this is one.
+        leaf: The type it is compared against, which types a temporal literal. Without
+            it a string compiles as text, which is what every non-temporal column wants.
+
+    Returns:
+        The SQL operand.
+    """
     if value.compound is not None:
         if value.compound not in compounds:
             compounds.append(value.compound)
         return f"${value.compound}"
     if isinstance(value.literal, str):
+        if leaf is not None and _is_temporal(leaf):
+            # Typed rather than quoted, so the comparison is between instants. A string
+            # beside a TIMESTAMP casts in DuckDB, but the same string beside a DATE
+            # compares as text and answers by spelling.
+            instant = _parsed_instant(value.literal)
+            if instant is None:
+                raise QueryError(
+                    f"{value.literal!r} is not an ISO 8601 date or timestamp"
+                )
+            if pa.types.is_date(leaf):
+                return f"DATE '{instant.date().isoformat()}'"
+            return f"TIMESTAMP '{instant.isoformat(sep=' ')}'"
         escaped = value.literal.replace("'", "''")
         return f"'{escaped}'"
     if isinstance(value.literal, bool):
@@ -729,15 +778,24 @@ def _check_operand(node: Comparison, resolved: _Resolved) -> None:
     if node.op in _TEXT and not pa.types.is_string(leaf):
         raise QueryError(f"{node.path}: {node.op} needs a text column, not {leaf}")
     if node.op in _ORDERED and not (
-        pa.types.is_integer(leaf) or pa.types.is_floating(leaf)
+        pa.types.is_integer(leaf) or pa.types.is_floating(leaf) or _is_temporal(leaf)
     ):
-        raise QueryError(f"{node.path}: {node.op} needs a numeric column, not {leaf}")
+        raise QueryError(
+            f"{node.path}: {node.op} needs a numeric or temporal column, not {leaf}"
+        )
     if node.value.compound is not None and not pa.types.is_string(leaf):
         raise QueryError(f"{node.path}: a compound compares against text, not {leaf}")
     literal = node.value.literal
     if literal is None:
         return
-    if isinstance(literal, str) and not pa.types.is_string(leaf):
+    if isinstance(literal, str) and _is_temporal(leaf):
+        # Parsed here rather than left to _literal, so the path is in the message.
+        if _parsed_instant(literal) is None:
+            raise QueryError(
+                f"{node.path}: holds {leaf}, compared against {literal!r}, which is "
+                "not an ISO 8601 date or timestamp"
+            )
+    elif isinstance(literal, str) and not pa.types.is_string(leaf):
         raise QueryError(f"{node.path}: holds {leaf}, compared against a string")
     if isinstance(literal, bool) and not pa.types.is_boolean(leaf):
         raise QueryError(f"{node.path}: holds {leaf}, compared against a boolean")
@@ -755,7 +813,7 @@ def _leaf(node: Any, resolved: _Resolved, compounds: list[str]) -> str:
         keyword = "NULL" if node.op == "is_null" else "NOT NULL"
         return f"{resolved.expression} IS {keyword}"
     _check_operand(node, resolved)
-    operand = _literal(node.value, compounds)
+    operand = _literal(node.value, compounds, resolved.type)
     if node.op in _TEXT:
         return f"{_TEXT[node.op]}({resolved.expression}, {operand})"
     return f"{resolved.expression} {_COMPARISONS[node.op]} {operand}"

--- a/ord_schema/search/query.py
+++ b/ord_schema/search/query.py
@@ -160,8 +160,10 @@ def _parsed_instant(literal: str) -> datetime.datetime | None:
 
     Returns:
         The parsed value, with a bare date reading as that day's midnight so a query
-        for a day compares against the first instant of it. None where the string is
-        not ISO 8601, which the caller refuses where the query is compiled.
+        for a day compares against the first instant of it. Aware where the literal
+        carries an offset, which the caller refuses rather than compares against a
+        column holding no zone. None where the string is not ISO 8601, refused the same
+        way.
     """
     try:
         return datetime.datetime.fromisoformat(literal)
@@ -790,10 +792,21 @@ def _check_operand(node: Comparison, resolved: _Resolved) -> None:
         return
     if isinstance(literal, str) and _is_temporal(leaf):
         # Parsed here rather than left to _literal, so the path is in the message.
-        if _parsed_instant(literal) is None:
+        instant = _parsed_instant(literal)
+        if instant is None:
             raise QueryError(
                 f"{node.path}: holds {leaf}, compared against {literal!r}, which is "
                 "not an ISO 8601 date or timestamp"
+            )
+        if instant.tzinfo is not None:
+            # The column holds no zone, because no shape the projection reads carries
+            # one: a value that does is left unparsed rather than read as a wall clock.
+            # DuckDB drops the offset from a TIMESTAMP literal rather than shifting by
+            # it, so accepting one here would compare the caller's wall clock while
+            # reading as though it compared their instant.
+            raise QueryError(
+                f"{node.path}: holds {leaf}, which records no time zone, and "
+                f"{literal!r} carries an offset; give the instant without one"
             )
     elif isinstance(literal, str) and not pa.types.is_string(leaf):
         raise QueryError(f"{node.path}: holds {leaf}, compared against a string")

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -794,6 +794,19 @@ def test_a_date_column_compares_as_a_date_not_as_text():
     assert "day >= DATE '2025-01-01'" in compiled.sql
 
 
+@pytest.mark.parametrize(
+    "literal", ["2025-01-01T12:30:00+05:00", "2025-01-01T12:30:00Z"]
+)
+def test_a_literal_carrying_an_offset_is_refused(literal):
+    # The column records no zone, because no shape the projection reads carries one --
+    # a value that does is left unparsed rather than read as a wall clock. DuckDB drops
+    # the offset from a TIMESTAMP literal rather than shifting by it, so accepting one
+    # would compare the caller's wall clock while reading as though it compared their
+    # instant.
+    with pytest.raises(query.QueryError, match="records no time zone"):
+        _compile({"where": {"op": "ge", "path": _WHEN, "value": {"literal": literal}}})
+
+
 @pytest.mark.parametrize("literal", ["last tuesday", "2025-13-45", ""])
 def test_a_literal_that_is_not_a_date_is_refused_where_it_compiles(literal):
     with pytest.raises(query.QueryError, match="not an ISO 8601 date or timestamp"):

--- a/ord_schema/search/query_test.py
+++ b/ord_schema/search/query_test.py
@@ -327,7 +327,7 @@ def test_count_distinct_counts_distinctly():
         ),
         (
             {"where": {"op": "gt", "path": "reaction_id", "value": {"literal": 1}}},
-            "needs a numeric column",
+            "needs a numeric or temporal column",
         ),
         # A compound resolves to a SMILES, so it can only compare against text.
         (
@@ -755,6 +755,56 @@ def test_a_recorded_date_is_answered_by_its_timestamp_not_its_spelling(path):
     assert query.resolve(path.replace(".value", ".timestamp")).type == pa.timestamp(
         "us"
     )
+
+
+_WHEN = "provenance.record_created.time.timestamp"
+
+
+@pytest.mark.parametrize(
+    ("op", "literal", "expected"),
+    [
+        ("ge", "2025-01-01", "TIMESTAMP '2025-01-01 00:00:00'"),
+        ("lt", "2026-01-01", "TIMESTAMP '2026-01-01 00:00:00'"),
+        ("ge", "2025-01-01 12:30:00", "TIMESTAMP '2025-01-01 12:30:00'"),
+        ("eq", "2025-01-01T12:30:00", "TIMESTAMP '2025-01-01 12:30:00'"),
+    ],
+)
+def test_a_timestamp_compares_against_an_iso_literal(op, literal, expected):
+    # Typed rather than quoted: a bare date reads as that day's midnight, so asking for
+    # a year is a pair of comparisons rather than a text match on the spelling.
+    compiled = _compile(
+        {"where": {"op": op, "path": _WHEN, "value": {"literal": literal}}}
+    )
+    assert expected in compiled.sql
+    assert _run(compiled) == []
+
+
+def test_a_date_column_compares_as_a_date_not_as_text():
+    # A string beside a TIMESTAMP casts in DuckDB, but beside a DATE it compares as
+    # text and answers by spelling, so the literal carries its type either way.
+    schema = pa.schema(
+        [pa.field("reaction_id", pa.string()), pa.field("day", pa.date32())]
+    )
+    compiled = query.compile_query(
+        query.Query.model_validate(
+            {"where": {"op": "ge", "path": "day", "value": {"literal": "2025-01-01"}}}
+        ),
+        schema=schema,
+    )
+    assert "day >= DATE '2025-01-01'" in compiled.sql
+
+
+@pytest.mark.parametrize("literal", ["last tuesday", "2025-13-45", ""])
+def test_a_literal_that_is_not_a_date_is_refused_where_it_compiles(literal):
+    with pytest.raises(query.QueryError, match="not an ISO 8601 date or timestamp"):
+        _compile({"where": {"op": "ge", "path": _WHEN, "value": {"literal": literal}}})
+
+
+def test_an_ordered_comparison_still_refuses_text():
+    with pytest.raises(query.QueryError, match="numeric or temporal"):
+        _compile(
+            {"where": {"op": "gt", "path": "reaction_id", "value": {"literal": "a"}}}
+        )
 
 
 def test_suggestions_do_not_name_internal_columns():


### PR DESCRIPTION
## Summary

#1018 gives every `DateTime` a typed `timestamp`, and nothing could query it: ordered comparisons accepted numeric columns only, so `ge` on a `TIMESTAMP` was refused exactly as it is on a `DATE` — which is why a second, date-typed column would not have helped either. The gap was in the grammar, not the projection.

Stacked on #1018, which is where the column comes from.

## Changes

- `lt`/`le`/`gt`/`ge` accept a temporal column beside the numeric ones.
- A string literal compared against one parses as ISO 8601 and compiles to a typed literal. A bare date reads as that day's midnight, so a year is a half-open pair rather than an equality.
- A literal that is not ISO 8601 is refused where the query is compiled, the way arithmetic over text already is, rather than left to fail where it runs.
- A literal carrying an offset is refused too. The column records no zone because no shape the projection reads carries one, and `parse_timestamp` leaves such a value unparsed rather than reading it as a wall clock.
- An eval case asking for a year, and a prompt rule saying how a year is written and that "the last five years" still cannot be.

## Testing

- `pytest -n auto` — 1729 passed.
- All three guards mutation-checked: dropping temporal from the ordered check fails 11 tests, compiling the literal as text rather than typing it fails 5, and removing the offset refusal fails exactly its two cases. None touches anything else.
- Verified against the real projection schema, not a synthetic one: `ge "2025-01-01"` → `>= TIMESTAMP '2025-01-01 00:00:00'`, `eq "2025-01-01T12:30:00"` → `= TIMESTAMP '2025-01-01 12:30:00'`, and `"last tuesday"` and `"2025-13-45"` both refused by name.

## Notes

- DuckDB **drops** the offset from a `TIMESTAMP` literal rather than shifting by it, which is what made the offset case silently wrong rather than merely inconsistent: `+05:00` compared the caller's wall clock while reading as though it compared their instant.
- Typing the literal matters most for `DATE`. A string beside a `TIMESTAMP` casts in DuckDB and would have worked by accident; beside a `DATE` it compares as *text* and answers by spelling, so both carry their type.
- A `temporal_range` canonical query belongs with this change but is **not** in it. `corpus_baseline.json` is keyed to a corpus digest and the recorded corpus has no `timestamp` column to answer from, so the entry cannot be produced yet; adding the query without one makes every corpus check exit unsuccessfully. Query and entry land together with the re-derive #1018 already forces.
- `min`/`max` of a timestamp are still refused, deliberately: `order_by` on the column already answers "the most recent reactions", and widening `_check_numeric` would also have to decide what a `sum` of instants means.
- "The last five years" stays `compiles: false`. Comparing against a date the caller names is a different question from date arithmetic and a notion of today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extends structured search comparisons to support Arrow date and timestamp columns, compiling validated ISO 8601 strings into typed DuckDB literals.
- Allows ordered comparisons on numeric or temporal columns.
- Parses bare dates as midnight and rejects malformed or offset-bearing temporal literals.
- Documents natural-language translation rules for calendar years and adds an evaluation case using a half-open year range.
- Adds focused tests for timestamp and date compilation, invalid literals, offsets, and continued rejection of ordered text comparisons.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; both previously reported problems are resolved and no new actionable failures remain.

Offset-bearing temporal values are now rejected before SQL generation, and the canonical query that lacked a matching corpus baseline was removed. The current temporal comparison path validates literals, emits typed SQL literals, and is covered for timestamps, dates, malformed values, offsets, and non-temporal ordered comparisons.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/query.py | Extends comparison validation and SQL literal generation to handle date and timestamp columns with explicit ISO parsing and offset rejection. |
| ord_schema/search/query_test.py | Covers valid temporal comparisons, typed DATE behavior, invalid inputs, offset rejection, and the existing text-ordering restriction. |
| ord_schema/search/nl_prompt.md | Documents how natural-language requests should express fixed calendar ranges and refuse unsupported relative-date arithmetic. |
| ord_schema/search/nl_cases.json | Adds a calendar-year evaluation case represented by an inclusive lower bound and exclusive upper bound. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Structured temporal comparison] --> B[Resolve projection column type]
  B --> C{Date or timestamp?}
  C -->|No| D[Use existing literal handling]
  C -->|Yes| E[Parse ISO 8601 literal]
  E --> F{Valid and offset-free?}
  F -->|No| G[Raise QueryError]
  F -->|Yes: DATE| H[Compile typed DATE literal]
  F -->|Yes: TIMESTAMP| I[Compile typed TIMESTAMP literal]
  H --> J[DuckDB comparison]
  I --> J
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;agent/normalize-dates&#39; int..."](https://github.com/open-reaction-database/ord-schema/commit/2c4f83f4993bbeeddb9ebe2e65a7dd6953ff519b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60858627)</sub>

**Context used:**

- Knowledge Base — [Structured reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/structured-reaction-search.md)
- Knowledge Base — [Database access and reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/database-and-search.md)

<!-- /greptile_comment -->