### PR TITLE
Refuse pivot and occurrence artifacts that predate a schema column

### DIFF
--- a/ord_schema/artifacts/base.py
+++ b/ord_schema/artifacts/base.py
@@ -65,6 +65,7 @@ import dataclasses
 import glob
 import os
 import pathlib
+from collections.abc import Callable, Collection, Mapping
 from importlib import metadata
 from typing import Protocol
 
@@ -742,3 +743,55 @@ def derive_tree(
         ignored,
     )
     return written, skipped, ignored
+
+
+def left_behind(
+    directory: str | os.PathLike[str],
+    artifact: str,
+    schemas: Mapping[str, pa.Schema],
+    artifact_paths: Callable[[str | os.PathLike[str], str], list[pathlib.Path]],
+    derived: Collection[str],
+) -> dict[str, str]:
+    """Returns the keys already under ``directory`` that a run left short of a column.
+
+    An artifact split across a tree -- one subdirectory per pivot level, per indexed
+    path -- is derived a subset at a time, which is the cheaper run and often the only
+    one wanted. The tree that run writes into holds whatever earlier runs put there, and
+    those files stamp current forever, so a schema that grew a column leaves every key
+    nobody named short of it. A corpus reads the whole tree rather than the part the run
+    touched.
+
+    Columns only, matching what a reader refuses whatever its policy: an artifact short
+    a column fails every corpus that opens it, while one whose stamps are merely old is
+    refused where ``require_current`` says so and read otherwise. A build that stopped
+    on the second would decide that question on the reader's behalf, and leave no way to
+    finish a subset run against a tree an older library wrote.
+
+    Args:
+        directory: The directory the keys sit under.
+        artifact: Artifact name the files are expected to hold; anything else is left
+            alone, since a tree is not a build's to police.
+        schemas: Every key this artifact covers, mapped to the columns it carries.
+        artifact_paths: Lists one key's artifacts exactly as a reader finds them, taking
+            ``directory`` and the key.
+        derived: The keys the run covered, which are current by construction.
+
+    Returns:
+        One entry per uncovered key whose artifacts no longer match its schema, naming
+        the first artifact that does not and what it lacks. Keys with no artifacts are
+        not included: there is nothing there to be out of date.
+    """
+    behind: dict[str, str] = {}
+    for key in sorted(set(schemas) - set(derived)):
+        for path in artifact_paths(directory, key):
+            try:
+                stamps = load_stamps(path)
+            except (OSError, ValueError):
+                continue
+            if stamps.artifact != artifact:
+                continue
+            missing = missing_columns(path, schemas[key])
+            if missing:
+                behind[key] = f"{path} is without {missing}"
+                break
+    return behind

--- a/ord_schema/artifacts/scripts/derive_occurrences.py
+++ b/ord_schema/artifacts/scripts/derive_occurrences.py
@@ -42,14 +42,16 @@ Artifacts whose footer already records the current source content, library versi
 artifact version are skipped, so re-running is cheap; --force rewrites them anyway.
 
 These are errors: an --output_dir that would write over any input, a path this schema
-does not carry a structure at, a pivot that is stale or holds another level, and a run
-that finds no pivots for a path at all.
+does not carry a structure at, a pivot that is stale or holds another level, a run that
+finds no pivots for a path at all, and a path the tree already holds that this run did
+not name whose artifacts are short a column the schema declares.
 """
 
 import argparse
 import functools
 import glob
 import pathlib
+from collections.abc import Collection
 
 import pyarrow.parquet as pq
 
@@ -158,6 +160,43 @@ def _audit(
     return len(found), empty, mismatched
 
 
+def _left_behind(output_dir: str, derived: Collection[str]) -> dict[str, str]:
+    """Returns the paths already in the tree that this run left short of a column.
+
+    ``--paths`` is for rebuilding one path rather than for choosing what to carry, so
+    the tree a subset run writes into holds the rest at whatever schema an earlier run
+    wrote them at. Those artifacts stamp current and nothing revisits them.
+
+    Columns only, matching what a reader refuses whatever its policy: an artifact short
+    a column fails every corpus that opens it, while one whose stamps are merely old is
+    refused where ``require_current`` says so and read otherwise.
+
+    Args:
+        output_dir: The directory the paths sit under.
+        derived: The paths this run covered, which are current by construction.
+
+    Returns:
+        One entry per uncovered path whose artifacts no longer match the schema, naming
+        the first artifact that does not and what it lacks. Empty today whatever the
+        tree holds, since the three columns are the same at every path and have not
+        moved; it answers differently the day the schema grows one.
+    """
+    behind: dict[str, str] = {}
+    for path in sorted(set(occurrences.PATHS) - set(derived)):
+        for artifact in occurrences.artifact_paths(output_dir, path):
+            try:
+                stamps = base.load_stamps(artifact)
+            except (OSError, ValueError):
+                continue
+            if stamps.artifact != occurrences.ARTIFACT:
+                continue
+            missing = base.missing_columns(artifact, occurrences.SCHEMA)
+            if missing:
+                behind[path] = f"{artifact} is without {missing}"
+                break
+    return behind
+
+
 def main(args: argparse.Namespace) -> None:
     """Derives the occurrences at each requested path.
 
