### PR TITLE
Check every artifact a corpus opens the same way

### DIFF
--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -302,8 +302,20 @@ def _max_structure_id(path: str) -> int | None:
 
 
 def _article(word: str) -> str:
-    """Returns the indefinite article ``word`` takes."""
-    return "an" if word[0] in "aeiou" else "a"
+    """Returns the indefinite article ``word`` takes, or "a" for an empty name.
+
+    ``load_stamps`` requires the artifact key to be present rather than non-empty, so
+    an empty name reaches here from a footer written by hand or truncated mid-write.
+    Tested with ``startswith`` rather than by indexing, which raises on it, or against
+    a string of vowels, which contains the empty one and would answer "an".
+
+    Args:
+        word: The name to precede.
+
+    Returns:
+        "an" before a vowel, "a" otherwise.
+    """
+    return "an" if word.startswith(("a", "e", "i", "o", "u")) else "a"
 
 
 def _refuse_unreadable(

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -301,6 +301,84 @@ def _max_structure_id(path: str) -> int | None:
     return largest
 
 
+def _article(word: str) -> str:
+    """Returns the indefinite article ``word`` takes."""
+    return "an" if word[0] in "aeiou" else "a"
+
+
+def _refuse_unreadable(
+    path: str,
+    stamps: base.Stamps,
+    *,
+    artifact: str,
+    schema: pa.Schema,
+    require_current: bool,
+    held: Callable[[str], str | None] | None = None,
+    expected: str | None = None,
+    reading: str = "",
+) -> None:
+    """Refuses a file a corpus cannot read as the artifact it is filed as.
+
+    The one definition of what makes an artifact readable, for every artifact a corpus
+    opens. One definition because the checks have to agree and nothing else makes them:
+    a copy per artifact still runs when it falls behind the others, so the artifact
+    whose copy is short a check is admitted and fails somewhere far from here.
+
+    Order matters. What the file *is* comes first, since the later checks read it as
+    the artifact it claims to be, and a level or path stamped on something else says
+    nothing.
+
+    Args:
+        path: The file to check, named in every message.
+        stamps: Its stamps, already read.
+        artifact: Artifact name it is expected to hold.
+        schema: The columns this library's version of that artifact carries.
+        require_current: Refuse an artifact not written by the current versions. A
+            column is refused whatever this says, because a reader binding one that is
+            absent fails however old the file is; stamps alone are the caller's policy.
+        held: Reads the level or path a file is stamped with, for an artifact split
+            across a tree. None where the artifact is one file per dataset and where it
+            sits says nothing.
+        expected: The level or path ``path`` sits under, which ``held`` must match.
+        reading: How a message names the relation to ``expected`` -- "over" for a pivot
+            level, "at" for an indexed path.
+
+    Raises:
+        PairingError: If the file holds another artifact, is stamped with another level
+            or path, lacks a column this library reads, or is stale under
+            ``require_current``.
+    """
+    if stamps.artifact != artifact:
+        raise PairingError(
+            f"{path} is {_article(stamps.artifact)} {stamps.artifact}, not "
+            f"{_article(artifact)} {artifact}"
+        )
+    at = f" {reading} {expected}" if expected is not None else ""
+    if held is not None:
+        stamped = held(path)
+        if stamped != expected:
+            raise PairingError(
+                f"{path} holds the {artifact} {reading} {stamped}, but sits where "
+                f"{expected} is read from, so a quantifier would be answered by the "
+                "wrong elements"
+            )
+    missing = base.missing_columns(path, schema)
+    if missing:
+        # The stamps say nothing about a file's columns, so this is the only check that
+        # sees a schema change. Without it a file predating a column is read as a corpus
+        # member and fails deep in DuckDB -- as a binder error on the query that wants
+        # the column, or, where some files have it and some do not, as a schema mismatch
+        # that takes down every structure query.
+        raise PairingError(
+            f"{path} is {_article(artifact)} {artifact} artifact{at} without "
+            f"{missing}, which this library reads; derive it again first"
+        )
+    if require_current and not base.stamps_are_current(stamps, artifact):
+        raise PairingError(
+            f"{path} is a stale {artifact} artifact; derive it again first"
+        )
+
+
 def _index(
     pattern: str, artifact: str, schema: pa.Schema, require_current: bool
 ) -> dict[str, tuple[str, base.Stamps]]:
@@ -330,21 +408,13 @@ def _index(
     index: dict[str, tuple[str, base.Stamps]] = {}
     for path in sorted(glob.glob(pattern, recursive=True)):
         stamps = base.load_stamps(path)
-        if stamps.artifact != artifact:
-            raise PairingError(f"{path} is a {stamps.artifact}, not a {artifact}")
-        missing = base.missing_columns(path, schema)
-        if missing:
-            # The stamps say nothing about a file's columns, so this is the only check
-            # that sees a schema change. Without it a file predating a column is read
-            # as a corpus member and fails deep in DuckDB -- as a binder error on the
-            # query that wants the column, or, where some files have it and some do
-            # not, as a schema mismatch that takes down every structure query.
-            raise PairingError(
-                f"{path} is a {artifact} artifact without {missing}, which this "
-                "library reads; derive it again first"
-            )
-        if require_current and not base.stamps_are_current(stamps, artifact):
-            raise PairingError(f"{path} is stale; derive it again first")
+        _refuse_unreadable(
+            path,
+            stamps,
+            artifact=artifact,
+            schema=schema,
+            require_current=require_current,
+        )
         if stamps.source_md5 in index:
             raise PairingError(
                 f"{path} and {index[stamps.source_md5][0]} are both {artifact} "
@@ -1819,33 +1889,16 @@ class Corpus:
         derived_from: dict[str, str] = {}
         for name in files:
             stamps = base.load_stamps(name)
-            if stamps.artifact != occurrences.ARTIFACT:
-                raise PairingError(
-                    f"{name} is a {stamps.artifact}, not an {occurrences.ARTIFACT} "
-                    "artifact"
-                )
-            held = occurrences.occurrence_path(name)
-            if held != path:
-                raise PairingError(
-                    f"{name} holds the occurrences at {held}, but sits where {path} is "
-                    "read from, so a quantifier over it would be answered by another "
-                    "path's elements"
-                )
-            missing = base.missing_columns(name, occurrences.SCHEMA)
-            if missing:
-                # The three columns are the same at every path and have not moved, so
-                # nothing on disk fails this today. It is here because the stamps say
-                # nothing about columns whatever the artifact: the day this schema
-                # grows one, every file written before it reads as current and fails
-                # deep in DuckDB instead of here.
-                raise PairingError(
-                    f"{name} is an {occurrences.ARTIFACT} artifact at {path} without "
-                    f"{missing}, which this library reads; derive it again first"
-                )
-            if self._require_current and not base.stamps_are_current(
-                stamps, occurrences.ARTIFACT
-            ):
-                raise PairingError(f"{name} is a stale {occurrences.ARTIFACT} artifact")
+            _refuse_unreadable(
+                name,
+                stamps,
+                artifact=occurrences.ARTIFACT,
+                schema=occurrences.SCHEMA,
+                require_current=self._require_current,
+                held=occurrences.occurrence_path,
+                expected=path,
+                reading="at",
+            )
             # Two artifacts of one dataset pass the set comparison below and are both
             # read, so every occurrence at the path is stated twice. A quantifier cannot
             # see it -- a semi-join returns a reaction once however many rows name it --
@@ -2477,31 +2530,16 @@ class Corpus:
         derived_from: dict[str, str] = {}
         for name in files:
             stamps = base.load_stamps(name)
-            if stamps.artifact != pivot.ARTIFACT:
-                raise PairingError(
-                    f"{name} is a {stamps.artifact}, not a {pivot.ARTIFACT}"
-                )
-            held = pivot.pivot_path(name)
-            if held != path:
-                raise PairingError(
-                    f"{name} holds the pivot over {held}, but sits where {path} is "
-                    "read from, so a quantifier would be answered by the wrong level"
-                )
-            missing = base.missing_columns(name, schema)
-            if missing:
-                # A level's element struct grows whenever the projection's does, and
-                # the stamps say nothing about columns. Without this the artifact is
-                # read as a corpus member and a predicate over the new field fails deep
-                # in DuckDB, as a binder error naming a struct key rather than the file
-                # that predates it.
-                raise PairingError(
-                    f"{name} is a {pivot.ARTIFACT} artifact over {path} without "
-                    f"{missing}, which this library reads; derive it again first"
-                )
-            if self._require_current and not base.stamps_are_current(
-                stamps, pivot.ARTIFACT
-            ):
-                raise PairingError(f"{name} is a stale {pivot.ARTIFACT}")
+            _refuse_unreadable(
+                name,
+                stamps,
+                artifact=pivot.ARTIFACT,
+                schema=schema,
+                require_current=self._require_current,
+                held=pivot.pivot_path,
+                expected=path,
+                reading="over",
+            )
             # Two artifacts of one dataset pass the set comparison below and are both
             # read, so every element of the level is stated twice. A quantifier cannot
             # see it -- a semi-join returns a reaction once however many rows name it --

--- a/ord_schema/search/execute.py
+++ b/ord_schema/search/execute.py
@@ -1836,7 +1836,7 @@ class Corpus:
 
         Raises:
             PairingError: If the artifacts do not belong to this corpus; see
-                ``_check_occurrences``.
+                ``_check_split``.
         """
         if self._occurrences_dir is None:
             return None
@@ -1850,78 +1850,16 @@ class Corpus:
             if not files:
                 self._occurrence_artifacts_found[path] = None
                 return None
-            sources = self._check_occurrences(path, files)
-            self._occurrence_artifacts_found[path] = sources
-            return sources
-
-    def _check_occurrences(self, path: str, files: list[str]) -> dict[str, str]:
-        """Refuses occurrence artifacts that do not belong to this corpus.
-
-        The check ``_check_pivots`` makes, for the same reason: an occurrence names its
-        reaction by ID and its structure by a dataset-local ``structure_id``, and both
-        resolve against whatever this corpus holds. Artifacts derived from another
-        corpus therefore answer a quantifier confidently and wrongly rather than
-        failing.
-
-        Every indexed path writes the same three columns, so where a file sits says
-        nothing about what it holds and the stamped path is the only thing that does. A
-        file under the wrong one would answer that path's quantifiers with another
-        level's elements.
-
-        Args:
-            path: The indexed path the files claim to hold.
-            files: The artifacts found for it.
-
-        Returns:
-            The source dataset each artifact was derived from, keyed by its path, which
-            is what pairs an artifact with the offset its projection was given; see
-            ``_artifact_offsets``.
-
-        Raises:
-            PairingError: If a file is not an occurrences artifact, if it is stamped
-                with another path, if it lacks a column this library reads, if two
-                artifacts restate one source dataset, if the set of source datasets
-                differs from the projections', or -- with ``require_current`` -- if any
-                artifact is stale.
-        """
-        wanted = {base.load_stamps(name).source_md5 for name in self._projections}
-        sources: dict[str, str] = {}
-        derived_from: dict[str, str] = {}
-        for name in files:
-            stamps = base.load_stamps(name)
-            _refuse_unreadable(
-                name,
-                stamps,
+            sources = self._check_split(
+                path,
+                files,
                 artifact=occurrences.ARTIFACT,
                 schema=occurrences.SCHEMA,
-                require_current=self._require_current,
                 held=occurrences.occurrence_path,
-                expected=path,
                 reading="at",
             )
-            # Two artifacts of one dataset pass the set comparison below and are both
-            # read, so every occurrence at the path is stated twice. A quantifier cannot
-            # see it -- a semi-join returns a reaction once however many rows name it --
-            # but the structure count that decides whether the index reaches the corpus
-            # is taken over distinct IDs, so it cannot see it either, and check_index
-            # reports the doubled count as the corpus's own.
-            if stamps.source_md5 in derived_from:
-                raise PairingError(
-                    f"{name} and {derived_from[stamps.source_md5]} are both "
-                    f"{occurrences.ARTIFACT} artifacts at {path} of the same source "
-                    "dataset, so its occurrences would each be read twice"
-                )
-            derived_from[stamps.source_md5] = name
-            sources[name] = stamps.source_md5
-        if set(sources.values()) != wanted:
-            found = set(sources.values())
-            raise PairingError(
-                f"the {occurrences.ARTIFACT} artifacts at {path} were derived from "
-                f"{len(found)} source datasets and the projections from {len(wanted)}, "
-                f"and {len(wanted - found)} of the projections' are missing; an "
-                "artifact of another corpus names reactions this one does not hold"
-            )
-        return sources
+            self._occurrence_artifacts_found[path] = sources
+            return sources
 
     def _occurrences_from_artifact(self, path: str) -> str | None:
         """Returns the SELECT reading ``path``'s occurrences from artifacts, or None.
@@ -1940,7 +1878,7 @@ class Corpus:
 
         Raises:
             PairingError: If the artifacts do not belong to this corpus; see
-                ``_check_occurrences``.
+                ``_check_split``.
         """
         sources = self._occurrence_artifacts(path)
         if sources is None:
@@ -2497,35 +2435,56 @@ class Corpus:
             if not files:
                 self._pivot_artifacts_found[path] = None
                 return None
-            sources = self._check_pivots(path, files)
+            sources = self._check_split(
+                path,
+                files,
+                artifact=pivot.ARTIFACT,
+                schema=pivot.schema(pivot.LEVELS[path]),
+                held=pivot.pivot_path,
+                reading="over",
+            )
             self._pivot_artifacts_found[path] = sources
             return sources
 
-    def _check_pivots(self, path: str, files: list[str]) -> dict[str, str]:
-        """Refuses pivot artifacts that do not belong to this corpus.
+    def _check_split(
+        self,
+        path: str,
+        files: list[str],
+        *,
+        artifact: str,
+        schema: pa.Schema,
+        held: Callable[[str], str | None],
+        reading: str,
+    ) -> dict[str, str]:
+        """Refuses artifacts of a tree-split artifact that do not belong to this corpus.
 
-        A pivot names its reactions by ID, and an ID resolves against whatever rows the
-        projections hold. Artifacts derived from another corpus therefore answer a
-        quantifier confidently and wrongly rather than failing, which is why the check
-        is on the source datasets rather than on the file count.
+        These artifacts name their reactions by ID, and an ID resolves against whatever
+        rows the projections hold. Artifacts derived from another corpus therefore
+        answer a quantifier confidently and wrongly rather than failing, which is why
+        the check is on the source datasets rather than on the file count.
 
         Args:
-            path: The repeated level the files claim to hold.
+            path: The level or indexed path the files claim to hold.
             files: The artifacts found for it.
+            artifact: Artifact name every file must hold.
+            schema: The columns this library's version of that artifact carries at
+                ``path``.
+            held: Reads the level or path a file is stamped with.
+            reading: How a message names the relation to ``path`` -- "over" for a pivot
+                level, "at" for an indexed path.
 
         Returns:
             The source dataset each artifact was derived from, keyed by its path, which
             is what pairs an artifact with the offset its projection was given; see
-            ``_pivot_offsets``.
+            ``_artifact_offsets``.
 
         Raises:
-            PairingError: If a file is not a pivot over ``path``, if it lacks a column
-                this library reads, if two artifacts restate one source dataset, if the
-                set of source datasets differs from the projections', or -- with
+            PairingError: If a file is not this artifact over ``path``, if it lacks a
+                column this library reads, if two artifacts restate one source dataset,
+                if the set of source datasets differs from the projections', or -- with
                 ``require_current`` -- if any artifact is stale.
         """
         wanted = {base.load_stamps(name).source_md5 for name in self._projections}
-        schema = pivot.schema(pivot.LEVELS[path])
         sources: dict[str, str] = {}
         derived_from: dict[str, str] = {}
         for name in files:
@@ -2533,33 +2492,34 @@ class Corpus:
             _refuse_unreadable(
                 name,
                 stamps,
-                artifact=pivot.ARTIFACT,
+                artifact=artifact,
                 schema=schema,
                 require_current=self._require_current,
-                held=pivot.pivot_path,
+                held=held,
                 expected=path,
-                reading="over",
+                reading=reading,
             )
             # Two artifacts of one dataset pass the set comparison below and are both
-            # read, so every element of the level is stated twice. A quantifier cannot
-            # see it -- a semi-join returns a reaction once however many rows name it --
-            # but the occurrence index counts those rows, and check_index reports the
-            # count.
+            # read, so every element is stated twice. A quantifier cannot see it -- a
+            # semi-join returns a reaction once however many rows name it -- and
+            # neither can the structure count that decides whether the index reaches
+            # the corpus, which is taken over distinct IDs. What does see it is
+            # check_index, which reports the doubled count as the corpus's own.
             if stamps.source_md5 in derived_from:
                 raise PairingError(
-                    f"{name} and {derived_from[stamps.source_md5]} are both "
-                    f"{pivot.ARTIFACT} artifacts over {path} of the same source "
-                    "dataset, so the level's elements would each be read twice"
+                    f"{name} and {derived_from[stamps.source_md5]} are both {artifact} "
+                    f"artifacts {reading} {path} of the same source dataset, so its "
+                    "elements would each be read twice"
                 )
             derived_from[stamps.source_md5] = name
             sources[name] = stamps.source_md5
         if set(sources.values()) != wanted:
             found = set(sources.values())
             raise PairingError(
-                f"the {pivot.ARTIFACT} artifacts for {path} were derived from "
+                f"the {artifact} artifacts {reading} {path} were derived from "
                 f"{len(found)} source datasets and the projections from {len(wanted)}, "
-                f"and {len(wanted - found)} of the projections' are missing; a pivot "
-                "of another corpus names reactions this one does not hold"
+                f"and {len(wanted - found)} of the projections' are missing; an "
+                "artifact of another corpus names reactions this one does not hold"
             )
         return sources
 

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -4186,7 +4186,7 @@ def test_a_pivot_filed_under_the_wrong_level_is_refused(wide_root, tmp_path):
             pivots_dir=str(pivots),
             warm=False,
         ) as corpus,
-        pytest.raises(execute.PairingError, match="wrong level"),
+        pytest.raises(execute.PairingError, match="holds the pivot over"),
     ):
         _search(corpus, _white("exists"))
 

--- a/ord_schema/search/execute_test.py
+++ b/ord_schema/search/execute_test.py
@@ -4502,6 +4502,24 @@ def _without_mol_hash(corpus_dir, tmp_path, *, files: int) -> pathlib.Path:
     return root
 
 
+def test_an_artifact_stamped_with_an_empty_name_is_refused_by_name(
+    corpus_dir, tmp_path
+):
+    # load_stamps requires the artifact key to be present, not to be non-empty, so a
+    # footer written by hand or truncated mid-write reaches the check with an empty
+    # name. Naming the article off it must not be what fails: an IndexError raised
+    # while composing the message would bury the file this is refusing.
+    root = tmp_path / "unnamed"
+    shutil.copytree(corpus_dir, root)
+    target = next((root / "structures").glob("*.parquet"))
+    table = pq.read_table(target)
+    metadata = dict(table.schema.metadata)
+    metadata[b"ord.artifact"] = b""
+    pq.write_table(table.replace_schema_metadata(metadata), target)
+    with pytest.raises(execute.PairingError, match=re.escape(str(target))):
+        _open(root)
+
+
 def test_a_structures_artifact_without_mol_hash_is_refused(corpus_dir, tmp_path):
     # Stale is not what this is: the stamps still match, so nothing rebuilds the file
     # and nothing else would notice until DuckDB failed to bind the column.


### PR DESCRIPTION
## Summary

`_index`, `_check_pivots` and `_check_occurrences` each carried their own copy of the same per-file sequence: what the file is, where it is filed, what columns it carries, whether its stamps are current. Three copies of one contract, all still running when one falls behind — which is how the pivot copy came to be missing the column check that #1036 adds while the projection copy already had it.

Stacked on #1036, which fixes that instance; this removes the shape that produced it.

## Changes

- `_refuse_unreadable` holds the sequence once. All three callers use it.
- The location check is data, not a branch: the accessor that reads a file's stamped level or path, plus the preposition a message names it with. An artifact that is one file per dataset passes neither and gets the same three checks.
- Messages converge on one wording per failure, with the article and preposition following the artifact. A pivot filed under the wrong level reports the wrong *elements* rather than the wrong *level* — the wording the occurrences copy already used.
- `_check_pivots` and `_check_occurrences` were the same walk twice down to the duplicate-source check and the comparison against the projections' datasets. `_check_split` takes the four things that differ — artifact, schema, the accessor reading a file's stamped location, and the preposition — and does the rest once.
- `_article` answers for an empty artifact name instead of raising. `load_stamps` requires the key to be present rather than non-empty, so a footer written by hand or truncated mid-write reached it, and an `IndexError` composing the message buried the file being refused.

## Testing

- `pytest -n auto`: 1741 passed.
- Each merged check now fails tests from more than one artifact kind, which is what says the definition is actually shared rather than merely co-located. The column check: four tests across structures, pivots and occurrences. The duplicate-source check: two, pivots and structures. The source-set check: five, pivots and occurrences. Before the merge each kind needed its own mutation.
- `_article`'s empty-name branch fails only `test_an_artifact_stamped_with_an_empty_name_is_refused_by_name`.
- One assertion updated: `test_a_pivot_filed_under_the_wrong_level_is_refused` now matches `holds the pivot over`, which names the failure more precisely than the consequence clause did.

## Notes

The two messages that carried a consequence rather than a rule converge on the general one: elements read twice, and an artifact of another corpus naming reactions this one does not hold. No test asserted the artifact-specific halves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)






