### PR TITLE
Fail CI on a wire-breaking schema change

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -220,8 +220,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          # buf reads the baseline out of the local clone, so it needs real history rather
-          # than the single commit a shallow checkout provides.
+          # buf reads the baseline out of the local clone, so the full fetch is what
+          # supplies it: a shallow checkout has neither main's history nor a ref that
+          # points at it.
           fetch-depth: 0
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
@@ -231,9 +232,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check for breaking schema changes
         # Every .pb.gz and .parquet in ord-data is read by field number, so a renumbering
-        # quietly changes what existing records mean instead of failing loudly. Field
-        # numbers and reserved ranges are what keep the archive parseable.
-        run: buf breaking --against '.git#branch=main'
+        # quietly changes what existing records mean instead of failing loudly.
+        #
+        # The baseline is the remote-tracking ref: checking out a pull request leaves HEAD
+        # detached and creates no local main branch, so '#branch=main' resolves to nothing.
+        run: buf breaking --against '.git#ref=origin/main'
 
   test_js:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -225,15 +225,14 @@ jobs:
           fetch-depth: 0
       - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
         with:
-          # Pin the CLI. A floating version can start reporting findings on a schema that
-          # did not change, which turns a red check into something nobody trusts.
+          # Pin the CLI: a floating version can report new findings on a schema that
+          # did not change.
           version: '1.72.0'
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check for breaking schema changes
-        # Field numbers and reserved ranges are what keep serialized records parseable for
-        # as long as the archive lasts. Every .pb.gz and .parquet in ord-data is read by
-        # field number, so a renumbering quietly changes what existing records mean instead
-        # of failing loudly. Reviewer attention was the only thing enforcing that.
+        # Every .pb.gz and .parquet in ord-data is read by field number, so a renumbering
+        # quietly changes what existing records mean instead of failing loudly. Field
+        # numbers and reserved ranges are what keep the archive parseable.
         run: buf breaking --against '.git#branch=main'
 
   test_js:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -215,6 +215,27 @@ jobs:
             exit 1
           fi
 
+  test_proto_breaking:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # buf reads the baseline out of the local clone, so it needs real history rather
+          # than the single commit a shallow checkout provides.
+          fetch-depth: 0
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # v1.50.0
+        with:
+          # Pin the CLI. A floating version can start reporting findings on a schema that
+          # did not change, which turns a red check into something nobody trusts.
+          version: '1.72.0'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for breaking schema changes
+        # Field numbers and reserved ranges are what keep serialized records parseable for
+        # as long as the archive lasts. Every .pb.gz and .parquet in ord-data is read by
+        # field number, so a renumbering quietly changes what existing records mean instead
+        # of failing loudly. Reviewer attention was the only thing enforcing that.
+        run: buf breaking --against '.git#branch=main'
+
   test_js:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Nothing in CI catches a wire-breaking edit to `reaction.proto` today: a renumbered field tag, a changed type, or a deletion without `reserved` passes on reviewer attention alone. Every `.pb.gz` and `.parquet` in ord-data is read by field number, so a renumbering quietly changes what existing records mean rather than failing loudly. This adds a `buf breaking` job that compares each pull request's schema against `main`.

Stacked on #1033, which declares the buf module. Merge that first — buf cannot build a `main` that predates it, so this job only works once #1033 has landed.

## Changes

- `test_proto_breaking` in `run_tests.yml`: SHA-pinned `buf-setup-action`, buf pinned to 1.72.0, `fetch-depth: 0` so the `.git` input sees real history, and `buf breaking --against '.git#ref=origin/main'`.
- The baseline is the remote-tracking ref rather than `#branch=main`. Checking out a pull request leaves HEAD detached at the merge ref and creates no local `main`, so `#branch=main` has nothing to resolve and the job dies on `couldn't find remote ref main` without ever reading the schema.

## Testing

A breaking-change check that has never been seen to fail is indistinguishable from one that is misconfigured, so each case was run against the branch:

- Renumbering `Dataset.name` from 1 to 7 — fails, exit 100.
- Deleting `Dataset.description` without reserving tag 2 — fails, exit 100.
- Changing `Dataset.name` from `string` to `int32` — fails, exit 100.
- The unmodified branch compared against itself — passes.

Rerun against a clone with the local `main` deleted, which is the shape `actions/checkout` leaves on a pull request: `#branch=main` exits 1 on the clone failure, `#ref=origin/main` exits 0 clean and 100 on all three cases above.

## Notes

- The `FILE` category is configured in `buf.yaml` on #1033. It is the strictest, which is the right setting here because the generated code is committed and consumers import its message and field names directly rather than only parsing bytes.
- `buf breaking` does not check semantic compatibility. Redefining what an existing field means, tightening a validation rule, or changing a unit convention are all wire-compatible and all breaking. This raises the floor; it does not replace review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a CI job that rejects wire-breaking Protocol Buffer schema changes by comparing the pull request schema with the base repository’s `main` branch.
- Pins the checkout action, Buf setup action, and Buf CLI version.
- Fetches complete Git refs so the baseline is available locally.
- Uses the `origin/main` remote-tracking ref, correcting the previously unresolved local-branch baseline.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the corrected remote-tracking baseline is available and resolvable in the configured pull-request checkout.

No new actionable issues remain, and the previous baseline-resolution finding is manually resolved and fully addressed by changing the comparison target from a nonexistent local `main` branch to `origin/main`.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/run_tests.yml | Adds a pinned Buf breaking-change check using the correctly fetched `origin/main` baseline. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  PR[Pull request schema] --> Buf[buf breaking]
  Main[origin/main schema] --> Buf
  Buf -->|Compatible| Pass[CI passes]
  Buf -->|Breaking change| Fail[CI fails]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/age..."](https://github.com/open-reaction-database/ord-schema/commit/5214e89099245f3b982697a183f4c49f185c2911) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60866969)</sub>

<!-- /greptile_comment -->