@@ -169,7 +208,8 @@ def main(args: argparse.Namespace) -> None:
             is named twice; if a pivot is stale or holds another level; or if a path's
             level has no pivots at all -- which usually means they have not been derived
             yet, and would otherwise leave a tree a corpus refuses for reaching too few
-            structures.
+            structures; or if the tree holds a path this run did not derive whose
+            artifacts are short a column the schema declares.
     """
     paths = check_paths(args.paths)
     if args.print_levels:
@@ -256,6 +296,16 @@ def main(args: argparse.Namespace) -> None:
                 f"than the {written + skipped} this run wrote or found current; the "
                 "rest are where no reader looks"
             )
+    behind = _left_behind(args.output_dir, paths)
+    if behind:
+        # Raised rather than reported: the run succeeded at what it was asked to do and
+        # still left a tree a corpus refuses. Naming the paths says which to add to
+        # --paths.
+        raise ValueError(
+            f"{args.output_dir} holds {len(behind)} paths this run did not derive "
+            "whose artifacts no longer match the schema: "
+            + "; ".join(f"{path} ({reason})" for path, reason in behind.items())
+        )
 
 
 if __name__ == "__main__":

--- a/ord_schema/artifacts/scripts/derive_occurrences.py
+++ b/ord_schema/artifacts/scripts/derive_occurrences.py
@@ -51,7 +51,6 @@ import argparse
 import functools
 import glob
 import pathlib
-from collections.abc import Collection
 
 import pyarrow.parquet as pq
 
@@ -160,43 +159,6 @@ def _audit(
     return len(found), empty, mismatched
 
 
-def _left_behind(output_dir: str, derived: Collection[str]) -> dict[str, str]:
-    """Returns the paths already in the tree that this run left short of a column.
-
-    ``--paths`` is for rebuilding one path rather than for choosing what to carry, so
-    the tree a subset run writes into holds the rest at whatever schema an earlier run
-    wrote them at. Those artifacts stamp current and nothing revisits them.
-
-    Columns only, matching what a reader refuses whatever its policy: an artifact short
-    a column fails every corpus that opens it, while one whose stamps are merely old is
-    refused where ``require_current`` says so and read otherwise.
-
-    Args:
-        output_dir: The directory the paths sit under.
-        derived: The paths this run covered, which are current by construction.
-
-    Returns:
-        One entry per uncovered path whose artifacts no longer match the schema, naming
-        the first artifact that does not and what it lacks. Empty today whatever the
-        tree holds, since the three columns are the same at every path and have not
-        moved; it answers differently the day the schema grows one.
-    """
-    behind: dict[str, str] = {}
-    for path in sorted(set(occurrences.PATHS) - set(derived)):
-        for artifact in occurrences.artifact_paths(output_dir, path):
-            try:
-                stamps = base.load_stamps(artifact)
-            except (OSError, ValueError):
-                continue
-            if stamps.artifact != occurrences.ARTIFACT:
-                continue
-            missing = base.missing_columns(artifact, occurrences.SCHEMA)
-            if missing:
-                behind[path] = f"{artifact} is without {missing}"
-                break
-    return behind
-
-
 def main(args: argparse.Namespace) -> None:
     """Derives the occurrences at each requested path.
 
@@ -296,7 +258,15 @@ def main(args: argparse.Namespace) -> None:
                 f"than the {written + skipped} this run wrote or found current; the "
                 "rest are where no reader looks"
             )
-    behind = _left_behind(args.output_dir, paths)
+    behind = base.left_behind(
+        args.output_dir,
+        occurrences.ARTIFACT,
+        # One schema for every path: the three columns are the same wherever a
+        # structure sits, so nothing on disk is short one until this schema grows.
+        dict.fromkeys(occurrences.PATHS, occurrences.SCHEMA),
+        occurrences.artifact_paths,
+        paths,
+    )
     if behind:
         # Raised rather than reported: the run succeeded at what it was asked to do and
         # still left a tree a corpus refuses. Naming the paths says which to add to

--- a/ord_schema/artifacts/scripts/derive_occurrences_test.py
+++ b/ord_schema/artifacts/scripts/derive_occurrences_test.py
@@ -189,3 +189,61 @@ def test_a_pivots_dir_named_with_a_glob_metacharacter_is_read_literally(
             ("aa", "ord_dataset-aa.parquet"),
             ("bb", "ord_dataset-bb.parquet"),
         ], path