<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralizes artifact readability validation so projection, pivot, and occurrence files consistently undergo artifact-name, location, schema-column, and freshness checks.
- Introduces `_refuse_unreadable` as the shared validation path.
- Consolidates pivot and occurrence validation through `_check_split` while preserving source-set and duplicate-source checks.
- Safely handles empty artifact metadata and adds regression coverage.
- Updates failure-message expectations for incorrectly filed pivots.
</details>


<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the previous empty-name failure is resolved and no new actionable issue remains.

`_article` now handles empty artifact names without indexing, so malformed metadata reaches the intended `PairingError`. The shared validation preserves artifact identity, placement, required-column, freshness, duplicate-source, and source-set checks across each corpus artifact path.

<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ord_schema/search/execute.py | Centralizes artifact validation, unifies split-artifact checks, and safely formats errors for empty artifact names. |
| ord_schema/search/execute_test.py | Adds regression coverage for empty artifact metadata and updates the wrong-level pivot error expectation. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Corpus opens artifact] --> B[Load stamps]
  B --> C[_refuse_unreadable]
  C --> D{Expected artifact type?}
  D -->|No| X[Raise PairingError]
  D -->|Yes| E{Expected path or level?}
  E -->|No| X
  E -->|Yes| F{Required columns present?}
  F -->|No| X
  F -->|Yes| G{Current when required?}
  G -->|No| X
  G -->|Yes| H[Continue corpus pairing]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Name an artifact whose stamp is empty"](https://github.com/open-reaction-database/ord-schema/commit/440e6a3cf7e1527b1b9717b53882ce95f35dc9cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60877884)</sub>

**Context used:**

- Knowledge Base — [Database access and reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/database-and-search.md)
- Knowledge Base — [Structured reaction search](https://app.greptile.com/open-reaction-database/-/custom-context/knowledge-base/open-reaction-database/ord-schema/-/docs/structured-reaction-search.md)

<!-- /greptile_comment -->