+
+
+def _drop_column(path: pathlib.Path, column: str) -> None:
+    """Rewrites the artifact at ``path`` without ``column``, keeping its footer.
+
+    Stands in for an artifact written before the schema carried that column, by a
+    library version that would not have bumped for it: the stamps are what a run reads
+    to decide the file is current, and they say nothing about its columns.
+
+    Args:
+        path: The artifact to rewrite.
+        column: The column to drop.
+    """
+    table = pq.read_table(path)
+    metadata = table.schema.metadata
+    table = table.drop_columns([column])
+    pq.write_table(table.replace_schema_metadata(metadata), path)
+
+
+def _stamp_an_older_library(path: pathlib.Path) -> None:
+    """Rewrites the artifact at ``path`` as an older library would have stamped it.
+
+    Every column stays where it was, so the file is structurally what this schema
+    declares and only the stamps say otherwise.
+
+    Args:
+        path: The artifact to rewrite.
+    """
+    table = pq.read_table(path)
+    metadata = dict(table.schema.metadata)
+    metadata[b"ord.rdkit_version"] = b"0000.00.0"
+    pq.write_table(table.replace_schema_metadata(metadata), path)
+
+
+def test_a_path_this_run_did_not_name_is_checked_against_the_schema(pivots, tmp_path):
+    # --paths rebuilds one path rather than choosing what to carry, so the tree a
+    # subset run writes into holds the rest at whatever schema wrote them. Those stamp
+    # current and nothing revisits them -- and a corpus reads the whole tree, not the
+    # part this run touched.
+    output = tmp_path / "occurrences"
+    _run(pivots, output)
+    left_behind = occurrences.artifact_paths(output, "inputs.components")[0]
+    _drop_column(left_behind, "reaction_role")
+    with pytest.raises(ValueError, match="did not derive"):
+        _run(pivots, output, "--paths", "outcomes.products")
+
+
+def test_a_path_left_behind_with_old_stamps_and_every_column_is_not_an_error(
+    pivots, tmp_path
+):
+    # Freshness is the reader's policy, not the build's: an artifact short a column
+    # fails every corpus that opens it, while one whose stamps are merely old is
+    # refused only where require_current says so. --force is how an operator asks for
+    # the rewrite.
+    output = tmp_path / "occurrences"
+    _run(pivots, output)
+    _stamp_an_older_library(occurrences.artifact_paths(output, "inputs.components")[0])
+    _run(pivots, output, "--paths", "outcomes.products")

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -41,8 +41,11 @@ run -- is ignored rather than derived from, so --output_dir may sit inside a rec
 pattern's reach. These are errors: an --output_dir that would write over any input, an
 input that cannot be read as Parquet at all, a level the schema does not have or that
 is named twice, a projection that changed while the run was deriving from it or whose
-count and unnest disagreed, a run that finds no projections at all, and a level whose
-artifacts cannot be found once it has derived them.
+count and unnest disagreed, a run that finds no projections at all, a level whose
+artifacts cannot be found once it has derived them, and a level the tree already holds
+that this run did not name and whose artifacts the current schema has outgrown -- a
+subset run is the cheaper run, but the levels it leaves behind still have to match the
+projections a corpus reads them beside.
 
 Every run reports, per level, how many of the artifacts on disk hold no rows, and warns
 when all of them do. That is ordinary for a level nothing in the corpus records, and it
@@ -57,6 +60,7 @@ ending the run, since the output tree is not this script's to police.
 import argparse
 import functools
 import pathlib
+from collections.abc import Collection
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -206,6 +210,44 @@ def _empty_artifacts(
     return found, empty, skipped
 
 
+def _left_behind(pivots_dir: str, derived: Collection[str]) -> dict[str, str]:
+    """Returns the levels already in the tree that this run left at an older schema.
+
+    A run naming a subset of the levels is the cheaper run and the documented one, but
+    the tree it writes into holds whatever earlier runs put there. Those artifacts are
+    stamped current and nothing revisits them, so a projection that grew a column
+    leaves every uncovered level short of it -- and a corpus reading the tree pairs the
+    new projections with pivots that predate them.
+
+    Args:
+        pivots_dir: The directory the levels sit under.
+        derived: The levels this run covered, which are current by construction.
+
+    Returns:
+        One entry per uncovered level whose artifacts no longer match the schema,
+        naming the first artifact that does not and what it lacks. Levels the schema
+        does not have are not included: a directory nobody derives is nobody's to
+        police, and a corpus never reads one.
+    """
+    behind: dict[str, str] = {}
+    for level_path in sorted(set(pivot.LEVELS) - set(derived)):
+        for path in pivot.artifact_paths(pivots_dir, level_path):
+            try:
+                stamps = base.load_stamps(path)
+            except (OSError, ValueError):
+                continue
+            if stamps.artifact != pivot.ARTIFACT:
+                continue
+            missing = base.missing_columns(path, pivot.schema(pivot.LEVELS[level_path]))
+            if missing:
+                behind[level_path] = f"{path} is without {missing}"
+                break
+            if not base.stamps_are_current(stamps, pivot.ARTIFACT):
+                behind[level_path] = f"{path} is stale"
+                break
+    return behind
+
+
 def main(args: argparse.Namespace) -> None:
     """Derives a pivot artifact per level for every projection matching the pattern.
 
@@ -220,8 +262,9 @@ def main(args: argparse.Namespace) -> None:
             which usually means it was aimed at the source tree, or at an output tree,
             rather than at the projections; or if a level's artifacts cannot be found
             after the run derived them, which means they were written somewhere no
-            reader looks. Silence in any of those would let a pipeline step downstream
-            proceed as though the artifacts had been built.
+            reader looks; or if the tree holds a level this run did not derive whose
+            artifacts no longer match the schema. Silence in any of those would let a
+            pipeline step downstream proceed as though the artifacts had been built.
     """
     levels = pivot.check_levels(args.levels)
     for level_path in levels:
@@ -235,11 +278,11 @@ def main(args: argparse.Namespace) -> None:
                 level_path=level_path,
                 level_paths=tuple(levels),
             ),
-            # Reaches the ordinals, which are top-level columns: a repeated level added
-            # to the schema above this one gives every level beneath it another one,
-            # and the artifacts carrying the old set are derived again rather than
-            # stamping as current. What it does not reach is the element struct, which
-            # is one column however its fields change; that is what a version is for.
+            # Reaches the ordinals, which are top-level columns, and the fields of the
+            # element struct, which are compared down through it: a level added above
+            # this one gives every level beneath it another ordinal, and a field added
+            # to the element gives it another leaf. Artifacts carrying the old set of
+            # either are derived again rather than stamping as current.
             schema=pivot.schema(pivot.LEVELS[level_path]),
             force=args.force,
             parent_artifact=projection.ARTIFACT,
@@ -290,6 +333,16 @@ def main(args: argparse.Namespace) -> None:
             # the two apart. Nothing else in the chain aggregates rows across a tree,
             # or says anything about them above INFO.
             logger.warning("%s: every artifact is empty at this level", level_path)
+    behind = _left_behind(args.output_dir, levels)
+    if behind:
+        # Raised rather than reported: the run succeeded at what it was asked to do and
+        # still left a tree a corpus refuses, and a pipeline that reads the exit status
+        # would go on to publish it. Naming the levels says which to add to --levels.
+        raise ValueError(
+            f"{args.output_dir} holds {len(behind)} levels this run did not derive "
+            "whose artifacts no longer match the schema: "
+            + "; ".join(f"{level} ({reason})" for level, reason in behind.items())
+        )
 
 
 if __name__ == "__main__":

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -219,6 +219,12 @@ def _left_behind(pivots_dir: str, derived: Collection[str]) -> dict[str, str]:
     leaves every uncovered level short of it -- and a corpus reading the tree pairs the
     new projections with pivots that predate them.
 
+    Columns only, matching what a reader refuses whatever its policy: an artifact short
+    a column fails every corpus that opens it, while one whose stamps are merely old is
+    refused whenever ``require_current`` says so and read otherwise. A build that
+    stopped on the second would decide that question on the reader's behalf, and leave
+    no way to finish a subset run against a tree an older library wrote.
+
     Args:
         pivots_dir: The directory the levels sit under.
         derived: The levels this run covered, which are current by construction.
@@ -241,9 +247,6 @@ def _left_behind(pivots_dir: str, derived: Collection[str]) -> dict[str, str]:
             missing = base.missing_columns(path, pivot.schema(pivot.LEVELS[level_path]))
             if missing:
                 behind[level_path] = f"{path} is without {missing}"
-                break
-            if not base.stamps_are_current(stamps, pivot.ARTIFACT):
-                behind[level_path] = f"{path} is stale"
                 break
     return behind
 

--- a/ord_schema/artifacts/scripts/derive_pivots.py
+++ b/ord_schema/artifacts/scripts/derive_pivots.py
@@ -60,7 +60,6 @@ ending the run, since the output tree is not this script's to police.
 import argparse
 import functools
 import pathlib
-from collections.abc import Collection
 
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -210,47 +209,6 @@ def _empty_artifacts(
     return found, empty, skipped
 
 
-def _left_behind(pivots_dir: str, derived: Collection[str]) -> dict[str, str]:
-    """Returns the levels already in the tree that this run left at an older schema.
-
-    A run naming a subset of the levels is the cheaper run and the documented one, but
-    the tree it writes into holds whatever earlier runs put there. Those artifacts are
-    stamped current and nothing revisits them, so a projection that grew a column
-    leaves every uncovered level short of it -- and a corpus reading the tree pairs the
-    new projections with pivots that predate them.
-
-    Columns only, matching what a reader refuses whatever its policy: an artifact short
-    a column fails every corpus that opens it, while one whose stamps are merely old is
-    refused whenever ``require_current`` says so and read otherwise. A build that
-    stopped on the second would decide that question on the reader's behalf, and leave
-    no way to finish a subset run against a tree an older library wrote.
-
-    Args:
-        pivots_dir: The directory the levels sit under.
-        derived: The levels this run covered, which are current by construction.
-
-    Returns:
-        One entry per uncovered level whose artifacts no longer match the schema,
-        naming the first artifact that does not and what it lacks. Levels the schema
-        does not have are not included: a directory nobody derives is nobody's to
-        police, and a corpus never reads one.
-    """
-    behind: dict[str, str] = {}
-    for level_path in sorted(set(pivot.LEVELS) - set(derived)):
-        for path in pivot.artifact_paths(pivots_dir, level_path):
-            try:
-                stamps = base.load_stamps(path)
-            except (OSError, ValueError):
-                continue
-            if stamps.artifact != pivot.ARTIFACT:
-                continue
-            missing = base.missing_columns(path, pivot.schema(pivot.LEVELS[level_path]))
-            if missing:
-                behind[level_path] = f"{path} is without {missing}"
-                break
-    return behind
-
-
 def main(args: argparse.Namespace) -> None:
     """Derives a pivot artifact per level for every projection matching the pattern.
 
@@ -336,7 +294,13 @@ def main(args: argparse.Namespace) -> None:
             # the two apart. Nothing else in the chain aggregates rows across a tree,
             # or says anything about them above INFO.
             logger.warning("%s: every artifact is empty at this level", level_path)
-    behind = _left_behind(args.output_dir, levels)
+    behind = base.left_behind(
+        args.output_dir,
+        pivot.ARTIFACT,
+        {level: pivot.schema(pivot.LEVELS[level]) for level in pivot.LEVELS},
+        pivot.artifact_paths,
+        levels,
+    )
     if behind:
         # Raised rather than reported: the run succeeded at what it was asked to do and
         # still left a tree a corpus refuses, and a pipeline that reads the exit status

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -416,6 +416,21 @@ def _drop_column(path: pathlib.Path, column: str) -> None:
     pq.write_table(table.replace_schema_metadata(metadata), path)
 
 
+def _stamp_an_older_library(path: pathlib.Path) -> None:
+    """Rewrites the artifact at ``path`` as an older library would have stamped it.
+
+    Every column stays where it was, so the file is structurally what this schema
+    declares and only the stamps say otherwise.
+
+    Args:
+        path: The artifact to rewrite.
+    """
+    table = pq.read_table(path)
+    metadata = dict(table.schema.metadata)
+    metadata[b"ord.rdkit_version"] = b"0000.00.0"
+    pq.write_table(table.replace_schema_metadata(metadata), path)
+
+
 def test_an_artifact_missing_an_ordinal_is_derived_again(projected):
     # A repeated level added above this one gives it another ordinal, and the artifacts
     # written before it carry stamps a later run cannot tell apart, absent a version
@@ -558,6 +573,20 @@ def test_a_level_this_run_did_not_name_and_did_not_outgrow_is_not_an_error(proje
     # the schema is exactly what --levels is for, and stopping on it would make every
     # deployment derive all 39 levels to answer questions over four.
     _run(projected, "--levels", "workups", "outcomes.products")
+    _run(projected, "--levels", "outcomes.products")
+
+
+def test_a_level_left_behind_with_old_stamps_and_every_column_is_not_an_error(
+    projected,
+):
+    # Freshness is the reader's policy, not the build's: an artifact short a column
+    # fails every corpus that opens it, while one whose stamps are merely old is
+    # refused only where require_current says so. Stopping here would decide that on
+    # the reader's behalf and leave no way to finish a subset run against a tree an
+    # older library wrote -- --force is how an operator asks for the rewrite.
+    _run(projected, "--levels", "workups", "outcomes.products")
+    left_behind = projected / "pivots" / "workups" / "aa" / "ord_dataset-aa.parquet"
+    _stamp_an_older_library(left_behind)
     _run(projected, "--levels", "outcomes.products")
 
 

--- a/ord_schema/artifacts/scripts/derive_pivots_test.py
+++ b/ord_schema/artifacts/scripts/derive_pivots_test.py
@@ -539,3 +539,29 @@ def test_each_level_is_derived_against_its_own_columns(projected):
     _drop_column(written, "product_index")
     _run(projected, "--levels", "outcomes", "outcomes.products")
     assert "product_index" in pq.read_schema(written).names
+
+
+def test_a_level_this_run_did_not_name_is_checked_against_the_schema(projected):
+    # Naming a subset is the documented cheaper run, and the tree it writes into keeps
+    # whatever an earlier, larger run put there. Those artifacts stamp current forever,
+    # so a projection that grew a column leaves every level nobody named short of it --
+    # which is the whole tree a corpus reads, not just the part this run touched.
+    _run(projected, "--levels", "workups", "outcomes.products")
+    left_behind = projected / "pivots" / "workups" / "aa" / "ord_dataset-aa.parquet"
+    _drop_column(left_behind, "workup_index")
+    with pytest.raises(ValueError, match="did not derive"):
+        _run(projected, "--levels", "outcomes.products")
+
+
+def test_a_level_this_run_did_not_name_and_did_not_outgrow_is_not_an_error(projected):
+    # The subset run has to stay usable. A level left alone whose artifacts still match
+    # the schema is exactly what --levels is for, and stopping on it would make every
+    # deployment derive all 39 levels to answer questions over four.
+    _run(projected, "--levels", "workups", "outcomes.products")
+    _run(projected, "--levels", "outcomes.products")
+
+
+def test_a_level_the_tree_does_not_hold_is_not_left_behind(projected):
+    # A level nobody has ever derived has no artifacts to be stale, and a run that
+    # stopped on one would refuse every first build of a subset.
+    _run(projected, "--levels", "outcomes.products")

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -2378,7 +2378,8 @@ class Corpus:
             PairingError: If the artifacts for this level were not derived from the
                 projections this corpus reads -- a pivot of another corpus answers
                 confidently and wrongly, since its reaction IDs resolve against the
-                wrong rows -- or, with ``require_current``, if any of them is stale.
+                wrong rows -- if any lacks a column this library reads, or, with
+                ``require_current``, if any of them is stale.
         """
         sources = self._pivot_artifacts(path)
         if sources is None:
@@ -2417,7 +2418,8 @@ class Corpus:
 
         Raises:
             PairingError: If the artifacts were not derived from the projections this
-                corpus reads, or -- with ``require_current`` -- if any is stale.
+                corpus reads, if any lacks a column this library reads, or -- with
+                ``require_current`` -- if any is stale.
         """
         if self._pivots_dir is None:
             return None
@@ -2452,12 +2454,13 @@ class Corpus:
             ``_pivot_offsets``.
 
         Raises:
-            PairingError: If a file is not a pivot over ``path``, if two artifacts
-                restate one source dataset, if the set of source datasets differs from
-                the projections', or -- with ``require_current`` -- if any artifact is
-                stale.
+            PairingError: If a file is not a pivot over ``path``, if it lacks a column
+                this library reads, if two artifacts restate one source dataset, if the
+                set of source datasets differs from the projections', or -- with
+                ``require_current`` -- if any artifact is stale.
         """
         wanted = {base.load_stamps(name).source_md5 for name in self._projections}
+        schema = pivot.schema(pivot.LEVELS[path])
         sources: dict[str, str] = {}
         derived_from: dict[str, str] = {}
         for name in files:
@@ -2471,6 +2474,17 @@ class Corpus:
                 raise PairingError(
                     f"{name} holds the pivot over {held}, but sits where {path} is "
                     "read from, so a quantifier would be answered by the wrong level"
+                )
+            missing = base.missing_columns(name, schema)
+            if missing:
+                # A level's element struct grows whenever the projection's does, and
+                # the stamps say nothing about columns. Without this the artifact is
+                # read as a corpus member and a predicate over the new field fails deep
+                # in DuckDB, as a binder error naming a struct key rather than the file
+                # that predates it.
+                raise PairingError(
+                    f"{name} is a {pivot.ARTIFACT} artifact over {path} without "
+                    f"{missing}, which this library reads; derive it again first"
                 )
             if self._require_current and not base.stamps_are_current(
                 stamps, pivot.ARTIFACT

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -1809,9 +1809,10 @@ class Corpus:
 
         Raises:
             PairingError: If a file is not an occurrences artifact, if it is stamped
-                with another path, if two artifacts restate one source dataset, if the
-                set of source datasets differs from the projections', or -- with
-                ``require_current`` -- if any artifact is stale.
+                with another path, if it lacks a column this library reads, if two
+                artifacts restate one source dataset, if the set of source datasets
+                differs from the projections', or -- with ``require_current`` -- if any
+                artifact is stale.
         """
         wanted = {base.load_stamps(name).source_md5 for name in self._projections}
         sources: dict[str, str] = {}
@@ -1829,6 +1830,17 @@ class Corpus:
                     f"{name} holds the occurrences at {held}, but sits where {path} is "
                     "read from, so a quantifier over it would be answered by another "
                     "path's elements"
+                )
+            missing = base.missing_columns(name, occurrences.SCHEMA)
+            if missing:
+                # The three columns are the same at every path and have not moved, so
+                # nothing on disk fails this today. It is here because the stamps say
+                # nothing about columns whatever the artifact: the day this schema
+                # grows one, every file written before it reads as current and fails
+                # deep in DuckDB instead of here.
+                raise PairingError(
+                    f"{name} is an {occurrences.ARTIFACT} artifact at {path} without "
+                    f"{missing}, which this library reads; derive it again first"
                 )
             if self._require_current and not base.stamps_are_current(
                 stamps, occurrences.ARTIFACT

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -4143,6 +4143,32 @@ def test_a_stale_pivot_is_refused(corpus_dir, tmp_path):
         )
 
 
+def test_a_pivot_missing_a_column_the_schema_declares_is_refused(corpus_dir, tmp_path):
+    # The element struct grows whenever the projection's does, and the stamps say
+    # nothing about columns -- so an artifact derived before the column is current by
+    # every other measure here. Read as a corpus member it fails deep in DuckDB, as a
+    # binder error naming a struct key rather than the file that predates it, which
+    # sends whoever reads it looking at the query instead of the tree.
+    pivots = _write_pivots(corpus_dir, ("inputs.components",), into=tmp_path / "pivots")
+    target = next((pivots / "inputs.components").rglob("*.parquet"))
+    table = pq.read_table(target)
+    metadata = table.schema.metadata
+    element = table.column("element").combine_chunks()
+    dropped = element.field(element.type.field(0).name)
+    table = table.drop_columns(["element"]).append_column(
+        pa.field("element", pa.struct([element.type.field(0)])),
+        pa.StructArray.from_arrays([dropped], fields=[element.type.field(0)]),
+    )
+    pq.write_table(table.replace_schema_metadata(metadata), target)
+    with pytest.raises(execute.PairingError, match="without"):
+        execute.Corpus(
+            str(corpus_dir / "projections" / "*.parquet"),
+            str(corpus_dir / "structures" / "*.parquet"),
+            resolver={}.__getitem__,
+            pivots_dir=str(pivots),
+        )
+
+
 def test_a_pivot_filed_under_the_wrong_level_is_refused(wide_root, tmp_path):
     pivots = tmp_path / "pivots"
     (pivots / "outcomes.products").mkdir(parents=True)

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -4634,6 +4634,28 @@ def occurrence_dirs(tmp_path, corpus_dir) -> tuple[pathlib.Path, pathlib.Path]:
     return pivots, _write_occurrences(pivots, tmp_path / "occurrences")
 
 
+def test_an_occurrences_artifact_missing_a_column_is_refused(
+    corpus_dir, occurrence_dirs
+):
+    # The same check _check_pivots makes, for an artifact whose columns cannot drift
+    # today: the three are the same at every path and have not moved. It is here
+    # because the stamps say nothing about columns whatever the artifact, so the day
+    # this schema grows one, every file written before it would read as current and
+    # fail deep in DuckDB rather than here.
+    _, occurrence_dir = occurrence_dirs
+    target = occurrences.artifact_paths(occurrence_dir, "inputs.components")[0]
+    table = pq.read_table(target)
+    metadata = table.schema.metadata
+    pq.write_table(
+        table.drop_columns(["reaction_role"]).replace_schema_metadata(metadata), target
+    )
+    with (
+        pytest.raises(execute.PairingError, match="without"),
+        _indexed_corpus(corpus_dir, None, occurrences_dir=str(occurrence_dir)) as read,
+    ):
+        _search(read, _white("exists"))
+
+
 @pytest.mark.parametrize("smarts", ["c1ccncc1", "[OX2H]", "c1ccccc1", "[#6]"])
 def test_an_index_read_from_artifacts_answers_what_unnesting_answers(
     corpus_dir, occurrence_dirs, smarts


### PR DESCRIPTION
## Summary

A projection that gains a column leaves every pivot whose element struct carries it short of one, and an artifact's stamps say nothing about its columns. The corpus read those pivots as members and failed deep in DuckDB — a binder error naming a struct key, which sends the reader to the query rather than to the tree.

Found while re-deriving the local corpus after #1018 added the parsed `timestamp` leaves: five levels gained `element...timestamp`, and any quantifier over one died on `Could not find key "timestamp" in struct`.

## Changes

- `Corpus._check_pivots` refuses a pivot lacking a column the current schema declares, naming the artifact and what it lacks. `_index` already did this for projections and structures; the pivot path is the parallel check and did not have it.
- `derive_pivots` refuses to finish when the output tree holds a level the run did not derive that is short a column the schema declares, naming the levels to add to `--levels`. Columns only: a stale stamp is refused by a reader under `require_current` and read otherwise, so the build leaves that to the reader — and `--force` only rewrites the levels a run names, which would leave a subset run against an older tree no way to finish.
- The freshness comment beside `schema=pivot.schema(...)` said the check cannot reach the element struct. `missing_columns` compares down through structs, so it can and does; the comment now says which changes it catches.
- `base.left_behind` holds the one definition of the subset-run walk; both scripts call it, differing only in their keys, artifact name, schema, and how a key's artifacts are listed.
- The occurrences path gets both checks for symmetry: `_check_occurrences` refuses an artifact short a declared column, and `derive_occurrences` refuses to finish when the tree holds a path the run did not derive that is short one. Neither can fire today — the three columns are the same at every indexed path and have not moved — but the stamps say nothing about columns whatever the artifact, so a schema that grows one would repeat the pivot failure.

## Testing

- `pytest -n auto`: 1740 passed.
- Six guards mutation-checked. Each corpus-side check fails only its own test: `test_a_pivot_missing_a_column_the_schema_declares_is_refused` and `test_an_occurrences_artifact_missing_a_column_is_refused`. On each build side, the column check and the freshness branch deliberately left out of it are pinned against each other: `test_a_level_this_run_did_not_name_is_checked_against_the_schema` / `test_a_level_left_behind_with_old_stamps_and_every_column_is_not_an_error`, and the two occurrences equivalents.
- One mutation of `base.left_behind` fails both scripts' tests, which is what says the definition is actually shared.
- A clean scan of the 35 levels a four-level run leaves behind costs 0.98s against the real corpus, and the corpus-side check adds 7ms per level of 53 artifacts.
- Against the re-derived local corpus, the three queries that motivated this: top-level `provenance.record_created.time.timestamp` 2,418,635 rows; pivoted `provenance.record_modified` 2,428,291 rows; pivoted `outcomes.analyses` 0 rows, matching the corpus holding no calibration dates. The two pivoted ones raised `BinderException` before the rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)










<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents schema-incomplete pivot and occurrence artifacts from reaching DuckDB and producing misleading binder failures.
- Validates artifact columns when a corpus loads pivots and occurrences.
- Detects schema-incomplete artifacts left untouched by subset derivation runs.
- Consolidates the shared left-behind artifact check without changing its behavior.
- Preserves support for structurally compatible artifacts with older freshness stamps.
- Adds regression coverage for missing columns, subset builds, stale stamps, and absent levels.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the previous subset-run issue was fixed and manually resolved, and the subsequent helper consolidation preserves the corrected behavior.

No actionable new defects or repository-rule violations remain. The prior freshness-policy finding is fully addressed because left-behind checks now compare required columns only, allowing structurally compatible artifacts with older stamps.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/artifacts/base.py | Adds a behavior-preserving shared helper that detects unrequested artifact keys whose files lack required schema columns. |
| ord_schema/artifacts/scripts/derive_pivots.py | Rejects subset pivot builds that leave existing levels structurally incompatible with the current schema. |
| ord_schema/artifacts/scripts/derive_occurrences.py | Applies the equivalent structural compatibility guard to occurrence subset builds. |
| ord_schema/search/execute.py | Validates pivot and occurrence columns while constructing a corpus so failures identify the outdated artifact directly. |
| ord_schema/artifacts/scripts/derive_pivots_test.py | Covers missing columns, compatible old stamps, valid subset runs, and levels absent from the artifact tree. |
| ord_schema/artifacts/scripts/derive_occurrences_test.py | Covers occurrence artifacts left schema-incomplete by subset runs while preserving compatible stale-stamp behavior. |
| ord_schema/search/execute_test.py | Verifies that corpus loading refuses schema-incomplete pivot and occurrence artifacts before query execution. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Subset derivation run] --> B[Derive requested levels or paths]
    B --> C[Scan existing unrequested artifacts]
    C --> D{Required columns present?}
    D -->|No| E[Raise ValueError and identify artifacts to rebuild]
    D -->|Yes| F[Finish derivation]
    F --> G[Corpus loads artifact tree]
    G --> H{Each artifact matches current schema?}
    H -->|No| I[Raise PairingError before querying]
    H -->|Yes| J[Execute DuckDB query]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Share the one definition of a level left..."](https://github.com/open-reaction-database/ord-schema/commit/313072a4b446fc6402d6c5f993453708a763fdb1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60873611)</sub>

<!-- /greptile_comment -->